### PR TITLE
Renaming the oauth package to be more accurately named oauth2

### DIFF
--- a/genie-client/src/main/java/com/netflix/genie/client/apis/TokenService.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/apis/TokenService.java
@@ -17,7 +17,7 @@
  */
 package com.netflix.genie.client.apis;
 
-import com.netflix.genie.client.security.oauth.AccessToken;
+import com.netflix.genie.client.security.oauth2.AccessToken;
 import retrofit2.Call;
 import retrofit2.http.FieldMap;
 import retrofit2.http.FormUrlEncoded;

--- a/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/AccessToken.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/AccessToken.java
@@ -15,10 +15,31 @@
  *     limitations under the License.
  *
  */
+package com.netflix.genie.client.security.oauth2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * Package containing tests for the oauth security impl package.
+ * Class that encapsulates the OAuth credentials.
  *
  * @author amsharma
  * @since 3.0.0
  */
-package com.netflix.genie.client.security.oauth.impl;
+@Getter
+@Setter
+public class AccessToken {
+
+    // The type of the token
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    // The accessToken
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    // Time to expire from creation
+    @JsonProperty("expires_in")
+    private int expiresIn;
+}

--- a/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/TokenFetcher.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/TokenFetcher.java
@@ -15,7 +15,7 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.client.security.oauth;
+package com.netflix.genie.client.security.oauth2;
 
 import com.netflix.genie.client.apis.TokenService;
 import com.netflix.genie.common.exceptions.GenieException;
