### PR TITLE
Change the order of downloading config files and sourcing env files

### DIFF
--- a/genie-web/conf/system/apps/genie/bin/joblauncher.sh
+++ b/genie-web/conf/system/apps/genie/bin/joblauncher.sh
@@ -87,6 +87,14 @@ function setupApplication {
         echo "$(date +"%F %T.%3N") Copied application jars files"
     fi
 
+    if [ -n "$S3_APPLICATION_CONF_FILES" ]; then
+        echo "$(date +"%F %T.%3N") Copying application Config files ..."
+        copyFiles "$S3_APPLICATION_CONF_FILES" "file://$CURRENT_JOB_CONF_DIR"/
+        checkError 208
+        echo "$(date +"%F %T.%3N") Copied application config files"
+        echo $'\n'
+    fi
+
     if [ -n "$APPLICATION_ENV_FILE" ]
     then
         echo "$(date +"%F %T.%3N") Copy down and Source Application Env File"
@@ -99,18 +107,18 @@ function setupApplication {
         echo "$(date +"%F %T.%3N") Application Name = $APPNAME"
     fi
 
-    if [ -n "$S3_APPLICATION_CONF_FILES" ]; then
-        echo "$(date +"%F %T.%3N") Copying application Config files ..."
-        copyFiles "$S3_APPLICATION_CONF_FILES" "file://$CURRENT_JOB_CONF_DIR"/
-        checkError 208
-        echo "$(date +"%F %T.%3N") Copied application config files"
-        echo $'\n'
-    fi
-
     return 0
 }
 
 function setupCommand {
+    if [ -n "$S3_COMMAND_CONF_FILES" ]; then
+        echo "$(date +"%F %T.%3N") Copying command Config files ..."
+        copyFiles "$S3_COMMAND_CONF_FILES" "file://$CURRENT_JOB_CONF_DIR"/
+        checkError 207
+        echo "$(date +"%F %T.%3N") Copied command config files"
+        echo $'\n'
+    fi
+
     if [ -n "$COMMAND_ENV_FILE" ]
     then
         echo "$(date +"%F %T.%3N") Copy down and Source Command Env File"
@@ -121,14 +129,6 @@ function setupCommand {
         source "$CURRENT_JOB_CONF_DIR/$COMMAND_FILENAME"
         checkError 205
         echo "$(date +"%F %T.%3N") Command Name=$CMDNAME"
-    fi
-
-    if [ -n "$S3_COMMAND_CONF_FILES" ]; then
-        echo "$(date +"%F %T.%3N") Copying command Config files ..."
-        copyFiles "$S3_COMMAND_CONF_FILES" "file://$CURRENT_JOB_CONF_DIR"/
-        checkError 207
-        echo "$(date +"%F %T.%3N") Copied command config files"
-        echo $'\n'
     fi
 
     return 0


### PR DESCRIPTION
Currently, Genie sources env files [1], and then downloads config files [2]. But it would make more sense if we changed the order to [2] and [1]. Here is why:

I am launching a Spark job via Genie. I wanted to create a single Spark application and link two Spark commands with different configs (for eg, prod and test) to the application. I also wanted to download config files and set SPARK_CONF_DIR in the env files. But since sourcing env files happens prior to downloading config files, I cannot do this now. As a workaround, I ended up creating two Spark applications.

I think setting XX_CONF_DIR on the fly is a common practice in Hadoop and Spark. So it makes sense to download config files before sourcing env files.