### PR TITLE
Added (simpler) Groovy sample and reviewed the Java client

### DIFF
--- a/genie-client/build.gradle
+++ b/genie-client/build.gradle
@@ -6,7 +6,7 @@ dependencies {
      *******************************/
 
     compile project(":genie-common")
-    compile "org.codehaus.groovy:groovy:2.3.3"
+    compile "org.codehaus.groovy:groovy:$groovy_lang_version"
 
     /*******************************
      * Provided Dependencies

--- a/genie-client/build.gradle
+++ b/genie-client/build.gradle
@@ -1,16 +1,12 @@
 apply plugin: 'groovy'
 
-// module versions
-groovyVersion="2.3.3"
-
-
 dependencies {
     /*******************************
      * Compile Dependencies
      *******************************/
 
     compile project(":genie-common")
-    compile "org.codehaus.groovy:groovy:$groovyVersion"
+    compile "org.codehaus.groovy:groovy:2.3.3"
 
     /*******************************
      * Provided Dependencies

--- a/genie-client/build.gradle
+++ b/genie-client/build.gradle
@@ -1,9 +1,16 @@
+apply plugin: 'groovy'
+
+// module versions
+groovyVersion="2.3.3"
+
+
 dependencies {
     /*******************************
      * Compile Dependencies
      *******************************/
 
     compile project(":genie-common")
+    compile "org.codehaus.groovy:groovy:$groovyVersion"
 
     /*******************************
      * Provided Dependencies

--- a/genie-client/src/main/groovy/com/netflix/genie/client/sample/GExecutionServiceSampleClient.groovy
+++ b/genie-client/src/main/groovy/com/netflix/genie/client/sample/GExecutionServiceSampleClient.groovy
@@ -102,15 +102,15 @@ public final class GExecutionServiceSampleClient {
         LOG.info "Output URL: $job.outputURI"
 
         LOG.info 'Getting jobInfo by jobID'
-        job = client.getJob(jobID)
+        job = client.getJob(job.id)
         LOG.info job.toString()
 
         LOG.info 'Waiting for job to finish'
-        job = client.waitForCompletion(jobID, 600000, 5000)
+        job = client.waitForCompletion(job.id, 600000, 5000)
         LOG.info "Job status: $job.status" 
 
         LOG.info 'Killing jobs using jobID'
-        def killedJob = client.killJob(jobID)
+        def killedJob = client.killJob(job.id)
         LOG.info "Job status: $killedJob.status"
 
         LOG.info 'Done'

--- a/genie-client/src/main/groovy/com/netflix/genie/client/sample/GExecutionServiceSampleClient.groovy
+++ b/genie-client/src/main/groovy/com/netflix/genie/client/sample/GExecutionServiceSampleClient.groovy
@@ -40,8 +40,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A sample client demonstrating usage of the Execution Service Client.
  *
- * @author skrishnan
- * @author tgianos
+ * @author liviutudor
  */
 public final class GExecutionServiceSampleClient {
 

--- a/genie-client/src/main/groovy/com/netflix/genie/client/sample/GExecutionServiceSampleClient.groovy
+++ b/genie-client/src/main/groovy/com/netflix/genie/client/sample/GExecutionServiceSampleClient.groovy
@@ -1,0 +1,118 @@
+/*
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.client.sample;
+
+import com.netflix.config.ConfigurationManager;
+import com.netflix.genie.client.ExecutionServiceClient;
+import com.netflix.genie.common.model.ClusterCriteria;
+import com.netflix.genie.common.model.FileAttachment;
+import com.netflix.genie.common.model.Job;
+import com.netflix.genie.common.model.JobStatus;
+
+import java.io.ByteArrayOutputStream;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A sample client demonstrating usage of the Execution Service Client.
+ *
+ * @author skrishnan
+ * @author tgianos
+ */
+public final class GExecutionServiceSampleClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExecutionServiceSampleClient.class) 
+
+    private ExecutionServiceSampleClient() {
+        // never called
+    }
+
+    /**
+     * Main for running client code .
+     *
+     * @param args command line arguments
+     * @throws Exception On any issue.
+     */
+    public static void main(final String[] args) throws Exception {
+
+        // Initialize Eureka, if it is being used
+        // LOG.info("Initializing Eureka");
+        // ExecutionServiceClient.initEureka("test");
+        LOG.info 'Initializing list of Genie servers'
+        ConfigurationManager.getConfigInstance().setProperty('genie2Client.ribbon.listOfServers',
+                'http://localhost:7001')
+
+        LOG.info 'Initializing ExecutionServiceClient'
+        def client = ExecutionServiceClient.getInstance()
+
+        final String userName = 'genietest'
+        final String jobName = 'sampleClientTestJob'
+        LOG.info 'Getting jobs using specified filter criteria'
+        def params = [userName: userName, status: JobStatus.FAILED.name(), limit: 3] as Map
+        for (final Job ji : client.getJobs(params)) {
+            LOG.info "Job: {id, status, finishTime} - {$ji.id, $ji.status, $ji.finished}"
+        }
+
+        LOG.info 'Running Hive job'
+        def clusterCriterias = [new ClusterCriteria(['adhoc'] as Set)] as List
+        def commandCriteria = ['hive'] as Set
+
+        def fa = new FileAttachment()
+        fa.with { (name, data)=['hive.q', 'select count(*) from counters where dateint=20120430 and hour=10;'.getBytes('UTF-8')] }
+
+        def job = new Job(
+                userName,
+                jobName,
+                '-f hive.q',
+                commandCriteria,
+                clusterCriterias,
+                null)
+        job.with {
+            (description, tags, attachments) = ['This is a test', ['testgenie', 'sample'] as Set, [fa]]
+        }
+
+        job = client.submitJob(job)
+
+        final String outputURI = job.getOutputURI();
+        LOG.info "Job ID: $job.id"
+        LOG.info "Output URL: $job.outputURI"
+
+        LOG.info 'Getting jobInfo by jobID'
+        job = client.getJob(jobID)
+        LOG.info job.toString()
+
+        LOG.info 'Waiting for job to finish'
+        job = client.waitForCompletion(jobID, 600000, 5000)
+        LOG.info "Job status: $job.status" 
+
+        LOG.info 'Killing jobs using jobID'
+        def killedJob = client.killJob(jobID)
+        LOG.info "Job status: $killedJob.status"
+
+        LOG.info 'Done'
+    }
+}

