### PR TITLE
Initial setup for Arquillian integration tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,15 +3,15 @@ ext.githubProjectName = rootProject.name // Change if github project name is not
 
 buildscript {
     repositories {
-        mavenLocal()
         mavenCentral() // maven { url 'http://jcenter.bintray.com' }
     }
-    apply from: file('gradle/buildscript.gradle'), to: buildscript 
+    apply from: file('gradle/buildscript.gradle'), to: buildscript
 }
 
 allprojects {
-    repositories { 
+    repositories {
         mavenCentral() // maven { url: 'http://jcenter.bintray.com' }
+        mavenLocal()
     }
 }
 
@@ -56,52 +56,71 @@ project(':genie-client') {
 
 project(':genie-server') {
     apply plugin: 'java'
-    
+
     // we are doing this rather than a dependency since we 
     // must perform build-time enhancement for OpenJPA
     sourceSets.main.java.srcDirs += '../genie-common/src/main/java'
-    
+
     dependencies {
         compile 'com.netflix.archaius:archaius-core:0.5.8'
         compile 'commons-collections:commons-collections:3.2.1'
         compile 'com.google.inject.extensions:guice-servlet:3.0'
         compile 'com.sun.jersey.contribs:jersey-guice:1.9.1'
         compile 'com.netflix.servo:servo-core:0.4.34'
-        compile 'com.netflix.karyon:karyon-extensions:1.0.16'
-                
+        compile 'com.netflix.karyon:karyon-extensions:1.0.22'
+
         runtime 'org.apache.derby:derby:10.2.2.0'
         runtime 'mysql:mysql-connector-java:5.1.16'
         runtime 'com.mchange:c3p0:0.9.2'
         runtime 'com.mchange:mchange-commons-java:0.2.3.3'
 
-        provided 'javax.servlet:servlet-api:2.5'        
+        provided 'javax.servlet:servlet-api:2.5'
     }
-    
+
     task enhance << {
 	    ant.taskdef(
 	        name      : 'openjpaenhancer',
 	        classpath : project.runtimeClasspath.asPath,
 	        classname : 'org.apache.openjpa.ant.PCEnhancerTask'
 	    )
-	
+
 	    ant.openjpaenhancer(
 	        classpath : project.runtimeClasspath.asPath)
 	}
-    
+
     jar {
     	it.dependsOn enhance
     }
-    
+
     test {
     	it.dependsOn enhance
     }
 }
-   
+
 project(':genie-web') {
     apply plugin: 'war'
-    
+
     dependencies {
-        compile 'com.netflix.karyon:karyon-admin-web:1.0.16'
+        compile 'com.netflix.karyon:karyon-admin-web:1.0.22'
         compile project(':genie-server')
+    }
+}
+
+project(':genie-web-int-tests') {
+    apply plugin: 'java'
+
+    dependencies {
+        compile project(':genie-web')
+
+        testCompile 'com.netflix.karyon:karyon-extensions-testsuite:1.0.22'
+        testCompile 'org.jboss.arquillian.junit:arquillian-junit-container:1.1.0.Final'
+        testCompile 'org.jboss.shrinkwrap:shrinkwrap-impl-base:1.1.2'
+        testCompile 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:2.0.0'
+        testRuntime 'org.jboss.arquillian.container:arquillian-tomcat-embedded-7:1.0.0.CR5'
+        testRuntime 'org.apache.tomcat.embed:tomcat-embed-core:7.0.42'
+        testRuntime 'org.apache.tomcat.embed:tomcat-embed-logging-juli:7.0.42'
+        testRuntime ('org.apache.tomcat.embed:tomcat-embed-jasper:7.0.42') {
+            exclude group: 'org.eclipse.jdt.core.compiler', module: 'ecj'
+        }
     }
 }

--- a/genie-web-int-tests/src/test/java/com/netflix/genie/server/resources/HiveConfigResourceV0TestCase.java
+++ b/genie-web-int-tests/src/test/java/com/netflix/genie/server/resources/HiveConfigResourceV0TestCase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.genie.server.resources;
+
+import com.google.inject.Inject;
+import com.netflix.genie.common.messages.HiveConfigResponse;
+import com.netflix.genie.server.utils.Deployments;
+import com.netflix.kayron.server.test.RunInKaryon;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link HiveConfigResourceV0} class.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+@RunWith(Arquillian.class)
+@RunInKaryon(applicationId = "genie")
+public class HiveConfigResourceV0TestCase {
+
+    /**
+     * Creates the test deployment.
+     *
+     * @return the test deployment
+     */
+    @Deployment
+    public static Archive createTestArchive() {
+
+        return Deployments.createDeployment();
+    }
+
+    /**
+     * The injected {@link HiveConfigResourceV0} class.
+     */
+    @Inject
+    private HiveConfigResourceV0 resource;
+
+    /**
+     * Test the {@link HiveConfigResourceV0#getHiveConfig(String, String, String)} method.
+     */
+    @Test
+    public void shouldRetrieveConfigs() {
+
+        // when
+        Response response = resource.getHiveConfig(null, null, null);
+
+        // then
+        assertNotNull("The response entity was null.", response);
+        assertNotNull("The response entity was null.", response.getEntity());
+        assertTrue("The response entity had incorrect type.", response.getEntity() instanceof HiveConfigResponse);
+        assertNull("The response list was expected to be null.",
+                ((HiveConfigResponse) response.getEntity()).getHiveConfigs());
+    }
+}

--- a/genie-web-int-tests/src/test/java/com/netflix/genie/server/utils/Deployments.java
+++ b/genie-web-int-tests/src/test/java/com/netflix/genie/server/utils/Deployments.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.genie.server.utils;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import java.io.File;
+import java.io.FileFilter;
+
+/**
+ * An example test case that demonstrates injection of a simple component into a test case.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+public final class Deployments {
+
+    /**
+     * Creates new instance of {@link Deployments} class.
+     */
+    private Deployments() {
+        // empty constructor
+    }
+
+    /**
+     * Creates tbe test deployment.
+     *
+     * @return the test deployment
+     */
+    public static Archive createDeployment() {
+
+        WebArchive archive = ShrinkWrap.create(ZipImporter.class, "genie-web.war")
+                .importFrom(resolveTestWar("../genie-web/"))
+                .as(WebArchive.class);
+
+        // overwrites the web.xml file
+        archive.setWebXML("web.xml");
+        // adds the archaius configuration
+        archive.addAsResource("config.properties");
+
+        return archive;
+    }
+
+    /**
+     * Resolves the path to the genie-web war, that need to be build prior executing this test.
+     *
+     * @param rootProjectPath the root project path of the genie-web module
+     *
+     * @return the path pointing to the build war
+     */
+    private static File resolveTestWar(String rootProjectPath) {
+
+        File buildDir = new File(rootProjectPath, "/build/libs/");
+        File[] war = buildDir.listFiles(new FileFilter() {
+            @Override
+            public boolean accept(File pathname) {
+                return pathname.isFile()
+                        && pathname.getName().endsWith(".war");
+            }
+        });
+
+        return war[0];
+    }
+}

