### PR TITLE
changes to way conf is passed around and how AuthHandler is used

### DIFF
--- a/genie-client/src/main/python/pygenie/jobs/adapter/adapter.py
+++ b/genie-client/src/main/python/pygenie/jobs/adapter/adapter.py
@@ -28,9 +28,9 @@ def get_adapter_for_version(version):
 
     major_version = str(version).split('.', 1)[0]
     if major_version == '2':
-        return Genie2Adapter()
+        return Genie2Adapter
     elif major_version == '3':
-        return Genie3Adapter()
+        return Genie3Adapter
     raise GenieAdapterError("no adapter for version '{}'".format(version))
 
 
@@ -44,11 +44,11 @@ def execute_job(job):
     """
 
     version = job.conf.get('genie.version')
-    adapter = get_adapter_for_version(version)
+    adapter = get_adapter_for_version(version)(conf=job.conf)
     if adapter is not None:
         try:
             adapter.submit_job(job)
-            return RunningJob(job.get('job_id'), adapter=adapter)
+            return RunningJob(job.get('job_id'), adapter=adapter, conf=job.conf)
         except NotImplementedError:
             pass
     raise GenieAdapterError("no adapter for '{}' to version '{}'" \

--- a/genie-client/src/main/python/pygenie/jobs/running.py
+++ b/genie-client/src/main/python/pygenie/jobs/running.py
@@ -26,7 +26,7 @@ class RunningJob(object):
     def __init__(self, job_id, adapter=None, conf=None):
         self.__cached_genie_log = None
         self.__cached_stderr = None
-        self.__conf = conf if conf is not None else GenieConf()
+        self.__conf = conf or GenieConf()
         self.__sys_stream = None
 
         self._cached_genie_log = None
@@ -35,8 +35,8 @@ class RunningJob(object):
         self._job_id = job_id
 
         # get_adapter_version is set in main __init__.py to get around circular imports
-        self._adapter = adapter if adapter is not None \
-            else get_adapter_for_version(self.__conf.genie.version)
+        self._adapter = adapter \
+            or get_adapter_for_version(self.__conf.genie.version)(conf=self.__conf)
 
         stream = self.__conf.get('genie.progress_stream', 'stdout').lower()
         if stream in {'stderr', 'stdout'}:

--- a/genie-client/src/main/python/pygenie/utils.py
+++ b/genie-client/src/main/python/pygenie/utils.py
@@ -29,8 +29,6 @@ from .exceptions import GenieHTTPError
 logger = logging.getLogger('com.netflix.pygenie.utils')
 
 
-AUTH_HANDLER = AuthHandler()
-
 USER_AGENT_HEADER = {
     'user-agent': '/'.join([
         socket.getfqdn(),
@@ -51,7 +49,7 @@ class DotDict(dict):
 
 
 def call(url, method='get', headers=None, raise_not_status=None,
-         none_on_404=False, *args, **kwargs):
+         none_on_404=False, auth_handler=None, *args, **kwargs):
     """
     Wrap HTTP request calls to the Genie server.
 
@@ -67,6 +65,8 @@ def call(url, method='get', headers=None, raise_not_status=None,
             GenieHTTPError.
     """
 
+    auth_handler = auth_handler or AuthHandler()
+
     headers = USER_AGENT_HEADER if headers is None \
         else dict(headers, **USER_AGENT_HEADER)
 
@@ -76,7 +76,7 @@ def call(url, method='get', headers=None, raise_not_status=None,
     resp = requests.request(method,
                             url=url,
                             headers=headers,
-                            auth=AUTH_HANDLER.auth,
+                            auth=auth_handler.auth,
                             *args,
                             **kwargs)
 

--- a/genie-client/src/main/python/tests/test_auth.py
+++ b/genie-client/src/main/python/tests/test_auth.py
@@ -56,8 +56,8 @@ class TestingAuthHandler(unittest.TestCase):
 
         request.side_effect = check_request_auth_kwargs
 
-        pygenie.utils.AUTH_HANDLER = pygenie.auth.AuthHandler(conf=self.conf)
-        pygenie.utils.call('http://localhost')
+        pygenie.utils.call('http://localhost',
+                           auth_handler=pygenie.auth.AuthHandler(conf=self.conf))
 
         if patcher:
             patcher.stop()


### PR DESCRIPTION
Pass the job's conf through to the adapter and running job.

The auth handler is now a kwarg into the call() function and not a
global variable.