### PR TITLE
JSON serialization uses toString of Duration class for ISO 8601 standard duration output

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
@@ -20,6 +20,7 @@ package com.netflix.genie.common.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.netflix.genie.common.util.JsonDateDeserializer;
 import com.netflix.genie.common.util.JsonDateSerializer;
 import com.netflix.genie.common.util.TimeUtils;
@@ -59,6 +60,7 @@ public class Job extends CommonDTO {
     @Size(max = 255, message = "Max character length is 255 characters")
     private final String commandName;
     @NotNull
+    @JsonSerialize(using = ToStringSerializer.class)
     private final Duration runtime;
 
     /**

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/search/JobSearchResult.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/search/JobSearchResult.java
@@ -20,6 +20,7 @@ package com.netflix.genie.common.dto.search;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.util.JsonDateSerializer;
 import com.netflix.genie.common.util.TimeUtils;
@@ -50,6 +51,7 @@ public class JobSearchResult extends BaseSearchResult {
     private final Date finished;
     private final String clusterName;
     private final String commandName;
+    @JsonSerialize(using = ToStringSerializer.class)
     private final Duration runtime;
 
     /**


### PR DESCRIPTION
Changing the JSON serialization of the duration fields to use toString which uses the ISO 8601 format

Fixes the serialization in #237 which serialized all the fields rather than a condensed ISO format.