### PR TITLE
Fixed issue with previous pull request

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -51,7 +51,6 @@ import com.netflix.genie.core.services.impl.LocalJobRunner;
 import com.netflix.genie.core.services.impl.MailServiceImpl;
 import com.netflix.genie.core.services.impl.RandomizedClusterLoadBalancerImpl;
 import com.netflix.spectator.api.Registry;
-import com.sun.management.OperatingSystemMXBean;
 import org.apache.commons.exec.Executor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -64,7 +63,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.mail.javamail.JavaMailSender;
 
-import java.lang.management.ManagementFactory;
 import java.util.List;
 
 /**
@@ -342,15 +340,5 @@ public class ServicesConfig {
             registry,
             eventPublisher
         );
-    }
-
-    /**
-     * Returns the operating system MX bean.
-     *
-     * @return The operating system MX bean.
-     */
-    @Bean
-    public OperatingSystemMXBean operatingSystemMXBean() {
-        return (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/health/MemoryHealthIndicator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/health/MemoryHealthIndicator.java
@@ -21,6 +21,8 @@ import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
 
+import java.lang.management.ManagementFactory;
+
 /**
  * Health indicator for system memory usage. Also mark the service out-of-service if it crosses the threshold.
  * @author amajumdar
@@ -39,14 +41,17 @@ public class MemoryHealthIndicator implements HealthIndicator {
      * Constructor.
      *
      * @param maxUsedPhysicalMemoryPercentage The maximum physical memory threshold
-     * @param operatingSystemMXBean MX bean for operating system
      */
     @Autowired
     public MemoryHealthIndicator(
             @Value("${genie.health.memory.usedPhysicalMemoryPercent:90}")
-            final double maxUsedPhysicalMemoryPercentage,
-            final OperatingSystemMXBean operatingSystemMXBean
+            final double maxUsedPhysicalMemoryPercentage
     ) {
+        this(maxUsedPhysicalMemoryPercentage, (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean());
+    }
+
+    MemoryHealthIndicator(final double maxUsedPhysicalMemoryPercentage,
+            final OperatingSystemMXBean operatingSystemMXBean) {
         this.maxUsedPhysicalMemoryPercentage = maxUsedPhysicalMemoryPercentage;
         this.operatingSystemMXBean = operatingSystemMXBean;
     }


### PR DESCRIPTION
Issue: Application failed to start because the operatingSystemMXBean was conflicting with already registered MXBean.

Previous pull request: Added health indicator for physical memory used on the instance. Also mark the service out-of-service if it crosses the threshold.