### PR TITLE
Add logging libraries to common classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,8 +105,6 @@ subprojects {
          * Compile Dependencies
          *******************************/
 
-        compile("org.apache.commons:commons-lang3")
-
         /*******************************
          * Provided Dependencies
          *******************************/

--- a/genie-common/build.gradle
+++ b/genie-common/build.gradle
@@ -3,14 +3,11 @@ dependencies {
      * Compile Dependencies
      *******************************/
 
-    // Guava
-    compile("com.google.guava:guava")
-
-    // Hibernate Validator Libs
-    compile("org.hibernate:hibernate-validator")
-
-    // Jackson
     compile("com.fasterxml.jackson.core:jackson-databind")
+    compile("com.google.guava:guava")
+    compile("org.apache.commons:commons-lang3")
+    compile("org.hibernate:hibernate-validator")
+    compile("org.springframework.boot:spring-boot-starter-logging")
 
     /*******************************
      * Provided Dependencies


### PR DESCRIPTION
This PR simply adds spring-boot-starter-logging to the compile class path of Genie common. This allows all projects to find a binding for using ```@Slf4j``` in code at compile time via lombok.