### PR TITLE
Support for PostgreSQL

### DIFF
--- a/genie-core/build.gradle
+++ b/genie-core/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     // Database Libs
     runtime("mysql:mysql-connector-java")
     runtime("org.hsqldb:hsqldb")
+    runtime("org.postgresql:postgresql")
 
     /*******************************
      * Test Dependencies

--- a/genie-core/scripts/postgresql/2.0.0-schema.postgresql.sql
+++ b/genie-core/scripts/postgresql/2.0.0-schema.postgresql.sql
@@ -1,0 +1,336 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 9.5.1
+-- Dumped by pg_dump version 9.5.1
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+SET search_path = public, pg_catalog;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: application; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE application (
+    id character varying(255) NOT NULL,
+    created timestamp without time zone,
+    updated timestamp without time zone,
+    name character varying(255),
+    user0 character varying(255),
+    version character varying(255),
+    envpropfile character varying(255),
+    status character varying(20),
+    entityversion bigint
+);
+
+
+--
+-- Name: application_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE application_configs (
+    application_id character varying(255),
+    element character varying(255)
+);
+
+
+--
+-- Name: application_jars; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE application_jars (
+    application_id character varying(255),
+    element character varying(255)
+);
+
+
+--
+-- Name: application_tags; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE application_tags (
+    application_id character varying(255),
+    element character varying(255)
+);
+
+
+--
+-- Name: cluster; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE cluster (
+    id character varying(255) NOT NULL,
+    created timestamp without time zone,
+    updated timestamp without time zone,
+    name character varying(255),
+    user0 character varying(255),
+    version character varying(255),
+    clustertype character varying(255),
+    status character varying(20),
+    entityversion bigint
+);
+
+
+--
+-- Name: cluster_command; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE cluster_command (
+    clusters_id character varying(255),
+    commands_id character varying(255),
+    commands_order integer
+);
+
+
+--
+-- Name: cluster_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE cluster_configs (
+    cluster_id character varying(255),
+    element character varying(255)
+);
+
+
+--
+-- Name: cluster_tags; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE cluster_tags (
+    cluster_id character varying(255),
+    element character varying(255)
+);
+
+
+--
+-- Name: command; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE command (
+    id character varying(255) NOT NULL,
+    created timestamp without time zone,
+    updated timestamp without time zone,
+    name character varying(255),
+    user0 character varying(255),
+    version character varying(255),
+    envpropfile character varying(255),
+    executable character varying(255),
+    jobtype character varying(255),
+    status character varying(20),
+    entityversion bigint,
+    application_id character varying(255)
+);
+
+
+--
+-- Name: command_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE command_configs (
+    command_id character varying(255),
+    element character varying(255)
+);
+
+
+--
+-- Name: command_tags; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE command_tags (
+    command_id character varying(255),
+    element character varying(255)
+);
+
+
+--
+-- Name: job; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE job (
+    id character varying(255) NOT NULL,
+    created timestamp without time zone,
+    updated timestamp without time zone,
+    name character varying(255),
+    user0 character varying(255),
+    version character varying(255),
+    applicationid character varying(255),
+    applicationname character varying(255),
+    archivelocation text,
+    chosenclustercriteriastring text,
+    clienthost character varying(255),
+    clustercriteriasstring text,
+    commandargs text,
+    commandcriteriastring text,
+    commandid character varying(255),
+    commandname character varying(255),
+    description character varying(255),
+    disablelogarchival boolean,
+    email character varying(255),
+    envpropfile character varying(255),
+    executionclusterid character varying(255),
+    executionclustername character varying(255),
+    exitcode integer,
+    filedependencies text,
+    finished timestamp without time zone,
+    forwarded boolean,
+    groupname character varying(255),
+    hostname character varying(255),
+    killuri character varying(255),
+    outputuri character varying(255),
+    processhandle integer,
+    started timestamp without time zone,
+    status character varying(20),
+    statusmsg character varying(255),
+    entityversion bigint
+);
+
+
+--
+-- Name: job_tags; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE job_tags (
+    job_id character varying(255),
+    element character varying(255)
+);
+
+
+--
+-- Name: application_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY application
+    ADD CONSTRAINT application_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: cluster_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY cluster
+    ADD CONSTRAINT cluster_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: command_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY command
+    ADD CONSTRAINT command_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: job_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY job
+    ADD CONSTRAINT job_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: i_clstfgs_cluster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_clstfgs_cluster_id ON cluster_configs USING btree (cluster_id);
+
+
+--
+-- Name: i_clstmnd_clusters_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_clstmnd_clusters_id ON cluster_command USING btree (clusters_id);
+
+
+--
+-- Name: i_clstmnd_element; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_clstmnd_element ON cluster_command USING btree (commands_id);
+
+
+--
+-- Name: i_clsttgs_cluster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_clsttgs_cluster_id ON cluster_tags USING btree (cluster_id);
+
+
+--
+-- Name: i_cmmnfgs_command_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_cmmnfgs_command_id ON command_configs USING btree (command_id);
+
+
+--
+-- Name: i_cmmntgs_command_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_cmmntgs_command_id ON command_tags USING btree (command_id);
+
+
+--
+-- Name: i_command_application; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_command_application ON command USING btree (application_id);
+
+
+--
+-- Name: i_job_tgs_job_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_job_tgs_job_id ON job_tags USING btree (job_id);
+
+
+--
+-- Name: i_pplcfgs_application_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_pplcfgs_application_id ON application_configs USING btree (application_id);
+
+
+--
+-- Name: i_pplcjrs_application_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_pplcjrs_application_id ON application_jars USING btree (application_id);
+
+
+--
+-- Name: i_pplctgs_application_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX i_pplctgs_application_id ON application_tags USING btree (application_id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/genie-core/scripts/postgresql/upgrade-2.0.0-to-3.0.0.postgresql.sql
+++ b/genie-core/scripts/postgresql/upgrade-2.0.0-to-3.0.0.postgresql.sql
@@ -1,0 +1,443 @@
+BEGIN;
+SELECT CURRENT_TIMESTAMP, 'Fixing https://github.com/Netflix/genie/issues/148';
+-- Fix referential integrity problem described in https://github.com/Netflix/genie/issues/148
+DELETE FROM application_configs WHERE application_id NOT IN (SELECT id from application);
+DELETE FROM application_jars WHERE application_id NOT IN (SELECT id from application);
+DELETE FROM application_tags WHERE application_id NOT IN (SELECT id from application);
+DELETE FROM cluster_command WHERE clusters_id NOT IN (SELECT id FROM cluster);
+DELETE FROM cluster_tags WHERE cluster_id NOT IN (SELECT id from cluster);
+DELETE FROM cluster_configs WHERE cluster_id NOT IN (SELECT id FROM cluster);
+DELETE FROM cluster_command WHERE commands_id NOT IN (SELECT id FROM command);
+DELETE FROM command_tags WHERE command_id NOT IN (SELECT id from command);
+DELETE FROM command_configs WHERE command_id NOT IN (SELECT id FROM command);
+DELETE FROM job_tags WHERE job_id NOT IN (SELECT id FROM job);
+SELECT CURRENT_TIMESTAMP, 'Finished applying fix for https://github.com/Netflix/genie/issues/148';
+COMMIT;
+
+BEGIN;
+SELECT CURRENT_TIMESTAMP, 'Beginning upgrade of Genie schema from version 2.0.0 to 3.0.0';
+
+-- Rename the tables to be a little bit nicer
+SELECT CURRENT_TIMESTAMP, 'Renaming all the tables to be more friendly...';
+ALTER TABLE application RENAME TO applications;
+ALTER TABLE application_jars RENAME TO application_dependencies;
+ALTER TABLE cluster RENAME TO clusters;
+ALTER TABLE cluster_command RENAME TO clusters_commands;
+ALTER TABLE command RENAME TO commands;
+ALTER TABLE job RENAME TO jobs;
+SELECT CURRENT_TIMESTAMP, 'Successfully renamed all tables';
+
+-- Create a new Many to Many table for commands to applications
+SELECT CURRENT_TIMESTAMP, 'Creating commands_applications table...';
+CREATE TABLE commands_applications (
+  command_id VARCHAR(255) NOT NULL,
+  application_id VARCHAR(255) NOT NULL,
+  FOREIGN KEY (command_id) REFERENCES commands (id) ON DELETE CASCADE,
+  FOREIGN KEY (application_id) REFERENCES applications (id) ON DELETE RESTRICT
+);
+SELECT CURRENT_TIMESTAMP, 'Successfully created commands_applications table.';
+
+-- Save the values of the current command to application relationship for the new table
+SELECT CURRENT_TIMESTAMP, 'Adding existing applications to commands...';
+INSERT INTO commands_applications (command_id, application_id)
+  SELECT id, application_id FROM commands WHERE application_id IS NOT NULL;
+SELECT CURRENT_TIMESTAMP, 'Successfully added existing applications to commands.';
+
+-- Modify the applications and the associated children tables
+SELECT CURRENT_TIMESTAMP, 'Altering the applications table for 3.0...';
+ALTER TABLE applications ALTER COLUMN created SET NOT NULL;
+ALTER TABLE applications ALTER COLUMN created SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE applications ALTER COLUMN updated SET NOT NULL;
+ALTER TABLE applications ALTER COLUMN updated SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE applications ALTER COLUMN name SET NOT NULL;
+ALTER TABLE applications ALTER COLUMN user0 SET NOT NULL;
+ALTER TABLE applications RENAME COLUMN user0 TO "user";
+ALTER TABLE applications ALTER COLUMN version SET NOT NULL;
+ALTER TABLE applications ADD COLUMN description TEXT DEFAULT NULL;
+ALTER TABLE applications ADD COLUMN tags VARCHAR(2048) DEFAULT NULL;
+ALTER TABLE applications ALTER COLUMN status SET NOT NULL;
+ALTER TABLE applications ALTER COLUMN status SET DEFAULT 'INACTIVE';
+ALTER TABLE applications ALTER COLUMN envpropfile TYPE VARCHAR(1024);
+ALTER TABLE applications ALTER COLUMN envpropfile SET DEFAULT NULL;
+ALTER TABLE applications RENAME COLUMN envPropFile TO setup_file;
+ALTER TABLE applications ALTER COLUMN entityversion SET NOT NULL;
+ALTER TABLE applications ALTER COLUMN entityversion SET DEFAULT 0;
+ALTER TABLE applications ALTER COLUMN entityversion TYPE INT;
+ALTER TABLE applications RENAME COLUMN entityversion TO entity_version;
+
+CREATE INDEX APPLICATIONS_NAME_INDEX ON applications (name);
+CREATE INDEX APPLICATIONS_TAGS_INDEX ON applications (tags);
+CREATE INDEX APPLICATIONS_STATUS_INDEX ON applications (status);
+SELECT CURRENT_TIMESTAMP, 'Successfully updated the applications table.';
+
+SELECT CURRENT_TIMESTAMP, 'De-normalizing application tags for 3.0...';
+UPDATE applications SET tags =
+(
+  SELECT string_agg(DISTINCT element, ',' ORDER BY element)
+  FROM application_tags
+  WHERE applications.id = application_tags.application_id
+  GROUP BY application_id
+);
+SELECT CURRENT_TIMESTAMP, 'Finished de-normalizing application tags for 3.0.';
+
+SELECT CURRENT_TIMESTAMP, 'Altering the application_configs table for 3.0...';
+DROP INDEX i_pplcfgs_application_id;
+ALTER TABLE application_configs ALTER COLUMN application_id SET NOT NULL;
+ALTER TABLE application_configs ALTER COLUMN element SET NOT NULL;
+ALTER TABLE application_configs ALTER COLUMN element TYPE VARCHAR(1024);
+ALTER TABLE application_configs RENAME COLUMN element TO config;
+ALTER TABLE application_configs ADD FOREIGN KEY (application_id) REFERENCES applications (id) ON DELETE CASCADE;
+SELECT CURRENT_TIMESTAMP, 'Successfully updated the application_configs table.';
+
+SELECT CURRENT_TIMESTAMP, 'Altering the application_dependencies table for 3.0...';
+DROP INDEX i_pplcjrs_application_id;
+ALTER TABLE application_dependencies ALTER COLUMN application_id SET NOT NULL;
+ALTER TABLE application_dependencies ALTER COLUMN element SET NOT NULL;
+ALTER TABLE application_dependencies ALTER COLUMN element TYPE VARCHAR(1024);
+ALTER TABLE application_dependencies RENAME COLUMN element TO dependency;
+ALTER TABLE application_dependencies ADD FOREIGN KEY (application_id) REFERENCES applications (id) ON DELETE CASCADE;
+SELECT CURRENT_TIMESTAMP, 'Successfully updated the application_dependencies table.';
+
+SELECT CURRENT_TIMESTAMP, 'Dropping the application_tags table from 3.0...';
+DROP TABLE application_tags;
+SELECT CURRENT_TIMESTAMP, 'Successfully dropped the application_tags table.';
+
+-- Modify the clusters and associated children tables
+SELECT CURRENT_TIMESTAMP, 'Updating the clusters table for 3.0...';
+ALTER TABLE clusters ALTER COLUMN created SET NOT NULL;
+ALTER TABLE clusters ALTER COLUMN created SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE clusters ALTER COLUMN updated SET NOT NULL;
+ALTER TABLE clusters ALTER COLUMN updated SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE clusters ALTER COLUMN name SET NOT NULL;
+ALTER TABLE clusters ALTER COLUMN user0 SET NOT NULL;
+ALTER TABLE clusters RENAME COLUMN user0 TO "user";
+ALTER TABLE clusters ALTER COLUMN version SET NOT NULL;
+ALTER TABLE clusters ADD COLUMN description TEXT DEFAULT NULL;
+ALTER TABLE clusters ADD COLUMN tags VARCHAR(2048) DEFAULT NULL;
+ALTER TABLE clusters ADD COLUMN setup_file VARCHAR(1024) DEFAULT NULL;
+ALTER TABLE clusters ALTER COLUMN status SET NOT NULL;
+ALTER TABLE clusters ALTER COLUMN status SET DEFAULT 'OUT_OF_SERVICE';
+ALTER TABLE clusters ALTER COLUMN entityversion SET NOT NULL;
+ALTER TABLE clusters ALTER COLUMN entityversion SET DEFAULT 0;
+ALTER TABLE clusters ALTER COLUMN entityversion TYPE INT;
+ALTER TABLE clusters RENAME COLUMN entityversion TO entity_version;
+ALTER TABLE clusters DROP COLUMN clusterType;
+
+CREATE INDEX CLUSTERS_NAME_INDEX ON clusters (name);
+CREATE INDEX CLUSTERS_TAG_INDEX ON clusters (tags);
+CREATE INDEX CLUSTERS_STATUS_INDEX ON clusters (status);
+SELECT CURRENT_TIMESTAMP, 'Successfully updated the clusters table.';
+
+SELECT CURRENT_TIMESTAMP, 'De-normalizing cluster tags for 3.0...';
+UPDATE clusters SET tags =
+(
+  SELECT string_agg(DISTINCT element, ',' ORDER BY element)
+  FROM cluster_tags
+  WHERE clusters.id = cluster_tags.cluster_id
+  GROUP BY cluster_id
+);
+SELECT CURRENT_TIMESTAMP, 'Finished de-normalizing cluster tags for 3.0.';
+
+SELECT CURRENT_TIMESTAMP, 'Updating the clusters_commands table for 3.0...';
+DROP INDEX i_clstmnd_clusters_id;
+DROP INDEX i_clstmnd_element;
+
+ALTER TABLE clusters_commands ALTER COLUMN clusters_id SET NOT NULL;
+ALTER TABLE clusters_commands RENAME COLUMN clusters_id TO cluster_id;
+ALTER TABLE clusters_commands ALTER COLUMN commands_id SET NOT NULL;
+ALTER TABLE clusters_commands RENAME COLUMN commands_id TO command_id;
+ALTER TABLE clusters_commands ALTER COLUMN commands_order SET NOT NULL;
+ALTER TABLE clusters_commands RENAME COLUMN commands_order TO command_order;
+ALTER TABLE clusters_commands ADD FOREIGN KEY (cluster_id) REFERENCES clusters (id) ON DELETE CASCADE;
+ALTER TABLE clusters_commands ADD FOREIGN KEY (command_id) REFERENCES commands (id) ON DELETE RESTRICT;
+SELECT CURRENT_TIMESTAMP, 'Successfully updated the clusters_commands table.';
+
+SELECT CURRENT_TIMESTAMP, 'Updating the cluster_configs table for 3.0...';
+DROP INDEX i_clstfgs_cluster_id;
+ALTER TABLE cluster_configs ALTER COLUMN cluster_id SET NOT NULL;
+ALTER TABLE cluster_configs ALTER COLUMN element TYPE VARCHAR(1024);
+ALTER TABLE cluster_configs ALTER COLUMN element SET NOT NULL;
+ALTER TABLE cluster_configs RENAME COLUMN element TO config;
+ALTER TABLE cluster_configs ADD FOREIGN KEY (cluster_id) REFERENCES clusters (id) ON DELETE CASCADE;
+SELECT CURRENT_TIMESTAMP, 'Successfully updated the cluster_configs table.';
+
+SELECT CURRENT_TIMESTAMP, 'Dropping the cluster_tags table for 3.0...';
+DROP TABLE cluster_tags;
+SELECT CURRENT_TIMESTAMP, 'Dropped the cluster_tags table.';
+
+-- Modify the commands and associated children tables
+SELECT CURRENT_TIMESTAMP, 'Updating the commands table for 3.0...';
+ALTER TABLE commands ALTER COLUMN created SET NOT NULL;
+ALTER TABLE commands ALTER COLUMN created SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE commands ALTER COLUMN updated SET NOT NULL;
+ALTER TABLE commands ALTER COLUMN updated SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE commands ALTER COLUMN name SET NOT NULL;
+ALTER TABLE commands ALTER COLUMN user0 SET NOT NULL;
+ALTER TABLE commands RENAME COLUMN user0 TO "user";
+ALTER TABLE commands ALTER COLUMN version SET NOT NULL;
+ALTER TABLE commands ADD COLUMN description TEXT DEFAULT NULL;
+ALTER TABLE commands ADD COLUMN tags VARCHAR(2048) DEFAULT NULL;
+ALTER TABLE commands ADD COLUMN check_delay BIGINT NOT NULL DEFAULT 10000;
+ALTER TABLE commands ALTER COLUMN status SET NOT NULL;
+ALTER TABLE commands ALTER COLUMN status SET DEFAULT 'INACTIVE';
+ALTER TABLE commands ALTER COLUMN executable SET NOT NULL;
+ALTER TABLE commands ALTER COLUMN envpropfile TYPE VARCHAR(1024);
+ALTER TABLE commands ALTER COLUMN envpropfile SET DEFAULT NULL;
+ALTER TABLE commands RENAME COLUMN envPropFile TO setup_file;
+ALTER TABLE commands ALTER COLUMN entityversion SET NOT NULL;
+ALTER TABLE commands ALTER COLUMN entityversion SET DEFAULT 0;
+ALTER TABLE commands ALTER COLUMN entityversion TYPE INT;
+ALTER TABLE commands DROP application_id;
+ALTER TABLE commands DROP jobType;
+
+CREATE INDEX COMMANDS_NAME_INDEX ON commands (name);
+CREATE INDEX COMMANDS_TAGS_INDEX ON commands (tags);
+CREATE INDEX COMMANDS_STATUS_INDEX on commands (status);
+SELECT CURRENT_TIMESTAMP, 'Successfully updated the commands table.';
+
+SELECT CURRENT_TIMESTAMP, 'De-normalizing command tags for 3.0...';
+UPDATE commands SET tags =
+(
+  SELECT string_agg(DISTINCT element, ',' ORDER BY element)
+  FROM command_tags
+  WHERE commands.id = command_tags.command_id
+  GROUP BY command_id
+);
+SELECT CURRENT_TIMESTAMP, 'Finished de-normalizing command tags for 3.0.';
+
+SELECT CURRENT_TIMESTAMP, 'Updating the command_configs table for 3.0...';
+DROP INDEX i_cmmnfgs_command_id;
+
+ALTER TABLE command_configs ALTER COLUMN command_id SET NOT NULL;
+ALTER TABLE command_configs ALTER COLUMN element TYPE VARCHAR(1024);
+ALTER TABLE command_configs ALTER COLUMN element SET NOT NULL;
+ALTER TABLE command_configs RENAME COLUMN element TO config;
+ALTER TABLE command_configs ADD FOREIGN KEY (command_id) REFERENCES commands (id) ON DELETE CASCADE;
+SELECT CURRENT_TIMESTAMP, 'Successfully updated the command_configs table.';
+
+SELECT CURRENT_TIMESTAMP, 'Dropping the command_tags table for 3.0...';
+DROP TABLE command_tags;
+SELECT CURRENT_TIMESTAMP, 'Successfully dropped the command_tags table.';
+
+-- TODO: May want these TEXT fields to be large varchars instead?
+SELECT CURRENT_TIMESTAMP, 'Creating the job_requests table...';
+CREATE TABLE job_requests (
+  id VARCHAR(255) NOT NULL,
+  created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  name VARCHAR(255) NOT NULL,
+  "user" VARCHAR(255) NOT NULL,
+  version VARCHAR(255) NOT NULL,
+  description TEXT DEFAULT NULL,
+  entity_version INT NOT NULL DEFAULT 0,
+  command_args TEXT NOT NULL,
+  group_name VARCHAR(255) DEFAULT NULL,
+  setup_file VARCHAR(1024) DEFAULT NULL,
+  cluster_criterias VARCHAR(2048) NOT NULL,
+  command_criteria VARCHAR(1024) NOT NULL,
+  file_dependencies TEXT DEFAULT NULL,
+  disable_log_archival BOOLEAN NOT NULL DEFAULT FALSE,
+  email VARCHAR(255) DEFAULT NULL,
+  tags VARCHAR(2048) DEFAULT NULL,
+  cpu INT NOT NULL DEFAULT 1,
+  memory INT NOT NULL DEFAULT 1560,
+  client_host VARCHAR(255) DEFAULT NULL,
+  PRIMARY KEY (id)
+);
+SELECT CURRENT_TIMESTAMP, 'Successfully created the job_requests table.';
+
+SELECT CURRENT_TIMESTAMP, 'Inserting values into job_requests table from the jobs table...';
+INSERT INTO job_requests (
+  id,
+  created,
+  updated,
+  name,
+  "user",
+  version,
+  description,
+  entity_version,
+  command_args,
+  group_name,
+  setup_file,
+  cluster_criterias,
+  command_criteria,
+  file_dependencies,
+  disable_log_archival,
+  email,
+  tags,
+  cpu,
+  memory,
+  client_host
+) SELECT
+  j.id,
+  j.created,
+  j.updated,
+  j.name,
+  j.user0,
+  j.version,
+  j.description,
+  1,
+  j.commandargs,
+  j.groupname,
+  j.envpropfile,
+  j.clustercriteriasstring,
+  j.commandcriteriastring,
+  j.filedependencies,
+  j.disablelogarchival,
+  j.email,
+  (
+    SELECT string_agg(DISTINCT element, ',' ORDER BY element)
+    FROM job_tags
+    WHERE j.id = job_tags.job_id
+    GROUP BY job_id
+  ),
+  1,
+  1560,
+  j.clientHost
+  FROM jobs j;
+
+-- TODO: Do this in one pass instead of 3?
+UPDATE job_requests SET command_criteria = RPAD(command_criteria, LENGTH(command_criteria) + 2, '"]');
+UPDATE job_requests SET command_criteria = LPAD(command_criteria, LENGTH(command_criteria) + 2, '["');
+UPDATE job_requests SET command_criteria = REPLACE(command_criteria, ',', '","');
+UPDATE job_requests SET command_criteria = '[]' WHERE command_criteria = '[""]' OR command_criteria IS NULL;
+-- TODO: Less passes?
+UPDATE job_requests SET cluster_criterias = RPAD(cluster_criterias, LENGTH(cluster_criterias) + 4, '"]}]');
+UPDATE job_requests SET cluster_criterias = LPAD(cluster_criterias, LENGTH(cluster_criterias) + 11, '[{"tags":["');
+UPDATE job_requests SET cluster_criterias = REPLACE(cluster_criterias, ',', '","');
+UPDATE job_requests SET cluster_criterias = REPLACE(cluster_criterias, '|', '"]},{"tags":["');
+UPDATE job_requests SET cluster_criterias = '[]' WHERE cluster_criterias = '[""]' OR cluster_criterias IS NULL;
+-- TODO: Do this in one pass instead of 3?
+UPDATE job_requests SET file_dependencies = RPAD(file_dependencies, LENGTH(file_dependencies) + 2, '"]');
+UPDATE job_requests SET file_dependencies = LPAD(file_dependencies, LENGTH(file_dependencies) + 2, '["');
+UPDATE job_requests SET file_dependencies = REPLACE(file_dependencies, ',', '","');
+UPDATE job_requests SET file_dependencies = '[]' WHERE file_dependencies = '[""]' OR file_dependencies IS NULL;
+SELECT CURRENT_TIMESTAMP, 'Successfully inserted values into job_requests table.';
+
+SELECT CURRENT_TIMESTAMP, 'Creating the job_executions table...';
+CREATE TABLE job_executions (
+  id VARCHAR(255) NOT NULL,
+  created TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  entity_version INT NOT NULL DEFAULT 0,
+  hostname VARCHAR(255) NOT NULL,
+  process_id INT NOT NULL,
+  exit_code INT NOT NULL DEFAULT -1,
+  check_delay BIGINT NOT NULL DEFAULT 10000,
+  FOREIGN KEY (id) REFERENCES jobs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX JOB_EXECUTIONS_HOSTNAME_INDEX ON job_executions (hostname);
+CREATE INDEX JOB_EXECUTIONS_EXIT_CODE_INDEX ON job_executions (exit_code);
+SELECT CURRENT_TIMESTAMP, 'Successfully created the job_executions table.';
+
+SELECT CURRENT_TIMESTAMP, 'Inserting values into job_executions from the jobs table...';
+INSERT INTO job_executions (
+  id,
+  created,
+  updated,
+  entity_version,
+  hostname,
+  process_id,
+  exit_code
+) SELECT
+  id,
+  created,
+  updated,
+  entityversion,
+  hostname,
+  processhandle,
+  exitcode
+  FROM jobs;
+SELECT CURRENT_TIMESTAMP, 'Successfully inserted values into the job_executions table.';
+
+-- Modify the job table to remove the cluster id if cluster doesn't exist to prepare for foreign key constraints
+SELECT CURRENT_TIMESTAMP, 'Setting executionClusterId in jobs table to NULL if cluster no longer exists...';
+UPDATE jobs SET executionclusterid = NULL WHERE executionclusterid NOT IN (SELECT id FROM clusters);
+SELECT CURRENT_TIMESTAMP, 'Successfully updated executionClusterId.';
+
+-- Modify the job table to remove the command id if the command doesn't exist to prepare for foreign key constraints
+SELECT CURRENT_TIMESTAMP, 'Setting commandId in Job table to NULL if command no longer exists...';
+UPDATE jobs SET commandid = NULL WHERE commandid NOT IN (SELECT id FROM commands);
+SELECT CURRENT_TIMESTAMP, 'Successfully updated commandId.';
+
+-- Modify the jobs and associated children tables
+SELECT CURRENT_TIMESTAMP, 'Updating the jobs table for 3.0...';
+ALTER TABLE jobs ALTER COLUMN created SET NOT NULL;
+ALTER TABLE jobs ALTER COLUMN created SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE jobs ALTER COLUMN updated SET NOT NULL;
+ALTER TABLE jobs ALTER COLUMN updated SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE jobs ALTER COLUMN name SET NOT NULL;
+ALTER TABLE jobs ALTER COLUMN user0 SET NOT NULL;
+ALTER TABLE jobs RENAME COLUMN user0 TO "user";
+ALTER TABLE jobs ALTER COLUMN version SET NOT NULL;
+ALTER TABLE jobs ALTER COLUMN description SET DEFAULT NULL;
+ALTER TABLE jobs ALTER COLUMN description TYPE TEXT;
+ALTER TABLE jobs ALTER COLUMN entityversion SET NOT NULL;
+ALTER TABLE jobs ALTER COLUMN entityversion SET DEFAULT 0;
+ALTER TABLE jobs ALTER COLUMN entityversion TYPE INT;
+ALTER TABLE jobs ALTER COLUMN status SET NOT NULL;
+ALTER TABLE jobs ALTER COLUMN status SET DEFAULT 'INIT';
+ALTER TABLE jobs ALTER COLUMN statusmsg SET NOT NULL;
+ALTER TABLE jobs RENAME COLUMN statusmsg TO status_msg;
+ALTER TABLE jobs ALTER COLUMN archivelocation TYPE VARCHAR(1024);
+ALTER TABLE jobs ALTER COLUMN archivelocation SET DEFAULT NULL;
+ALTER TABLE jobs RENAME COLUMN archivelocation TO archive_location;
+ALTER TABLE jobs ALTER COLUMN executionclusterid SET DEFAULT NULL;
+ALTER TABLE jobs RENAME COLUMN executionclusterid TO cluster_id;
+ALTER TABLE jobs ALTER COLUMN executionclustername SET DEFAULT NULL;
+ALTER TABLE jobs RENAME COLUMN executionclustername TO cluster_name;
+ALTER TABLE jobs ALTER COLUMN commandid SET DEFAULT NULL;
+ALTER TABLE jobs RENAME COLUMN commandid TO command_id;
+ALTER TABLE jobs ALTER COLUMN commandname SET DEFAULT NULL;
+ALTER TABLE jobs RENAME COLUMN commandname TO command_name;
+ALTER TABLE jobs ADD COLUMN tags VARCHAR(2048) DEFAULT NULL;
+ALTER TABLE jobs DROP forwarded;
+ALTER TABLE jobs DROP applicationid;
+ALTER TABLE jobs DROP applicationname;
+ALTER TABLE jobs DROP hostname;
+ALTER TABLE jobs DROP clienthost;
+ALTER TABLE jobs DROP filedependencies;
+ALTER TABLE jobs DROP envpropfile;
+ALTER TABLE jobs DROP exitcode;
+ALTER TABLE jobs DROP disablelogarchival;
+ALTER TABLE jobs DROP clustercriteriasstring;
+ALTER TABLE jobs DROP commandcriteriastring;
+ALTER TABLE jobs DROP chosenclustercriteriastring;
+ALTER TABLE jobs DROP processhandle;
+ALTER TABLE jobs DROP email;
+ALTER TABLE jobs DROP groupname;
+ALTER TABLE jobs DROP commandargs;
+ALTER TABLE jobs DROP killuri;
+ALTER TABLE jobs DROP outputuri;
+ALTER TABLE jobs ADD FOREIGN KEY (id) REFERENCES job_requests (id) ON DELETE CASCADE;
+ALTER TABLE jobs ADD FOREIGN KEY (cluster_id) REFERENCES clusters (id) ON DELETE RESTRICT;
+ALTER TABLE jobs ADD FOREIGN KEY (command_id) REFERENCES commands (id) ON DELETE RESTRICT;
+
+CREATE INDEX JOBS_STARTED_INDEX ON jobs (started);
+CREATE INDEX JOBS_FINISHED_INDEX ON jobs (finished);
+CREATE INDEX JOBS_STATUS_INDEX ON jobs (status);
+CREATE INDEX JOBS_USER_INDEX ON jobs ("user");
+CREATE INDEX JOBS_UPDATED_INDEX ON jobs (updated);
+CREATE INDEX JOBS_CLUSTER_NAME_INDEX ON jobs (cluster_name);
+CREATE INDEX JOBS_COMMAND_NAME_INDEX ON jobs (command_name);
+CREATE INDEX JOBS_TAGS_INDEX ON jobs (tags);
+SELECT CURRENT_TIMESTAMP, 'Successfully updated the jobs table.';
+
+SELECT CURRENT_TIMESTAMP, 'De-normalizing jobs tags for 3.0...';
+UPDATE jobs SET tags =
+(
+  SELECT string_agg(DISTINCT element, ',' ORDER BY element)
+  FROM job_tags
+  WHERE jobs.id = job_tags.job_id
+  GROUP BY job_id
+);
+SELECT CURRENT_TIMESTAMP, 'Finished de-normalizing job tags for 3.0.';
+
+SELECT CURRENT_TIMESTAMP, 'Dropping the job_tags table for 3.0...';
+DROP TABLE job_tags;
+SELECT CURRENT_TIMESTAMP, 'Successfully dropped the job_tags table.';
+
+SELECT CURRENT_TIMESTAMP, 'Finished upgrading Genie schema from version 2.0.0 to 3.0.0';
+
+COMMIT;


### PR DESCRIPTION
This PR adds schema generation for PostgreSQL and the JDBC driver to the runtime configuration of genie-web.

The original 2.0.0 schema was generated by running Genie 2 against PostgreSQL 9.5.1 and taking a schema only dump using psql. The permissions and ownerships weren't dumped so they could be used by anyone.

Then took the current mysql upgrade script and tried to modify it as closely as possible to support upgrading the 2.0.0 schema to 3.0.0. Will try to keep them in sync going forward.

Tested by successfully running Genie 3.0.0-SNAPSHOT on top of PostgreSQL database. Have no large data set internally to test against for the migration. May try to generate one later or look for outside help.

The Postgres jdbc driver version is defined by the Spring Platform IO managed version.