### PR TITLE
Limit output file lengths

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/properties/JobOutputMaxProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/JobOutputMaxProperties.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import javax.validation.constraints.Min;
+
+/**
+ * Properties related to the maximum length of certain job related files.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@ConfigurationProperties(prefix = "genie.jobs.output.max")
+@Component
+@Getter
+@Setter
+public class JobOutputMaxProperties {
+    @Min(1L)
+    private long stdOut = 8589934592L;
+    @Min(1L)
+    private long stdErr = 8589934592L;
+}

--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -25,18 +25,26 @@ eureka:
 
 genie:
   jobs:
+    archive:
+      location: base_archival_location_path
     createuser:
       enabled: false
     dir:
       location: file:///tmp/genie/jobs/
     forwarding:
       enabled: true
+    output:
+      max:
+        stdOut: 8589934592
+        stdErr: 8589934592
     runasuser:
       enabled: false
-    archive:
-      location: base_archival_location_path
   leader:
     enabled: false
+  mail:
+    fromAddress: no-reply-genie@geniehost.com
+    #user:
+    #password:
   redis:
     enabled: false
   security:
@@ -54,10 +62,6 @@ genie:
   tasks:
     pool:
       size: 10
-  mail:
-    fromAddress: no-reply-genie@geniehost.com
-    #user:
-    #password:
 
 management:
   context-path: /actuator

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/JobOutputMaxPropertiesUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/JobOutputMaxPropertiesUnitTests.java
@@ -1,0 +1,74 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import com.netflix.genie.test.categories.UnitTest;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Unit tests for JobOutputMaxProperties.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class JobOutputMaxPropertiesUnitTests {
+
+    private JobOutputMaxProperties properties;
+
+    /**
+     * Setup for the tests.
+     */
+    @Before
+    public void setup() {
+        this.properties = new JobOutputMaxProperties();
+    }
+
+    /**
+     * Make sure the default properties are set.
+     */
+    @Test
+    public void canConstruct() {
+        Assert.assertThat(this.properties.getStdOut(), Matchers.is(8589934592L));
+        Assert.assertThat(this.properties.getStdErr(), Matchers.is(8589934592L));
+    }
+
+    /**
+     * Make sure can set and get the std out variable.
+     */
+    @Test
+    public void canSetStdOut() {
+        final long newStdOut = 180234L;
+        this.properties.setStdOut(newStdOut);
+        Assert.assertThat(this.properties.getStdOut(), Matchers.is(newStdOut));
+    }
+
+    /**
+     * Make sure can set and get the std err variable.
+     */
+    @Test
+    public void canSetStdErr() {
+        final long newStdErr = 180234L;
+        this.properties.setStdErr(newStdErr);
+        Assert.assertThat(this.properties.getStdErr(), Matchers.is(newStdErr));
+    }
+}


### PR DESCRIPTION
This pull request adds support for limiting the length of the standard job output files (stdout and stderr). This is accomplished by checking these file lengths every time the JobMonitor run method is invoked so it is possible for the output files to pass the threshold but it shouldn't be by too much. Admins should set the properties low enough to account for some buffer between check time and data generation. ```genie.jobs.output.max.stdOut``` and ```genie.jobs.output.max.stdErr``` are properties that can be used to set the limits. Both default to 8 GB. Values of the properties should be in bytes.