### PR TITLE
Fix script to cleanup grandchildren procs.

### DIFF
--- a/root/apps/genie/bin/jobkill.sh
+++ b/root/apps/genie/bin/jobkill.sh
@@ -72,7 +72,7 @@ executeWithRetry "kill -CONT -$parent_pid"
 waitWithTimeout "$parent_pid"
 
 # Follow with a sigkill to the entire group if there are still processes
-if pgrep -g "$parent_pid"; then
+if pgrep -g "$parent_pid" > /dev/null; then
     executeWithRetry "kill -9 -$parent_pid"
 fi
 

--- a/root/apps/genie/bin/jobkill.sh
+++ b/root/apps/genie/bin/jobkill.sh
@@ -34,27 +34,47 @@ function executeWithRetry()
     fi
 }
 
+function waitWithTimeout()
+{
+    local pid=$1
+    local timeout=$((`date +%s` + 60))
+    while true; do
+        if ! $(kill -0 $pid > /dev/null 2>&1); then
+            return
+        elif [[ $(date +%s) -gt $timeout ]]; then
+            echo "Timeout reached waiting for pid $pid"
+            return
+        fi
+        echo "Waiting for pid $pid to exit gracefully..."
+        sleep 3
+    done
+}
+
 # basic error checking
 if [[ $# != 1 ]]; then
-	echo "Incorrect number of arguments"
-	echo "Usage: jobkill.sh PARENT_PID"
-	exit 1
+    echo "Incorrect number of arguments"
+    echo "Usage: jobkill.sh PARENT_PID"
+    exit 1
 fi
 
 # the process id of the launcher
 parent_pid=$1
 
-# pause the parent so it doesn't trigger any retries
-executeWithRetry "kill -STOP $parent_pid"
+# pause the process group so it doesn't trigger any retries
+executeWithRetry "kill -STOP -$parent_pid"
 
-# kill all the children
-executeWithRetry "pkill -P $parent_pid"
-
-# now kill the parent - but it won't be killed yet since it is paused
-executeWithRetry "kill $parent_pid"
+# send a sigterm to all untrapped procs in the group
+executeWithRetry "kill -- -$parent_pid"
 
 # continue parent, this will kill it - and the trap will ensure that files are archived to S3
-executeWithRetry "kill -CONT $parent_pid"
+executeWithRetry "kill -CONT -$parent_pid"
+
+waitWithTimeout "$parent_pid"
+
+# Follow with a sigkill to the entire group if there are still processes
+if pgrep -g "$parent_pid"; then
+    executeWithRetry "kill -9 -$parent_pid"
+fi
 
 echo "Done"
 exit 0


### PR DESCRIPTION
Currently the ```jobkill.sh``` script doesn't kill grandchildren processes, only children. The defect can be demonstrated by creating a script that forks to a new script, which also forks. The grandchild will be orphaned after a ```pgrep -P <proc>``` is sent to the original parent.

```
root@acd91a5b48b4:/tmp# ps auxf
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
....       ... .... ....    ...   ... ...      .... .....   .... .......
root       712  0.0  0.0   9520  1304 pts/1    S+   17:38   0:00              \_ /bin/bash ./parent
root       713  0.0  0.0   9520  1116 pts/1    S+   17:38   0:00                  \_ /bin/bash ./child
root       715  0.0  0.0   4340   360 pts/1    S+   17:38   0:00                  |   \_ sleep 8888888    <----- grandchild of parent
root       714  0.0  0.0   4340   360 pts/1    S+   17:38   0:00                  \_ sleep 10000
root@acd91a5b48b4:/tmp# pkill -P 712
root@acd91a5b48b4:/tmp# ps auxf
root       109  0.0  0.0   4440   652 pts/1    Ss   16:08   0:00      \_ /bin/sh
root       110  0.0  0.0  18208  2068 pts/1    S+   16:08   0:00          \_ bash
root       715  0.0  0.0   4340   360 pts/1    S    17:38   0:00 sleep 8888888    <---- grandchild now orphaned
```

This fix has the following improvements:
1. Timeout introduced before parent process is killed with a sigkill
2. Will kill child processes with a sigkill if they don't exit with a sigterm
3. Entire process group is killed

I'm not sure how long it usually takes the parent process to upload to s3, but the default I introduced here is 60 seconds before the process is ungracefully terminated.