### PR TITLE
Generated HTML is Truncated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_script:
   - mysql -u root -e 'create database genie;'
   - mysql -u root genie < genie-ddl/mysql/3.0.0-schema.mysql.sql
 
-#script: travis_wait 40 "./gradle/buildViaTravis.sh"
-script: "./gradle/buildViaTravis.sh"
+script: travis_wait 40 ./gradle/buildViaTravis.sh
+#script: "./gradle/buildViaTravis.sh"
 
 # https://docs.travis-ci.com/user/languages/java#Caching
 before_cache:
@@ -45,6 +45,6 @@ env:
     - secure: EQtZL4/gipYNu+YoDuElpowOpak7r9BLgUQ1UE6TAWGHepqp76S6pR8drlwWZDzv8YrP7Ze+QrNZqErKFieDneOTVOhoOqc8YAAd0qV3h8hmmo3xUHNR3CdPErc9QvfxHyZ7yO4+mCW6FP77tKzHVRm2VjkjMIhJBqGmA240Mq4=
     - secure: HKTf4wmQwXXMduNACwvQ4PSHMIs8DaE3bOMJoS3hx7WpalhqCKoa9vdcCtId4ZIVaY+KJoXRV4H11IYQNcvcagwJ6q5C7NhpYSu/GohpXFpzseIaB8oCC1RKzJCf0oGCMhs3WnNOGhpg/zFj2I+3PGMMaJIdlBG6D0ObLV7BIQs=
 
-notifications:
-  slack:
-    secure: H5nS+GX6TYTU27ur6YFG5OgrQeUbzXLok5ub6+xcmyYEeVPpnQ1Gg/wKqTAGsP9j6tAkqPpxgYT9i9Do6eyTEplK6bTvQVyhilsEDtxGJbUO8XOE9TSo6jAe/lD3EB5l46gxFID+Hg9IkPii4LwEabP7PVehrB1JfNZ6QDgSRRM=
+#notifications:
+#  slack:
+#    secure: H5nS+GX6TYTU27ur6YFG5OgrQeUbzXLok5ub6+xcmyYEeVPpnQ1Gg/wKqTAGsP9j6tAkqPpxgYT9i9Do6eyTEplK6bTvQVyhilsEDtxGJbUO8XOE9TSo6jAe/lD3EB5l46gxFID+Hg9IkPii4LwEabP7PVehrB1JfNZ6QDgSRRM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 git:
   depth: 100
 
-install: "./gradle/installViaTravis.sh"
+install: travis_wait "./gradle/installViaTravis.sh"
 
 # Setup the database for the integration tests
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ services:
 git:
   depth: 100
 
-install: travis_wait "./gradle/installViaTravis.sh"
+install: "./gradle/installViaTravis.sh"
 
 # Setup the database for the integration tests
 before_script:
   - mysql -u root -e 'create database genie;'
   - mysql -u root genie < genie-ddl/mysql/3.0.0-schema.mysql.sql
 
-script: "./gradle/buildViaTravis.sh"
+script: travis_wait "./gradle/buildViaTravis.sh"
 
 # https://docs.travis-ci.com/user/languages/java#Caching
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
   - mysql
 
 git:
-  depth: 100
+  depth: 200
 
 install: "./gradle/installViaTravis.sh"
 
@@ -24,7 +24,8 @@ before_script:
   - mysql -u root -e 'create database genie;'
   - mysql -u root genie < genie-ddl/mysql/3.0.0-schema.mysql.sql
 
-script: travis_wait 40 "./gradle/buildViaTravis.sh"
+#script: travis_wait 40 "./gradle/buildViaTravis.sh"
+script: "./gradle/buildViaTravis.sh"
 
 # https://docs.travis-ci.com/user/languages/java#Caching
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - mysql -u root -e 'create database genie;'
   - mysql -u root genie < genie-ddl/mysql/3.0.0-schema.mysql.sql
 
-script: travis_wait "./gradle/buildViaTravis.sh"
+script: travis_wait 40 "./gradle/buildViaTravis.sh"
 
 # https://docs.travis-ci.com/user/languages/java#Caching
 before_cache:

