### PR TITLE
Add entityBaseURL to SAML configuration properties

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLConfig.java
@@ -417,6 +417,9 @@ public class SAMLConfig extends WebSecurityConfigurerAdapter {
         metadataGenerator.setExtendedMetadata(extendedMetadata());
         metadataGenerator.setIncludeDiscoveryExtension(false);
         metadataGenerator.setKeyManager(keyManager());
+        if (this.samlProperties.getSp().getEntityBaseURL() != null) {
+            metadataGenerator.setEntityBaseURL(this.samlProperties.getSp().getEntityBaseURL());
+        }
         return metadataGenerator;
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLProperties.java
@@ -140,5 +140,6 @@ public class SAMLProperties {
     public static class Sp {
         @NotBlank
         private String entityId;
+        private String entityBaseURL;
     }
 }

--- a/genie-web/src/main/resources/application-dev.yml
+++ b/genie-web/src/main/resources/application-dev.yml
@@ -25,29 +25,3 @@ spring:
     url: jdbc:hsqldb:mem:genie-db;shutdown=true
     username: SA
     password:
-
-com:
-  netflix:
-    genie:
-      environment: dev
-      server:
-        janitor:
-          min:
-            sleep:
-              ms: 150000
-          max:
-            sleep:
-              ms: 300000
-          zombie:
-            delta:
-              ms: 360000
-        max:
-          running:
-            jobs: 3
-        idle:
-          host:
-            threshold:
-              delta: 1
-        forward:
-          jobs:
-            treshold: 5

--- a/genie-web/src/main/resources/application-prod.yml
+++ b/genie-web/src/main/resources/application-prod.yml
@@ -31,8 +31,3 @@ spring:
     test-while-idle: true
     min-evictable-idle-time-millis: 60000
     time-between-eviction-runs-millis: 10000
-
-com:
-  netflix:
-    genie:
-      environment: prod

--- a/genie-web/src/test/java/com/netflix/genie/web/security/saml/SAMLPropertiesUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/security/saml/SAMLPropertiesUnitTests.java
@@ -44,6 +44,7 @@ public class SAMLPropertiesUnitTests {
     private static final String DEFAULT_KEY_NAME = UUID.randomUUID().toString();
     private static final String DEFAULT_KEY_PASSWORD = UUID.randomUUID().toString();
     private static final String SP_ENTITY_ID = UUID.randomUUID().toString();
+    private static final String SP_ENTITY_BASE_URL = UUID.randomUUID().toString();
 
     private SAMLProperties properties;
 
@@ -85,6 +86,7 @@ public class SAMLPropertiesUnitTests {
 
         final SAMLProperties.Sp sp = new SAMLProperties.Sp();
         sp.setEntityId(SP_ENTITY_ID);
+        sp.setEntityBaseURL(SP_ENTITY_BASE_URL);
         this.properties.setSp(sp);
 
         Assert.assertThat(this.properties.getAttributes(), Matchers.is(attributes));
@@ -109,5 +111,6 @@ public class SAMLPropertiesUnitTests {
         );
         Assert.assertThat(this.properties.getSp(), Matchers.is(sp));
         Assert.assertThat(this.properties.getSp().getEntityId(), Matchers.is(SP_ENTITY_ID));
+        Assert.assertThat(this.properties.getSp().getEntityBaseURL(), Matchers.is(SP_ENTITY_BASE_URL));
     }
 }


### PR DESCRIPTION
entityBaseURL can be set to fixate the endpoint the SAML callbacks go to.