### PR TITLE
Can't run job as a user due to group and permission issues.

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/JobConstants.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/JobConstants.java
@@ -129,7 +129,10 @@ public final class JobConstants {
      **/
     public static final String GENIE_LOG_PATH = "/genie/logs/genie.log";
 
-
+    /**
+     * Genie env file path.
+     **/
+    public static final String GENIE_ENV_PATH = "/genie/logs/env.log";
 
     /**
      * File Path prefix to be used while creating directories for application files to local dir.

--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTask.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTask.java
@@ -158,9 +158,23 @@ public class JobKickoffTask extends GenieBaseTask {
 
         try {
             this.executor.execute(idCheckCommandLine);
-            log.info("User already exists");
+            log.debug("User already exists");
         } catch (IOException ioe) {
-            log.info("User does not exist. Creating it now.");
+            log.debug("User does not exist. Creating it now.");
+
+            // Create the group for the user.
+            final CommandLine groupCreateCommandLine = new CommandLine("sudo");
+            groupCreateCommandLine.addArgument("groupadd");
+            groupCreateCommandLine.addArgument(group);
+
+            // We create the group and ignore the error as it will fail if group already exists.
+            // If the failure is due to some other reason, then user creation will fail and we catch that.
+            try {
+                this.executor.execute(groupCreateCommandLine);
+            } catch (IOException ioexception) {
+                log.debug("Group creation  threw an error as it might already exist");
+            }
+
             final CommandLine userCreateCommandLine = new CommandLine("sudo");
             userCreateCommandLine.addArgument("useradd");
             userCreateCommandLine.addArgument(user);
@@ -191,10 +205,8 @@ public class JobKickoffTask extends GenieBaseTask {
         final String dir,
         final String user) throws GenieException {
 
-        final CommandLine commandLine = new CommandLine("chown");
-        // Don;t need sudo probably as the genie user is the one creating the working directory.
-        //command.add("sudo");
-        //command.add("chown");
+        final CommandLine commandLine = new CommandLine("sudo");
+        commandLine.addArgument("chown");
         commandLine.addArgument("-R");
         commandLine.addArgument(user);
         commandLine.addArgument(dir);

--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobTask.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobTask.java
@@ -94,6 +94,13 @@ public class JobTask extends GenieBaseTask {
             jobExecEnv.getJobRequest().getId(),
             jobExecEnv.getJobWorkingDir());
 
+        // Print out the current Envrionment to a env file before running the command.
+        writer.write("# Dump the environment to a env.log file" + System.lineSeparator());
+        writer.write("env > " + "${"
+            + JobConstants.GENIE_JOB_DIR_ENV_VAR + "}"
+            + JobConstants.GENIE_ENV_PATH
+            + System.lineSeparator());
+
         // Append new line
         writer.write(System.lineSeparator());
 

--- a/genie-core/src/test/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTaskUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTaskUnitTests.java
@@ -74,7 +74,7 @@ public class JobKickoffTaskUnitTests {
         final String user = "user";
         final String dir = "dir";
         final ArgumentCaptor<CommandLine> argumentCaptor = ArgumentCaptor.forClass(CommandLine.class);
-        final List<String> command = Arrays.asList("chown", "-R", user, dir);
+        final List<String> command = Arrays.asList("sudo", "chown", "-R", user, dir);
 
         this.jobKickoffTask.changeOwnershipOfDirectory(
             dir,
@@ -155,8 +155,8 @@ public class JobKickoffTaskUnitTests {
             log.debug("Ignoring exception to capture arguments.");
         }
 
-        Mockito.verify(this.executor, Mockito.times(2)).execute(argumentCaptor.capture());
-        Assert.assertArrayEquals(command.toArray(), argumentCaptor.getAllValues().get(1).toStrings());
+        Mockito.verify(this.executor, Mockito.times(3)).execute(argumentCaptor.capture());
+        Assert.assertArrayEquals(command.toArray(), argumentCaptor.getAllValues().get(2).toStrings());
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionHandler.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionHandler.java
@@ -193,7 +193,11 @@ public class JobCompletionHandler {
 
                 // Create the tar file exluding the run.sh file and everything under the genie directory
                 final String jobWorkingDir = this.baseWorkingDir + JobConstants.FILE_PATH_DELIMITER + jobId;
-                final String localArchiveFile = jobWorkingDir + JobConstants.FILE_PATH_DELIMITER + jobId + ".tar.gz";
+                final String localArchiveFile = jobWorkingDir
+                    + JobConstants.FILE_PATH_DELIMITER
+                    + "genie/logs/"
+                    + jobId
+                    + ".tar.gz";
 
                 final CommandLine commandLine = new CommandLine("tar");
                 commandLine.addArgument("-c");

--- a/genie-web/src/test/resources/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests/linux-runsh.txt
+++ b/genie-web/src/test/resources/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests/linux-runsh.txt
@@ -77,6 +77,8 @@ source ${GENIE_JOB_DIR}/genie/command/cmd1/setupfile
 # Sourcing setup file specified in job request
 source ${GENIE_JOB_DIR}/jobsetupfile
 
+# Dump the environment to a env.log file
+env > ${GENIE_JOB_DIR}/genie/logs/env.log
 
 # Kick off the command in background mode and wait for it using its pid
 /bin/bash -c 'echo hello world' > stdout 2> stderr &

--- a/genie-web/src/test/resources/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests/non-linux-runsh.txt
+++ b/genie-web/src/test/resources/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests/non-linux-runsh.txt
@@ -77,6 +77,8 @@ source ${GENIE_JOB_DIR}/genie/command/cmd1/setupfile
 # Sourcing setup file specified in job request
 source ${GENIE_JOB_DIR}/jobsetupfile
 
+# Dump the environment to a env.log file
+env > ${GENIE_JOB_DIR}/genie/logs/env.log
 
 # Kick off the command in background mode and wait for it using its pid
 /bin/bash -c 'echo hello world' > stdout 2> stderr &


### PR DESCRIPTION
* While running the job as a user, the job submission failed if the group did not exist. This fix creates the group before user creation.
* The permissions for the log directory need to be modified to write to the genie.log directory.
* Dump the environment to a env.log file before launching the job.
* Move the archive tar to the logs directory.
