### PR TITLE
New Job Monitoring Subsystem

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/events/JobFinishedEvent.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/events/JobFinishedEvent.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.events;
+
+import com.netflix.genie.common.dto.JobExecution;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+/**
+ * An event thrown when a job is completed.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Getter
+public class JobFinishedEvent extends ApplicationEvent {
+
+    private static final long serialVersionUID = -1653432902625721721L;
+
+    private final JobExecution jobExecution;
+
+    /**
+     * Constructor.
+     *
+     * @param jobExecution The job execution object of the job that just finished
+     * @param source       The source which created the event.
+     */
+    public JobFinishedEvent(@NotNull @Valid final JobExecution jobExecution, @NotNull final Object source) {
+        super(source);
+        this.jobExecution = jobExecution;
+    }
+}

--- a/genie-core/src/main/java/com/netflix/genie/core/events/JobStartedEvent.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/events/JobStartedEvent.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.events;
+
+import com.netflix.genie.common.dto.JobExecution;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+/**
+ * An event fired when a new job is started on a node.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Getter
+public class JobStartedEvent extends ApplicationEvent {
+
+    private static final long serialVersionUID = -8417875991681866646L;
+
+    private final JobExecution jobExecution;
+
+    /**
+     * Constructor.
+     *
+     * @param jobExecution The job execution information for the job that was started.
+     * @param source       The source which threw this event
+     */
+    public JobStartedEvent(@NotNull @Valid final JobExecution jobExecution, @NotNull final Object source) {
+        super(source);
+        this.jobExecution = jobExecution;
+    }
+}

--- a/genie-core/src/main/java/com/netflix/genie/core/events/package-info.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/events/package-info.java
@@ -1,0 +1,26 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Contains all the classes which extend {@link org.springframework.context.ApplicationEvent} for customized events
+ * within Genie.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie.core.events;

--- a/genie-core/src/test/java/com/netflix/genie/core/events/JobFinishedEventUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/events/JobFinishedEventUnitTests.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.events;
+
+import com.netflix.genie.common.dto.JobExecution;
+import com.netflix.genie.test.categories.UnitTest;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.UUID;
+
+/**
+ * Tests for the JobFinishedEvent class.
+ */
+@Category(UnitTest.class)
+public class JobFinishedEventUnitTests {
+
+    /**
+     * Make sure we can successfully create a Job Finished Event.
+     */
+    @Test
+    public void canConstruct() {
+        final JobExecution.Builder jobExecutionBuilder = new JobExecution.Builder(UUID.randomUUID().toString(), 3028);
+        jobExecutionBuilder.withId(UUID.randomUUID().toString());
+        final JobExecution jobExecution = jobExecutionBuilder.build();
+        final Object source = new Object();
+        final JobFinishedEvent event = new JobFinishedEvent(jobExecution, source);
+        Assert.assertNotNull(event);
+        Assert.assertThat(event.getJobExecution(), Matchers.is(jobExecution));
+        Assert.assertThat(event.getSource(), Matchers.is(source));
+    }
+}

--- a/genie-core/src/test/java/com/netflix/genie/core/events/JobStartedEventUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/events/JobStartedEventUnitTests.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.events;
+
+import com.netflix.genie.common.dto.JobExecution;
+import com.netflix.genie.test.categories.UnitTest;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.UUID;
+
+/**
+ * Tests for the JobStartedEvent class.
+ */
+@Category(UnitTest.class)
+public class JobStartedEventUnitTests {
+
+    /**
+     * Make sure we can successfully create a Job Started Event.
+     */
+    @Test
+    public void canConstruct() {
+        final JobExecution.Builder jobExecutionBuilder = new JobExecution.Builder(UUID.randomUUID().toString(), 3029);
+        jobExecutionBuilder.withId(UUID.randomUUID().toString());
+        final JobExecution jobExecution = jobExecutionBuilder.build();
+        final Object source = new Object();
+        final JobStartedEvent event = new JobStartedEvent(jobExecution, source);
+        Assert.assertNotNull(event);
+        Assert.assertThat(event.getJobExecution(), Matchers.is(jobExecution));
+        Assert.assertThat(event.getSource(), Matchers.is(source));
+    }
+}

