### PR TITLE
Add runtime field to Job and JobSearchResult returns

### DIFF
--- a/genie-client/src/test/java/com/netflix/genie/client/GenieClientsIntegrationTestsBase.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/GenieClientsIntegrationTestsBase.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.genie.client;
 
 import com.netflix.genie.GenieWeb;

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
@@ -22,10 +22,12 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.netflix.genie.common.util.JsonDateDeserializer;
 import com.netflix.genie.common.util.JsonDateSerializer;
+import com.netflix.genie.common.util.TimeUtils;
 import lombok.Getter;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.time.Duration;
 import java.util.Date;
 
 /**
@@ -56,6 +58,8 @@ public class Job extends CommonDTO {
     private final String clusterName;
     @Size(max = 255, message = "Max character length is 255 characters")
     private final String commandName;
+    @NotNull
+    private final Duration runtime;
 
     /**
      * Constructor used by the builder.
@@ -72,6 +76,8 @@ public class Job extends CommonDTO {
         this.archiveLocation = builder.bArchiveLocation;
         this.clusterName = builder.bClusterName;
         this.commandName = builder.bCommandName;
+
+        this.runtime = TimeUtils.getDuration(this.started, this.finished);
     }
 
     /**

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/search/JobSearchResult.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/search/JobSearchResult.java
@@ -22,11 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.util.JsonDateSerializer;
+import com.netflix.genie.common.util.TimeUtils;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.hibernate.validator.constraints.NotBlank;
 
 import javax.validation.constraints.NotNull;
+import java.time.Duration;
 import java.util.Date;
 
 /**
@@ -48,6 +50,7 @@ public class JobSearchResult extends BaseSearchResult {
     private final Date finished;
     private final String clusterName;
     private final String commandName;
+    private final Duration runtime;
 
     /**
      * Constructor.
@@ -78,6 +81,8 @@ public class JobSearchResult extends BaseSearchResult {
         this.finished = finished == null ? null : new Date(finished.getTime());
         this.clusterName = clusterName;
         this.commandName = commandName;
+
+        this.runtime = TimeUtils.getDuration(this.started, this.finished);
     }
 
     /**

--- a/genie-common/src/main/java/com/netflix/genie/common/util/TimeUtils.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/util/TimeUtils.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.util;
+
+import java.time.Duration;
+import java.util.Date;
+
+/**
+ * Utility methods for dealing with time. Particularly duration.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+public final class TimeUtils {
+
+    /**
+     * Protected constructor for utility class.
+     */
+    protected TimeUtils() {
+    }
+
+    /**
+     * Get the duration between when something was started and finished.
+     *
+     * @param started  The start time. Can be null will automatically set the duration to 0
+     * @param finished The finish time. If null will use (current time - started time) to get the duration
+     * @return The duration or zero if no duration
+     */
+    public static Duration getDuration(final Date started, final Date finished) {
+        if (started == null || started.getTime() == 0) {
+            // Never started
+            return Duration.ZERO;
+        } else if (finished == null || finished.getTime() == 0) {
+            // Started but hasn't finished
+            return Duration.ofMillis(new Date().getTime() - started.getTime());
+        } else {
+            // Started and finished
+            return Duration.ofMillis(finished.getTime() - started.getTime());
+        }
+    }
+}

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/JobUnitTests.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/JobUnitTests.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
@@ -64,6 +65,7 @@ public class JobUnitTests {
         Assert.assertThat(job.getId(), Matchers.nullValue());
         Assert.assertThat(job.getTags(), Matchers.empty());
         Assert.assertThat(job.getUpdated(), Matchers.nullValue());
+        Assert.assertThat(job.getRuntime(), Matchers.is(Duration.ZERO));
     }
 
     /**
@@ -129,6 +131,7 @@ public class JobUnitTests {
         Assert.assertThat(job.getId(), Matchers.is(id));
         Assert.assertThat(job.getTags(), Matchers.is(tags));
         Assert.assertThat(job.getUpdated(), Matchers.is(updated));
+        Assert.assertThat(job.getRuntime(), Matchers.is(Duration.ofMillis(finished.getTime() - started.getTime())));
     }
 
     /**
@@ -167,6 +170,7 @@ public class JobUnitTests {
         Assert.assertThat(job.getId(), Matchers.nullValue());
         Assert.assertThat(job.getTags(), Matchers.empty());
         Assert.assertThat(job.getUpdated(), Matchers.nullValue());
+        Assert.assertThat(job.getRuntime(), Matchers.is(Duration.ZERO));
     }
 
     /**

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/search/JobSearchResultUnitTests.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/search/JobSearchResultUnitTests.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
 
@@ -60,6 +61,10 @@ public class JobSearchResultUnitTests {
         Assert.assertThat(searchResult.getFinished(), Matchers.is(finished));
         Assert.assertThat(searchResult.getClusterName(), Matchers.is(clusterName));
         Assert.assertThat(searchResult.getCommandName(), Matchers.is(commandName));
+        Assert.assertThat(
+            searchResult.getRuntime(),
+            Matchers.is(Duration.ofMillis(finished.getTime() - started.getTime()))
+        );
 
         final JobSearchResult searchResult2 = new JobSearchResult(id, name, user, status, null, null, null, null);
 
@@ -71,5 +76,6 @@ public class JobSearchResultUnitTests {
         Assert.assertNull(searchResult2.getFinished());
         Assert.assertNull(searchResult2.getClusterName());
         Assert.assertNull(searchResult2.getCommandName());
+        Assert.assertThat(searchResult2.getRuntime(), Matchers.is(Duration.ZERO));
     }
 }

--- a/genie-common/src/test/java/com/netflix/genie/common/util/TimeUtilsUnitTests.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/util/TimeUtilsUnitTests.java
@@ -1,0 +1,65 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.util;
+
+import com.netflix.genie.test.categories.UnitTest;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.time.Duration;
+import java.util.Date;
+
+/**
+ * Unit tests for TimeUtils.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class TimeUtilsUnitTests {
+
+    /**
+     * Just ignore the constructor.
+     */
+    @Test
+    public void canConstruct() {
+        Assert.assertNotNull(new TimeUtils());
+    }
+
+    /**
+     * Can get the duration for various cases.
+     */
+    @Test
+    public void canGetDuration() {
+        final Date epoch = new Date(0);
+        final long durationMillis = 50823L;
+        final Duration duration = Duration.ofMillis(durationMillis);
+        final Date started = new Date();
+        final Date finished = new Date(started.getTime() + durationMillis);
+
+        Assert.assertThat(TimeUtils.getDuration(null, finished), Matchers.is(Duration.ZERO));
+        Assert.assertThat(TimeUtils.getDuration(epoch, finished), Matchers.is(Duration.ZERO));
+
+        Assert.assertNotNull(TimeUtils.getDuration(started, null));
+        Assert.assertNotNull(TimeUtils.getDuration(started, epoch));
+
+        Assert.assertThat(TimeUtils.getDuration(started, finished), Matchers.is(duration));
+    }
+}


### PR DESCRIPTION
Adding a runtime field to the Job and JobSearchResult DTO's which is calculated from the started and finished time of the job. The field is a Duration type which when serialized will come back in [ISO-8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations).

Will finally close #59. 