--- a/genie-web-int-tests/src/test/resources/arquillian.xml
+++ b/genie-web-int-tests/src/test/resources/arquillian.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <engine>
+        <property name="deploymentExportPath">build/deployments</property>
+    </engine>
+
+    <container qualifier="jetty" default="true">
+        <configuration>
+            <property name="bindHttpPort">7001</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/genie-web-int-tests/src/test/resources/config.properties
+++ b/genie-web-int-tests/src/test/resources/config.properties
@@ -1,0 +1,2 @@
+archaius.deployment.applicationId=genie
+archaius.deployment.environment=dev

--- a/genie-web-int-tests/src/test/resources/web.xml
+++ b/genie-web-int-tests/src/test/resources/web.xml
@@ -1,0 +1,39 @@
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee">
+
+    <servlet>
+        <servlet-name>Jersey REST Service</servlet-name>
+        <servlet-class>
+            com.sun.jersey.spi.container.servlet.ServletContainer
+        </servlet-class>
+        <init-param>
+            <param-name>com.sun.jersey.config.property.resourceConfigClass</param-name>
+            <param-value>com.sun.jersey.api.core.PackagesResourceConfig</param-value>
+        </init-param>
+        <init-param>
+            <param-name>com.sun.jersey.config.property.packages</param-name>
+            <param-value>com.netflix.genie.server, com.netflix.appinfo</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Jersey REST Service</servlet-name>
+        <url-pattern>/genie/*</url-pattern>
+    </servlet-mapping>
+
+    <filter>
+        <filter-name>guiceFilter</filter-name>
+        <filter-class>com.google.inject.servlet.GuiceFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>guiceFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <listener>
+        <listener-class>com.netflix.kayron.server.test.KayronTestGuiceContextListener</listener-class>
+    </listener>
+</web-app>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name='genie'
-include 'genie-common','genie-client','genie-server', 'genie-web'
+include 'genie-common','genie-client','genie-server', 'genie-web', 'genie-web-int-tests'
 


### PR DESCRIPTION
I have added a seperate module for running  the integration tests, although when I run it I'm getting an error:

com.google.inject.ProvisionException: Guice provision errors:

1) Error injecting constructor, com.netflix.genie.common.exceptions.CloudServiceException: Configuration error - netflix.genie.server.hiveConfigImpl is not found
  at com.netflix.genie.server.resources.HiveConfigResourceV0.<init>()
  at Key[type=com.netflix.genie.server.resources.HiveConfigResourceV0, annotation=[none]]@com.netflix.genie.server.resources.HiveConfigResourceV0TestCase.resource
  at com.netflix.genie.server.resources.HiveConfigResourceV0TestCase

Could you help me find the cause of it? 

Note: I've used the kayron build from the master branch.