--- a/genie-core/src/test/java/com/netflix/genie/core/events/package-info.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/events/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Tests for the event classes.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie.core.events;

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
@@ -20,6 +20,8 @@ package com.netflix.genie.web.configs;
 import com.netflix.genie.web.tasks.leader.LeadershipTask;
 import com.netflix.genie.web.tasks.leader.LeadershipTasksCoordinator;
 import com.netflix.genie.web.tasks.leader.LocalLeader;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.Executor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -41,13 +43,26 @@ import java.util.Collection;
 public class TaskConfig {
 
     /**
+     * Get an {@link Executor} to use for executing processes from tasks.
+     *
+     * @return The executor to use
+     */
+    @Bean
+    public Executor processExecutor() {
+        return new DefaultExecutor();
+    }
+
+    /**
      * Get a task scheduler.
      *
+     * @param poolSize The initial size of the thread pool that should be allocated
      * @return The task scheduler
      */
     @Bean
-    public TaskScheduler taskScheduler() {
-        return new ThreadPoolTaskScheduler();
+    public TaskScheduler taskScheduler(@Value("${genie.tasks.pool.size:1}") final int poolSize) {
+        final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(poolSize);
+        return scheduler;
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
@@ -59,7 +59,7 @@ public class TaskConfig {
      * @return The task scheduler
      */
     @Bean
-    public TaskScheduler taskScheduler(@Value("${genie.tasks.pool.size:1}") final int poolSize) {
+    public ThreadPoolTaskScheduler taskScheduler(@Value("${genie.tasks.pool.size:1}") final int poolSize) {
         final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setPoolSize(poolSize);
         return scheduler;

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/GenieTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/GenieTask.java
@@ -28,10 +28,16 @@ import org.springframework.scheduling.Trigger;
 public interface GenieTask extends Runnable {
 
     /**
-     * Get the Trigger which this task should be scheduled with. If no trigger is necessary return null and callers
-     * will fall back to getPeriod().
+     * Get the type of scheduling mechanism which should be used to schedule this task.
      *
-     * @return The trigger or null if prefer to use a period fixed rate scheduling mechanism
+     * @return The schedule type
+     */
+    GenieTaskScheduleType getScheduleType();
+
+    /**
+     * Get the Trigger which this task should be scheduled with.
+     *
+     * @return The trigger
      */
     Trigger getTrigger();
 
@@ -40,5 +46,13 @@ public interface GenieTask extends Runnable {
      *
      * @return The period to wait between invocations of run for this task
      */
-    long getPeriod();
+    long getFixedRate();
+
+    /**
+     * Get how long the system should wait between invoking the run() method of this task in milliseconds after the
+     * last successful run of the task.
+     *
+     * @return The time to delay between task completions
+     */
+    long getFixedDelay();
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/GenieTaskScheduleType.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/GenieTaskScheduleType.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.tasks;
+
+/**
+ * The enumeration values which a {@link GenieTask} can be be scheduled with.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+public enum GenieTaskScheduleType {
+    /**
+     * When you want your task scheduled using a {@link org.springframework.scheduling.Trigger}.
+     */
+    TRIGGER,
+
+    /**
+     * When you want your task scheduled using a fixed rate in milliseconds.
+     */
+    FIXED_RATE,
+
+    /**
+     * When you want your tasked scheduled at a fixed rate but held for a time after the last completion of the task.
+     */
+    FIXED_DELAY
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/TasksCleanup.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/TasksCleanup.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.tasks;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Performs any cleanup when the system is shutting down.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Component
+public class TasksCleanup {
+
+    private final ThreadPoolTaskScheduler scheduler;
+
+    /**
+     * Constructor.
+     *
+     * @param scheduler The task scheduler for the system.
+     */
+    @Autowired
+    public TasksCleanup(@NotNull final ThreadPoolTaskScheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * When the spring context is about to close make sure we shutdown the thread pool and anything else we need to do.
+     *
+     * @param event The context closed event
+     */
+    @EventListener
+    public void onShutdown(final ContextClosedEvent event) {
+        this.scheduler.shutdown();
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitor.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitor.java
@@ -1,0 +1,138 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.tasks.job;
+
+import com.netflix.genie.common.dto.JobExecution;
+import com.netflix.genie.core.events.JobFinishedEvent;
+import com.netflix.genie.web.tasks.GenieTaskScheduleType;
+import com.netflix.genie.web.tasks.node.NodeTask;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.Executor;
+import org.apache.commons.lang3.SystemUtils;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.Trigger;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Given a process id this class will check if the job client process is running or not.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Slf4j
+public class JobMonitor implements NodeTask {
+
+    private static final String PID_KEY = "pid";
+    private static final int PS_SUCCESS = 0;
+
+    private final JobExecution execution;
+    private final Executor executor;
+    private final ApplicationEventPublisher publisher;
+
+    /**
+     * Constructor.
+     *
+     * @param execution The job execution object including the pid
+     * @param executor  The process executor to use
+     * @param publisher The event publisher to use when a job isn't running anymore
+     */
+    public JobMonitor(
+        @Valid final JobExecution execution,
+        @NotNull final Executor executor,
+        @NotNull final ApplicationEventPublisher publisher
+    ) {
+        this.execution = execution;
+        this.executor = executor;
+        this.publisher = publisher;
+    }
+
+    /**
+     * This will check the process identified by the pid supplied to the constructor. If the pid no longer exists fires
+     * an event to the system saying the job is done.
+     */
+    @Override
+    public void run() {
+        if (!SystemUtils.IS_OS_UNIX) {
+            throw new UnsupportedOperationException("Genie doesn't currently support " + SystemUtils.OS_NAME);
+        }
+
+        final int pid = this.execution.getProcessId();
+        final Map<String, Object> substitutionMap = new HashMap<>();
+        substitutionMap.put(PID_KEY, pid);
+
+        final CommandLine commandLine = new CommandLine("ps");
+        commandLine.addArgument("-p");
+        commandLine.addArgument("${" + PID_KEY + "}");
+        commandLine.setSubstitutionMap(substitutionMap);
+
+        // TODO: Should we add a timeout?
+        try {
+            // Blocks until result
+            final int result = this.executor.execute(commandLine);
+            if (result == PS_SUCCESS) {
+                //TODO: If the process is still running check the length of the Stdout and Stderr
+                log.debug("Job {} is still running...", this.execution.getId());
+            } else {
+                log.info("Job {} has finished", this.execution.getId());
+                this.publisher.publishEvent(new JobFinishedEvent(this.execution, this));
+            }
+        } catch (final IOException ioe) {
+            // Some other error
+            log.error("Some IOException happened unable to check process status for pid {}", pid, ioe);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenieTaskScheduleType getScheduleType() {
+        return GenieTaskScheduleType.FIXED_DELAY;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Trigger getTrigger() {
+        throw new UnsupportedOperationException("Tracking can only currently be scheduled via fixed delay");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getFixedRate() {
+        throw new UnsupportedOperationException("Tracking can only currently be scheduled via fixed delay");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getFixedDelay() {
+        //TODO: Make flexible via property
+        return 1000L;
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
@@ -1,0 +1,117 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.tasks.job;
+
+import com.netflix.genie.core.events.JobFinishedEvent;
+import com.netflix.genie.core.events.JobStartedEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.exec.Executor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * A Task to monitor running jobs on a Genie node.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Component
+@Slf4j
+public class JobMonitoringCoordinator {
+
+    private final Map<String, ScheduledFuture<?>> jobMonitors;
+    private final TaskScheduler scheduler;
+    private final ApplicationEventPublisher publisher;
+    private final Executor executor;
+
+    /**
+     * Constructor.
+     *
+     * @param publisher The event publisher to use to publish events
+     * @param scheduler The task scheduler to use to register scheduling of job checkers
+     * @param executor  The executor to use to launch processes
+     */
+    @Autowired
+    public JobMonitoringCoordinator(
+        final ApplicationEventPublisher publisher,
+        final TaskScheduler scheduler,
+        final Executor executor
+    ) {
+        this.jobMonitors = new HashMap<>();
+        this.publisher = publisher;
+        this.scheduler = scheduler;
+        this.executor = executor;
+    }
+
+    /**
+     * This event is fired when a job is started on this Genie node. Will create a JobMonitor and schedule it
+     * for monitoring.
+     *
+     * @param event The event of the started job
+     */
+    @EventListener
+    public void onJobStarted(final JobStartedEvent event) {
+        if (!this.jobMonitors.containsKey(event.getJobExecution().getId())) {
+            final JobMonitor monitor
+                = new JobMonitor(event.getJobExecution(), this.executor, this.publisher);
+            final ScheduledFuture<?> future;
+            switch (monitor.getScheduleType()) {
+                case TRIGGER:
+                    future = this.scheduler.schedule(monitor, monitor.getTrigger());
+                    break;
+                case FIXED_DELAY:
+                    future = this.scheduler.scheduleWithFixedDelay(monitor, monitor.getFixedDelay());
+                    break;
+                case FIXED_RATE:
+                    future = this.scheduler.scheduleAtFixedRate(monitor, monitor.getFixedRate());
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unknown schedule type: " + monitor.getScheduleType());
+            }
+            this.jobMonitors.put(event.getJobExecution().getId(), future);
+        }
+    }
+
+    /**
+     * When a job is finished this event is fired. This method will cancel the task monitoring the job process.
+     *
+     * @param event the event of the finished job
+     */
+    @EventListener
+    public void onJobFinished(final JobFinishedEvent event) {
+        final String jobId = event.getJobExecution().getId();
+        if (this.jobMonitors.containsKey(jobId)) {
+            final ScheduledFuture<?> future = this.jobMonitors.get(jobId);
+            //TODO: should we add back off it is unable to cancel?
+            if (future.cancel(true)) {
+                log.debug("Successfully cancelled task monitoring job {}", jobId);
+                this.jobMonitors.remove(jobId);
+            } else {
+                log.error("Unable to cancel task monitoring job {}", jobId);
+                //TODO: Add metric here
+            }
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/package-info.java
@@ -15,41 +15,11 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.web.tasks.node;
-
-import org.springframework.scheduling.Trigger;
-import org.springframework.stereotype.Component;
 
 /**
- * A Task to monitor running jobs on a Genie node.
+ * Tasks for monitoring and acting on jobs.
  *
  * @author tgianos
  * @since 3.0.0
  */
-@Component
-public class JobsMonitoringTask implements NodeTask {
-
-    /**
-     * Checks the status' of all the processes running on the node to see if they're done.
-     */
-    @Override
-    public void run() {
-
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Trigger getTrigger() {
-        return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public long getPeriod() {
-        return 0;
-    }
-}
+package com.netflix.genie.web.tasks.job;

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ZombieTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ZombieTask.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.tasks.leader;
 
+import com.netflix.genie.web.tasks.GenieTaskScheduleType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.Trigger;
 import org.springframework.stereotype.Component;
@@ -47,16 +48,32 @@ public class ZombieTask implements LeadershipTask {
      * {@inheritDoc}
      */
     @Override
-    public Trigger getTrigger() {
-        return null;
+    public GenieTaskScheduleType getScheduleType() {
+        return GenieTaskScheduleType.FIXED_RATE;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public long getPeriod() {
+    public Trigger getTrigger() {
+        throw new UnsupportedOperationException("This task should only be scheduled at a fixed rate.");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getFixedRate() {
         //TODO: Implement getting this value from a property...for now for testing just hard code
         return 45000;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getFixedDelay() {
+        throw new UnsupportedOperationException("This task should only be scheduled at a fixed rate.");
     }
 }

--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -31,6 +31,9 @@ genie:
       location: file:///tmp/genie/jobs/
   leader:
     enabled: false
+  tasks:
+    pool:
+      size: 10
 
 management:
   context-path: /actuator

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/TaskConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/TaskConfigUnitTests.java
@@ -39,11 +39,19 @@ import java.util.Collection;
 public class TaskConfigUnitTests {
 
     /**
+     * Make sure we get a valid process executor to use.
+     */
+    @Test
+    public void canGetExecutor() {
+        Assert.assertNotNull(new TaskConfig().processExecutor());
+    }
+
+    /**
      * Make sure we get a valid task scheduler to use.
      */
     @Test
     public void canGetTaskScheduler() {
-        Assert.assertNotNull(new TaskConfig().taskScheduler());
+        Assert.assertNotNull(new TaskConfig().taskScheduler(7));
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/TasksCleanupUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/TasksCleanupUnitTests.java
@@ -1,0 +1,57 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.tasks;
+
+import com.netflix.genie.test.categories.UnitTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * Tests the TasksCleanup class.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class TasksCleanupUnitTests {
+
+    private ThreadPoolTaskScheduler scheduler;
+
+    /**
+     * Setup for the tests.
+     */
+    @Before
+    public void setup() {
+        this.scheduler = Mockito.mock(ThreadPoolTaskScheduler.class);
+    }
+
+    /**
+     * Make sure the thread pool scheduler is shutdown.
+     */
+    @Test
+    public void canShutdown() {
+        final ContextClosedEvent event = Mockito.mock(ContextClosedEvent.class);
+        final TasksCleanup cleanup = new TasksCleanup(this.scheduler);
+        cleanup.onShutdown(event);
+        Mockito.verify(this.scheduler, Mockito.times(1)).shutdown();
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitorUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitorUnitTests.java
@@ -1,0 +1,161 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.tasks.job;
+
+import com.netflix.genie.common.dto.JobExecution;
+import com.netflix.genie.core.events.JobFinishedEvent;
+import com.netflix.genie.test.categories.UnitTest;
+import com.netflix.genie.web.tasks.GenieTaskScheduleType;
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.Executor;
+import org.apache.commons.lang3.SystemUtils;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Unit tests for JobMonitor.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class JobMonitorUnitTests {
+
+    private JobMonitor monitor;
+    private JobExecution jobExecution;
+    private Executor executor;
+    private ApplicationEventPublisher publisher;
+
+    /**
+     * Setup for the tests.
+     */
+    @Before
+    public void setup() {
+        final JobExecution.Builder builder = new JobExecution.Builder(UUID.randomUUID().toString(), 3808);
+        builder.withId(UUID.randomUUID().toString());
+        this.jobExecution = builder.build();
+        this.executor = Mockito.mock(Executor.class);
+        this.publisher = Mockito.mock(ApplicationEventPublisher.class);
+
+        this.monitor = new JobMonitor(this.jobExecution, this.executor, this.publisher);
+    }
+
+    /**
+     * This test should only run on windows machines and asserts that the system fails on Windows.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void cantRunOnWindows() {
+        Assume.assumeTrue(SystemUtils.IS_OS_WINDOWS);
+        this.monitor.run();
+    }
+
+    /**
+     * Make sure that a running process doesn't publish anything.
+     *
+     * @throws IOException on error
+     */
+    @Test
+    public void canCheckRunningProcessOnUnixLikeSystem() throws IOException {
+        Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
+        Mockito.when(this.executor.execute(Mockito.any(CommandLine.class))).thenReturn(0);
+
+        this.monitor.run();
+
+        Mockito.verify(this.publisher, Mockito.never()).publishEvent(Mockito.any(ApplicationEvent.class));
+    }
+
+    /**
+     * Make sure that a finished process sends event.
+     *
+     * @throws IOException on error
+     */
+    @Test
+    public void canCheckFinishedProcessOnUnixLikeSystem() throws IOException {
+        Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
+        Mockito.when(this.executor.execute(Mockito.any(CommandLine.class))).thenReturn(1);
+
+        this.monitor.run();
+
+        final ArgumentCaptor<JobFinishedEvent> captor = ArgumentCaptor.forClass(JobFinishedEvent.class);
+        Mockito
+            .verify(this.publisher, Mockito.times(1))
+            .publishEvent(captor.capture());
+
+        Assert.assertNotNull(captor.getValue());
+        Assert.assertThat(captor.getValue().getJobExecution(), Matchers.is(this.jobExecution));
+        Assert.assertThat(captor.getValue().getSource(), Matchers.is(this.monitor));
+    }
+
+    /**
+     * Make sure that an error doesn't publish anything.
+     *
+     * @throws IOException on error
+     */
+    @Test
+    public void cantGetStatusIfErrorOnUnixLikeSystem() throws IOException {
+        Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
+        Mockito.when(this.executor.execute(Mockito.any(CommandLine.class))).thenThrow(new IOException());
+
+        this.monitor.run();
+
+        Mockito.verify(this.publisher, Mockito.never()).publishEvent(Mockito.any(ApplicationEvent.class));
+    }
+
+    /**
+     * Make sure the right schedule type is returned.
+     */
+    @Test
+    public void canGetScheduleType() {
+        Assert.assertThat(this.monitor.getScheduleType(), Matchers.is(GenieTaskScheduleType.FIXED_DELAY));
+    }
+
+    /**
+     * Make sure asking for a trigger isn't allowed.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void cantGetTrigger() {
+        this.monitor.getTrigger();
+    }
+
+    /**
+     * Make sure asking for a trigger isn't allowed.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void cantGetFixedRate() {
+        this.monitor.getFixedRate();
+    }
+
+    /**
+     * Make sure the fixed delay value is what we expect.
+     */
+    @Test
+    public void canGetFixedDelay() {
+        Assert.assertThat(1000L, Matchers.is(this.monitor.getFixedDelay()));
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorUnitTests.java
@@ -1,0 +1,144 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.tasks.job;
+
+import com.netflix.genie.common.dto.JobExecution;
+import com.netflix.genie.core.events.JobFinishedEvent;
+import com.netflix.genie.core.events.JobStartedEvent;
+import com.netflix.genie.test.categories.UnitTest;
+import org.apache.commons.exec.Executor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.TaskScheduler;
+
+import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * Tests for the JobMonitoringCoordinator.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class JobMonitoringCoordinatorUnitTests {
+
+    private TaskScheduler scheduler;
+    private JobMonitoringCoordinator coordinator;
+
+    /**
+     * Setup for the tests.
+     */
+    @Before
+    public void setup() {
+        final Executor executor = Mockito.mock(Executor.class);
+        this.scheduler = Mockito.mock(TaskScheduler.class);
+        final ApplicationEventPublisher publisher = Mockito.mock(ApplicationEventPublisher.class);
+
+        this.coordinator = new JobMonitoringCoordinator(publisher, this.scheduler, executor);
+    }
+
+    /**
+     * Make sure when a {@link com.netflix.genie.core.events.JobStartedEvent} is sent a new monitor is spawned.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canStartJobMonitor() {
+        final String job1Id = UUID.randomUUID().toString();
+        final String job2Id = UUID.randomUUID().toString();
+        final String job3Id = UUID.randomUUID().toString();
+        final String job4Id = UUID.randomUUID().toString();
+        final JobExecution.Builder builder = new JobExecution.Builder(UUID.randomUUID().toString(), 2818);
+        builder.withId(job1Id);
+        final JobExecution job1 = builder.build();
+        builder.withId(job2Id);
+        final JobExecution job2 = builder.build();
+        builder.withId(job3Id);
+        final JobExecution job3 = builder.build();
+        builder.withId(job4Id);
+        final JobExecution job4 = builder.build();
+
+        final JobStartedEvent event1 = new JobStartedEvent(job1, this);
+        final JobStartedEvent event2 = new JobStartedEvent(job2, this);
+        final JobStartedEvent event3 = new JobStartedEvent(job3, this);
+        final JobStartedEvent event4 = new JobStartedEvent(job4, this);
+        final JobStartedEvent event5 = new JobStartedEvent(job1, this);
+
+        final ScheduledFuture future = Mockito.mock(ScheduledFuture.class);
+
+        Mockito.when(
+            this.scheduler.scheduleWithFixedDelay(Mockito.any(JobMonitor.class), Mockito.eq(1000L))
+        ).thenReturn(future);
+
+        this.coordinator.onJobStarted(event1);
+        this.coordinator.onJobStarted(event2);
+        this.coordinator.onJobStarted(event3);
+        this.coordinator.onJobStarted(event4);
+        this.coordinator.onJobStarted(event5);
+
+        Mockito
+            .verify(this.scheduler, Mockito.times(4))
+            .scheduleWithFixedDelay(Mockito.any(JobMonitor.class), Mockito.eq(1000L));
+    }
+
+    /**
+     * Make sure when a {@link com.netflix.genie.core.events.JobFinishedEvent} is sent the monitor is cancelled.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canStopJobMonitor() {
+        final String job1Id = UUID.randomUUID().toString();
+        final JobExecution.Builder builder = new JobExecution.Builder(UUID.randomUUID().toString(), 2818);
+        builder.withId(job1Id);
+        final JobExecution job1 = builder.build();
+        final String job2Id = UUID.randomUUID().toString();
+        builder.withId(job2Id);
+        final JobExecution job2 = builder.build();
+
+        final JobStartedEvent startedEvent1 = new JobStartedEvent(job1, this);
+        final JobFinishedEvent finishedEvent1 = new JobFinishedEvent(job1, this);
+        final JobStartedEvent startedEvent2 = new JobStartedEvent(job2, this);
+        final JobFinishedEvent finishedEvent2 = new JobFinishedEvent(job2, this);
+
+        final ScheduledFuture future1 = Mockito.mock(ScheduledFuture.class);
+        Mockito.when(future1.cancel(true)).thenReturn(true);
+        final ScheduledFuture future2 = Mockito.mock(ScheduledFuture.class);
+        Mockito.when(future2.cancel(true)).thenReturn(false);
+
+        Mockito.when(
+            this.scheduler.scheduleWithFixedDelay(Mockito.any(JobMonitor.class), Mockito.eq(1000L))
+        ).thenReturn(future1, future2);
+
+        this.coordinator.onJobStarted(startedEvent1);
+        this.coordinator.onJobStarted(startedEvent2);
+
+        Mockito
+            .verify(this.scheduler, Mockito.times(2))
+            .scheduleWithFixedDelay(Mockito.any(JobMonitor.class), Mockito.eq(1000L));
+
+        this.coordinator.onJobFinished(finishedEvent1);
+        this.coordinator.onJobFinished(finishedEvent2);
+        this.coordinator.onJobFinished(finishedEvent1);
+
+        Mockito.verify(future1, Mockito.times(1)).cancel(true);
+        Mockito.verify(future2, Mockito.times(1)).cancel(true);
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/job/package-info.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/job/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Tests for the Job related tasks.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie.web.tasks.job;

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/ZombieTaskUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/ZombieTaskUnitTests.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.tasks.leader;
 
 import com.netflix.genie.test.categories.UnitTest;
+import com.netflix.genie.web.tasks.GenieTaskScheduleType;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,19 +54,35 @@ public class ZombieTaskUnitTests {
     }
 
     /**
-     * Make sure the trigger is null.
+     * Make sure we get the right schedule type.
      */
     @Test
+    public void canGetScheduleType() {
+        Assert.assertThat(this.task.getScheduleType(), Matchers.is(GenieTaskScheduleType.FIXED_RATE));
+    }
+
+    /**
+     * Make sure the trigger is null.
+     */
+    @Test(expected = UnsupportedOperationException.class)
     public void canGetTrigger() {
-        Assert.assertNull(this.task.getTrigger());
+        this.task.getTrigger();
     }
 
     /**
      * Make sure the get period returns the correct value.
      */
     @Test
-    public void canGetPeriod() {
+    public void canGetFixedRate() {
         // TODO: flesh out
-        Assert.assertThat(this.task.getPeriod(), Matchers.is(45000L));
+        Assert.assertThat(this.task.getFixedRate(), Matchers.is(45000L));
+    }
+
+    /**
+     * Make sure the trigger is null.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void canGetFixedDelay() {
+        this.task.getFixedDelay();
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/node/package-info.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/node/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Tests for node tasks.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie.web.tasks.node;

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/package-info.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Tests for tasks classes.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie.web.tasks;


### PR DESCRIPTION
This pull request introduces a new Job Monitoring mechanism for Genie 3.0.

When a job is started (via the Job Execution system @amitsharma1981 is working on) a ```JobStartedEvent``` should be fired. When this happens the ```JobMonitoringCoordinator``` is listening to the events and will create a new ```JobMonitor``` for the running job. This ```JobMonitor``` will then be scheduled to run with fixed delay period with the system [TaskScheduler](http://docs.spring.io/autorepo/docs/spring/current/javadoc-api/org/springframework/scheduling/TaskScheduler.html).

The ```JobMonitor``` when its run method is invoked will execute a ```PS``` on the system for the job client PID. Once this comes back with a non-zero exit code it will fire a ```JobFinishedEvent``` which the ```JobMonitoringCoordinator``` is also listening for to cancel execution of the ```JobMonitor```.

This system was designed to use events so as to take advantage of extensibly adding features which need to key off key events like jobs being started and completed without us re-writing a lot of interfaces to take new classes.

This PR doesn't include complete checking for the length of stdout or stderr and also is missing a flexible way to schedule the duration of the time between checks of the job monitor. These features will be added later.