### PR TITLE
Add a colon between errorCode and msg when constructing GenieClientException.

### DIFF
--- a/genie-client/src/main/java/com/netflix/genie/client/exceptions/GenieClientException.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/exceptions/GenieClientException.java
@@ -39,7 +39,7 @@ public class GenieClientException extends IOException {
      * @param msg human readable message
      */
     public GenieClientException(final int errorCode, final String msg) {
-        super(String.valueOf(errorCode) + msg);
+        super(errorCode + ": " + msg);
         this.errorCode = errorCode;
     }
 


### PR DESCRIPTION
This fixes (for example) "503Service Unavailable" in the string representation of a GenieClientException.