### PR TITLE
Immutable Creation Time and Serialization Consistency

### DIFF
--- a/genie-client/src/main/java/com/netflix/genie/client/ExecutionServiceClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/ExecutionServiceClient.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import com.netflix.genie.common.model.JobStatus;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -171,17 +172,17 @@ public final class ExecutionServiceClient extends BaseGenieClient {
 
         final long startTime = System.currentTimeMillis();
 
+        // wait for job to finish
         while (true) {
             final Job job = getJob(id);
 
-            // wait for job to finish - and finish time to be updated
-            if (!job.getFinished().equals(new Date(0))) {
+            final JobStatus status = job.getStatus();
+            if (status == JobStatus.FAILED || status == JobStatus.KILLED || status == JobStatus.SUCCEEDED) {
                 return job;
             }
 
             // block until timeout
-            long currTime = System.currentTimeMillis();
-            if (currTime - startTime < blockTimeout) {
+            if (System.currentTimeMillis() - startTime < blockTimeout) {
                 Thread.sleep(pollTime);
             } else {
                 throw new InterruptedException("Timed out waiting for job to finish");

--- a/genie-client/src/main/java/com/netflix/genie/client/ExecutionServiceClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/ExecutionServiceClient.java
@@ -26,7 +26,6 @@ import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.model.Job;
 
 import java.io.IOException;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 

--- a/genie-common/src/main/java/com/netflix/genie/common/model/Auditable.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/model/Auditable.java
@@ -59,6 +59,7 @@ public class Auditable implements Serializable, Validate {
      * Unique ID.
      */
     @Id
+    @Column(updatable = false)
     @ApiModelProperty(
             value = "The unique id of this resource. If one is not provided it is created internally"
     )
@@ -76,7 +77,7 @@ public class Auditable implements Serializable, Validate {
     )
     @JsonSerialize(using = JsonDateSerializer.class)
     @JsonDeserialize(using = JsonDateDeserializer.class)
-    private Date created;
+    private Date created = new Date();
 
     /**
      * The update timestamp.
@@ -89,7 +90,7 @@ public class Auditable implements Serializable, Validate {
     )
     @JsonSerialize(using = JsonDateSerializer.class)
     @JsonDeserialize(using = JsonDateDeserializer.class)
-    private Date updated;
+    private Date updated = new Date();
 
     /**
      * The version of this entity. Auto handled by JPA.
@@ -151,11 +152,7 @@ public class Auditable implements Serializable, Validate {
      * @return The created timestamps
      */
     public Date getCreated() {
-        if (this.created == null) {
-            return null;
-        } else {
-            return new Date(this.created.getTime());
-        }
+        return new Date(this.created.getTime());
     }
 
     /**
@@ -165,7 +162,9 @@ public class Auditable implements Serializable, Validate {
      */
     public void setCreated(final Date created) {
         LOG.info("Tried to set created to " + created + " for entity " + this.id + ". Will not be persisted.");
-        this.created = new Date(created.getTime());
+        if (created.before(this.created)) {
+            this.created = new Date(created.getTime());
+        }
     }
 
     /**
@@ -174,11 +173,7 @@ public class Auditable implements Serializable, Validate {
      * @return The updated timestamp
      */
     public Date getUpdated() {
-        if (this.updated == null) {
-            return null;
-        } else {
-            return new Date(this.updated.getTime());
-        }
+        return new Date(this.updated.getTime());
     }
 
     /**

--- a/genie-common/src/main/java/com/netflix/genie/common/model/Auditable.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/model/Auditable.java
@@ -18,11 +18,12 @@
 package com.netflix.genie.common.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
+import com.netflix.genie.common.util.JsonDateDeserializer;
 import com.netflix.genie.common.util.JsonDateSerializer;
 import com.wordnik.swagger.annotations.ApiModel;
 import com.wordnik.swagger.annotations.ApiModelProperty;
@@ -68,11 +69,13 @@ public class Auditable implements Serializable, Validate {
      */
     @Temporal(TemporalType.TIMESTAMP)
     @Basic(optional = false)
+    @Column(updatable = false)
     @ApiModelProperty(
             value = "When this resource was created. Set automatically by system",
             dataType = "date"
     )
-    @JsonIgnore
+    @JsonSerialize(using = JsonDateSerializer.class)
+    @JsonDeserialize(using = JsonDateDeserializer.class)
     private Date created;
 
     /**
@@ -84,7 +87,8 @@ public class Auditable implements Serializable, Validate {
             value = "When this resource was last updated. Set automatically by system",
             dataType = "date"
     )
-    @JsonIgnore
+    @JsonSerialize(using = JsonDateSerializer.class)
+    @JsonDeserialize(using = JsonDateDeserializer.class)
     private Date updated;
 
     /**
@@ -146,8 +150,6 @@ public class Auditable implements Serializable, Validate {
      *
      * @return The created timestamps
      */
-    @JsonProperty("created")
-    @JsonSerialize(using = JsonDateSerializer.class)
     public Date getCreated() {
         if (this.created == null) {
             return null;
@@ -161,9 +163,9 @@ public class Auditable implements Serializable, Validate {
      *
      * @param created The created timestamp
      */
-    @JsonIgnore
     public void setCreated(final Date created) {
-        LOG.info("Tried to set created time to " + created + " for entity " + this.id + ". Ignoring.");
+        LOG.info("Tried to set created to " + created + " for entity " + this.id + ". Will not be persisted.");
+        this.created = new Date(created.getTime());
     }
 
     /**
@@ -171,8 +173,6 @@ public class Auditable implements Serializable, Validate {
      *
      * @return The updated timestamp
      */
-    @JsonProperty("updated")
-    @JsonSerialize(using = JsonDateSerializer.class)
     public Date getUpdated() {
         if (this.updated == null) {
             return null;
@@ -186,9 +186,8 @@ public class Auditable implements Serializable, Validate {
      *
      * @param updated The updated timestamp
      */
-    @JsonIgnore
     public void setUpdated(final Date updated) {
-        LOG.info("Tried to set updated time to " + updated + " for entity " + this.id + ". Ignoring.");
+        this.updated = new Date(updated.getTime());
     }
 
     /**

--- a/genie-common/src/main/java/com/netflix/genie/common/util/JsonDateDeserializer.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/util/JsonDateDeserializer.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.text.DateFormat;
@@ -40,8 +41,15 @@ public class JsonDateDeserializer extends JsonDeserializer<Date> {
     public Date deserialize(final JsonParser parser,
                             final DeserializationContext context) throws IOException {
         final DateFormat format = new ISO8601DateFormat();
+
+        final String text = parser.getText();
+
+        if (StringUtils.isBlank(text)) {
+            return null;
+        }
+
         try {
-            return format.parse(parser.getText());
+            return format.parse(text);
         } catch (final ParseException pe) {
             throw new IOException(pe);
         }

--- a/genie-common/src/main/java/com/netflix/genie/common/util/JsonDateSerializer.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/util/JsonDateSerializer.java
@@ -38,7 +38,11 @@ public class JsonDateSerializer extends JsonSerializer<Date> {
     @Override
     public void serialize(final Date date, final JsonGenerator gen, final SerializerProvider provider)
             throws IOException {
-        gen.writeString(ISO8601Utils.format(date));
+        if (date == null) {
+            gen.writeString((String) null);
+        } else {
+            gen.writeString(ISO8601Utils.format(date));
+        }
     }
 }
 

--- a/genie-common/src/test/java/com/netflix/genie/common/util/TestJsonDateDeserializer.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/util/TestJsonDateDeserializer.java
@@ -63,6 +63,20 @@ public class TestJsonDateDeserializer {
     }
 
     /**
+     * Test the de-serialization method with null.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testDeserializeNull() throws IOException {
+        Mockito.when(this.parser.getText()).thenReturn(null);
+
+        final JsonDateDeserializer deserializer = new JsonDateDeserializer();
+        final Date date = deserializer.deserialize(this.parser, this.context);
+        Assert.assertNull(date);
+    }
+
+    /**
      * Test the de-serialization method.
      *
      * @throws IOException

--- a/genie-common/src/test/java/com/netflix/genie/common/util/TestJsonDateSerializer.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/util/TestJsonDateSerializer.java
@@ -60,4 +60,19 @@ public class TestJsonDateSerializer {
         serializer.serialize(DATE, gen, provider);
         Mockito.verify(gen, Mockito.times(1)).writeString(this.expectedString);
     }
+
+    /**
+     * Test the serialization method with a null date.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testSerializeNull() throws IOException {
+        final JsonGenerator gen = Mockito.mock(JsonGenerator.class);
+        final SerializerProvider provider = Mockito.mock(SerializerProvider.class);
+
+        final JsonDateSerializer serializer = new JsonDateSerializer();
+        serializer.serialize(null, gen, provider);
+        Mockito.verify(gen, Mockito.times(1)).writeString((String) null);
+    }
 }

--- a/genie-server/src/test/java/com/netflix/genie/server/services/impl/jpa/TestApplicationConfigServiceJPAImpl.java
+++ b/genie-server/src/test/java/com/netflix/genie/server/services/impl/jpa/TestApplicationConfigServiceJPAImpl.java
@@ -29,6 +29,7 @@ import com.netflix.genie.common.model.Command;
 import com.netflix.genie.server.services.ApplicationConfigService;
 import com.netflix.genie.server.services.CommandConfigService;
 import java.net.HttpURLConnection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -359,6 +360,27 @@ public class TestApplicationConfigServiceJPAImpl extends DBUnitTestBase {
         Assert.assertEquals(APP_2_USER, updated.getUser());
         Assert.assertEquals(ApplicationStatus.ACTIVE, updated.getStatus());
         Assert.assertEquals(6, updated.getTags().size());
+    }
+
+    /**
+     * Test to make sure setting the created and updated outside the system control doesn't change record in database.
+     *
+     * @throws GenieException
+     */
+    @Test
+    public void testUpdateCreateAndUpdate() throws GenieException {
+        final Application init = this.service.getApplication(APP_1_ID);
+        final Date created = init.getCreated();
+        final Date updated = init.getUpdated();
+
+        init.setCreated(new Date());
+        final Date zero = new Date(0);
+        init.setUpdated(zero);
+
+        final Application updatedApp = this.service.updateApplication(APP_1_ID, init);
+        Assert.assertEquals(created, updatedApp.getCreated());
+        Assert.assertNotEquals(updated, updatedApp.getUpdated());
+        Assert.assertNotEquals(zero, updatedApp.getUpdated());
     }
 
     /**

--- a/genie-server/src/test/java/com/netflix/genie/server/services/impl/jpa/TestClusterConfigServiceJPAImpl.java
+++ b/genie-server/src/test/java/com/netflix/genie/server/services/impl/jpa/TestClusterConfigServiceJPAImpl.java
@@ -34,6 +34,7 @@ import com.netflix.genie.server.services.JobService;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -434,6 +435,27 @@ public class TestClusterConfigServiceJPAImpl extends DBUnitTestBase {
         Assert.assertEquals(CLUSTER_2_USER, updated.getUser());
         Assert.assertEquals(ClusterStatus.OUT_OF_SERVICE, updated.getStatus());
         Assert.assertEquals(6, updated.getTags().size());
+    }
+
+    /**
+     * Test to make sure setting the created and updated outside the system control doesn't change record in database.
+     *
+     * @throws GenieException
+     */
+    @Test
+    public void testUpdateCreateAndUpdate() throws GenieException {
+        final Cluster init = this.service.getCluster(CLUSTER_1_ID);
+        final Date created = init.getCreated();
+        final Date updated = init.getUpdated();
+
+        init.setCreated(new Date());
+        final Date zero = new Date(0);
+        init.setUpdated(zero);
+
+        final Cluster updatedCluster = this.service.updateCluster(CLUSTER_1_ID, init);
+        Assert.assertEquals(created, updatedCluster.getCreated());
+        Assert.assertNotEquals(updated, updatedCluster.getUpdated());
+        Assert.assertNotEquals(zero, updatedCluster.getUpdated());
     }
 
     /**

--- a/genie-server/src/test/java/com/netflix/genie/server/services/impl/jpa/TestCommandConfigServiceJPAImpl.java
+++ b/genie-server/src/test/java/com/netflix/genie/server/services/impl/jpa/TestCommandConfigServiceJPAImpl.java
@@ -31,6 +31,7 @@ import com.netflix.genie.server.services.ApplicationConfigService;
 import com.netflix.genie.server.services.ClusterConfigService;
 import com.netflix.genie.server.services.CommandConfigService;
 import java.net.HttpURLConnection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -384,6 +385,27 @@ public class TestCommandConfigServiceJPAImpl extends DBUnitTestBase {
         Assert.assertEquals(COMMAND_2_USER, updated.getUser());
         Assert.assertEquals(CommandStatus.INACTIVE, updated.getStatus());
         Assert.assertEquals(6, updated.getTags().size());
+    }
+
+    /**
+     * Test to make sure setting the created and updated outside the system control doesn't change record in database.
+     *
+     * @throws GenieException
+     */
+    @Test
+    public void testUpdateCreateAndUpdate() throws GenieException {
+        final Command init = this.service.getCommand(COMMAND_1_ID);
+        final Date created = init.getCreated();
+        final Date updated = init.getUpdated();
+
+        init.setCreated(new Date());
+        final Date zero = new Date(0);
+        init.setUpdated(zero);
+
+        final Command updatedCommand = this.service.updateCommand(COMMAND_1_ID, init);
+        Assert.assertEquals(created, updatedCommand.getCreated());
+        Assert.assertNotEquals(updated, updatedCommand.getUpdated());
+        Assert.assertNotEquals(zero, updatedCommand.getUpdated());
     }
 
     /**

--- a/genie-server/src/test/java/com/netflix/genie/server/services/impl/jpa/TestExecutionServiceJPAImpl.java
+++ b/genie-server/src/test/java/com/netflix/genie/server/services/impl/jpa/TestExecutionServiceJPAImpl.java
@@ -108,15 +108,6 @@ public class TestExecutionServiceJPAImpl extends DBUnitTestBase {
     @Test(expected = GeniePreconditionException.class)
     public void testTryingToKillInitializingJob() throws GenieException {
         this.xs.killJob(JOB_4_ID);
-//        try {
-//            this.xs.killJob(JOB_5_ID);
-//            Assert.fail();
-//        } catch (final GenieException ge) {
-//            Assert.assertEquals(
-//                    HttpURLConnection.HTTP_PRECON_FAILED,
-//                    ge.getErrorCode()
-//            );
-//        }
     }
 
     /**

--- a/genie-web/src/main/webapp/WEB-INF/web.xml
+++ b/genie-web/src/main/webapp/WEB-INF/web.xml
@@ -46,7 +46,7 @@
         <servlet-class>com.wordnik.swagger.jersey.config.JerseyJaxrsConfig</servlet-class>
         <init-param>
             <param-name>api.version</param-name>
-            <param-value>2.1.1</param-value>
+            <param-value>2.1.2</param-value>
         </init-param>
         <init-param>
             <param-name>swagger.api.basepath</param-name>


### PR DESCRIPTION
Currently the creation time logic introduced in 2.1.1 works fine on the server side but it fails when combined with the Java client. The creation time will not be serialized back into the client and waitForCompletion() fails begin occurring due to serialization inconsistencies.

This pull request includes changes to enforce immutability at the database level via the ```@Column(updatable = false)``` annotation/flag in JPA. It ensures that the generated SQL for updates do not include the annotated field. Rest of code modified to accommodate this change and associated tests. This should ensure that no matter what is done outside of the ```@PrePersist``` and ```@PreUpdate``` methods nothing changes.

The entity ID's have also been marked immutable.

Client code slightly cleaned up to use ```JobStatus``` instead of flakey logic based on job finish time. Clients need to be reworked for [Ribbon](https://github.com/Netflix/ribbon) [2.0.0](https://github.com/Netflix/ribbon/releases/tag/v2.0.0) but that work should be part of #97. 