### PR TITLE
Removing reverse side mappings for job entities

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/ApplicationEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/ApplicationEntity.java
@@ -83,9 +83,6 @@ public class ApplicationEntity extends SetupFileEntity {
     @ManyToMany(mappedBy = "applications", fetch = FetchType.LAZY)
     private Set<CommandEntity> commands = new HashSet<>();
 
-//    @ManyToMany(mappedBy = "applications", fetch = FetchType.LAZY)
-//    private Set<JobEntity> jobs = new HashSet<>();
-
     /**
      * Default constructor.
      */

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/ClusterEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/ClusterEntity.java
@@ -34,7 +34,6 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
-import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
@@ -85,9 +84,6 @@ public class ClusterEntity extends SetupFileEntity {
     )
     @OrderColumn(name = "command_order", nullable = false)
     private List<CommandEntity> commands = new ArrayList<>();
-
-    @OneToMany(mappedBy = "cluster", fetch = FetchType.LAZY)
-    private Set<JobEntity> jobs = new HashSet<>();
 
     /**
      * Default Constructor.
@@ -222,39 +218,6 @@ public class ClusterEntity extends SetupFileEntity {
      */
     public void removeAllCommands() {
         Lists.newArrayList(this.commands).forEach(this::removeCommand);
-    }
-
-    /**
-     * Get the jobs which ran on this cluster. Probably shouldn't be used as it will return an enormous list.
-     *
-     * @return The jobs this cluster ran
-     */
-    protected Set<JobEntity> getJobs() {
-        return this.jobs;
-    }
-
-    /**
-     * Set the jobs run on this cluster.
-     *
-     * @param jobs The jobs
-     */
-    public void setJobs(final Set<JobEntity> jobs) {
-        this.jobs.clear();
-
-        if (jobs != null) {
-            this.jobs.addAll(jobs);
-        }
-    }
-
-    /**
-     * Add a job to the set of jobs this cluster ran.
-     *
-     * @param job The job
-     */
-    public void addJob(final JobEntity job) {
-        if (job != null) {
-            this.jobs.add(job);
-        }
     }
 
     /**

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/CommandEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/CommandEntity.java
@@ -37,7 +37,6 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
-import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
@@ -104,9 +103,6 @@ public class CommandEntity extends SetupFileEntity {
 
     @ManyToMany(mappedBy = "commands", fetch = FetchType.LAZY)
     private Set<ClusterEntity> clusters = new HashSet<>();
-
-    @OneToMany(mappedBy = "cluster", fetch = FetchType.LAZY)
-    private Set<JobEntity> jobs = new HashSet<>();
 
     /**
      * Default Constructor.
@@ -272,39 +268,6 @@ public class CommandEntity extends SetupFileEntity {
         this.clusters.clear();
         if (clusters != null) {
             this.clusters.addAll(clusters);
-        }
-    }
-
-    /**
-     * Get the jobs which used this command. Probably shouldn't be used as it will return an enormous list.
-     *
-     * @return The jobs this command is used for
-     */
-    protected Set<JobEntity> getJobs() {
-        return this.jobs;
-    }
-
-    /**
-     * Set the jobs run using this command.
-     *
-     * @param jobs The jobs
-     */
-    public void setJobs(final Set<JobEntity> jobs) {
-        this.jobs.clear();
-
-        if (jobs != null) {
-            this.jobs.addAll(jobs);
-        }
-    }
-
-    /**
-     * Add a job to the set of jobs this command was used for.
-     *
-     * @param job The job
-     */
-    public void addJob(final JobEntity job) {
-        if (job != null) {
-            this.jobs.add(job);
         }
     }
 

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobEntity.java
@@ -369,7 +369,6 @@ public class JobEntity extends CommonFieldsEntity {
      */
     public void setCluster(final ClusterEntity cluster) {
         if (this.cluster != null) {
-            this.cluster.getJobs().remove(this);
             this.clusterName = null;
         }
 
@@ -377,7 +376,6 @@ public class JobEntity extends CommonFieldsEntity {
 
         // Reverse side of the relationship
         if (this.cluster != null) {
-            this.cluster.addJob(this);
             this.clusterName = cluster.getName();
         }
     }
@@ -398,7 +396,6 @@ public class JobEntity extends CommonFieldsEntity {
      */
     public void setCommand(final CommandEntity command) {
         if (this.command != null) {
-            this.command.getJobs().remove(this);
             this.commandName = null;
         }
 
@@ -406,7 +403,6 @@ public class JobEntity extends CommonFieldsEntity {
 
         // Reverse side of the relationship
         if (this.command != null) {
-            this.command.addJob(this);
             this.commandName = command.getName();
         }
     }

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/ClusterEntityUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/ClusterEntityUnitTests.java
@@ -334,36 +334,6 @@ public class ClusterEntityUnitTests extends EntityTestsBase {
     }
 
     /**
-     * Test to make sure we can set the jobs for the cluster.
-     */
-    @Test
-    public void canSetJobs() {
-        final Set<JobEntity> jobEntities = Sets.newHashSet(new JobEntity(), new JobEntity());
-        this.c.setJobs(jobEntities);
-        Assert.assertThat(this.c.getJobs(), Matchers.is(jobEntities));
-
-        this.c.setJobs(null);
-        Assert.assertThat(this.c.getJobs(), Matchers.empty());
-    }
-
-    /**
-     * Test to make sure we can add a job to the set of jobs for the cluster.
-     *
-     * @throws GeniePreconditionException for any error
-     */
-    @Test
-    public void canAddJob() throws GeniePreconditionException {
-        final JobEntity job = new JobEntity();
-        job.setId(UUID.randomUUID().toString());
-        this.c.addJob(job);
-        Assert.assertThat(this.c.getJobs(), Matchers.contains(job));
-
-        Assert.assertThat(this.c.getJobs().size(), Matchers.is(1));
-        this.c.addJob(null);
-        Assert.assertThat(this.c.getJobs().size(), Matchers.is(1));
-    }
-
-    /**
      * Test to make sure the entity can return a valid DTO.
      *
      * @throws GenieException on error

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/CommandEntityUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/CommandEntityUnitTests.java
@@ -383,38 +383,6 @@ public class CommandEntityUnitTests extends EntityTestsBase {
     }
 
     /**
-     * Test to make sure we can set the jobs for the cluster.
-     */
-    @Test
-    public void canSetJobs() {
-        final CommandEntity entity = new CommandEntity();
-        final Set<JobEntity> jobEntities = Sets.newHashSet(new JobEntity(), new JobEntity());
-        entity.setJobs(jobEntities);
-        Assert.assertThat(entity.getJobs(), Matchers.is(jobEntities));
-
-        entity.setJobs(null);
-        Assert.assertThat(entity.getJobs(), Matchers.empty());
-    }
-
-    /**
-     * Test to make sure we can add a job to the set of jobs for the cluster.
-     *
-     * @throws GeniePreconditionException for any error
-     */
-    @Test
-    public void canAddJob() throws GeniePreconditionException {
-        final CommandEntity entity = new CommandEntity();
-        final JobEntity job = new JobEntity();
-        job.setId(UUID.randomUUID().toString());
-        entity.addJob(job);
-        Assert.assertThat(entity.getJobs(), Matchers.contains(job));
-
-        Assert.assertThat(entity.getJobs().size(), Matchers.is(1));
-        entity.addJob(null);
-        Assert.assertThat(entity.getJobs().size(), Matchers.is(1));
-    }
-
-    /**
      * Make sure we can get a valid Command DTO.
      *
      * @throws GenieException on error

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/JobEntityUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/JobEntityUnitTests.java
@@ -318,16 +318,13 @@ public class JobEntityUnitTests extends EntityTestsBase {
         final ClusterEntity cluster = new ClusterEntity();
         final String clusterName = UUID.randomUUID().toString();
         cluster.setName(clusterName);
-        Assert.assertThat(cluster.getJobs(), Matchers.empty());
         Assert.assertThat(this.jobEntity.getClusterName(), Matchers.nullValue());
         this.jobEntity.setCluster(cluster);
         Assert.assertThat(this.jobEntity.getCluster(), Matchers.is(cluster));
-        Assert.assertThat(cluster.getJobs(), Matchers.contains(this.jobEntity));
         Assert.assertThat(this.jobEntity.getClusterName(), Matchers.is(clusterName));
 
         this.jobEntity.setCluster(null);
         Assert.assertThat(this.jobEntity.getCluster(), Matchers.nullValue());
-        Assert.assertThat(cluster.getJobs(), Matchers.empty());
         Assert.assertThat(this.jobEntity.getClusterName(), Matchers.nullValue());
     }
 
@@ -339,16 +336,13 @@ public class JobEntityUnitTests extends EntityTestsBase {
         final CommandEntity command = new CommandEntity();
         final String commandName = UUID.randomUUID().toString();
         command.setName(commandName);
-        Assert.assertThat(command.getJobs(), Matchers.empty());
         Assert.assertThat(this.jobEntity.getCommandName(), Matchers.nullValue());
         this.jobEntity.setCommand(command);
         Assert.assertThat(this.jobEntity.getCommand(), Matchers.is(command));
-        Assert.assertThat(command.getJobs(), Matchers.contains(this.jobEntity));
         Assert.assertThat(this.jobEntity.getCommandName(), Matchers.is(commandName));
 
         this.jobEntity.setCommand(null);
         Assert.assertThat(this.jobEntity.getCommand(), Matchers.nullValue());
-        Assert.assertThat(command.getJobs(), Matchers.empty());
         Assert.assertThat(this.jobEntity.getCommandName(), Matchers.nullValue());
     }
 


### PR DESCRIPTION
This PR removes the reverse side mappings on Job Entities from commands and clusters. They already didn't exist in applications. This is in response to observed performance degradation during internal testing around the time taken to save which clusters and commands are used for the job. Belief is every job being tied to a cluster or command is being pulled back to server in order to just add one more job to the list in JPA. Really only need to update database table and only care about relationship from the job side within application code.

If we ever need to care about the reverse relationship we will write some more performant way of accessing that data. Likely lower level JDBC type query.