### PR TITLE
Add error handling case to JobMonitor

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/events/KillJobEvent.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/events/KillJobEvent.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.events;
+
+import lombok.Getter;
+import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * An event fired from within the Genie system when it needs a specific job killed.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Getter
+public class KillJobEvent extends ApplicationEvent {
+
+    private static final long serialVersionUID = 1701855508124286343L;
+    private final String id;
+
+    /**
+     * Constructor.
+     *
+     * @param id  The id of the job to kill
+     * @param source The source object which threw this event
+     */
+    public KillJobEvent(@NotBlank final String id, final Object source) {
+        super(source);
+        this.id = id;
+    }
+}

--- a/genie-core/src/test/java/com/netflix/genie/core/events/KillJobEventUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/events/KillJobEventUnitTests.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.events;
+
+import com.netflix.genie.test.categories.UnitTest;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.UUID;
+
+/**
+ * Unit tests for the kill job event.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class KillJobEventUnitTests {
+
+    /**
+     * Make sure can get the Job Id back from the event.
+     */
+    @Test
+    public void canGetJobId() {
+        final String id = UUID.randomUUID().toString();
+        final KillJobEvent event = new KillJobEvent(id, this);
+
+        Assert.assertThat(event.getId(), Matchers.is(id));
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
@@ -163,5 +163,6 @@ public class JobMonitoringCoordinator {
                 throw new UnsupportedOperationException("Unknown schedule type: " + monitor.getScheduleType());
         }
         this.jobMonitors.put(jobExecution.getId(), future);
+        log.info("Scheduled job monitoring for Job {}", jobExecution.getId());
     }
 }


### PR DESCRIPTION
This pull request adds error handling case to the JobMonitor where if a certain number of errors happen in succession when trying to do a PS the system will attempt to kill the job.

Also switches the job check back to expecting an exception to be thrown when the PS process returns 1 instead of 0 indicating the process no longer exists.

Redirected the output to /dev/null so it doesn't clutter the logs.

Added tests.