### PR TITLE
Tag substrings are matching when they shouldn't

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaSpecificationUtils.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaSpecificationUtils.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.core.jpa.specifications;
 
+import com.netflix.genie.core.jpa.entities.CommonFieldsEntity;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.validation.constraints.NotNull;
@@ -30,7 +31,7 @@ import java.util.Set;
  */
 public final class JpaSpecificationUtils {
 
-//    private static final String PIPE_REGEX = "\\|";
+    private static final char PERCENT = '%';
 
     protected JpaSpecificationUtils() {
     }
@@ -43,11 +44,16 @@ public final class JpaSpecificationUtils {
      */
     public static String getTagLikeString(@NotNull final Set<String> tags) {
         final StringBuilder builder = new StringBuilder();
-        builder.append("%");
         tags.stream()
                 .filter(StringUtils::isNotBlank)
                 .sorted(String.CASE_INSENSITIVE_ORDER)
-                .forEach(tag -> builder.append(tag).append("%"));
-        return builder.toString();
+                .forEach(
+                    tag -> builder
+                        .append(PERCENT)
+                        .append(CommonFieldsEntity.TAG_DELIMITER)
+                        .append(tag)
+                        .append(CommonFieldsEntity.TAG_DELIMITER)
+                );
+        return builder.append(PERCENT).toString();
     }
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaClusterServiceImplIntegrationTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaClusterServiceImplIntegrationTests.java
@@ -21,10 +21,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.jsonpatch.JsonPatch;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.Cluster;
+import com.netflix.genie.common.dto.ClusterCriteria;
 import com.netflix.genie.common.dto.ClusterStatus;
 import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.CommandStatus;
+import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.core.services.ClusterService;
 import com.netflix.genie.core.services.CommandService;
@@ -262,22 +266,58 @@ public class JpaClusterServiceImplIntegrationTests extends DBUnitTestBase {
     }
 
     /**
-     * Test the choseClusterForJob function.
+     * Test the choseClusterForJobRequest function.
      *
      * @throws GenieException For any problem
      */
-    @Ignore
     @Test
     public void testChooseClusterForJob() throws GenieException {
-//        final List<Cluster> clusters = this.service.chooseClusterForJob(JOB_1_ID);
-//        Assert.assertEquals(1, clusters.size());
-//        Assert.assertEquals(CLUSTER_1_ID, clusters.get(0).getId());
-//        final JobEntity jobEntity = this.jpaJobRepository.findOne(JOB_1_ID);
-//        final String chosen = jobEntity.getChosenClusterCriteriaString();
-//        Assert.assertEquals(8, chosen.length());
-//        Assert.assertTrue(chosen.contains("prod"));
-//        Assert.assertTrue(chosen.contains("pig"));
-//        Assert.assertTrue(chosen.contains(","));
+        final JobRequest one = new JobRequest.Builder(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Lists.newArrayList(new ClusterCriteria(Sets.newHashSet("genie.id:cluster1"))),
+            Sets.newHashSet("pig")
+        ).build();
+        final JobRequest two = new JobRequest.Builder(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Lists.newArrayList(new ClusterCriteria(Sets.newHashSet("genie.id:cluster"))),
+            Sets.newHashSet("pig")
+        ).build();
+        final JobRequest three = new JobRequest.Builder(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Lists.newArrayList(new ClusterCriteria(Sets.newHashSet("genie.id:cluster1"))),
+            Sets.newHashSet("pi")
+        ).build();
+        final JobRequest four = new JobRequest.Builder(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Lists.newArrayList(new ClusterCriteria(Sets.newHashSet("pig"))),
+            Sets.newHashSet("pig")
+        ).build();
+        final JobRequest five = new JobRequest.Builder(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            Lists.newArrayList(new ClusterCriteria(Sets.newHashSet("pig", "hive"))),
+            Sets.newHashSet("pig")
+        ).build();
+
+        Assert.assertThat(this.service.chooseClusterForJobRequest(one).size(), Matchers.is(1));
+        Assert.assertThat(this.service.chooseClusterForJobRequest(two).size(), Matchers.is(0));
+        Assert.assertThat(this.service.chooseClusterForJobRequest(three).size(), Matchers.is(0));
+        Assert.assertThat(this.service.chooseClusterForJobRequest(four).size(), Matchers.is(2));
+        Assert.assertThat(this.service.chooseClusterForJobRequest(five).size(), Matchers.is(2));
     }
 
     // TODO Add tests where jobRequest object is
@@ -488,7 +528,7 @@ public class JpaClusterServiceImplIntegrationTests extends DBUnitTestBase {
      * Test to patch a cluster.
      *
      * @throws GenieException For any problem
-     * @throws IOException For Json serialization problem
+     * @throws IOException    For Json serialization problem
      */
     @Test
     public void testPatchCluster() throws GenieException, IOException {

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaSpecificationUtilsUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaSpecificationUtilsUnitTests.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.core.jpa.specifications;
 
 import com.google.common.collect.Sets;
+import com.netflix.genie.core.jpa.entities.CommonFieldsEntity;
 import com.netflix.genie.test.categories.UnitTest;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -48,10 +49,27 @@ public class JpaSpecificationUtilsUnitTests {
     @Test
     public void canGetTagLikeString() {
         Assert.assertThat(JpaSpecificationUtils.getTagLikeString(Sets.newHashSet()), Matchers.is("%"));
-        Assert.assertThat(JpaSpecificationUtils.getTagLikeString(Sets.newHashSet("tag")), Matchers.is("%tag%"));
+        Assert.assertThat(
+            JpaSpecificationUtils.getTagLikeString(Sets.newHashSet("tag")),
+            Matchers.is("%" + CommonFieldsEntity.TAG_DELIMITER + "tag" + CommonFieldsEntity.TAG_DELIMITER + "%")
+        );
         Assert.assertThat(
             JpaSpecificationUtils.getTagLikeString(Sets.newHashSet("tag", "Stag", "rag")),
-            Matchers.is("%rag%Stag%tag%")
+            Matchers.is(
+                "%"
+                    + CommonFieldsEntity.TAG_DELIMITER
+                    + "rag"
+                    + CommonFieldsEntity.TAG_DELIMITER
+                    + "%"
+                    + CommonFieldsEntity.TAG_DELIMITER
+                    + "Stag"
+                    + CommonFieldsEntity.TAG_DELIMITER
+                    + "%"
+                    + CommonFieldsEntity.TAG_DELIMITER
+                    + "tag"
+                    + CommonFieldsEntity.TAG_DELIMITER
+                    + "%"
+            )
         );
     }
 }

--- a/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaApplicationServiceImplIntegrationTests/init.xml
+++ b/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaApplicationServiceImplIntegrationTests/init.xml
@@ -24,7 +24,7 @@
         version="1.2.3"
         status="INACTIVE"
         entity_version="0"
-        tags="genie.id:app1|genie.name:tez|prod"
+        tags="|genie.id:app1||genie.name:tez||prod|"
     />
     <application_configs
         application_id="app1"
@@ -48,7 +48,7 @@
         version="4.5.6"
         status="ACTIVE"
         entity_version="0"
-        tags="genie.id:app2|genie.name:spark|prod|yarn"
+        tags="|genie.id:app2||genie.name:spark||prod||yarn|"
         type="spark"
     />
     <application_configs
@@ -70,7 +70,7 @@
         version="7.8.9"
         status="DEPRECATED"
         entity_version="0"
-        tags="genie.id:app3|genie.name:storm|prod"
+        tags="|genie.id:app3||genie.name:storm||prod|"
         type="storm"
     />
     <application_configs
@@ -94,7 +94,7 @@
         check_delay="10000"
         status="INACTIVE"
         entity_version="0"
-        tags="genie.id:command1|genie.name:pig_13_prod"
+        tags="|genie.id:command1||genie.name:pig_13_prod|"
     />
 
     <commands_applications command_id="command1" application_id="app1" application_order="0"/>

--- a/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaClusterServiceImplIntegrationTests/init.xml
+++ b/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaClusterServiceImplIntegrationTests/init.xml
@@ -26,7 +26,7 @@
         check_delay="15000"
         status="ACTIVE"
         entity_version="0"
-        tags="genie.id:command1|genie:name:pig_13_prod|pig|prod|tez"
+        tags="|genie.id:command1||genie:name:pig_13_prod||pig||prod||tez|"
     />
     <command_configs
         command_id="command1"
@@ -46,7 +46,7 @@
         check_delay="16000"
         status="INACTIVE"
         entity_version="0"
-        tags="genie.id:command2|genie:name:hive_11_prod|hive|prod"
+        tags="|genie.id:command2||genie:name:hive_11_prod||hive||prod|"
     />
     <command_configs
         command_id="command2"
@@ -63,7 +63,7 @@
         check_delay="17000"
         status="DEPRECATED"
         entity_version="0"
-        tags="deprecated|genie.id:command3|genie:name:pig_11_prod|pig|prod"
+        tags="|deprecated||genie.id:command3||genie:name:pig_11_prod||pig||prod|"
     />
     <command_configs
         command_id="command3"
@@ -78,7 +78,7 @@
         version="2.4.0"
         status="UP"
         entity_version="0"
-        tags="genie.id:cluster1|genie.name:h2prod|hive|pig|prod"
+        tags="|genie.id:cluster1||genie.name:h2prod||hive||pig||prod|"
     />
     <cluster_configs
         cluster_id="cluster1"
@@ -106,7 +106,7 @@
         version="2.4.0"
         status="UP"
         entity_version="0"
-        tags="genie.id:cluster2|genie.name:h2query|hive|pig|query"
+        tags="|genie.id:cluster2||genie.name:h2query||hive||pig||query|"
     />
     <cluster_configs
         cluster_id="cluster2"

--- a/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaCommandServiceImplIntegrationTests/init.xml
+++ b/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaCommandServiceImplIntegrationTests/init.xml
@@ -24,7 +24,7 @@
             version="1.2.3"
             status="ACTIVE"
             entity_version="0"
-            tags="genie.id:app1|genie.name:tez|prod|yarn"
+            tags="|genie.id:app1||genie.name:tez||prod||yarn|"
     />
     <application_configs
             application_id="app1"
@@ -50,7 +50,7 @@
             check_delay="18000"
             status="ACTIVE"
             entity_version="0"
-            tags="genie.id:command1|genie.name:pig_13_prod|pig|prod|tez"
+            tags="|genie.id:command1||genie.name:pig_13_prod||pig||prod||tez|"
     />
     <command_configs
             command_id="command1"
@@ -70,7 +70,7 @@
             check_delay="19000"
             status="INACTIVE"
             entity_version="0"
-            tags="genie.id:command2|genie.name:hive_11_prod|hive|prod"
+            tags="|genie.id:command2||genie.name:hive_11_prod||hive||prod|"
     />
     <command_configs
             command_id="command2"
@@ -87,7 +87,7 @@
             check_delay="20000"
             status="DEPRECATED"
             entity_version="0"
-            tags="deprecated|genie.id:command3|genie.name:pig_11_prod|pig|prod"
+            tags="|deprecated||genie.id:command3||genie.name:pig_11_prod||pig||prod|"
     />
     <command_configs
             command_id="command3"
@@ -102,7 +102,7 @@
             version="2.4.0"
             status="UP"
             entity_version="0"
-            tags="genie.id:cluster1|genie.name:h2prod|hive|pig|prod"
+            tags="|genie.id:cluster1||genie.name:h2prod||hive||pig||prod|"
     />
     <cluster_configs
             cluster_id="cluster1"

--- a/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaJobPersistenceServiceImplIntegrationTests/init.xml
+++ b/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaJobPersistenceServiceImplIntegrationTests/init.xml
@@ -26,7 +26,7 @@
         status="ACTIVE"
         entity_version="0"
         type="hadoop"
-        tags="genie.id:app1|genie.name:hadoop|type:hadoop"
+        tags="|genie.id:app1||genie.name:hadoop||type:hadoop|"
     />
     <application_configs
         application_id="app1"
@@ -48,7 +48,7 @@
         status="ACTIVE"
         entity_version="0"
         type="spark"
-        tags="genie.id:app2|genie.name:spark|type:spark"
+        tags="|genie.id:app2||genie.name:spark||type:spark|"
     />
     <application_configs
         application_id="app2"
@@ -70,7 +70,7 @@
         status="ACTIVE"
         entity_version="0"
         type="spark"
-        tags="genie.id:app3|genie.name:spark|type:spark"
+        tags="|genie.id:app3||genie.name:spark||type:spark|"
     />
     <application_configs
         application_id="app3"
@@ -93,7 +93,7 @@
         check_delay="10000"
         status="ACTIVE"
         entity_version="0"
-        tags="genie.id:command1|genie.name:spark"
+        tags="|genie.id:command1||genie.name:spark|"
     />
 
     <commands_applications command_id="command1" application_id="app1" application_order="0"/>
@@ -108,7 +108,7 @@
         version="2.4.0"
         status="UP"
         entity_version="0"
-        tags="genie.id:cluster1|genie.name:h2query|sched:adhoc|type:yarn"
+        tags="|genie.id:cluster1||genie.name:h2query||sched:adhoc||type:yarn|"
     />
     <cluster_configs
         cluster_id="cluster1"

--- a/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplIntegrationTests/init.xml
+++ b/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplIntegrationTests/init.xml
@@ -26,7 +26,7 @@
         status="ACTIVE"
         entity_version="0"
         type="hadoop"
-        tags="genie.id:app1|genie.name:hadoop|type:hadoop"
+        tags="|genie.id:app1||genie.name:hadoop||type:hadoop|"
     />
     <application_configs
         application_id="app1"
@@ -48,7 +48,7 @@
         status="ACTIVE"
         entity_version="0"
         type="spark"
-        tags="genie.id:app2|genie.name:spark|type:spark"
+        tags="|genie.id:app2||genie.name:spark||type:spark|"
     />
     <application_configs
         application_id="app2"
@@ -70,7 +70,7 @@
         status="ACTIVE"
         entity_version="0"
         type="spark"
-        tags="genie.id:app3|genie.name:spark|type:spark"
+        tags="|genie.id:app3||genie.name:spark||type:spark|"
     />
     <application_configs
         application_id="app3"
@@ -93,7 +93,7 @@
         check_delay="10000"
         status="ACTIVE"
         entity_version="0"
-        tags="genie.id:command1|genie.name:spark"
+        tags="|genie.id:command1||genie.name:spark|"
     />
 
     <commands_applications command_id="command1" application_id="app1" application_order="0"/>
@@ -108,7 +108,7 @@
         version="2.4.0"
         status="UP"
         entity_version="0"
-        tags="genie.id:cluster1|genie.name:h2query|sched:adhoc|type:yarn"
+        tags="|genie.id:cluster1||genie.name:h2query||sched:adhoc||type:yarn|"
     />
     <cluster_configs
         cluster_id="cluster1"

--- a/genie-ddl/mysql/upgrade-2.0.0-to-3.0.0.mysql.sql
+++ b/genie-ddl/mysql/upgrade-2.0.0-to-3.0.0.mysql.sql
@@ -111,12 +111,19 @@ ALTER TABLE `applications`
 SELECT CURRENT_TIMESTAMP AS '', 'Successfully updated the applications table.' AS '';
 
 SELECT CURRENT_TIMESTAMP AS '', 'De-normalizing application tags for 3.0...' AS '';
-UPDATE `applications` AS `a` SET `a`.`tags` =
-(
-  SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
-  FROM `application_tags` AS `t`
-  WHERE `a`.`id` = `t`.`APPLICATION_ID`
-  GROUP BY `t`.`APPLICATION_ID`
+UPDATE `applications` AS `a` SET `a`.`tags` = CONCAT(
+  '|',
+  REPLACE(
+    (
+      SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
+      FROM `application_tags` AS `t`
+      WHERE `a`.`id` = `t`.`APPLICATION_ID`
+      GROUP BY `t`.`APPLICATION_ID`
+    ),
+    '|',
+    '||'
+  ),
+  '|'
 );
 SELECT CURRENT_TIMESTAMP AS '', 'Finished de-normalizing application tags for 3.0.' AS '';
 
@@ -160,12 +167,19 @@ ALTER TABLE `clusters`
 SELECT CURRENT_TIMESTAMP AS '', 'Successfully updated the clusters table.' AS '';
 
 SELECT CURRENT_TIMESTAMP AS '', 'De-normalizing cluster tags for 3.0...' AS '';
-UPDATE `clusters` AS `c` SET `c`.`tags` =
-(
-  SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
-  FROM `cluster_tags` AS `t`
-  WHERE `c`.`id` = `t`.`CLUSTER_ID`
-  GROUP BY `t`.`CLUSTER_ID`
+UPDATE `clusters` AS `c` SET `c`.`tags` = CONCAT(
+  '|',
+  REPLACE(
+    (
+      SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
+      FROM `cluster_tags` AS `t`
+      WHERE `c`.`id` = `t`.`CLUSTER_ID`
+      GROUP BY `t`.`CLUSTER_ID`
+    ),
+    '|',
+    '||'
+  ),
+  '|'
 );
 SELECT CURRENT_TIMESTAMP AS '', 'Finished de-normalizing cluster tags for 3.0.' AS '';
 
@@ -216,12 +230,19 @@ ALTER TABLE `commands`
 SELECT CURRENT_TIMESTAMP AS '', 'Successfully updated the commands table.' AS '';
 
 SELECT CURRENT_TIMESTAMP AS '', 'De-normalizing command tags for 3.0...' AS '';
-UPDATE `commands` AS `c` SET `c`.`tags` =
-(
-  SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
-  FROM `command_tags` AS `t`
-  WHERE `c`.`id` = `t`.`COMMAND_ID`
-  GROUP BY `t`.`COMMAND_ID`
+UPDATE `commands` AS `c` SET `c`.`tags` = CONCAT(
+  '|',
+  REPLACE(
+    (
+      SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
+      FROM `command_tags` AS `t`
+      WHERE `c`.`id` = `t`.`COMMAND_ID`
+      GROUP BY `t`.`COMMAND_ID`
+    ),
+    '|',
+    '||'
+  ),
+  '|'
 );
 SELECT CURRENT_TIMESTAMP AS '', 'Finished de-normalizing command tags for 3.0.' AS '';
 
@@ -304,11 +325,19 @@ INSERT INTO `job_requests` (
     `j`.`fileDependencies`,
     `j`.`disableLogArchival`,
     `j`.`email`,
-    (
-      SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
-      FROM `job_tags` `t`
-      WHERE `j`.`id` = `t`.`JOB_ID`
-      GROUP BY `t`.`JOB_ID`
+    CONCAT(
+      '|',
+      REPLACE(
+        (
+          SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
+          FROM `job_tags` `t`
+          WHERE `j`.`id` = `t`.`JOB_ID`
+          GROUP BY `t`.`JOB_ID`
+        ),
+        '|',
+        '||'
+      ),
+      '|'
     ),
     1,
     1560
@@ -501,12 +530,19 @@ ALTER TABLE `jobs`
 SELECT CURRENT_TIMESTAMP AS '', 'Successfully updated the jobs table.' AS '';
 
 SELECT CURRENT_TIMESTAMP AS '', 'De-normalizing jobs tags for 3.0...' AS '';
-UPDATE `jobs` AS `j` SET `j`.`tags` =
-(
-  SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
-  FROM `job_tags` AS `t`
-  WHERE `j`.`id` = `t`.`JOB_ID`
-  GROUP BY `t`.`JOB_ID`
+UPDATE `jobs` AS `j` SET `j`.`tags` = CONCAT(
+  '|',
+  REPLACE(
+    (
+      SELECT GROUP_CONCAT(DISTINCT `t`.`element` ORDER BY `t`.`element` SEPARATOR '|')
+      FROM `job_tags` AS `t`
+      WHERE `j`.`id` = `t`.`JOB_ID`
+      GROUP BY `t`.`JOB_ID`
+    ),
+    '|',
+    '||'
+  ),
+  '|'
 );
 SELECT CURRENT_TIMESTAMP AS '', 'Finished de-normalizing job tags for 3.0.' AS '';
 

--- a/genie-ddl/postgresql/upgrade-2.0.0-to-3.0.0.postgresql.sql
+++ b/genie-ddl/postgresql/upgrade-2.0.0-to-3.0.0.postgresql.sql
@@ -107,12 +107,19 @@ CREATE INDEX APPLICATIONS_TYPE_INDEX ON applications (type);
 SELECT CURRENT_TIMESTAMP, 'Successfully updated the applications table.';
 
 SELECT CURRENT_TIMESTAMP, 'De-normalizing application tags for 3.0...';
-UPDATE applications SET tags =
-(
-  SELECT string_agg(DISTINCT element, '|' ORDER BY element)
-  FROM application_tags
-  WHERE applications.id = application_tags.application_id
-  GROUP BY application_id
+UPDATE applications SET tags = CONCAT(
+  '|',
+  REPLACE(
+    (
+      SELECT string_agg(DISTINCT element, '|' ORDER BY element)
+      FROM application_tags
+      WHERE applications.id = application_tags.application_id
+      GROUP BY application_id
+    ),
+    '|',
+    '||'
+  ),
+  '|'
 );
 SELECT CURRENT_TIMESTAMP, 'Finished de-normalizing application tags for 3.0.';
 
@@ -167,12 +174,19 @@ CREATE INDEX CLUSTERS_STATUS_INDEX ON clusters (status);
 SELECT CURRENT_TIMESTAMP, 'Successfully updated the clusters table.';
 
 SELECT CURRENT_TIMESTAMP, 'De-normalizing cluster tags for 3.0...';
-UPDATE clusters SET tags =
-(
-  SELECT string_agg(DISTINCT element, '|' ORDER BY element)
-  FROM cluster_tags
-  WHERE clusters.id = cluster_tags.cluster_id
-  GROUP BY cluster_id
+UPDATE clusters SET tags = CONCAT(
+  '|',
+  REPLACE(
+    (
+      SELECT string_agg(DISTINCT element, '|' ORDER BY element)
+      FROM cluster_tags
+      WHERE clusters.id = cluster_tags.cluster_id
+      GROUP BY cluster_id
+    ),
+    '|',
+    '||'
+  ),
+  '|'
 );
 SELECT CURRENT_TIMESTAMP, 'Finished de-normalizing cluster tags for 3.0.';
 
@@ -236,13 +250,22 @@ CREATE INDEX COMMANDS_STATUS_INDEX on commands (status);
 SELECT CURRENT_TIMESTAMP, 'Successfully updated the commands table.';
 
 SELECT CURRENT_TIMESTAMP, 'De-normalizing command tags for 3.0...';
-UPDATE commands SET tags =
-(
-  SELECT string_agg(DISTINCT element, '|' ORDER BY element)
-  FROM command_tags
-  WHERE commands.id = command_tags.command_id
-  GROUP BY command_id
+UPDATE commands SET tags = CONCAT(
+  '|',
+  REPLACE(
+    (
+      SELECT string_agg(DISTINCT element, '|' ORDER BY element)
+      FROM command_tags
+      WHERE commands.id = command_tags.command_id
+      GROUP BY command_id
+    ),
+    '|',
+    '||'
+  ),
+  '|'
 );
+UPDATE commands SET tags = REPLACE(tags, '|', '||');
+UPDATE commands SET tags = CONCAT('|', tags, '|');
 SELECT CURRENT_TIMESTAMP, 'Finished de-normalizing command tags for 3.0.';
 
 SELECT CURRENT_TIMESTAMP, 'Updating the command_configs table for 3.0...';
@@ -326,11 +349,19 @@ INSERT INTO job_requests (
   j.filedependencies,
   j.disablelogarchival,
   j.email,
-  (
-    SELECT string_agg(DISTINCT element, '|' ORDER BY element)
-    FROM job_tags
-    WHERE j.id = job_tags.job_id
-    GROUP BY job_id
+  CONCAT(
+    '|',
+    REPLACE(
+      (
+        SELECT string_agg(DISTINCT element, '|' ORDER BY element)
+        FROM job_tags
+        WHERE j.id = job_tags.job_id
+        GROUP BY job_id
+      ),
+      '|',
+      '||'
+    ),
+    '|'
   ),
   1,
   1560
@@ -533,12 +564,19 @@ CREATE INDEX JOBS_TAGS_INDEX ON jobs (tags);
 SELECT CURRENT_TIMESTAMP, 'Successfully updated the jobs table.';
 
 SELECT CURRENT_TIMESTAMP, 'De-normalizing jobs tags for 3.0...';
-UPDATE jobs SET tags =
-(
-  SELECT string_agg(DISTINCT element, '|' ORDER BY element)
-  FROM job_tags
-  WHERE jobs.id = job_tags.job_id
-  GROUP BY job_id
+UPDATE jobs SET tags = CONCAT(
+  '|',
+  REPLACE(
+    (
+      SELECT string_agg(DISTINCT element, '|' ORDER BY element)
+      FROM job_tags
+      WHERE jobs.id = job_tags.job_id
+      GROUP BY job_id
+    ),
+    '|',
+    '||'
+  ),
+  '|'
 );
 SELECT CURRENT_TIMESTAMP, 'Finished de-normalizing job tags for 3.0.';
 

--- a/genie-web/src/main/java/com/netflix/genie/web/security/oauth2/pingfederate/PingFederateTokenServices.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/oauth2/pingfederate/PingFederateTokenServices.java
@@ -79,15 +79,17 @@ public class PingFederateTokenServices implements ResourceServerTokenServices {
         @NotNull final AccessTokenConverter converter
     ) {
         this.restOperations = new RestTemplate();
-        ((RestTemplate) this.restOperations).setErrorHandler(new DefaultResponseErrorHandler() {
-            @Override
-            // Ignore 400
-            public void handleError(final ClientHttpResponse response) throws IOException {
-                if (response.getRawStatusCode() != HttpStatus.BAD_REQUEST.value()) {
-                    super.handleError(response);
+        ((RestTemplate) this.restOperations).setErrorHandler(
+            new DefaultResponseErrorHandler() {
+                // Ignore 400
+                @Override
+                public void handleError(final ClientHttpResponse response) throws IOException {
+                    if (response.getRawStatusCode() != HttpStatus.BAD_REQUEST.value()) {
+                        super.handleError(response);
+                    }
                 }
             }
-        });
+        );
 
         this.checkTokenEndpointUrl = serverProperties.getTokenInfoUri();
         this.clientId = serverProperties.getClientId();
@@ -97,7 +99,7 @@ public class PingFederateTokenServices implements ResourceServerTokenServices {
         Assert.state(StringUtils.isNotBlank(this.clientId), "Client ID is required");
         Assert.state(StringUtils.isNotBlank(this.clientSecret), "Client secret is required");
 
-        log.debug("checkTokenEnpointUrl = {}", this.checkTokenEndpointUrl);
+        log.debug("checkTokenEndpointUrl = {}", this.checkTokenEndpointUrl);
         log.debug("clientId = {}", this.clientId);
         log.debug("clientSecret = {}", this.clientSecret);
 

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
@@ -32,6 +32,7 @@ import org.apache.commons.exec.Executor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.io.Resource;
 import org.springframework.scheduling.TaskScheduler;
@@ -53,6 +54,7 @@ import java.util.concurrent.ScheduledFuture;
  * @since 3.0.0
  */
 @Component
+@Primary
 @Slf4j
 public class JobMonitoringCoordinator implements JobCountService {
 


### PR DESCRIPTION
This PR fixes a bug where tag search was returning substring as matches when that wasn't desired.

For example if a user passed in cluster tags "presto" and two clusters in the database where one had tag "presto" and the other "presto2" both clusters would match when this wasn't desired by the user. This resulted in jobs randomly being sent to unintended clusters when similar naming schemes for tags were used.