### PR TITLE
Clean up job output directory formats

### DIFF
--- a/genie-web/src/test/java/com/netflix/genie/web/resources/writers/DefaultDirectoryWriterUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/resources/writers/DefaultDirectoryWriterUnitTests.java
@@ -48,18 +48,17 @@ public class DefaultDirectoryWriterUnitTests {
         = "http://genie.netflix.com:8080/api/v3/jobs/" + UUID.randomUUID().toString() + "/output";
     private static final String REQUEST_URL_WITH_PARENT = REQUEST_URL_BASE + "/" + UUID.randomUUID().toString();
 
-    private static final long PARENT_SIZE = 3082;
+    private static final long PARENT_SIZE = 0L;
     private static final Date PARENT_LAST_MODIFIED = new Date();
     private static final String PARENT_NAME = "../";
     private static final String PARENT_URL = REQUEST_URL_BASE;
 
-    private static final long DIR_1_SIZE = 83023;
+    private static final long DIR_1_SIZE = 0L;
     private static final Date DIR_1_LAST_MODIFIED = new Date(new Date().getTime() + 13142);
     private static final String DIR_1_NAME = UUID.randomUUID().toString();
     private static final String DIR_1_URL = REQUEST_URL_WITH_PARENT + "/" + DIR_1_NAME;
 
-
-    private static final long DIR_2_SIZE = 3023;
+    private static final long DIR_2_SIZE = 0L;
     private static final Date DIR_2_LAST_MODIFIED = new Date(new Date().getTime() - 1830);
     private static final String DIR_2_NAME = UUID.randomUUID().toString();
     private static final String DIR_2_URL = REQUEST_URL_WITH_PARENT + "/" + DIR_2_NAME;


### PR DESCRIPTION
Directories now size 0 bytes. Didn't see need to recursively get size especially as some files could be large depending on how users set up commands/applications.

Also return more human readable string with HTML output from API.

UI will be fixed by @cabhishek in another PR.