### PR TITLE
Allow unauthenticated access to health check endpoint

### DIFF
--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     // Web Jars
     compile("org.webjars:bootstrap:${bootstrap_version}")
     compile("org.webjars:datatables:${datatables_version}")
+    compile("org.webjars:hal-browser")
     compile("org.webjars:jquery:${jquery_version}")
     compile("org.webjars:knockout:${knockout_version}")
     compile("org.webjars:lodash:${lodash_version}")

--- a/genie-web/src/main/java/com/netflix/genie/web/security/SecurityUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/SecurityUtils.java
@@ -60,7 +60,7 @@ public final class SecurityUtils {
     ) throws Exception {
         // @formatter:off
         http
-            .regexMatcher("(/api|" + actuatorEndpoint + ")/.*")
+            .regexMatcher("(/api/.*)|(" + actuatorEndpoint + ")/(?!health).*")
                 .authorizeRequests()
                     .regexMatchers(HttpMethod.DELETE, APPLICATIONS_API_REGEX).hasRole(ADMIN_ROLE)
                     .regexMatchers(HttpMethod.PATCH, APPLICATIONS_API_REGEX).hasRole(ADMIN_ROLE)

--- a/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLConfig.java
@@ -722,8 +722,9 @@ public class SAMLConfig extends WebSecurityConfigurerAdapter {
         http
             .antMatcher("/**")
                 .authorizeRequests()
-                    .antMatchers("/error").permitAll()
+                    .antMatchers("/actuator/**").permitAll()
                     .antMatchers("/api/**").permitAll()
+                    .antMatchers("/error").permitAll()
                     .antMatchers("/saml/**").permitAll()
                     .antMatchers("/upload.html").hasRole("ADMIN")
                     .anyRequest().authenticated()

--- a/genie-web/src/test/java/com/netflix/genie/web/security/AbstractAPISecurityIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/security/AbstractAPISecurityIntegrationTests.java
@@ -255,7 +255,7 @@ public abstract class AbstractAPISecurityIntegrationTests {
         this.get(this.actuatorEndpoint + "/beans", expectedResult);
         this.get(this.actuatorEndpoint + "/configprops", expectedResult);
         this.get(this.actuatorEndpoint + "/env", expectedResult);
-        this.get(this.actuatorEndpoint + "/health", expectedResult);
+        this.get(this.actuatorEndpoint + "/health", OK);
         this.get(this.actuatorEndpoint + "/info", expectedResult);
         this.get(this.actuatorEndpoint + "/mappings", expectedResult);
         this.get(this.actuatorEndpoint + "/metrics", expectedResult);

--- a/genie-web/src/test/java/com/netflix/genie/web/security/SecurityUtilsUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/security/SecurityUtilsUnitTests.java
@@ -38,17 +38,4 @@ public class SecurityUtilsUnitTests {
     public void canConstructUsingProtectedConstructor() {
         Assert.assertNotNull(new SecurityUtils());
     }
-
-//    /**
-//     * Test to make sure we can build the proper API security.
-//     *
-//     * @throws Exception on any error
-//     */
-//    @Test
-//    public void canBuildAPIHttpSecurity() throws Exception {
-//        final HttpSecurity http = Mockito.mock(HttpSecurity.class);
-//        final X509UserDetailsService x509UserDetailsService = Mockito.mock(X509UserDetailsService.class);
-//
-//        SecurityUtils.buildAPIHttpSecurity(http, x509UserDetailsService);
-//    }
 }


### PR DESCRIPTION
This pull request modifies the security configuration on the API (OAuth2, X509) and UI (SAML) endpoints to allow any unauthenticated request to the actuator /health endpoint to get through. Actuator will only give back basic status information for any unauthenticated request. If the user making the request is authenticated as an admin it will give back more detailed information on the sub components.