@@ -62,12 +62,11 @@ public class TokenFetcher {
     /**
      * Constructor.
      *
-     * @param oauthUrl The url of the IDP from where to get the credentials.
-     * @param clientId The clientId to use to get the credentials.
+     * @param oauthUrl     The url of the IDP from where to get the credentials.
+     * @param clientId     The clientId to use to get the credentials.
      * @param clientSecret The clientSecret to use to get the credentials.
-     * @param grantType The type of the grant.
-     * @param scope The scope of the credentials returned.
-     *
+     * @param grantType    The type of the grant.
+     * @param scope        The scope of the credentials returned.
      * @throws GenieException If there is any problem.
      */
     public TokenFetcher(
@@ -121,7 +120,7 @@ public class TokenFetcher {
             credentialParams.put(GRANT_TYPE, grantType);
             credentialParams.put(SCOPE, scope);
         } catch (Exception e) {
-           throw new GenieException(400, "Could not instantiate Token Service.", e);
+            throw new GenieException(400, "Could not instantiate Token Service.", e);
         }
     }
 

--- a/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/impl/OAuth2SecurityInterceptor.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/impl/OAuth2SecurityInterceptor.java
@@ -15,12 +15,12 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.client.security.oauth.impl;
+package com.netflix.genie.client.security.oauth2.impl;
 
 import com.google.common.net.HttpHeaders;
 import com.netflix.genie.client.security.SecurityInterceptor;
-import com.netflix.genie.client.security.oauth.AccessToken;
-import com.netflix.genie.client.security.oauth.TokenFetcher;
+import com.netflix.genie.client.security.oauth2.AccessToken;
+import com.netflix.genie.client.security.oauth2.TokenFetcher;
 import com.netflix.genie.common.exceptions.GenieException;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Request;
@@ -34,28 +34,27 @@ import java.io.IOException;
  * @author amsharma
  */
 @Slf4j
-public class OAuthSecurityInterceptor implements SecurityInterceptor {
+public class OAuth2SecurityInterceptor implements SecurityInterceptor {
 
     private final TokenFetcher tokenFetcher;
 
     /**
      * Constructor.
      *
-     * @param url The URL of the IDP server for getting oauth token.
-     * @param clientId The client id to use to fetch credentials.
+     * @param url          The URL of the IDP server for getting oauth token.
+     * @param clientId     The client id to use to fetch credentials.
      * @param clientSecret The client secret to use to fetch credentials.
-     * @param grantType The grant type for the user.
-     * @param scope The scope of the user permissions.
-     *
+     * @param grantType    The grant type for the user.
+     * @param scope        The scope of the user permissions.
      * @throws GenieException If there is a problem initializing the object.
      */
-    public OAuthSecurityInterceptor(
+    public OAuth2SecurityInterceptor(
         final String url,
         final String clientId,
         final String clientSecret,
         final String grantType,
         final String scope
-        ) throws GenieException {
+    ) throws GenieException {
         log.debug("Constructor called.");
         tokenFetcher = new TokenFetcher(url, clientId, clientSecret, grantType, scope);
     }

--- a/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/impl/package-info.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/impl/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 Netflix, Inc.
+ *  Copyright 2016 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
  *
  */
 /**
- * Package containing tests for classes in the  com.netflix.genie.client.security.oauth package.
+ * Package containing implementations of interfaces defined in the oauth package.
  *
  * @author amsharma
  * @since 3.0.0
  */
-package com.netflix.genie.client.security.oauth;
+package com.netflix.genie.client.security.oauth2.impl;

--- a/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/package-info.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/security/oauth2/package-info.java
@@ -22,4 +22,4 @@
  * @author amsharma
  * @since 3.0.0
  */
-package com.netflix.genie.client.security.oauth;
+package com.netflix.genie.client.security.oauth2;

--- a/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/AccessTokenUnitTests.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/AccessTokenUnitTests.java
@@ -15,7 +15,7 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.client.security.oauth;
+package com.netflix.genie.client.security.oauth2;
 
 import com.netflix.genie.test.categories.UnitTest;
 import groovy.lang.Category;
@@ -68,7 +68,7 @@ public class AccessTokenUnitTests {
      */
     @Test
     public void canSetExpiresIn() {
-        final int expiresIn =  3600;
+        final int expiresIn = 3600;
         this.accessToken.setExpiresIn(expiresIn);
         Assert.assertThat(this.accessToken.getExpiresIn(), Matchers.is(expiresIn));
     }

--- a/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/TokenFetcherUnitTests.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/TokenFetcherUnitTests.java
@@ -15,7 +15,7 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.client.security.oauth;
+package com.netflix.genie.client.security.oauth2;
 
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;

--- a/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/impl/OAuth2SecurityInterceptorUnitTests.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/impl/OAuth2SecurityInterceptorUnitTests.java
@@ -15,7 +15,7 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.client.security.oauth.impl;
+package com.netflix.genie.client.security.oauth2.impl;
 
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.test.categories.UnitTest;
@@ -27,18 +27,18 @@ import org.mockito.Mockito;
 import java.io.IOException;
 
 /**
- * Unit Tests for OAuthSecurityInterceptory Class.
+ * Unit Tests for OAuth2SecurityInterceptor Class.
  *
  * @author amsharma
  * @since 3.0.0
  */
 @Category(UnitTest.class)
-public class OAuthSecurityInterceptorUnitTests {
+public class OAuth2SecurityInterceptorUnitTests {
 
     private static final String URL = "http://localhost/foo";
     private static final String CLIENT_ID = "client_id";
     private static final String CLIENT_SECRET = "client_secret";
-    private static final String GRANT_TYPE  = "grant_type";
+    private static final String GRANT_TYPE = "grant_type";
     private static final String SCOPE = "scope";
 
     /**
@@ -48,8 +48,7 @@ public class OAuthSecurityInterceptorUnitTests {
      */
     @Test
     public void testCanConstruct() throws GenieException {
-
-        new OAuthSecurityInterceptor(URL, CLIENT_ID, CLIENT_SECRET, GRANT_TYPE, SCOPE);
+        new OAuth2SecurityInterceptor(URL, CLIENT_ID, CLIENT_SECRET, GRANT_TYPE, SCOPE);
     }
 
     /**
@@ -61,7 +60,7 @@ public class OAuthSecurityInterceptorUnitTests {
     public void testTokenFetchFailure() throws Exception {
 
         final Interceptor.Chain chain = Mockito.mock(Interceptor.Chain.class);
-        final OAuthSecurityInterceptor oAuthSecurityInterceptor  = new OAuthSecurityInterceptor(
+        final OAuth2SecurityInterceptor oAuth2SecurityInterceptor = new OAuth2SecurityInterceptor(
             URL,
             CLIENT_ID,
             CLIENT_SECRET,
@@ -69,6 +68,6 @@ public class OAuthSecurityInterceptorUnitTests {
             SCOPE
         );
 
-        oAuthSecurityInterceptor.intercept(chain);
+        oAuth2SecurityInterceptor.intercept(chain);
     }
 }

--- a/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/impl/package-info.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/impl/package-info.java
@@ -16,9 +16,9 @@
  *
  */
 /**
- * Package containing implementations of interfaces defined in the oauth package.
+ * Package containing tests for the oauth security impl package.
  *
  * @author amsharma
  * @since 3.0.0
  */
-package com.netflix.genie.client.security.oauth.impl;
+package com.netflix.genie.client.security.oauth2.impl;

--- a/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/package-info.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/security/oauth2/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Netflix, Inc.
+ *  Copyright 2015 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -15,31 +15,10 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.client.security.oauth;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
-
 /**
- * Class that encapsulates the OAuth credentials.
+ * Package containing tests for classes in the  com.netflix.genie.client.security.oauth package.
  *
  * @author amsharma
  * @since 3.0.0
  */
-@Getter
-@Setter
-public class AccessToken {
-
-    // The type of the token
-    @JsonProperty("token_type")
-    private String tokenType;
-
-    // The accessToken
-    @JsonProperty("access_token")
-    private String accessToken;
-
-    // Time to expire from creation
-    @JsonProperty("expires_in")
-    private int expiresIn;
-}
+package com.netflix.genie.client.security.oauth2;

--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     // Swagger libs
     compile("io.springfox:springfox-swagger2:${springfox_version}")
     compile("io.springfox:springfox-swagger-ui:${springfox_version}")
+    compile("io.springfox:springfox-bean-validators:${springfox_version}")
 
     /*******************************
      * Provided Dependencies

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/SwaggerConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/SwaggerConfig.java
@@ -20,6 +20,8 @@ package com.netflix.genie.web.configs;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
@@ -38,6 +40,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @ConditionalOnProperty("genie.swagger.enabled")
 @EnableSwagger2
+@Import(BeanValidatorPluginsConfiguration.class)
 public class SwaggerConfig {
     /**
      * Configure Spring Fox.

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,22 +38,10 @@ spectator_version=0.30.0
 # Swagger Libraries
 springfox_version=2.4.0
 
-# WebJar Versions
-bootstrap_version=2.3.2
-datatables_version=1.10.7
-datatables_bootstrap_version=2-20120202-2
-jquery_version=2.0.2
-knockout_version=2.2.1
-lodash_version=1.3.1
-momentjs_version=2.10.3
-requirejs_version=2.1.20
-requirejs_text_version=2.0.14
-select2_version=3.4.5
-
 # Test Libraries
-dbunit_version=2.5.1
+dbunit_version=2.5.2
 jtidy_version=r938
-spring_test_dbunit_version=1.2.1
+spring_test_dbunit_version=1.3.0
 
 # Findbugs
 findbugs_annotations_version=3.0.1


### PR DESCRIPTION
Client OAuth2 package was misnamed and misleading as OAuth and OAuth2 are quite different.