### PR TITLE
Issue 161: Include errorCode in toString() when GenieException is con…

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/exceptions/GenieException.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/exceptions/GenieException.java
@@ -50,7 +50,7 @@ public class GenieException extends Exception {
      * @param cause reason for this exception
      */
     public GenieException(final int errorCode, final Throwable cause) {
-        super(cause);
+        super(String.valueOf(errorCode), cause);
         this.errorCode = errorCode;
     }
 

--- a/genie-common/src/test/java/com/netflix/genie/common/exceptions/TestGenieException.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/exceptions/TestGenieException.java
@@ -70,6 +70,7 @@ public class TestGenieException extends Exception {
     public void testTwoArgConstructorWithThrowable() throws GenieException {
         final GenieException ge = new GenieException(ERROR_CODE, IOE);
         Assert.assertEquals(ERROR_CODE, ge.getErrorCode());
+        Assert.assertEquals(String.valueOf(ERROR_CODE), ge.getMessage());
         Assert.assertEquals(IOE, ge.getCause());
         throw ge;
     }


### PR DESCRIPTION
…structed without a message.

This is especially helpful when the passed-in cause is null (which is allowed by java.lang.Exception).
