### PR TITLE
Add ability to kill jobs when run as user

### DIFF
--- a/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
@@ -170,7 +170,7 @@ public class ServicesConfigTest {
         final JobSearchService jobSearchService,
         final Executor executor
     ) {
-        return new LocalJobKillServiceImpl(hostname, jobSearchService, executor);
+        return new LocalJobKillServiceImpl(hostname, jobSearchService, executor, false);
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -255,7 +255,6 @@ public class ServicesConfigUnitTests {
         Assert.assertNotNull(
             this.servicesConfig.jobCoordinatorService(
                 jobPersistenceService,
-                this.jobSearchService,
                 jobSubmitterService,
                 jobKillService,
                 "file:///tmp"
@@ -272,7 +271,8 @@ public class ServicesConfigUnitTests {
             this.servicesConfig.jobKillService(
                 "localhost",
                 this.jobSearchService,
-                Mockito.mock(Executor.class)
+                Mockito.mock(Executor.class),
+                true
             )
         );
     }


### PR DESCRIPTION
This PR adds/fixes the ability to kill jobs when the ```genie.jobs.runasuser.enabled``` setting is true. Before it would fail but now it runs using sudo and succeeds.