--- a/genie-web/src/main/java/com/netflix/genie/web/resources/writers/DefaultDirectoryWriter.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/resources/writers/DefaultDirectoryWriter.java
@@ -69,15 +69,15 @@ public class DefaultDirectoryWriter implements DirectoryWriter {
 
         // Render the page header
         builder.append("<!DOCTYPE html>");
-        builder.append("<html>\r\n");
-        builder.append("<head>\r\n");
+        builder.append("<html>");
+        builder.append("<head>");
         builder.append("<title>");
         builder.append(directory.getName());
-        builder.append("</title>\r\n");
+        builder.append("</title>");
         builder.append("<style type=\"text/css\"><!--");
         builder.append(DEFAULT_CSS);
         builder.append("--></style> ");
-        builder.append("</head>\r\n");
+        builder.append("</head>");
 
         // Body
         builder.append("<body>");
@@ -85,19 +85,19 @@ public class DefaultDirectoryWriter implements DirectoryWriter {
 
         builder.append("<HR size=\"1\" noshade=\"noshade\">");
 
-        builder.append("<table width=\"100%\" cellspacing=\"0\"" + " cellpadding=\"5\" align=\"center\">\r\n");
+        builder.append("<table width=\"100%\" cellspacing=\"0\"" + " cellpadding=\"5\" align=\"center\">");
 
         // Render the column headings
-        builder.append("<tr>\r\n");
+        builder.append("<tr>");
         builder.append("<td align=\"left\"><font size=\"+1\"><strong>");
         builder.append("Filename");
-        builder.append("</strong></font></td>\r\n");
+        builder.append("</strong></font></td>");
         builder.append("<td align=\"right\"><font size=\"+1\"><strong>");
         builder.append("Size");
-        builder.append("</strong></font></td>\r\n");
+        builder.append("</strong></font></td>");
         builder.append("<td align=\"right\"><font size=\"+1\"><strong>");
         builder.append("Last Modified");
-        builder.append("</strong></font></td>\r\n");
+        builder.append("</strong></font></td>");
         builder.append("</tr>");
 
         // Write parent if necessary
@@ -124,13 +124,13 @@ public class DefaultDirectoryWriter implements DirectoryWriter {
         }
 
         // Render the page footer
-        builder.append("</table>\r\n");
+        builder.append("</table>");
 
         builder.append("<HR size=\"1\" noshade=\"noshade\">");
         // TODO: replace with something related to Genie
         builder.append("<h3>").append(ServerInfo.getServerInfo()).append("</h3>");
-        builder.append("</body>\r\n");
-        builder.append("</html>\r\n");
+        builder.append("</body>");
+        builder.append("</html>");
 
         return builder.toString();
     }
@@ -169,15 +169,17 @@ public class DefaultDirectoryWriter implements DirectoryWriter {
         if (shade) {
             builder.append(" bgcolor=\"#eeeeee\"");
         }
-        builder.append(">\r\n");
+        builder.append(">");
 
-        builder.append("<td align=\"left\">&nbsp;&nbsp;\r\n");
+        builder.append("<td align=\"left\">&nbsp;&nbsp;");
         builder.append("<a href=\"").append(entry.getUrl()).append("\">");
-        builder.append("<tt>").append(entry.getName()).append("</tt></a></td>\r\n");
-        builder.append("<td align=\"right\"><tt>").append(this.renderSize(entry.getSize())).append("</tt></td>\r\n");
+        builder.append("<tt>").append(entry.getName()).append("</tt></a></td>");
+        builder
+            .append("<td align=\"right\"><tt>")
+            .append(this.renderSize(entry.getSize())).append("</tt></td>");
         final String lastModified = ConcurrentDateFormat.formatRfc1123(new Date(entry.getLastModified()));
-        builder.append("<td align=\"right\"><tt>").append(lastModified).append("</tt></td>\r\n");
-        builder.append("</tr>\r\n");
+        builder.append("<td align=\"right\"><tt>").append(lastModified).append("</tt></td>");
+        builder.append("</tr>");
     }
 
     protected Directory getDirectory(final File directory, final String requestUrl, final boolean includeParent) {

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
@@ -43,6 +43,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -391,6 +392,7 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
+    @Ignore
     @Test
     public void testSubmitJobMethodSuccess() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -626,6 +628,7 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
+    @Ignore
     @Test
     public void testSubmitJobMethodMissingCluster() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -669,6 +672,7 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
+    @Ignore
     @Test
     public void testSubmitJobMethodMissingCommand() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -711,6 +715,7 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
+    @Ignore
     @Test
     public void testSubmitJobMethodKill() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -782,6 +787,7 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
+    @Ignore
     @Test
     public void testSubmitJobMethodKillOnTimeout() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -848,6 +854,7 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
+    @Ignore
     @Test
     public void testSubmitJobMethodFailure() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
@@ -43,7 +43,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -392,7 +391,6 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
-    @Ignore
     @Test
     public void testSubmitJobMethodSuccess() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -628,7 +626,6 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
-    @Ignore
     @Test
     public void testSubmitJobMethodMissingCluster() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -672,7 +669,6 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
-    @Ignore
     @Test
     public void testSubmitJobMethodMissingCommand() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -715,7 +711,6 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
-    @Ignore
     @Test
     public void testSubmitJobMethodKill() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -787,7 +782,6 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
-    @Ignore
     @Test
     public void testSubmitJobMethodKillOnTimeout() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
@@ -854,7 +848,6 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      *
      * @throws Exception If there is a problem.
      */
-    @Ignore
     @Test
     public void testSubmitJobMethodFailure() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);


### PR DESCRIPTION
This pull request fixes an issue where the generated HTML from getting a job output was being truncated on Linux behind Apache.

To fix this issue all line breaks (```\r\n```) were removed. Will send less across the wire anyway.