### PR TITLE
Refactored client exceptions and added logic for job dir clean up after job finishes.

### DIFF
--- a/genie-client/src/main/java/com/netflix/genie/client/ApplicationClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/ApplicationClient.java
@@ -81,14 +81,14 @@ public class ApplicationClient extends BaseGenieClient {
      *
      * @return The id of the application created.
      *
-     * @throws GenieClientException For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public String createApplication(
         final Application application
     ) throws IOException, GenieClientException {
         if (application == null) {
-            throw new GenieClientException("Application cannot be null.");
+            throw new IllegalArgumentException("Application cannot be null.");
         }
         return getIdFromLocation(applicationService.createApplication(application).execute().headers().get("location"));
     }
@@ -97,8 +97,9 @@ public class ApplicationClient extends BaseGenieClient {
      * Method to get a list of all the applications.
      *
      * @return A list of applications.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public List<Application> getApplications() throws IOException, GenieClientException {
         return this.getApplications(null, null, null, null, null);
@@ -114,8 +115,9 @@ public class ApplicationClient extends BaseGenieClient {
      * @param type The type of the application.
      *
      * @return A list of applications.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public List<Application> getApplications(
         final String name,
@@ -148,14 +150,15 @@ public class ApplicationClient extends BaseGenieClient {
      *
      * @param applicationId The id of the application to get.
      * @return The application details.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public Application getApplication(
         final String applicationId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
         return applicationService.getApplication(applicationId).execute().body();
     }
@@ -164,12 +167,13 @@ public class ApplicationClient extends BaseGenieClient {
      * Method to delete a application from Genie.
      *
      * @param applicationId The id of the application.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void deleteApplication(final String applicationId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
         applicationService.deleteApplication(applicationId).execute();
     }
@@ -177,8 +181,8 @@ public class ApplicationClient extends BaseGenieClient {
     /**
      * Method to delete all applications from Genie.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void deleteAllApplications() throws IOException, GenieClientException {
         applicationService.deleteAllApplications().execute();
@@ -196,11 +200,11 @@ public class ApplicationClient extends BaseGenieClient {
     public void patchApplication(final String applicationId, final JsonPatch patch)
         throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         if (patch == null) {
-            throw new GenieClientException("Patch cannot be null");
+            throw new IllegalArgumentException("Patch cannot be null");
         }
 
         applicationService.patchApplication(applicationId, patch).execute();
@@ -212,17 +216,17 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      * @param application The updated application object to use.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void updateApplication(final String applicationId, final Application application)
         throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         if (application == null) {
-            throw new GenieClientException("Patch cannot be null");
+            throw new IllegalArgumentException("Patch cannot be null");
         }
 
         applicationService.updateApplication(applicationId, application).execute();
@@ -234,13 +238,14 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      *
      * @return The set of commands for the applications.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public List<Command> getCommandsForApplication(final String applicationId)
         throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         return applicationService.getCommandsForApplication(applicationId).execute().body();
@@ -254,12 +259,13 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      *
      * @return The set of configs for the application.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public Set<String> getConfigsForApplication(final String applicationId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         return applicationService.getConfigsForApplication(applicationId).execute().body();
@@ -271,18 +277,18 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      * @param configs The set of configs to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void addConfigsToApplication(
         final String applicationId, final Set<String> configs
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         if (configs == null || configs.isEmpty()) {
-            throw new GenieClientException("Configs cannot be null or empty");
+            throw new IllegalArgumentException("Configs cannot be null or empty");
         }
 
         applicationService.addConfigsToApplication(applicationId, configs).execute();
@@ -294,18 +300,18 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      * @param configs The set of configs to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void updateConfigsForApplication(
         final String applicationId, final Set<String> configs
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         if (configs == null || configs.isEmpty()) {
-            throw new GenieClientException("Configs cannot be null or empty");
+            throw new IllegalArgumentException("Configs cannot be null or empty");
         }
 
         applicationService.updateConfigsForApplication(applicationId, configs).execute();
@@ -316,14 +322,14 @@ public class ApplicationClient extends BaseGenieClient {
      *
      * @param applicationId The id of the application.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void removeAllConfigsForApplication(
         final String applicationId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         applicationService.removeAllConfigsForApplication(applicationId).execute();
@@ -337,13 +343,14 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      *
      * @return The set of dependencies for the application.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public Set<String> getDependenciesForApplication(final String applicationId) throws IOException,
         GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         return applicationService.getDependenciesForApplication(applicationId).execute().body();
@@ -355,18 +362,18 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      * @param dependencies The set of dependencies to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void addDependenciesToApplication(
         final String applicationId, final Set<String> dependencies
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         if (dependencies == null || dependencies.isEmpty()) {
-            throw new GenieClientException("Dependencies cannot be null or empty");
+            throw new IllegalArgumentException("Dependencies cannot be null or empty");
         }
 
         applicationService.addDependenciesToApplication(applicationId, dependencies).execute();
@@ -378,18 +385,18 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      * @param dependencies The set of dependencies to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void updateDependenciesForApplication(
         final String applicationId, final Set<String> dependencies
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         if (dependencies == null || dependencies.isEmpty()) {
-            throw new GenieClientException("Dependencies cannot be null or empty");
+            throw new IllegalArgumentException("Dependencies cannot be null or empty");
         }
 
         applicationService.updateDependenciesForApplication(applicationId, dependencies).execute();
@@ -400,14 +407,14 @@ public class ApplicationClient extends BaseGenieClient {
      *
      * @param applicationId The id of the application.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void removeAllDependenciesForApplication(
         final String applicationId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         applicationService.removeAllDependenciesForApplication(applicationId).execute();
@@ -421,12 +428,13 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      *
      * @return The set of configs for the application.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public Set<String> getTagsForApplication(final String applicationId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         return applicationService.getTagsForApplication(applicationId).execute().body();
@@ -438,18 +446,18 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      * @param tags The set of tags to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void addTagsToApplication(
         final String applicationId, final Set<String> tags
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         if (tags == null || tags.isEmpty()) {
-            throw new GenieClientException("Tags cannot be null or empty");
+            throw new IllegalArgumentException("Tags cannot be null or empty");
         }
 
         applicationService.addTagsToApplication(applicationId, tags).execute();
@@ -461,18 +469,18 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      * @param tags The set of tags to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void updateTagsForApplication(
         final String applicationId, final Set<String> tags
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         if (tags == null || tags.isEmpty()) {
-            throw new GenieClientException("Tags cannot be null or empty");
+            throw new IllegalArgumentException("Tags cannot be null or empty");
         }
 
         applicationService.updateTagsForApplication(applicationId, tags).execute();
@@ -484,19 +492,19 @@ public class ApplicationClient extends BaseGenieClient {
      * @param applicationId The id of the application.
      * @param tag The tag to remove.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void removeTagFromApplication(
         final String applicationId,
         final String tag
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         if (StringUtils.isEmpty(tag)) {
-            throw new GenieClientException("Missing required parameter: tag.");
+            throw new IllegalArgumentException("Missing required parameter: tag.");
         }
 
         applicationService.removeTagForApplication(applicationId, tag).execute();
@@ -507,14 +515,14 @@ public class ApplicationClient extends BaseGenieClient {
      *
      * @param applicationId The id of the application.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues
      */
     public void removeAllTagsForApplication(
         final String applicationId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         applicationService.removeAllTagsForApplication(applicationId).execute();

--- a/genie-client/src/main/java/com/netflix/genie/client/BaseGenieClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/BaseGenieClient.java
@@ -63,7 +63,7 @@ public abstract class BaseGenieClient {
         final OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
         if (genieNetworkConfiguration != null) {
-            addConfigParamsFromConfig(builder, genieNetworkConfiguration);
+            this.addConfigParamsFromConfig(builder, genieNetworkConfiguration);
         }
 
         mapper = new ObjectMapper().
@@ -91,15 +91,15 @@ public abstract class BaseGenieClient {
         final OkHttpClient.Builder builder,
         final GenieNetworkConfiguration genieNetworkConfiguration) {
 
-        if (genieNetworkConfiguration.getConnectTimeout() != 0) {
+        if (genieNetworkConfiguration.getConnectTimeout() != GenieNetworkConfiguration.DEFAULT_TIMEOUT) {
             builder.connectTimeout(genieNetworkConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS);
         }
 
-        if (genieNetworkConfiguration.getReadTimeout() != 0) {
+        if (genieNetworkConfiguration.getReadTimeout() != GenieNetworkConfiguration.DEFAULT_TIMEOUT) {
             builder.readTimeout(genieNetworkConfiguration.getReadTimeout(), TimeUnit.MILLISECONDS);
         }
 
-        if (genieNetworkConfiguration.getWriteTimeout() != 0) {
+        if (genieNetworkConfiguration.getWriteTimeout() != GenieNetworkConfiguration.DEFAULT_TIMEOUT) {
             builder.writeTimeout(genieNetworkConfiguration.getWriteTimeout(), TimeUnit.MILLISECONDS);
         }
 

--- a/genie-client/src/main/java/com/netflix/genie/client/ClusterClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/ClusterClient.java
@@ -80,14 +80,14 @@ public class ClusterClient extends BaseGenieClient {
      *
      * @return The id of the cluster created.
      *
-     * @throws GenieClientException For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public String createCluster(
         final Cluster cluster
     ) throws IOException, GenieClientException {
         if (cluster == null) {
-            throw new GenieClientException("Cluster cannot be null.");
+            throw new IllegalArgumentException("Cluster cannot be null.");
         }
         return getIdFromLocation(clusterService.createCluster(cluster).execute().headers().get("location"));
     }
@@ -96,8 +96,9 @@ public class ClusterClient extends BaseGenieClient {
      * Method to get a list of all the clusters.
      *
      * @return A list of clusters.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<Cluster> getClusters() throws IOException, GenieClientException {
         return this.getClusters(
@@ -119,8 +120,9 @@ public class ClusterClient extends BaseGenieClient {
      * @param maxUpdateTime Maximum Time before which cluster was updated.
      *
      * @return A list of clusters.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<Cluster> getClusters(
         final String name,
@@ -153,14 +155,15 @@ public class ClusterClient extends BaseGenieClient {
      *
      * @param clusterId The id of the cluster to get.
      * @return The cluster details.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public Cluster getCluster(
         final String clusterId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
         return clusterService.getCluster(clusterId).execute().body();
     }
@@ -169,12 +172,13 @@ public class ClusterClient extends BaseGenieClient {
      * Method to delete a cluster from Genie.
      *
      * @param clusterId The id of the cluster.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void deleteCluster(final String clusterId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
         clusterService.deleteCluster(clusterId).execute();
     }
@@ -182,8 +186,9 @@ public class ClusterClient extends BaseGenieClient {
     /**
      * Method to delete all clusters from Genie.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void deleteAllClusters() throws IOException, GenieClientException {
         clusterService.deleteAllClusters().execute();
@@ -195,16 +200,16 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param patch The patch object specifying all the instructions.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void patchCluster(final String clusterId, final JsonPatch patch) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (patch == null) {
-            throw new GenieClientException("Patch cannot be null");
+            throw new IllegalArgumentException("Patch cannot be null");
         }
 
         clusterService.patchCluster(clusterId, patch).execute();
@@ -216,16 +221,16 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param cluster The updated cluster object to use.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void updateCluster(final String clusterId, final Cluster cluster) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (cluster == null) {
-            throw new GenieClientException("Patch cannot be null");
+            throw new IllegalArgumentException("Patch cannot be null");
         }
 
         clusterService.updateCluster(clusterId, cluster).execute();
@@ -239,12 +244,13 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      *
      * @return The set of configs for the cluster.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public Set<String> getConfigsForCluster(final String clusterId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         return clusterService.getConfigsForCluster(clusterId).execute().body();
@@ -256,18 +262,18 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param configs The set of configs to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void addConfigsToCluster(
         final String clusterId, final Set<String> configs
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (configs == null || configs.isEmpty()) {
-            throw new GenieClientException("Configs cannot be null or empty");
+            throw new IllegalArgumentException("Configs cannot be null or empty");
         }
 
         clusterService.addConfigsToCluster(clusterId, configs).execute();
@@ -279,18 +285,18 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param configs The set of configs to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void updateConfigsForCluster(
         final String clusterId, final Set<String> configs
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (configs == null || configs.isEmpty()) {
-            throw new GenieClientException("Configs cannot be null or empty");
+            throw new IllegalArgumentException("Configs cannot be null or empty");
         }
 
         clusterService.updateConfigsForCluster(clusterId, configs).execute();
@@ -301,14 +307,14 @@ public class ClusterClient extends BaseGenieClient {
      *
      * @param clusterId The id of the cluster.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeAllConfigsForCluster(
         final String clusterId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         clusterService.removeAllConfigsForCluster(clusterId).execute();
@@ -322,12 +328,13 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      *
      * @return The set of commands for the cluster.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<Command> getCommandsForCluster(final String clusterId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         return clusterService.getCommandsForCluster(clusterId).execute().body();
@@ -339,18 +346,18 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param commandIds The list of commands to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void addCommandsToCluster(
         final String clusterId, final List<String> commandIds
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (commandIds == null || commandIds.isEmpty()) {
-            throw new GenieClientException("Command Ids cannot be null or empty");
+            throw new IllegalArgumentException("Command Ids cannot be null or empty");
         }
 
         clusterService.addCommandsToCluster(clusterId, commandIds).execute();
@@ -362,18 +369,18 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param commandIds The set of commands to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void updateCommandsForCluster(
         final String clusterId, final List<String> commandIds
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (commandIds == null || commandIds.isEmpty()) {
-            throw new GenieClientException("commandIds cannot be null or empty");
+            throw new IllegalArgumentException("commandIds cannot be null or empty");
         }
 
         clusterService.setCommandsForCluster(clusterId, commandIds).execute();
@@ -385,19 +392,19 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param commandId The id of the command to remove.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeCommandFromCluster(
         final String clusterId,
         final String commandId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         clusterService.removeCommandForCluster(clusterId, commandId).execute();
@@ -408,14 +415,14 @@ public class ClusterClient extends BaseGenieClient {
      *
      * @param clusterId The id of the cluster.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeAllCommandsForCluster(
         final String clusterId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         clusterService.removeAllCommandsForCluster(clusterId).execute();
@@ -429,12 +436,13 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      *
      * @return The set of tags for the cluster.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public Set<String> getTagsForCluster(final String clusterId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         return clusterService.getTagsForCluster(clusterId).execute().body();
@@ -446,18 +454,18 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param tags The set of tags to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void addTagsToCluster(
         final String clusterId, final Set<String> tags
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (tags == null || tags.isEmpty()) {
-            throw new GenieClientException("Tags cannot be null or empty");
+            throw new IllegalArgumentException("Tags cannot be null or empty");
         }
 
         clusterService.addTagsToCluster(clusterId, tags).execute();
@@ -469,18 +477,18 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param tags The set of tags to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void updateTagsForCluster(
         final String clusterId, final Set<String> tags
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (tags == null || tags.isEmpty()) {
-            throw new GenieClientException("Tags cannot be null or empty");
+            throw new IllegalArgumentException("Tags cannot be null or empty");
         }
 
         clusterService.updateTagsForCluster(clusterId, tags).execute();
@@ -492,19 +500,19 @@ public class ClusterClient extends BaseGenieClient {
      * @param clusterId The id of the cluster.
      * @param tag The tag to remove.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeTagFromCluster(
         final String clusterId,
         final String tag
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         if (StringUtils.isEmpty(tag)) {
-            throw new GenieClientException("Missing required parameter: tag.");
+            throw new IllegalArgumentException("Missing required parameter: tag.");
         }
 
         clusterService.removeTagForCluster(clusterId, tag).execute();
@@ -515,14 +523,14 @@ public class ClusterClient extends BaseGenieClient {
      *
      * @param clusterId The id of the cluster.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeAllTagsForCluster(
         final String clusterId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(clusterId)) {
-            throw new GenieClientException("Missing required parameter: clusterId.");
+            throw new IllegalArgumentException("Missing required parameter: clusterId.");
         }
 
         clusterService.removeAllTagsForCluster(clusterId).execute();

--- a/genie-client/src/main/java/com/netflix/genie/client/CommandClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/CommandClient.java
@@ -80,16 +80,16 @@ public class CommandClient extends BaseGenieClient {
      *
      * @param command A command object.
      *
-     * @return The id of the command created.
+     * @return id Id of the command created.
      *
-     * @throws GenieClientException For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public String createCommand(
         final Command command
     ) throws IOException, GenieClientException {
         if (command == null) {
-            throw new GenieClientException("Command cannot be null.");
+            throw new IllegalArgumentException("Command cannot be null.");
         }
         return getIdFromLocation(commandService.createCommand(command).execute().headers().get("location"));
     }
@@ -98,8 +98,9 @@ public class CommandClient extends BaseGenieClient {
      * Method to get a list of all the commands.
      *
      * @return A list of commands.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<Command> getCommands() throws IOException, GenieClientException {
         return this.getCommands(null, null, null, null);
@@ -114,8 +115,9 @@ public class CommandClient extends BaseGenieClient {
      * @param tagList The list of tags.
      *
      * @return A list of commands.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<Command> getCommands(
         final String name,
@@ -146,14 +148,15 @@ public class CommandClient extends BaseGenieClient {
      *
      * @param commandId The id of the command to get.
      * @return The command details.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public Command getCommand(
         final String commandId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
         return commandService.getCommand(commandId).execute().body();
     }
@@ -162,12 +165,13 @@ public class CommandClient extends BaseGenieClient {
      * Method to delete a command from Genie.
      *
      * @param commandId The id of the command.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void deleteCommand(final String commandId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
         commandService.deleteCommand(commandId).execute();
     }
@@ -175,8 +179,8 @@ public class CommandClient extends BaseGenieClient {
     /**
      * Method to delete all commands from Genie.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void deleteAllCommands() throws IOException, GenieClientException {
         commandService.deleteAllCommands().execute();
@@ -188,16 +192,16 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param patch The patch object specifying all the instructions.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void patchCommand(final String commandId, final JsonPatch patch) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (patch == null) {
-            throw new GenieClientException("Patch cannot be null");
+            throw new IllegalArgumentException("Patch cannot be null");
         }
 
         commandService.patchCommand(commandId, patch).execute();
@@ -209,16 +213,16 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param command The updated command object to use.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void updateCommand(final String commandId, final Command command) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (command == null) {
-            throw new GenieClientException("Patch cannot be null");
+            throw new IllegalArgumentException("Patch cannot be null");
         }
 
         commandService.updateCommand(commandId, command).execute();
@@ -232,12 +236,13 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      *
      * @return The set of configs for the command.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public Set<String> getConfigsForCommand(final String commandId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         return commandService.getConfigsForCommand(commandId).execute().body();
@@ -249,18 +254,18 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param configs The set of configs to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void addConfigsToCommand(
         final String commandId, final Set<String> configs
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (configs == null || configs.isEmpty()) {
-            throw new GenieClientException("Configs cannot be null or empty");
+            throw new IllegalArgumentException("Configs cannot be null or empty");
         }
 
         commandService.addConfigsToCommand(commandId, configs).execute();
@@ -272,18 +277,18 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param configs The set of configs to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void updateConfigsForCommand(
         final String commandId, final Set<String> configs
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (configs == null || configs.isEmpty()) {
-            throw new GenieClientException("Configs cannot be null or empty");
+            throw new IllegalArgumentException("Configs cannot be null or empty");
         }
 
         commandService.updateConfigsForCommand(commandId, configs).execute();
@@ -294,14 +299,14 @@ public class CommandClient extends BaseGenieClient {
      *
      * @param commandId The id of the command.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeAllConfigsForCommand(
         final String commandId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         commandService.removeAllConfigsForCommand(commandId).execute();
@@ -315,13 +320,14 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      *
      * @return The set of applications for the command.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<Application> getApplicationsForCommand(final String commandId)
         throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         return commandService.getApplicationsForCommand(commandId).execute().body();
@@ -333,12 +339,13 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      *
      * @return The set of clusters for the command.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<Cluster> getClustersForCommand(final String commandId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         return commandService.getClustersForCommand(commandId).execute().body();
@@ -350,18 +357,18 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param applicationIds The set of applications ids to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void addApplicationsToCommand(
         final String commandId, final List<String> applicationIds
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (applicationIds == null || applicationIds.isEmpty()) {
-            throw new GenieClientException("applicationIds cannot be null or empty");
+            throw new IllegalArgumentException("applicationIds cannot be null or empty");
         }
 
         commandService.addApplicationsToCommand(commandId, applicationIds).execute();
@@ -373,18 +380,18 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param applicationIds The set of application ids to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void updateApplicationsForCommand(
         final String commandId, final List<String> applicationIds
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (applicationIds == null || applicationIds.isEmpty()) {
-            throw new GenieClientException("applicationIds cannot be null or empty");
+            throw new IllegalArgumentException("applicationIds cannot be null or empty");
         }
 
         commandService.setApplicationsForCommand(commandId, applicationIds).execute();
@@ -396,19 +403,19 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param applicationId The id of the application to remove.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeApplicationFromCommand(
         final String commandId,
         final String applicationId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (StringUtils.isEmpty(applicationId)) {
-            throw new GenieClientException("Missing required parameter: applicationId.");
+            throw new IllegalArgumentException("Missing required parameter: applicationId.");
         }
 
         commandService.removeApplicationForCommand(commandId, applicationId).execute();
@@ -419,14 +426,14 @@ public class CommandClient extends BaseGenieClient {
      *
      * @param commandId The id of the command.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeAllApplicationsForCommand(
         final String commandId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         commandService.removeAllApplicationsForCommand(commandId).execute();
@@ -440,12 +447,13 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      *
      * @return The set of configs for the command.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public Set<String> getTagsForCommand(final String commandId) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         return commandService.getTagsForCommand(commandId).execute().body();
@@ -457,18 +465,18 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param tags The set of tags to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void addTagsToCommand(
         final String commandId, final Set<String> tags
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (tags == null || tags.isEmpty()) {
-            throw new GenieClientException("Tags cannot be null or empty");
+            throw new IllegalArgumentException("Tags cannot be null or empty");
         }
 
         commandService.addTagsToCommand(commandId, tags).execute();
@@ -480,18 +488,18 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param tags The set of tags to add.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void updateTagsForCommand(
         final String commandId, final Set<String> tags
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (tags == null || tags.isEmpty()) {
-            throw new GenieClientException("Tags cannot be null or empty");
+            throw new IllegalArgumentException("Tags cannot be null or empty");
         }
 
         commandService.updateTagsForCommand(commandId, tags).execute();
@@ -503,19 +511,19 @@ public class CommandClient extends BaseGenieClient {
      * @param commandId The id of the command.
      * @param tag The tag to remove.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeTagFromCommand(
         final String commandId,
         final String tag
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         if (StringUtils.isEmpty(tag)) {
-            throw new GenieClientException("Missing required parameter: tag.");
+            throw new IllegalArgumentException("Missing required parameter: tag.");
         }
 
         commandService.removeTagForCommand(commandId, tag).execute();
@@ -526,14 +534,14 @@ public class CommandClient extends BaseGenieClient {
      *
      * @param commandId The id of the command.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public void removeAllTagsForCommand(
         final String commandId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(commandId)) {
-            throw new GenieClientException("Missing required parameter: commandId.");
+            throw new IllegalArgumentException("Missing required parameter: commandId.");
         }
 
         commandService.removeAllTagsForCommand(commandId).execute();

--- a/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
@@ -129,14 +129,14 @@ public class JobClient extends BaseGenieClient {
      *
      * @return jobId The id of the job submitted.
      *
-     * @throws GenieClientException For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public String submitJob(
         final JobRequest jobRequest
     ) throws IOException, GenieClientException {
         if (jobRequest == null) {
-            throw new GenieClientException("Job Request cannot be null.");
+            throw new IllegalArgumentException("Job Request cannot be null.");
         }
         return getIdFromLocation(jobService.submitJob(jobRequest).execute().headers().get("location"));
     }
@@ -149,15 +149,15 @@ public class JobClient extends BaseGenieClient {
      *
      * @return jobId The id of the job submitted.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public String submitJobWithAttachments(
         final JobRequest jobRequest,
         final Map<String, InputStream> attachments
     ) throws IOException, GenieClientException {
         if (jobRequest == null) {
-            throw new GenieClientException("Job Request cannot be null.");
+            throw new IllegalArgumentException("Job Request cannot be null.");
         }
 
         final MediaType attachmentMediaType = MediaType.parse(APPLICATION_OCTET_STREAM);
@@ -194,8 +194,9 @@ public class JobClient extends BaseGenieClient {
      * Method to get a list of all the jobs.
      *
      * @return A list of jobs.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<JobSearchResult> getJobs() throws IOException, GenieClientException {
         return this.getJobs(null, null, null, null, null, null, null, null, null, null, null, null, null);
@@ -219,8 +220,8 @@ public class JobClient extends BaseGenieClient {
      * @param maxFinished The time which the job had to finish before in order to be returned (exclusive)
      *
      * @return A list of jobs.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<JobSearchResult> getJobs(
         final String id,
@@ -269,14 +270,15 @@ public class JobClient extends BaseGenieClient {
      *
      * @param jobId The id of the job to get.
      * @return The job details.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public Job getJob(
         final String jobId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(jobId)) {
-            throw new GenieClientException("Missing required parameter: jobId.");
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
         }
         return jobService.getJob(jobId).execute().body();
     }
@@ -286,14 +288,15 @@ public class JobClient extends BaseGenieClient {
      *
      * @param jobId The id of the job.
      * @return The cluster object.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public Cluster getJobCluster(
         final String jobId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(jobId)) {
-            throw new GenieClientException("Missing required parameter: jobId.");
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
         }
         return jobService.getJobCluster(jobId).execute().body();
     }
@@ -303,14 +306,15 @@ public class JobClient extends BaseGenieClient {
      *
      * @param jobId The id of the job.
      * @return The command object.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public Command getJobCommand(
         final String jobId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(jobId)) {
-            throw new GenieClientException("Missing required parameter: jobId.");
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
         }
         return jobService.getJobCommand(jobId).execute().body();
     }
@@ -320,14 +324,15 @@ public class JobClient extends BaseGenieClient {
      *
      * @param jobId The id of the job.
      * @return The command object.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public JobRequest getJobRequest(
         final String jobId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(jobId)) {
-            throw new GenieClientException("Missing required parameter: jobId.");
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
         }
         return jobService.getJobRequest(jobId).execute().body();
     }
@@ -337,14 +342,15 @@ public class JobClient extends BaseGenieClient {
      *
      * @param jobId The id of the job.
      * @return The command object.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public JobExecution getJobExecution(
         final String jobId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(jobId)) {
-            throw new GenieClientException("Missing required parameter: jobId.");
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
         }
         return jobService.getJobExecution(jobId).execute().body();
     }
@@ -354,14 +360,15 @@ public class JobClient extends BaseGenieClient {
      *
      * @param jobId The id of the job.
      * @return The list of Applications.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public List<Application> getJobApplications(
         final String jobId
     ) throws IOException, GenieClientException {
         if (StringUtils.isEmpty(jobId)) {
-            throw new GenieClientException("Missing required parameter: jobId.");
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
         }
         return jobService.getJobApplications(jobId).execute().body();
     }
@@ -373,12 +380,15 @@ public class JobClient extends BaseGenieClient {
      *
      * @return An inputstream to the output contents.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public InputStream getJobStdout(
         final String jobId
     ) throws IOException, GenieClientException {
+        if (StringUtils.isEmpty(jobId)) {
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
+        }
         if (!this.getJobStatus(jobId).equals(JobStatus.SUCCEEDED)) {
             throw new GenieClientException(400, "Cannot request output of a job whose status is not SUCCEEDED.");
         }
@@ -392,12 +402,15 @@ public class JobClient extends BaseGenieClient {
      *
      * @return An inputstream to the stderr contents.
      *
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public InputStream getJobStderr(
         final String jobId
     ) throws IOException, GenieClientException {
+        if (StringUtils.isEmpty(jobId)) {
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
+        }
         return jobService.getJobStderr(jobId).execute().body().byteStream();
     }
 
@@ -407,12 +420,16 @@ public class JobClient extends BaseGenieClient {
      * @param jobId The id of the job.
      *
      * @return The status of the Job.
-     * @throws GenieClientException       For any other error.
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws GenieClientException If the response recieved is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public JobStatus getJobStatus(
         final String jobId
     ) throws IOException, GenieClientException {
+        if (StringUtils.isEmpty(jobId)) {
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
+        }
         final JsonNode jsonNode = jobService.getJobStatus(jobId).execute().body();
         try {
             return JobStatus.parse(jsonNode.get(STATUS).asText());
@@ -426,9 +443,14 @@ public class JobClient extends BaseGenieClient {
      * Method to send a kill job request to Genie.
      *
      * @param jobId The id of the job.
-     * @throws IOException If there is a problem while sending the request.
+     *
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
-    public void killJob(final String jobId) throws IOException {
+    public void killJob(final String jobId) throws IOException, GenieClientException {
+        if (StringUtils.isEmpty(jobId)) {
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
+        }
         jobService.killJob(jobId).execute();
     }
 
@@ -440,14 +462,15 @@ public class JobClient extends BaseGenieClient {
      *                     GenieClientException will be thrown
      * @param pollTime     the time to sleep between polling for job status
      * @return The job status for the job after completion
-     * @throws GenieClientException       For timeout or other errors.
-     * @throws InterruptedException on thread errors
-     * @throws IOException If the response received is not 2xx.
+     *
+     * @throws InterruptedException on thread errors.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
     public JobStatus waitForCompletion(final String jobId, final long blockTimeout, final long pollTime)
         throws GenieClientException, InterruptedException, IOException {
         if (StringUtils.isEmpty(jobId)) {
-            throw new GenieClientException("Missing required parameter: jobId.");
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
         }
 
         final long startTime = System.currentTimeMillis();
@@ -461,34 +484,32 @@ public class JobClient extends BaseGenieClient {
                 return status;
             }
 
-            // block until timeout
-            try {
-                if (System.currentTimeMillis() - startTime < blockTimeout) {
-                    Thread.sleep(pollTime);
-                } else {
-                    throw new GenieClientException("Timed out waiting for job to finish");
-                }
-            } catch (InterruptedException ie) {
-                throw new IOException("Received interreupted exception from wait thread.");
+            if (System.currentTimeMillis() - startTime < blockTimeout) {
+                Thread.sleep(pollTime);
+            } else {
+                throw new GenieClientException("Timed out waiting for job to finish");
             }
-
         }
     }
 
     /**
      * Wait for job to complete, until the given timeout.
      *
-     * @param id           the Genie job ID to wait for completion.
+     * @param jobId           the Genie job ID to wait for completion.
      * @param blockTimeout the time to block for (in ms), after which a
      *                     GenieClientException will be thrown.
      * @return The job status for the job after completion.
-     * @throws GenieClientException       For timeout or other errors.
-     * @throws InterruptedException on timeout/thread errors.
-     * @throws IOException If the response recieved is not 2xx.
+     *
+     * @throws InterruptedException on thread errors.
+     * @throws GenieClientException If the response received is not 2xx.
+     * @throws IOException For Network and other IO issues.
      */
-    public JobStatus waitForCompletion(final String id, final long blockTimeout)
+    public JobStatus waitForCompletion(final String jobId, final long blockTimeout)
         throws GenieClientException, InterruptedException, IOException {
+        if (StringUtils.isEmpty(jobId)) {
+            throw new IllegalArgumentException("Missing required parameter: jobId.");
+        }
         final long pollTime = 10000;
-        return waitForCompletion(id, blockTimeout, pollTime);
+        return waitForCompletion(jobId, blockTimeout, pollTime);
     }
 }

--- a/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
@@ -32,6 +32,7 @@ import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.dto.search.JobSearchResult;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
+import com.netflix.genie.common.exceptions.GenieTimeoutException;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
@@ -436,7 +437,6 @@ public class JobClient extends BaseGenieClient {
         } catch (GeniePreconditionException ge) {
             throw new GenieClientException(ge.getMessage());
         }
-
     }
 
     /**
@@ -466,9 +466,10 @@ public class JobClient extends BaseGenieClient {
      * @throws InterruptedException on thread errors.
      * @throws GenieClientException If the response received is not 2xx.
      * @throws IOException For Network and other IO issues.
+     * @throws GenieTimeoutException If the job times out.
      */
     public JobStatus waitForCompletion(final String jobId, final long blockTimeout, final long pollTime)
-        throws GenieClientException, InterruptedException, IOException {
+        throws GenieClientException, InterruptedException, IOException, GenieTimeoutException {
         if (StringUtils.isEmpty(jobId)) {
             throw new IllegalArgumentException("Missing required parameter: jobId.");
         }
@@ -487,7 +488,7 @@ public class JobClient extends BaseGenieClient {
             if (System.currentTimeMillis() - startTime < blockTimeout) {
                 Thread.sleep(pollTime);
             } else {
-                throw new GenieClientException("Timed out waiting for job to finish");
+                throw new GenieTimeoutException("Timed out waiting for job to finish");
             }
         }
     }
@@ -503,9 +504,10 @@ public class JobClient extends BaseGenieClient {
      * @throws InterruptedException on thread errors.
      * @throws GenieClientException If the response received is not 2xx.
      * @throws IOException For Network and other IO issues.
+     * @throws GenieTimeoutException If the job times out.
      */
     public JobStatus waitForCompletion(final String jobId, final long blockTimeout)
-        throws GenieClientException, InterruptedException, IOException {
+        throws GenieClientException, InterruptedException, IOException, GenieTimeoutException {
         if (StringUtils.isEmpty(jobId)) {
             throw new IllegalArgumentException("Missing required parameter: jobId.");
         }

--- a/genie-client/src/main/java/com/netflix/genie/client/config/GenieNetworkConfiguration.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/config/GenieNetworkConfiguration.java
@@ -30,14 +30,19 @@ import lombok.Setter;
 @Setter
 public class GenieNetworkConfiguration {
 
+    /**
+     * Default network timeout value if not specified.
+     */
+    public static final long DEFAULT_TIMEOUT = -1;
+
     // The default read timeout for new connections.
-    private long readTimeout;
+    private long readTimeout = DEFAULT_TIMEOUT;
 
     // The default write timeout for new connections.
-    private long writeTimeout;
+    private long writeTimeout = DEFAULT_TIMEOUT;
 
     // Default connection timeout in milliseconds for new connections.
-    private long connectTimeout;
+    private long connectTimeout = DEFAULT_TIMEOUT;
 
     // Decides if genie should retry or not when a connectivity problem is encountered.
     private boolean retryOnConnectionFailure;

--- a/genie-client/src/main/java/com/netflix/genie/client/interceptor/ResponseMappingInterceptor.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/interceptor/ResponseMappingInterceptor.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.client.interceptor;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.genie.client.exceptions.GenieClientException;
@@ -52,8 +53,13 @@ public class ResponseMappingInterceptor implements Interceptor {
         if (response.isSuccessful()) {
             return response;
         } else {
-            final JsonNode responseBody = mapper.readTree(response.body().string());
-            throw new GenieClientException(response.code(), response.message() + " : " + responseBody.get("message"));
+            try {
+                final JsonNode responseBody = mapper.readTree(response.body().string());
+                throw new GenieClientException(response.code(), response.message()
+                    + " : " + responseBody.get("message"));
+            } catch (JsonMappingException jme) {
+                throw new GenieClientException(response.code(), response.message() + response.body().toString());
+            }
         }
     }
 }

--- a/genie-client/src/main/java/com/netflix/genie/client/interceptor/ResponseMappingInterceptor.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/interceptor/ResponseMappingInterceptor.java
@@ -50,15 +50,18 @@ public class ResponseMappingInterceptor implements Interceptor {
     @Override
     public Response intercept(final Chain chain) throws IOException {
         final Response response = chain.proceed(chain.request());
+
         if (response.isSuccessful()) {
             return response;
         } else {
+            final String bodyContent = response.body().string();
+
             try {
-                final JsonNode responseBody = mapper.readTree(response.body().string());
+                final JsonNode responseBody = mapper.readTree(bodyContent);
                 throw new GenieClientException(response.code(), response.message()
                     + " : " + responseBody.get("message"));
             } catch (JsonProcessingException jpe) {
-                throw new GenieClientException(response.code(), response.message() + response.body().toString());
+                throw new GenieClientException(response.code(), response.message() + bodyContent);
             }
         }
     }

--- a/genie-client/src/main/java/com/netflix/genie/client/interceptor/ResponseMappingInterceptor.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/interceptor/ResponseMappingInterceptor.java
@@ -17,7 +17,7 @@
  */
 package com.netflix.genie.client.interceptor;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.genie.client.exceptions.GenieClientException;
@@ -57,7 +57,7 @@ public class ResponseMappingInterceptor implements Interceptor {
                 final JsonNode responseBody = mapper.readTree(response.body().string());
                 throw new GenieClientException(response.code(), response.message()
                     + " : " + responseBody.get("message"));
-            } catch (JsonMappingException jme) {
+            } catch (JsonProcessingException jpe) {
                 throw new GenieClientException(response.code(), response.message() + response.body().toString());
             }
         }


### PR DESCRIPTION
- The job dependencies are now deleted (configurable) before the archive is created. The deletion had a bug which is now fixed by deleting each application dependencies one-by-one

- The clients now throw IllegalArgumentException in case of missing params

- The wait method in JobClient now does not gobble up the the InterruptedException from the thread sleep method but lets it propagate up to the caller to handle it.

- All non 2xx response in the clients now throw GenieClientExceptions and IOExceptions are thrown for Network and other IO problems.