### PR TITLE
Fix issue with URL truncation due to periods

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/configs/MvcConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/MvcConfig.java
@@ -31,6 +31,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,7 +46,19 @@ import java.net.UnknownHostException;
  * @since 3.0.0
  */
 @Configuration
-public class MvcConfig {
+public class MvcConfig extends WebMvcConfigurerAdapter {
+
+    /**
+     * {@inheritDoc}
+     *
+     * Turn off {@literal .} recognition in paths. Needed due to Job id's in paths potentially having '.' as character.
+     *
+     * @see <a href="http://stackoverflow.com/a/23938850">Stack Overflow Issue Answer From Dave Syer</a>
+     */
+    @Override
+    public void configurePathMatch(final PathMatchConfigurer configurer) {
+        configurer.setUseRegisteredSuffixPatternMatch(true);
+    }
 
     /**
      * Get a resource loader.

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/MvcConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/MvcConfigUnitTests.java
@@ -31,6 +31,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,6 +56,16 @@ public class MvcConfigUnitTests {
     @Before
     public void setup() {
         this.mvcConfig = new MvcConfig();
+    }
+
+    /**
+     * Make sure the suffix pattern matcher is turned off.
+     */
+    @Test
+    public void doesTurnOffSuffixMatcher() {
+        final PathMatchConfigurer configurer = Mockito.mock(PathMatchConfigurer.class);
+        this.mvcConfig.configurePathMatch(configurer);
+        Mockito.verify(configurer, Mockito.times(1)).setUseRegisteredSuffixPatternMatch(true);
     }
 
     /**


### PR DESCRIPTION
We were running into [this](http://stackoverflow.com/questions/16332092/spring-mvc-pathvariable-with-dot-is-getting-truncated) issue. Solved it using Dave Syer's answer by modifying the path match configurer for MVC.

Looks to work in testing. Important since many jobs have ```.``` in the id's and was breaking the rest API at ```/api/v3/jobs/{id}```. Something like ```/api/v3/jobs/XX.YY.ZZ``` was coming in as ```XX.YY``` and returning 404.