### PR TITLE
Synchronize Job Coordination

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobCoordinatorService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobCoordinatorService.java
@@ -159,7 +159,9 @@ public class JobCoordinatorService {
                 .withStatus(JobStatus.FAILED)
                 .withStatusMsg("Unable to run job due to host being too busy during request.");
             this.jobPersistenceService.createJob(jobBuilder.build());
-            throw new GenieServerUnavailableException("Reached max running jobs on this host. Unable to run job.");
+            throw new GenieServerUnavailableException(
+                "Running max running jobs (" + this.maxRunningJobs + ") on this host. Unable to run job."
+            );
         }
     }
 

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobCoordinatorService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobCoordinatorService.java
@@ -136,32 +136,40 @@ public class JobCoordinatorService {
             .withId(jobRequest.getId())
             .withTags(jobRequest.getTags());
 
-        if (this.canRunJob()) {
-            jobBuilder
-                .withStatus(JobStatus.INIT)
-                .withStatusMsg("Job Accepted and in initialization phase.");
-            // TODO: if this throws exception the job will never be marked failed
-            this.jobPersistenceService.createJob(jobBuilder.build());
-            try {
-                final Future<?> task
-                    = this.taskExecutor.submit(new JobLauncher(this.jobSubmitterService, jobRequest, this.registry));
+        synchronized (this) {
+            final int numActiveJobs = this.jobCountService.getNumJobs();
+            if (numActiveJobs < this.maxRunningJobs) {
+                jobBuilder
+                    .withStatus(JobStatus.INIT)
+                    .withStatusMsg("Job Accepted and in initialization phase.");
+                // TODO: if this throws exception the job will never be marked failed
+                this.jobPersistenceService.createJob(jobBuilder.build());
+                try {
+                    final Future<?> task = this.taskExecutor.submit(
+                        new JobLauncher(this.jobSubmitterService, jobRequest, this.registry)
+                    );
 
-                // Tell the system a new job has been scheduled so any actions can be taken
-                this.eventPublisher.publishEvent(new JobScheduledEvent(jobRequest.getId(), task, this));
-            } catch (final TaskRejectedException e) {
-                final String errorMsg = "Unable to launch job due to exception: " + e.getMessage();
-                this.jobPersistenceService.updateJobStatus(jobRequest.getId(), JobStatus.FAILED, errorMsg);
-                throw new GenieServerException(errorMsg, e);
+                    // Tell the system a new job has been scheduled so any actions can be taken
+                    this.eventPublisher.publishEvent(new JobScheduledEvent(jobRequest.getId(), task, this));
+                } catch (final TaskRejectedException e) {
+                    final String errorMsg = "Unable to launch job due to exception: " + e.getMessage();
+                    this.jobPersistenceService.updateJobStatus(jobRequest.getId(), JobStatus.FAILED, errorMsg);
+                    throw new GenieServerException(errorMsg, e);
+                }
+                return jobRequest.getId();
+            } else {
+                jobBuilder
+                    .withStatus(JobStatus.FAILED)
+                    .withStatusMsg("Unable to run job due to host being too busy during request.");
+                this.jobPersistenceService.createJob(jobBuilder.build());
+                throw new GenieServerUnavailableException(
+                    "Running ("
+                        + numActiveJobs
+                        + ") when max running jobs is ("
+                        + this.maxRunningJobs
+                        + ") on this host. Unable to run job."
+                );
             }
-            return jobRequest.getId();
-        } else {
-            jobBuilder
-                .withStatus(JobStatus.FAILED)
-                .withStatusMsg("Unable to run job due to host being too busy during request.");
-            this.jobPersistenceService.createJob(jobBuilder.build());
-            throw new GenieServerUnavailableException(
-                "Running max running jobs (" + this.maxRunningJobs + ") on this host. Unable to run job."
-            );
         }
     }
 
@@ -173,15 +181,5 @@ public class JobCoordinatorService {
      */
     public void killJob(@NotBlank final String jobId) throws GenieException {
         this.jobKillService.killJob(jobId);
-    }
-
-
-    /**
-     * Synchronized to make sure only one request thread at a time is checking whether they can run.
-     *
-     * @return true if the job can run on this node or not
-     */
-    private synchronized boolean canRunJob() {
-        return this.jobCountService.getNumJobs() < this.maxRunningJobs;
     }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCountServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCountServiceImpl.java
@@ -49,7 +49,7 @@ public class JobCountServiceImpl implements JobCountService {
      * {@inheritDoc}
      */
     @Override
-    public int getNumJobs() {
+    public synchronized int getNumJobs() {
         return this.jobSearchService.getAllRunningJobExecutionsOnHost(this.hostName).size();
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
@@ -201,7 +201,7 @@ public class JobMonitoringCoordinator implements JobCountService {
      *
      * @return the number of jobs currently running on this node
      */
-    public int getNumJobs() {
+    public synchronized int getNumJobs() {
         return this.jobMonitors.size() + this.scheduledJobs.size();
     }
 

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
@@ -50,6 +50,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -353,13 +354,6 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
      */
     @After
     public void cleanup() throws Exception {
-        this.jobRequestRepository.deleteAll();
-        this.jobRepository.deleteAll();
-        this.jobExecutionRepository.deleteAll();
-        this.clusterRepository.deleteAll();
-        this.commandRepository.deleteAll();
-        this.applicationRepository.deleteAll();
-
         log.error("HEALTH ENDPOINT DATA: {}", this.mvc
             .perform(
                 MockMvcRequestBuilders
@@ -367,6 +361,13 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
                     .contentType(MediaType.APPLICATION_JSON)
             )
             .andReturn().getResponse().getContentAsString());
+
+        this.jobRequestRepository.deleteAll();
+        this.jobRepository.deleteAll();
+        this.jobExecutionRepository.deleteAll();
+        this.clusterRepository.deleteAll();
+        this.commandRepository.deleteAll();
+        this.applicationRepository.deleteAll();
     }
 
     /**
@@ -766,16 +767,33 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
             .withDisableLogArchival(true)
             .build();
 
+//        final MvcResult result = this.mvc
+//            .perform(
+//                MockMvcRequestBuilders
+//                    .post(JOBS_API)
+//                    .contentType(MediaType.APPLICATION_JSON)
+//                    .content(OBJECT_MAPPER.writeValueAsBytes(jobRequest))
+//            )
+//            .andExpect(MockMvcResultMatchers.status().isAccepted())
+//            .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.LOCATION, Matchers.notNullValue()))
+//            .andReturn();
+
         final MvcResult result = this.mvc
             .perform(
                 MockMvcRequestBuilders
                     .post(JOBS_API)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(OBJECT_MAPPER.writeValueAsBytes(jobRequest))
-            )
-            .andExpect(MockMvcResultMatchers.status().isAccepted())
-            .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.LOCATION, Matchers.notNullValue()))
-            .andReturn();
+            ).andReturn();
+
+        if (result.getResponse().getStatus() != HttpStatus.ACCEPTED.value()) {
+            log.error(
+                "RESPONSE WASN'T 202 IT WAS: {} AND THE MESSAGE IS: {}",
+                result.getResponse().getStatus(),
+                result.getResponse().getContentAsString()
+            );
+            Assert.fail();
+        }
 
         final String jobId = this.getIdFromLocation(result.getResponse().getHeader(HttpHeaders.LOCATION));
         final String statusEndpoint = JOBS_API + "/" + jobId + "/status";
@@ -819,16 +837,33 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
             .withDisableLogArchival(true)
             .build();
 
+//        final MvcResult result = this.mvc
+//            .perform(
+//                MockMvcRequestBuilders
+//                    .post(JOBS_API)
+//                    .contentType(MediaType.APPLICATION_JSON)
+//                    .content(OBJECT_MAPPER.writeValueAsBytes(jobRequest))
+//            )
+//            .andExpect(MockMvcResultMatchers.status().isAccepted())
+//            .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.LOCATION, Matchers.notNullValue()))
+//            .andReturn();
+
         final MvcResult result = this.mvc
             .perform(
                 MockMvcRequestBuilders
                     .post(JOBS_API)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(OBJECT_MAPPER.writeValueAsBytes(jobRequest))
-            )
-            .andExpect(MockMvcResultMatchers.status().isAccepted())
-            .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.LOCATION, Matchers.notNullValue()))
-            .andReturn();
+            ).andReturn();
+
+        if (result.getResponse().getStatus() != HttpStatus.ACCEPTED.value()) {
+            log.error(
+                "RESPONSE WASN'T 202 IT WAS: {} AND THE MESSAGE IS: {}",
+                result.getResponse().getStatus(),
+                result.getResponse().getContentAsString()
+            );
+            Assert.fail();
+        }
 
         final String jobId = this.getIdFromLocation(result.getResponse().getHeader(HttpHeaders.LOCATION));
         final String statusEndpoint


### PR DESCRIPTION
This PR synchronizes the entire Job Coordination code to make sure only one job per node can enter that block at a time and all metrics/job counts are consistent before another job is allowed.

This may slow down performance somewhat but the consistency tradeoff should be worth it. Will observe performance change in testing under load.