### PR TITLE
Make actuator endpoints only USER role protected

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/security/SecurityUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/SecurityUtils.java
@@ -74,7 +74,6 @@ public final class SecurityUtils {
                     .regexMatchers(HttpMethod.PATCH, COMMANDS_API_REGEX).hasRole(ADMIN_ROLE)
                     .regexMatchers(HttpMethod.POST, COMMANDS_API_REGEX).hasRole(ADMIN_ROLE)
                     .regexMatchers(HttpMethod.PUT, COMMANDS_API_REGEX).hasRole(ADMIN_ROLE)
-                    .regexMatchers(actuatorEndpoint + "/.*").hasRole(ADMIN_ROLE)
                     .anyRequest().hasRole(USER_ROLE)
             .and()
                 .x509().authenticationUserDetailsService(x509UserDetailsService)

--- a/genie-web/src/test/java/com/netflix/genie/web/security/AbstractAPISecurityIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/security/AbstractAPISecurityIntegrationTests.java
@@ -184,7 +184,7 @@ public abstract class AbstractAPISecurityIntegrationTests {
         this.get(JOBS_API + "/" + UUID.randomUUID().toString(), NOT_FOUND);
         this.delete(JOBS_API + "/" + UUID.randomUUID().toString(), NOT_FOUND);
 
-        this.checkActuatorEndpoints(FORBIDDEN);
+        this.checkActuatorEndpoints(OK);
     }
 
     /**


### PR DESCRIPTION
Previously  all API's except ```/health``` required the user be admin. Upon further review/thought we believe it will be helpful to allow any user access to the actuator endpoints as none are enabled that allow modification of the system via any of the endpoints like ```/shutdown```