### PR TITLE
Support SAML behind Load Balancer or Reverse Proxy

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLProperties.java
@@ -18,6 +18,8 @@
 package com.netflix.genie.web.security.saml;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.URL;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -29,13 +31,16 @@ import javax.validation.constraints.NotNull;
 /**
  * Class to bind properties to for SAML configurations.
  *
+ * See: http://docs.spring.io/spring-security-saml/docs/1.0.x/reference/html/
+ *
  * @author tgianos
  * @since 3.0.0
  */
 @ConditionalOnProperty("genie.security.saml.enabled")
 @ConfigurationProperties(prefix = "genie.security.saml")
 @Component
-@Data
+@Getter
+@Setter
 public class SAMLProperties {
 
     @NotNull
@@ -44,6 +49,7 @@ public class SAMLProperties {
     private Idp idp;
     @NotNull
     private Keystore keystore;
+    private LoadBalancer loadBalancer;
     @NotNull
     private Sp sp;
 
@@ -53,7 +59,8 @@ public class SAMLProperties {
      * @author tgianos
      * @since 3.0.0
      */
-    @Data
+    @Getter
+    @Setter
     public static class Attributes {
 
         @NotNull
@@ -67,7 +74,8 @@ public class SAMLProperties {
          * @author tgianos
          * @since 3.0.0
          */
-        @Data
+        @Getter
+        @Setter
         public static class User {
             @NotBlank
             private String name;
@@ -79,7 +87,8 @@ public class SAMLProperties {
          * @author tgianos
          * @since 3.0.0
          */
-        @Data
+        @Getter
+        @Setter
         public static class Groups {
             @NotBlank
             private String name;
@@ -94,7 +103,8 @@ public class SAMLProperties {
      * @author tgianos
      * @since 3.0.0
      */
-    @Data
+    @Getter
+    @Setter
     public static class Idp {
         @URL
         private String serviceProviderMetadataURL;
@@ -106,7 +116,8 @@ public class SAMLProperties {
      * @author tgianos
      * @since 3.0.0
      */
-    @Data
+    @Getter
+    @Setter
     public static class Keystore {
         @NotBlank
         private String name;
@@ -131,12 +142,32 @@ public class SAMLProperties {
     }
 
     /**
+     * Information about an optional load balancer this service could sit behind.
+     *
+     * @author tgianos
+     * @since 3.0.0
+     */
+    @Getter
+    @Setter
+    public static class LoadBalancer {
+        @NotBlank
+        private String scheme = "http";
+        @NotBlank
+        private String serverName;
+        private int serverPort = 80;
+        private boolean includeServerPortInRequestURL;
+        @NotBlank
+        private String contextPath = "/";
+    }
+
+    /**
      * Information about the service provider from the IDP.
      *
      * @author tgianos
      * @since 3.0.0
      */
-    @Data
+    @Getter
+    @Setter
     public static class Sp {
         @NotBlank
         private String entityId;


### PR DESCRIPTION
This pull request adds support for authenticating via SAML while behind a load balancer or reverse proxy.

Basically implements [this](http://docs.spring.io/spring-security-saml/docs/1.0.x/reference/html/configuration-advanced.html#configuration-load-balancing).

Adds properties that can optionally be set:
```genie.security.saml.loadBalancer.scheme``` defaults to http
```genie.security.saml.loadBalancer.serverName``` no default but example www.yourdomain.com
```genie.security.saml.loadBalancer.serverPort``` defaults to 80
```genie.security.saml.loadBalancer.contextPath``` defaults to "/"
```genie.security.saml.loadBalancer.includeServerPortInRequestURL``` defaults to false

These properties correspond to the documentation mentioned above and are used to set properties in [SAMLContextProviderLB](https://github.com/spring-projects/spring-security-saml/blob/1.0.2.RELEASE/core/src/main/java/org/springframework/security/saml/context/SAMLContextProviderLB.java).

If none of these properties are found and SAML security is enabled it defaults to using [SAMLContextProviderImpl](https://github.com/spring-projects/spring-security-saml/blob/1.0.2.RELEASE/core/src/main/java/org/springframework/security/saml/context/SAMLContextProviderImpl.java).

Note that if you enable this feature you should also set ```genie.security.saml.sp.entityBaseURL``` to match the above properties. For example if you had ```scheme``` ```https```, ```serverName``` ```www.genie.com```, ```serverPort``` ```443``` you'd set ```genie.security.saml.sp.entityBaseURL``` to be ```https://www.genie.com```. You don't need to add the context path here or the port (unless you're on a non-standard port)