### PR TITLE
Move All Genie Specific Properties Under Genie Namespace

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/CommandEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/CommandEntity.java
@@ -55,7 +55,7 @@ import java.util.Set;
 public class CommandEntity extends CommonFields {
 
     private static final long serialVersionUID = -8058995173025433517L;
-    
+
     @Basic(optional = false)
     @Column(name = "status", nullable = false, length = 20)
     @Enumerated(EnumType.STRING)

--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/FileSystemAttachmentServiceUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/FileSystemAttachmentServiceUnitTests.java
@@ -58,8 +58,7 @@ public class FileSystemAttachmentServiceUnitTests {
      */
     @Before
     public void setup() throws IOException {
-        this.service = new FileSystemAttachmentService();
-        this.service.setAttachmentsDirectory(this.folder.getRoot().getAbsolutePath());
+        this.service = new FileSystemAttachmentService(this.folder.getRoot().getAbsolutePath());
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/HttpSessionConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/HttpSessionConfig.java
@@ -31,7 +31,7 @@ import javax.annotation.PostConstruct;
  * @author tgianos
  * @since 3.0.0
  */
-@ConditionalOnProperty("spring.redis.enabled")
+@ConditionalOnProperty("genie.redis.enabled")
 @Import(RedisAutoConfiguration.class)
 @EnableRedisHttpSession
 @Slf4j

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/SwaggerConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/SwaggerConfig.java
@@ -35,7 +35,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
  * @since 3.0.0
  */
 @Configuration
-@ConditionalOnProperty("swagger.enabled")
+@ConditionalOnProperty("genie.swagger.enabled")
 @EnableSwagger2
 public class SwaggerConfig {
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/security/SecurityConditions.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/SecurityConditions.java
@@ -43,15 +43,15 @@ public class SecurityConditions {
             super(ConfigurationPhase.PARSE_CONFIGURATION);
         }
 
-        @ConditionalOnProperty("security.saml.enabled")
+        @ConditionalOnProperty("genie.security.saml.enabled")
         static class OnSAML {
         }
 
-        @ConditionalOnProperty("security.x509.enabled")
+        @ConditionalOnProperty("genie.security.x509.enabled")
         static class OnX509 {
         }
 
-        @ConditionalOnProperty("security.oauth2.enabled")
+        @ConditionalOnProperty("genie.security.oauth2.enabled")
         static class OnOAuth2 {
         }
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/security/oauth2/OAuth2Config.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/oauth2/OAuth2Config.java
@@ -38,7 +38,7 @@ import org.springframework.security.oauth2.config.annotation.web.configurers.Res
  * @author tgianos
  * @since 3.0.0
  */
-@ConditionalOnProperty("security.oauth2.enabled")
+@ConditionalOnProperty("genie.security.oauth2.enabled")
 @Configuration
 @EnableResourceServer
 public class OAuth2Config extends ResourceServerConfigurerAdapter {

--- a/genie-web/src/main/java/com/netflix/genie/web/security/oauth2/pingfederate/PingFederateConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/oauth2/pingfederate/PingFederateConfig.java
@@ -31,7 +31,7 @@ import org.springframework.security.oauth2.provider.token.DefaultAccessTokenConv
  * @author tgianos
  * @since 3.0.0
  */
-@ConditionalOnProperty(name = {"security.oauth2.enabled", "security.oauth2.pingfederate.enabled"})
+@ConditionalOnProperty(name = {"genie.security.oauth2.enabled", "genie.security.oauth2.pingfederate.enabled"})
 @Configuration
 public class PingFederateConfig {
 

--- a/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLConfig.java
@@ -101,7 +101,7 @@ import java.util.Timer;
  * @author tgianos
  * @since 3.0.0
  */
-@ConditionalOnProperty("security.saml.enabled")
+@ConditionalOnProperty("genie.security.saml.enabled")
 @Configuration
 @Order(5)
 //@EnableGlobalMethodSecurity(securedEnabled = true)

--- a/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLProperties.java
@@ -32,8 +32,8 @@ import javax.validation.constraints.NotNull;
  * @author tgianos
  * @since 3.0.0
  */
-@ConditionalOnProperty("security.saml.enabled")
-@ConfigurationProperties(prefix = "security.saml")
+@ConditionalOnProperty("genie.security.saml.enabled")
+@ConfigurationProperties(prefix = "genie.security.saml")
 @Component
 @Data
 public class SAMLProperties {

--- a/genie-web/src/main/java/com/netflix/genie/web/security/x509/X509Config.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/x509/X509Config.java
@@ -32,7 +32,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
  * @author tgianos
  * @since 3.0.0
  */
-@ConditionalOnProperty("security.x509.enabled")
+@ConditionalOnProperty("genie.security.x509.enabled")
 @Configuration
 @Order(4)
 public class X509Config extends WebSecurityConfigurerAdapter {

--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -19,10 +19,6 @@
 banner:
   location: genie-banner.txt
 
-eureka:
-  client:
-    enabled: false
-
 genie:
   jobs:
     dir:
@@ -30,6 +26,20 @@ genie:
         enabled: true
       location: file:///tmp/genie/jobs/
   leader:
+    enabled: false
+  redis:
+    enabled: false
+  security:
+    oauth2:
+      enabled: false
+      pingfederate:
+        enabled:
+          false
+    saml:
+      enabled: false
+    x509:
+      enabled: false
+  swagger:
     enabled: false
   tasks:
     pool:
@@ -45,14 +55,6 @@ multipart:
 security:
   basic:
     enabled: false
-  oauth2:
-    enabled: false
-    pingfederate:
-      enabled: false
-  saml:
-    enabled: false
-  x509:
-    enabled: false
 
 spring:
   application:
@@ -65,5 +67,3 @@ spring:
         namespace: /genie/leader/
   profiles:
     active: dev
-  redis:
-    enabled: false

--- a/genie-web/src/test/java/com/netflix/genie/web/security/SecurityConditionsUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/security/SecurityConditionsUnitTests.java
@@ -81,9 +81,9 @@ public class SecurityConditionsUnitTests {
     public void canEnableBeanWithSAMLEnabled() throws Exception {
         final AnnotationConfigApplicationContext context = this.load(
             SecurityEnabled.class,
-            "security.saml.enabled:true",
-            "security.x509.enabled:false",
-            "security.oauth2.enabled:false"
+            "genie.security.saml.enabled:true",
+            "genie.security.x509.enabled:false",
+            "genie.security.oauth2.enabled:false"
         );
         Assert.assertTrue(context.containsBean("myBean"));
         context.close();
@@ -98,9 +98,9 @@ public class SecurityConditionsUnitTests {
     public void canEnableBeanWithX509Enabled() throws Exception {
         final AnnotationConfigApplicationContext context = this.load(
             SecurityEnabled.class,
-            "security.saml.enabled:false",
-            "security.x509.enabled:true",
-            "security.oauth2.enabled:false"
+            "genie.security.saml.enabled:false",
+            "genie.security.x509.enabled:true",
+            "genie.security.oauth2.enabled:false"
         );
         Assert.assertTrue(context.containsBean("myBean"));
         context.close();
@@ -115,9 +115,9 @@ public class SecurityConditionsUnitTests {
     public void canEnableBeanWithOAuth2Enabled() throws Exception {
         final AnnotationConfigApplicationContext context = this.load(
             SecurityEnabled.class,
-            "security.saml.enabled:false",
-            "security.x509.enabled:false",
-            "security.oauth2.enabled:true"
+            "genie.security.saml.enabled:false",
+            "genie.security.x509.enabled:false",
+            "genie.security.oauth2.enabled:true"
         );
         Assert.assertTrue(context.containsBean("myBean"));
         context.close();
@@ -132,9 +132,9 @@ public class SecurityConditionsUnitTests {
     public void canEnableBeanWithAllSecurityEnabled() throws Exception {
         final AnnotationConfigApplicationContext context = this.load(
             SecurityEnabled.class,
-            "security.saml.enabled:true",
-            "security.x509.enabled:true",
-            "security.oauth2.enabled:true"
+            "genie.security.saml.enabled:true",
+            "genie.security.x509.enabled:true",
+            "genie.security.oauth2.enabled:true"
         );
         Assert.assertTrue(context.containsBean("myBean"));
         context.close();

--- a/genie-web/src/test/java/com/netflix/genie/web/security/saml/SAMLUserDetailsServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/security/saml/SAMLUserDetailsServiceImplUnitTests.java
@@ -55,10 +55,17 @@ public class SAMLUserDetailsServiceImplUnitTests {
      */
     @Before
     public void setup() {
-        this.service = new SAMLUserDetailsServiceImpl();
-        this.service.adminGroup = ADMIN_GROUP;
-        this.service.userAttributeName = USER_ATTRIBUTE_NAME;
-        this.service.groupAttributeName = GROUP_ATTRIBUTE_NAME;
+        final SAMLProperties samlProperties = new SAMLProperties();
+        final SAMLProperties.Attributes attributes = new SAMLProperties.Attributes();
+        final SAMLProperties.Attributes.User user = new SAMLProperties.Attributes.User();
+        user.setName(USER_ATTRIBUTE_NAME);
+        attributes.setUser(user);
+        final SAMLProperties.Attributes.Groups groups = new SAMLProperties.Attributes.Groups();
+        groups.setName(GROUP_ATTRIBUTE_NAME);
+        groups.setAdmin(ADMIN_GROUP);
+        attributes.setGroups(groups);
+        samlProperties.setAttributes(attributes);
+        this.service = new SAMLUserDetailsServiceImpl(samlProperties);
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/security/x509/X509ConfigIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/security/x509/X509ConfigIntegrationTests.java
@@ -43,7 +43,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @WebIntegrationTest(randomPort = true)
 @ActiveProfiles({"integration"})
 @DirtiesContext
-@TestPropertySource(properties = { "security.x509.enabled = true" })
+@TestPropertySource(properties = { "genie.security.x509.enabled = true" })
 public class X509ConfigIntegrationTests extends AbstractAPISecurityIntegrationTests {
 
     /**

--- a/genie-web/src/test/resources/application-oauth2.yml
+++ b/genie-web/src/test/resources/application-oauth2.yml
@@ -16,14 +16,18 @@
 #
 ##
 
+genie:
+  security:
+    oauth2:
+      enabled: true
+      pingfederate:
+        enabled: true
+
 security:
   oauth2:
-    enabled: true
     client:
       client-id: genie-resourceserver
       client-secret: someClientSecret
-    pingfederate:
-      enabled: true
     resource:
       id: genie-resourceserver
       token-info-uri: https://pingfederate.mydomain.com/as/token.oauth2

--- a/genie-web/src/test/resources/application-saml.yml
+++ b/genie-web/src/test/resources/application-saml.yml
@@ -16,22 +16,23 @@
 #
 ##
 
-security:
-  saml:
-      enabled: true
-      attributes:
-        user:
-          name: userName
-        groups:
-          name: googleGroups
-          admin: genie-admin@gmail.com
-      idp:
-        serviceProviderMetadataURL: https://idp.something.com/MetadataQuery?partnerId=genie
-      keystore:
-#        name: genie-keystore.jks
-        password: password
-        defaultKey:
-          name: genie
+genie:
+  security:
+    saml:
+        enabled: true
+        attributes:
+          user:
+            name: userName
+          groups:
+            name: googleGroups
+            admin: genie-admin@gmail.com
+        idp:
+          serviceProviderMetadataURL: https://idp.something.com/MetadataQuery?partnerId=genie
+        keystore:
+  #        name: genie-keystore.jks
           password: password
-      sp:
-        entityId: genie
+          defaultKey:
+            name: genie
+            password: password
+        sp:
+          entityId: genie


### PR DESCRIPTION
This PR moves all the properties we've created thus far in Genie 3.0 development under ```genie.``` namespace for clarity and consistency.

Will help when it comes to documenting Genie 3 as all transitive dependencies (e.g. Spring) properties can have their own documentation leveraged.