### PR TITLE
Updating Tomcat 6 version to fix broken bootstrap process

### DIFF
--- a/deploy/aws/emr_genie_bootstrap.sh
+++ b/deploy/aws/emr_genie_bootstrap.sh
@@ -24,7 +24,7 @@ set -e
 TOMCAT_VERSION=6.0.39
 
 # Install Tomcat
-cd $HOME; wget http://mirror.sdunix.com/apache/tomcat/tomcat-6/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz
+cd $HOME; wget http://archive.apache.org/dist/tomcat/tomcat-6/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz
 tar zxvf apache-tomcat-${TOMCAT_VERSION}.tar.gz
 
 # Change port to 7001 to work out of the box


### PR DESCRIPTION
The bootstrap process is currently failing as a result of 404s being thrown while trying to pull down apache-tomcat-6.0.37, which is no longer the latest stable release.  I've updated the script to reference the latest stable release (6.0.39) and pulled the version out into a variable that can be more easily updated in the future.

The alternative would be to point the script to the archive location for apache-tomcat-6.0.37 and remain on the older version, but I've tested the bootstrap process with apache-tomcat-6.0.39 and ran the genie tests without running into any problems.  
