### PR TITLE
Add ability to proxy requests for job output files through UI SAML flow

### DIFF
--- a/genie-docs/src/test/java/com/netflix/genie/docs/ApplicationRestDocs.java
+++ b/genie-docs/src/test/java/com/netflix/genie/docs/ApplicationRestDocs.java
@@ -397,7 +397,7 @@ public class ApplicationRestDocs {
                     .description("The found applications."),
                 PayloadDocumentation
                     .fieldWithPath("_links")
-                    .description("<<resources-getIndex-links,Links>> to other resources."),
+                    .description("<<resources-index-links,Links>> to other resources."),
                 PayloadDocumentation
                     .fieldWithPath("page")
                     .description("The result page information."),
@@ -506,7 +506,7 @@ public class ApplicationRestDocs {
             descriptors.add(
                 PayloadDocumentation
                     .fieldWithPath("_links")
-                    .description("<<resources-getIndex-links,Links>> to other resources")
+                    .description("<<resources-index-links,Links>> to other resources")
             );
         }
 

--- a/genie-docs/src/test/java/com/netflix/genie/docs/ApplicationRestDocs.java
+++ b/genie-docs/src/test/java/com/netflix/genie/docs/ApplicationRestDocs.java
@@ -397,7 +397,7 @@ public class ApplicationRestDocs {
                     .description("The found applications."),
                 PayloadDocumentation
                     .fieldWithPath("_links")
-                    .description("<<resources-index-links,Links>> to other resources."),
+                    .description("<<resources-getIndex-links,Links>> to other resources."),
                 PayloadDocumentation
                     .fieldWithPath("page")
                     .description("The result page information."),
@@ -506,7 +506,7 @@ public class ApplicationRestDocs {
             descriptors.add(
                 PayloadDocumentation
                     .fieldWithPath("_links")
-                    .description("<<resources-index-links,Links>> to other resources")
+                    .description("<<resources-getIndex-links,Links>> to other resources")
             );
         }
 

--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 dependencies {
     /*******************************
      * Compile Dependencies
@@ -76,4 +78,10 @@ jar {
     manifest {
         attributes("Implementation-Version": version)
     }
+}
+
+processResources {
+    filter ReplaceTokens, tokens: [
+            "project.version": project.version.toString()
+    ]
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ControllerUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ControllerUtils.java
@@ -1,0 +1,60 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.controllers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.servlet.HandlerMapping;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Utility methods re-used in various controllers.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Slf4j
+public final class ControllerUtils {
+
+    /**
+     * Constructor.
+     */
+    protected ControllerUtils() {
+    }
+
+    /**
+     * Get the remaining path from a given request. e.g. if the request went to a method with the matching pattern of
+     * /api/v3/jobs/output/** and the request was /api/v3/jobs/output/blah.txt the return value of this method would be
+     * blah.txt.
+     *
+     * @param request The http servlet request.
+     * @return The remaining path
+     */
+    public static String getRemainingPath(final HttpServletRequest request) {
+        String path = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+        if (path != null) {
+            final String bestMatchPattern
+                = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+            log.debug("bestMatchPattern = {}", bestMatchPattern);
+            path = new AntPathMatcher().extractPathWithinPattern(bestMatchPattern, path);
+        }
+        log.debug("Remaining path = {}", path);
+        return path;
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -69,7 +69,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -675,17 +674,11 @@ public class JobRestController {
             }
         }
 
-        String path = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
-        if (path != null) {
-            final String bestMatchPattern
-                = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
-            log.debug("bestMatchPattern = {}", bestMatchPattern);
-            path = new AntPathMatcher().extractPathWithinPattern(bestMatchPattern, path);
-            if (StringUtils.isNotBlank(path)) {
-                request.setAttribute(GenieResourceHttpRequestHandler.GENIE_JOB_IS_ROOT_DIRECTORY, false);
-            } else {
-                request.setAttribute(GenieResourceHttpRequestHandler.GENIE_JOB_IS_ROOT_DIRECTORY, true);
-            }
+        final String path = ControllerUtils.getRemainingPath(request);
+        if (StringUtils.isNotBlank(path)) {
+            request.setAttribute(GenieResourceHttpRequestHandler.GENIE_JOB_IS_ROOT_DIRECTORY, false);
+        } else {
+            request.setAttribute(GenieResourceHttpRequestHandler.GENIE_JOB_IS_ROOT_DIRECTORY, true);
         }
         log.debug("PATH = {}", path);
         request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, id + "/" + path);

--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -76,6 +76,10 @@ genie:
     pool:
       size: 10
 
+info:
+  genie:
+    version: @project.version@
+
 management:
   context-path: /actuator
   security:

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/ControllerUtilsUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/ControllerUtilsUnitTests.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.controllers;
+
+import com.netflix.genie.test.categories.UnitTest;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+import org.springframework.web.servlet.HandlerMapping;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Unit tests for the ControllerUtils class.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class ControllerUtilsUnitTests {
+
+    /**
+     * Dumb test.
+     */
+    @Test
+    public void canConstruct() {
+        Assert.assertNotNull(new ControllerUtils());
+    }
+
+    /**
+     * Test the getRemainingPath method.
+     */
+    @Test
+    public void canGetRemainingPath() {
+        final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)).thenReturn(null);
+        Assert.assertNull(ControllerUtils.getRemainingPath(request));
+
+        Mockito
+            .when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE))
+            .thenReturn("/api/v3/jobs/1234/output/genie/log.out");
+        Mockito
+            .when(request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
+            .thenReturn("/api/v3/jobs/{id}/output/**");
+        Assert.assertThat(ControllerUtils.getRemainingPath(request), Matchers.is("genie/log.out"));
+
+        Mockito
+            .when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE))
+            .thenReturn("/api/v3/jobs/1234/output");
+        Mockito
+            .when(request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
+            .thenReturn("/api/v3/jobs/{id}/output");
+        Assert.assertThat(ControllerUtils.getRemainingPath(request), Matchers.is(""));
+    }
+}


### PR DESCRIPTION
PR adds a /output/{jobId}/** endpoint to Genie which is secured only via SAML which the UI can use to get job output files without going through OAuth2 authentication.