### PR TITLE
Handle content requests longer than 2147483647 bytes

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/resources/handlers/GenieResourceHttpRequestHandler.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/resources/handlers/GenieResourceHttpRequestHandler.java
@@ -25,7 +25,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
 import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.resource.EncodedResource;
 import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
+import org.springframework.web.servlet.resource.VersionedResource;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -51,6 +53,8 @@ public class GenieResourceHttpRequestHandler extends ResourceHttpRequestHandler 
         = GenieResourceHttpRequestHandler.class.getName() + ".isRootDirectory";
 
     private static final Charset UTF_8 = Charset.forName("UTF-8");
+    private static final String CONTENT_LENGTH = "Content-Length";
+    private static final String BYTES = "bytes";
 
     private DirectoryWriter directoryWriter;
 
@@ -127,5 +131,34 @@ public class GenieResourceHttpRequestHandler extends ResourceHttpRequestHandler 
         } else {
             super.handleRequest(request, response);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Overriding this method so can handle content lengths greater than Integer.MAX_VALUE.
+     */
+    @Override
+    protected void setHeaders(
+        final HttpServletResponse response,
+        final Resource resource,
+        final MediaType mediaType
+    ) throws IOException {
+        // Note: This API call is only in Servlet spec 3.1+ (Tomcat 8.x or greater)
+        // This is to get around the resources with content lengths greater than Integer.MAX_VALUE which was limiting
+        // our ability to serve large files
+        response.setContentLengthLong(resource.contentLength());
+
+        // The rest of this is taken directly from the super implementation
+        if (mediaType != null) {
+            response.setContentType(mediaType.toString());
+        }
+        if (resource instanceof EncodedResource) {
+            response.setHeader(HttpHeaders.CONTENT_ENCODING, ((EncodedResource) resource).getContentEncoding());
+        }
+        if (resource instanceof VersionedResource) {
+            response.setHeader(HttpHeaders.ETAG, "\"" + ((VersionedResource) resource).getVersion() + "\"");
+        }
+        response.setHeader(HttpHeaders.ACCEPT_RANGES, BYTES);
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/resources/handlers/GenieResourceHttpRequestHandlerUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/resources/handlers/GenieResourceHttpRequestHandlerUnitTests.java
@@ -261,4 +261,30 @@ public class GenieResourceHttpRequestHandlerUnitTests {
 
         this.handler.handleRequest(request, response);
     }
+
+    /**
+     * Make sure we can use the overridden set headers method properly for large file sizes.
+     *
+     * @throws IOException on error
+     */
+    @Test
+    public void canSetHeaders() throws IOException {
+        final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        final Resource resource = Mockito.mock(Resource.class);
+        final MediaType mediaType = MediaType.APPLICATION_OCTET_STREAM;
+
+        final long justRight = (long) Integer.MAX_VALUE;
+        final long tooLong = (long) Integer.MAX_VALUE + 1;
+        Mockito
+            .when(resource.contentLength())
+            .thenReturn(justRight)
+            .thenReturn(tooLong);
+
+        this.handler.setHeaders(response, resource, mediaType);
+        this.handler.setHeaders(response, resource, null);
+
+        Mockito.verify(response, Mockito.times(1)).setContentLengthLong(justRight);
+        Mockito.verify(response, Mockito.times(1)).setContentLengthLong(tooLong);
+        Mockito.verify(response, Mockito.times(1)).setContentType(Mockito.anyString());
+    }
 }


### PR DESCRIPTION
There is a limitation in the ```ResourceHttpRequestHandler``` from Spring where the setHeader method limits the content length to Integer.MAX_VALUE (2147483647) bytes.

```java
	protected void setHeaders(HttpServletResponse response, Resource resource, MediaType mediaType) throws IOException {
		long length = resource.contentLength();
		if (length > Integer.MAX_VALUE) {
			throw new IOException("Resource content too long (beyond Integer.MAX_VALUE): " + resource);
		}
		response.setContentLength((int) length);
		...
	}
```
This looks to mostly be a limitation of the pre 3.1 servlet specification for setContentLength. People got around it by setting the ```Content-Length``` header directly as a string instead of an integer. Servlet specification 3.1+ has a ```setContentLengthLong``` API. Since Genie 3 uses Tomcat 8 embedded this API is available to us. As such if someone recompiles Genie as a war to run in Tomcat 7 or earlier this will break. We could patch to use If/Else at that point but I currently don't see issue going with Tomcat 8 as baseline as it is already mature and most people are moving up from 7 at this point.