### PR TITLE
Move integration tests on CI server to use MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+sudo: required
+dist: trusty
+addons:
+  apt:
+    packages:
+      - mysql-server-5.6
+      - mysql-client-core-5.6
+      - mysql-client-5.6
+
 language: java
 jdk:
   - oraclejdk8
@@ -8,7 +17,6 @@ services:
 git:
   depth: 100
 
-sudo: false
 install: "./gradle/installViaTravis.sh"
 
 # Setup the database for the integration tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,20 @@ language: java
 jdk:
   - oraclejdk8
 
+services:
+  - mysql
+
 git:
   depth: 100
 
 sudo: false
 install: "./gradle/installViaTravis.sh"
+
+# Setup the database for the integration tests
+before_script:
+  - mysql -u root -e 'create database genie;'
+  - mysql -u root genie < genie-ddl/mysql/genie-schema-3.0.0.mysql.sql
+
 script: "./gradle/buildViaTravis.sh"
 
 # https://docs.travis-ci.com/user/languages/java#Caching

--- a/build.gradle
+++ b/build.gradle
@@ -156,8 +156,9 @@ subprojects {
         minHeapSize = "256m"
         maxHeapSize = "1g"
 
-        if (project.hasProperty("TRAVIS_PULL_REQUEST")) {
-            systemProperty "TRAVIS_PULL_REQUEST", project.getProperty("TRAVIS_PULL_REQUEST")
+        // If the project is running on a CI server
+        if (System.getenv("CI") != null) {
+            systemProperty "CI", System.getenv("CI")
         }
 
         reports.html.destination = file("${reporting.baseDir}/test/${task.name}")

--- a/genie-ddl/mysql/genie-schema-3.0.0.mysql.sql
+++ b/genie-ddl/mysql/genie-schema-3.0.0.mysql.sql
@@ -1,0 +1,301 @@
+-- MySQL dump 10.13  Distrib 5.7.11, for osx10.11 (x86_64)
+--
+-- Host: localhost    Database: genie
+-- ------------------------------------------------------
+-- Server version	5.7.11
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `application_configs`
+--
+
+DROP TABLE IF EXISTS `application_configs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `application_configs` (
+  `application_id` varchar(255) NOT NULL,
+  `config` varchar(1024) NOT NULL,
+  KEY `application_id` (`application_id`),
+  CONSTRAINT `application_configs_ibfk_1` FOREIGN KEY (`application_id`) REFERENCES `applications` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `application_dependencies`
+--
+
+DROP TABLE IF EXISTS `application_dependencies`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `application_dependencies` (
+  `application_id` varchar(255) NOT NULL,
+  `dependency` varchar(1024) NOT NULL,
+  KEY `application_id` (`application_id`),
+  CONSTRAINT `application_dependencies_ibfk_1` FOREIGN KEY (`application_id`) REFERENCES `applications` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `applications`
+--
+
+DROP TABLE IF EXISTS `applications`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `applications` (
+  `id` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `name` varchar(255) NOT NULL,
+  `user` varchar(255) NOT NULL,
+  `version` varchar(255) NOT NULL,
+  `description` text,
+  `tags` varchar(2048) DEFAULT NULL,
+  `setup_file` varchar(1024) DEFAULT NULL,
+  `status` varchar(20) NOT NULL DEFAULT 'INACTIVE',
+  `entity_version` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `APPLICATIONS_NAME_INDEX` (`name`),
+  KEY `APPLICATIONS_TAGS_INDEX` (`tags`),
+  KEY `APPLICATIONS_STATUS_INDEX` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `cluster_configs`
+--
+
+DROP TABLE IF EXISTS `cluster_configs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `cluster_configs` (
+  `cluster_id` varchar(255) NOT NULL,
+  `config` varchar(1024) NOT NULL,
+  KEY `cluster_id` (`cluster_id`),
+  CONSTRAINT `cluster_configs_ibfk_1` FOREIGN KEY (`cluster_id`) REFERENCES `clusters` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `clusters`
+--
+
+DROP TABLE IF EXISTS `clusters`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `clusters` (
+  `id` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `name` varchar(255) NOT NULL,
+  `user` varchar(255) NOT NULL,
+  `version` varchar(255) NOT NULL,
+  `description` text,
+  `tags` varchar(2048) DEFAULT NULL,
+  `setup_file` varchar(1024) DEFAULT NULL,
+  `status` varchar(20) NOT NULL DEFAULT 'OUT_OF_SERVICE',
+  `entity_version` int(11) DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `CLUSTERS_NAME_INDEX` (`name`),
+  KEY `CLUSTERS_TAG_INDEX` (`tags`),
+  KEY `CLUSTERS_STATUS_INDEX` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `clusters_commands`
+--
+
+DROP TABLE IF EXISTS `clusters_commands`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `clusters_commands` (
+  `cluster_id` varchar(255) NOT NULL,
+  `command_id` varchar(255) NOT NULL,
+  `command_order` int(11) NOT NULL,
+  KEY `cluster_id` (`cluster_id`),
+  KEY `command_id` (`command_id`),
+  CONSTRAINT `clusters_commands_ibfk_1` FOREIGN KEY (`cluster_id`) REFERENCES `clusters` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `clusters_commands_ibfk_2` FOREIGN KEY (`command_id`) REFERENCES `commands` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `command_configs`
+--
+
+DROP TABLE IF EXISTS `command_configs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `command_configs` (
+  `command_id` varchar(255) NOT NULL,
+  `config` varchar(1024) NOT NULL,
+  KEY `command_id` (`command_id`),
+  CONSTRAINT `command_configs_ibfk_1` FOREIGN KEY (`command_id`) REFERENCES `commands` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `commands`
+--
+
+DROP TABLE IF EXISTS `commands`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `commands` (
+  `id` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `name` varchar(255) NOT NULL,
+  `user` varchar(255) NOT NULL,
+  `version` varchar(255) NOT NULL,
+  `description` text,
+  `tags` varchar(2048) DEFAULT NULL,
+  `setup_file` varchar(1024) DEFAULT NULL,
+  `executable` varchar(255) NOT NULL,
+  `check_delay` bigint(20) NOT NULL DEFAULT '10000',
+  `status` varchar(20) NOT NULL DEFAULT 'INACTIVE',
+  `entity_version` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `COMMANDS_NAME_INDEX` (`name`),
+  KEY `COMMANDS_TAGS_INDEX` (`tags`),
+  KEY `COMMANDS_STATUS_INDEX` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `commands_applications`
+--
+
+DROP TABLE IF EXISTS `commands_applications`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `commands_applications` (
+  `command_id` varchar(255) NOT NULL,
+  `application_id` varchar(255) NOT NULL,
+  `application_order` int(11) NOT NULL,
+  KEY `command_id` (`command_id`),
+  KEY `application_id` (`application_id`),
+  CONSTRAINT `commands_applications_ibfk_1` FOREIGN KEY (`command_id`) REFERENCES `commands` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `commands_applications_ibfk_2` FOREIGN KEY (`application_id`) REFERENCES `applications` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `job_executions`
+--
+
+DROP TABLE IF EXISTS `job_executions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `job_executions` (
+  `id` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `entity_version` int(11) NOT NULL DEFAULT '0',
+  `hostname` varchar(255) NOT NULL,
+  `process_id` int(11) NOT NULL,
+  `exit_code` int(11) NOT NULL DEFAULT '-1',
+  `check_delay` bigint(20) NOT NULL DEFAULT '10000',
+  KEY `id` (`id`),
+  KEY `JOB_EXECUTIONS_HOSTNAME_INDEX` (`hostname`),
+  KEY `JOB_EXECUTIONS_EXIT_CODE_INDEX` (`exit_code`),
+  CONSTRAINT `job_executions_ibfk_1` FOREIGN KEY (`id`) REFERENCES `jobs` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `job_requests`
+--
+
+DROP TABLE IF EXISTS `job_requests`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `job_requests` (
+  `id` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `name` varchar(255) NOT NULL,
+  `user` varchar(255) NOT NULL,
+  `version` varchar(255) NOT NULL,
+  `description` text,
+  `entity_version` int(11) NOT NULL DEFAULT '0',
+  `command_args` text NOT NULL,
+  `group_name` varchar(255) DEFAULT NULL,
+  `setup_file` varchar(1024) DEFAULT NULL,
+  `cluster_criterias` varchar(2048) NOT NULL,
+  `command_criteria` varchar(1024) NOT NULL,
+  `file_dependencies` text,
+  `disable_log_archival` bit(1) NOT NULL DEFAULT b'0',
+  `email` varchar(255) DEFAULT NULL,
+  `tags` varchar(2048) DEFAULT NULL,
+  `cpu` int(11) NOT NULL DEFAULT '1',
+  `memory` int(11) NOT NULL DEFAULT '1560',
+  `client_host` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `jobs`
+--
+
+DROP TABLE IF EXISTS `jobs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `jobs` (
+  `id` varchar(255) NOT NULL,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `name` varchar(255) NOT NULL,
+  `user` varchar(255) NOT NULL,
+  `version` varchar(255) NOT NULL,
+  `archive_location` varchar(1024) DEFAULT NULL,
+  `command_id` varchar(255) DEFAULT NULL,
+  `command_name` varchar(255) DEFAULT NULL,
+  `description` text,
+  `cluster_id` varchar(255) DEFAULT NULL,
+  `cluster_name` varchar(255) DEFAULT NULL,
+  `finished` datetime DEFAULT NULL,
+  `started` datetime DEFAULT NULL,
+  `status` varchar(20) NOT NULL DEFAULT 'INIT',
+  `status_msg` varchar(255) DEFAULT NULL,
+  `entity_version` int(11) NOT NULL DEFAULT '0',
+  `tags` varchar(2048) DEFAULT NULL,
+  KEY `id` (`id`),
+  KEY `cluster_id` (`cluster_id`),
+  KEY `command_id` (`command_id`),
+  KEY `JOBS_STARTED_INDEX` (`started`),
+  KEY `JOBS_FINISHED_INDEX` (`finished`),
+  KEY `JOBS_STATUS_INDEX` (`status`),
+  KEY `JOBS_USER_INDEX` (`user`),
+  KEY `JOBS_UPDATED_INDEX` (`updated`),
+  KEY `JOBS_CLUSTER_NAME_INDEX` (`cluster_name`),
+  KEY `JOBS_COMMAND_NAME_INDEX` (`command_name`),
+  KEY `JOBS_TAGS_INDEX` (`tags`),
+  CONSTRAINT `jobs_ibfk_1` FOREIGN KEY (`id`) REFERENCES `job_requests` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `jobs_ibfk_2` FOREIGN KEY (`cluster_id`) REFERENCES `clusters` (`id`),
+  CONSTRAINT `jobs_ibfk_3` FOREIGN KEY (`command_id`) REFERENCES `commands` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2016-03-16 12:24:12

--- a/genie-web/src/main/resources/application-dev.yml
+++ b/genie-web/src/main/resources/application-dev.yml
@@ -22,7 +22,7 @@ spring:
       ddl-auto: update
       naming-strategy: org.hibernate.cfg.ImprovedNamingStrategy
   datasource:
-    url: jdbc:hsqldb:mem:genie-db;hsqldb.lock_file=false;shutdown=true
+    url: jdbc:hsqldb:mem:genie-db;shutdown=true
     username: SA
     password:
 

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/ApplicationRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/ApplicationRestControllerIntegrationTests.java
@@ -195,7 +195,9 @@ public class ApplicationRestControllerIntegrationTests extends RestControllerInt
         final String version3 = UUID.randomUUID().toString();
 
         createApplication(id1, name1, user1, version1, ApplicationStatus.ACTIVE);
+        Thread.sleep(1000);
         createApplication(id2, name2, user2, version2, ApplicationStatus.DEPRECATED);
+        Thread.sleep(1000);
         createApplication(id3, name3, user3, version3, ApplicationStatus.INACTIVE);
 
         // Test finding all applications
@@ -393,12 +395,10 @@ public class ApplicationRestControllerIntegrationTests extends RestControllerInt
             .andExpect(MockMvcResultMatchers.status().isNoContent());
 
         this.mvc
-            .perform(MockMvcRequestBuilders.get(APPLICATIONS_API))
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.content().contentType(MediaTypes.HAL_JSON))
-            .andExpect(MockMvcResultMatchers.jsonPath(APPLICATIONS_LIST_PATH, Matchers.hasSize(2)))
-            .andExpect(MockMvcResultMatchers.jsonPath(APPLICATIONS_LIST_PATH + "[0].id", Matchers.is(id3)))
-            .andExpect(MockMvcResultMatchers.jsonPath(APPLICATIONS_LIST_PATH + "[1].id", Matchers.is(id1)));
+            .perform(MockMvcRequestBuilders.get(COMMANDS_API + "/" + id2))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+
+        Assert.assertThat(this.jpaApplicationRepository.count(), Matchers.is(2L));
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/ClusterRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/ClusterRestControllerIntegrationTests.java
@@ -166,7 +166,9 @@ public class ClusterRestControllerIntegrationTests extends RestControllerIntegra
         final String version3 = UUID.randomUUID().toString();
 
         createCluster(id1, name1, user1, version1, ClusterStatus.UP);
+        Thread.sleep(1000);
         createCluster(id2, name2, user2, version2, ClusterStatus.OUT_OF_SERVICE);
+        Thread.sleep(1000);
         createCluster(id3, name3, user3, version3, ClusterStatus.TERMINATED);
 
         // Test finding all clusters
@@ -357,12 +359,10 @@ public class ClusterRestControllerIntegrationTests extends RestControllerIntegra
             .andExpect(MockMvcResultMatchers.status().isNoContent());
 
         this.mvc
-            .perform(MockMvcRequestBuilders.get(CLUSTERS_API))
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.content().contentType(MediaTypes.HAL_JSON))
-            .andExpect(MockMvcResultMatchers.jsonPath(CLUSTERS_LIST_PATH, Matchers.hasSize(2)))
-            .andExpect(MockMvcResultMatchers.jsonPath(CLUSTERS_LIST_PATH + "[0].id", Matchers.is(id3)))
-            .andExpect(MockMvcResultMatchers.jsonPath(CLUSTERS_LIST_PATH + "[1].id", Matchers.is(id1)));
+            .perform(MockMvcRequestBuilders.get(CLUSTERS_API + "/" + id2))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+
+        Assert.assertThat(this.jpaClusterRepository.count(), Matchers.is(2L));
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/CommandRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/CommandRestControllerIntegrationTests.java
@@ -192,7 +192,9 @@ public class CommandRestControllerIntegrationTests extends RestControllerIntegra
         final String executable3 = UUID.randomUUID().toString();
 
         createCommand(id1, name1, user1, version1, CommandStatus.ACTIVE, executable1, CHECK_DELAY);
+        Thread.sleep(1000);
         createCommand(id2, name2, user2, version2, CommandStatus.DEPRECATED, executable2, CHECK_DELAY);
+        Thread.sleep(1000);
         createCommand(id3, name3, user3, version3, CommandStatus.INACTIVE, executable3, CHECK_DELAY);
 
         // Test finding all commands
@@ -396,12 +398,10 @@ public class CommandRestControllerIntegrationTests extends RestControllerIntegra
             .andExpect(MockMvcResultMatchers.status().isNoContent());
 
         this.mvc
-            .perform(MockMvcRequestBuilders.get(COMMANDS_API))
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.content().contentType(MediaTypes.HAL_JSON))
-            .andExpect(MockMvcResultMatchers.jsonPath(COMMANDS_LIST_PATH, Matchers.hasSize(2)))
-            .andExpect(MockMvcResultMatchers.jsonPath(COMMANDS_LIST_PATH + "[0].id", Matchers.is(id3)))
-            .andExpect(MockMvcResultMatchers.jsonPath(COMMANDS_LIST_PATH + "[1].id", Matchers.is(id1)));
+            .perform(MockMvcRequestBuilders.get(COMMANDS_API + "/" + id2))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+
+        Assert.assertThat(this.jpaCommandRepository.count(), Matchers.is(2L));
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/IntegrationTestActiveProfilesResolver.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/IntegrationTestActiveProfilesResolver.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.controllers;
+
+import org.springframework.test.context.ActiveProfilesResolver;
+
+/**
+ * A class to switch the active profiles for integration tests based on environment variables.
+ */
+public class IntegrationTestActiveProfilesResolver implements ActiveProfilesResolver {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] resolve(final Class<?> testClass) {
+        final String ciProperty = System.getProperty("CI", "false");
+        final boolean isCI = Boolean.valueOf(ciProperty);
+
+        final String[] activeProfiles;
+        if (isCI) {
+            activeProfiles = new String[]{"ci"};
+        } else {
+            activeProfiles = new String[]{"integration"};
+        }
+
+        return activeProfiles;
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
@@ -42,7 +42,6 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.hateoas.MediaTypes;
@@ -123,9 +122,6 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
     @Autowired
     private JpaClusterRepository clusterRepository;
 
-    @Value("${TRAVIS_PULL_REQUEST:false}")
-    private String isPullRequest;
-
     /**
      * Setup for tests.
      *
@@ -133,8 +129,6 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      */
     @Before
     public void setup() throws Exception {
-        log.error(this.isPullRequest);
-        Assume.assumeFalse(Boolean.valueOf(this.isPullRequest));
         super.setup();
         this.resourceLoader = new DefaultResourceLoader();
         //this.jobsBaseUrl = "http://localhost:" + this.port + "/api/v3/jobs";

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/RestControllerIntegrationTestsBase.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/RestControllerIntegrationTestsBase.java
@@ -61,7 +61,7 @@ import java.util.UUID;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = GenieWeb.class)
 @WebIntegrationTest(randomPort = true)
-@ActiveProfiles({"integration"})
+@ActiveProfiles(resolver = IntegrationTestActiveProfilesResolver.class)
 @DirtiesContext
 public abstract class RestControllerIntegrationTestsBase {
 
@@ -83,7 +83,6 @@ public abstract class RestControllerIntegrationTestsBase {
     protected static final String CONFIGS_PATH = "$.configs";
     protected static final String LINKS_PATH = "$._links";
     protected static final String EMBEDDED_PATH = "$._embedded";
-    protected static final String PAGED_PATH = "$.page";
 
     // Link Keys
     protected static final String SELF_LINK_KEY = "self";

--- a/genie-web/src/test/resources/application-ci.yml
+++ b/genie-web/src/test/resources/application-ci.yml
@@ -1,6 +1,6 @@
 ##
 #
-#  Copyright 2015 Netflix, Inc.
+#  Copyright 2016 Netflix, Inc.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
 #     you may not use this file except in compliance with the License.
@@ -22,11 +22,17 @@ genie:
       location: "file:///tmp/"
 
 spring:
-  jpa:
-    hibernate:
-      ddl-auto: update
-      naming-strategy: org.hibernate.cfg.ImprovedNamingStrategy
   datasource:
-    url: jdbc:hsqldb:mem:genie-int-db;shutdown=true
-    username: SA
+    url: jdbc:mysql://127.0.0.1/genie
+    username: root
     password:
+    min-idle: 5
+    max-idle: 20
+    max-active: 40
+    validation-query: select 0;
+    test-on-borrow: true
+    test-on-connect: true
+    test-on-return: true
+    test-while-idle: true
+    min-evictable-idle-time-millis: 60000
+    time-between-eviction-runs-millis: 10000

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -3,7 +3,7 @@
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew build -PTRAVIS_PULL_REQUEST=true
+  ./gradlew build
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
   ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build snapshot


### PR DESCRIPTION
To better represent end to end testing this PR attempts to change the database used by integration testing on the CI server to MySQL from HSQLDB.

Hopefully a side effect of this is it also fixes the issue with permissions on pull requests and lock files in the travis build.