### PR TITLE
Add job forwarding properties

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/properties/JobForwardingProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/JobForwardingProperties.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Properties related to job forwarding.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@ConfigurationProperties(prefix = "genie.jobs.forwarding")
+@Component
+@Getter
+@Setter
+public class JobForwardingProperties {
+    private boolean enabled;
+    private String scheme = "http";
+    private int port = 8080;
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * This package contains classes which represent Spring Configuration properties for type binding and simpler usage.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie.web.properties;

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/JobForwardingPropertiesUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/JobForwardingPropertiesUnitTests.java
@@ -1,0 +1,86 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import com.netflix.genie.test.categories.UnitTest;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.UUID;
+
+/**
+ * Unit tests for JobForwardingProperties.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class JobForwardingPropertiesUnitTests {
+
+    private JobForwardingProperties properties;
+
+    /**
+     * Setup for the tests.
+     */
+    @Before
+    public void setup() {
+        this.properties = new JobForwardingProperties();
+    }
+
+    /**
+     * Test to make sure default constructor sets default values.
+     */
+    @Test
+    public void hasDefaultValues() {
+        Assert.assertFalse(this.properties.isEnabled());
+        Assert.assertThat(this.properties.getScheme(), Matchers.is("http"));
+        Assert.assertThat(this.properties.getPort(), Matchers.is(8080));
+    }
+
+    /**
+     * Make sure setting the enabled property is persisted.
+     */
+    @Test
+    public void canEnable() {
+        this.properties.setEnabled(true);
+        Assert.assertTrue(this.properties.isEnabled());
+    }
+
+    /**
+     * Make sure setting the scheme property is persisted.
+     */
+    @Test
+    public void canSetScheme() {
+        final String scheme = UUID.randomUUID().toString();
+        this.properties.setScheme(scheme);
+        Assert.assertThat(this.properties.getScheme(), Matchers.is(scheme));
+    }
+
+    /**
+     * Make sure setting the port property is persisted.
+     */
+    @Test
+    public void canSetPort() {
+        final int port = 443;
+        this.properties.setPort(port);
+        Assert.assertThat(this.properties.getPort(), Matchers.is(port));
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/package-info.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Tests for properties clases.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie.web.properties;


### PR DESCRIPTION
This pull request adds the properties ```genie.jobs.forwarding.scheme``` and ```genie.jobs.forwarding.port``` to Genie. They have default values of ```http``` and ```8080``` by default. 

It was discovered that during testing behind ELB the Spring SAML library after successful login was trying to forward the user to ```request.getScheme() + host info + request.getServerPort() + other info```. This information for ```request.getSomething``` comes from the Tomcat connector configuration. See [here](https://tomcat.apache.org/tomcat-8.0-doc/config/http.html#Proxy_Support) for how to configure Tomcat behind a proxy/ELB. Once these settings (```proxyName```, ```proxyPort``` and ```scheme```) where changed on the Tomcat connector SAML worked well behind Load Balancer with other previous changes in #212.

The problem came that our logic for forwarding job output and job kill requests also used the request.getScheme and request.getPort methods. Once the Tomcat connector changed these would return invalid values for attempting to forward directly between backend Genie nodes rather than back through the Load Balancer (user facing). The properties introduced here will be used if job forwarding is enabled instead. They represent the true scheme of the Tomcat servers and their actual running port rather than the scheme and port of the ELB/proxy. Shouldn't have to change anything if user isn't running behind a proxy.