--- a/genie-client/src/main/java/com/netflix/genie/client/sample/ExecutionServiceSampleClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/sample/ExecutionServiceSampleClient.java
@@ -112,33 +112,11 @@ public final class ExecutionServiceSampleClient {
         job.setTags(jobTags);
 
         // send the query as an attachment
-        final File query = File.createTempFile("hive", ".q");
-        try (PrintWriter pw = new PrintWriter(query, "UTF-8")) {
-            pw.println("select count(*) from counters where dateint=20120430 and hour=10;");
-        }
         final Set<FileAttachment> attachments = new HashSet<>();
         final FileAttachment attachment = new FileAttachment();
         attachment.setName("hive.q");
+        attachment.setData("select count(*) from counters where dateint=20120430 and hour=10;".getBytes("UTF-8"));
 
-        FileInputStream fin = null;
-        ByteArrayOutputStream bos = null;
-        try {
-            fin = new FileInputStream(query);
-            bos = new ByteArrayOutputStream();
-            final byte[] buf = new byte[4096];
-            int read;
-            while ((read = fin.read(buf)) != -1) {
-                bos.write(buf, 0, read);
-            }
-            attachment.setData(bos.toByteArray());
-        } finally {
-            if (fin != null) {
-                fin.close();
-            }
-            if (bos != null) {
-                bos.close();
-            }
-        }
         attachments.add(attachment);
         job.setAttachments(attachments);
         job = client.submitJob(job);

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,6 +33,9 @@ commons_collections_version=3.2.1
 commons_lang3_version=3.3.2
 slf4j_log4j12_version=1.7.10
 
+# Groovy Libraries
+groovy_lang_version=2.3.3
+
 # Test Libraries
 dbunit_version=2.5.0
 junit_version=4.12


### PR DESCRIPTION
2 streams of changes here:

* on the Java client, the way the query is passed as a `FileAttachment` is way too convoluted and also incurs extra I/O due to going to disk when in fact everything can be done in memory.
* Since I know there are some of us in Netflix using Groovy, and due to the fact that Groovy has a lot of syntactical sugar around initialization and properties setting, I've put together a Groovy client sample too which is much more concise I feel than the Java one and as such might make it easier to understand the client (as well as help folks who rely on Groovy).