### PR TITLE
Handle jobs stuck in INIT state during error conditions

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobExecution.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobExecution.java
@@ -44,6 +44,16 @@ public class JobExecution extends BaseDTO {
     public static final int DEFAULT_EXIT_CODE = -1;
 
     /**
+     * The process id that will be used as a placeholder while the job isn't yet running.
+     */
+    public static final int DEFAULT_PROCESS_ID = -1;
+
+    /**
+     * The default check delay before it is set when the job moves to running state.
+     */
+    public static final long DEFAULT_CHECK_DELAY = Long.MAX_VALUE;
+
+    /**
      * The exit code that will be set to indicate a job is killed.
      */
     public static final int KILLED_EXIT_CODE = 999;
@@ -52,6 +62,11 @@ public class JobExecution extends BaseDTO {
      * The exit code that will be set to indicate a job is has been lost by Genie.
      */
     public static final int LOST_EXIT_CODE = 666;
+
+    /**
+     * The default timeout time which is forever in the future.
+     */
+    public static final Date DEFAULT_TIMEOUT = new Date(Long.MAX_VALUE);
 
     /**
      * The exit code that will be set to indicate a job has succeeded.

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobExecution.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobExecution.java
@@ -64,9 +64,9 @@ public class JobExecution extends BaseDTO {
     public static final int LOST_EXIT_CODE = 666;
 
     /**
-     * The default timeout time which is forever in the future.
+     * The default timeout date which is Jan 1 in the year 3000. That should be sufficient.
      */
-    public static final Date DEFAULT_TIMEOUT = new Date(Long.MAX_VALUE);
+    public static final Date DEFAULT_TIMEOUT = new Date(32503708800000L);
 
     /**
      * The exit code that will be set to indicate a job has succeeded.

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatus.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatus.java
@@ -34,27 +34,27 @@ public enum JobStatus {
     /**
      * Job has been initialized, but not running yet.
      */
-    INIT,
+    INIT(true),
     /**
      * Job is now running.
      */
-    RUNNING,
+    RUNNING(true),
     /**
      * Job has finished executing, and is successful.
      */
-    SUCCEEDED,
+    SUCCEEDED(false),
     /**
      * Job has been killed.
      */
-    KILLED,
+    KILLED(false),
     /**
      * Job failed.
      */
-    FAILED,
+    FAILED(false),
     /**
      * Job cannot be run due to invalid criteria.
      */
-    INVALID;
+    INVALID(false);
 
     private static final Set<JobStatus> ACTIVE_STATUSES = Collections.unmodifiableSet(
         EnumSet.of(JobStatus.INIT, JobStatus.RUNNING)
@@ -62,6 +62,17 @@ public enum JobStatus {
     private static final Set<JobStatus> FINISHED_STATUSES = Collections.unmodifiableSet(
         EnumSet.of(JobStatus.SUCCEEDED, JobStatus.KILLED, JobStatus.FAILED, JobStatus.INVALID)
     );
+
+    private final boolean active;
+
+    /**
+     * Constructor.
+     *
+     * @param isActive whether this status should be considered active or not
+     */
+    JobStatus(final boolean isActive) {
+        this.active = isActive;
+    }
 
     /**
      * Parse job status.
@@ -89,7 +100,7 @@ public enum JobStatus {
      * @return True if the job is still actively processing in some manner
      */
     public boolean isActive() {
-        return ACTIVE_STATUSES.contains(this);
+        return this.active;
     }
 
     /**
@@ -98,7 +109,7 @@ public enum JobStatus {
      * @return True if the job is no longer processing for one reason or another.
      */
     public boolean isFinished() {
-        return FINISHED_STATUSES.contains(this);
+        return !this.active;
     }
 
     /**

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatus.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatus.java
@@ -20,6 +20,10 @@ package com.netflix.genie.common.dto;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
 /**
  * Possible statuses for a Job.
  *
@@ -52,6 +56,13 @@ public enum JobStatus {
      */
     INVALID;
 
+    private static final Set<JobStatus> ACTIVE_STATUSES = Collections.unmodifiableSet(
+        EnumSet.of(JobStatus.INIT, JobStatus.RUNNING)
+    );
+    private static final Set<JobStatus> FINISHED_STATUSES = Collections.unmodifiableSet(
+        EnumSet.of(JobStatus.SUCCEEDED, JobStatus.KILLED, JobStatus.FAILED, JobStatus.INVALID)
+    );
+
     /**
      * Parse job status.
      *
@@ -78,7 +89,7 @@ public enum JobStatus {
      * @return True if the job is still actively processing in some manner
      */
     public boolean isActive() {
-        return this == INIT || this == RUNNING;
+        return ACTIVE_STATUSES.contains(this);
     }
 
     /**
@@ -87,6 +98,24 @@ public enum JobStatus {
      * @return True if the job is no longer processing for one reason or another.
      */
     public boolean isFinished() {
-        return this == SUCCEEDED || this == KILLED || this == FAILED || this == INVALID;
+        return FINISHED_STATUSES.contains(this);
+    }
+
+    /**
+     * Get an unmodifiable set of all the statuses that make up a job being considered active.
+     *
+     * @return Unmodifiable set of all active statuses
+     */
+    public static Set<JobStatus> getActiveStatuses() {
+        return ACTIVE_STATUSES;
+    }
+
+    /**
+     * Get an unmodifiable set of all the statuses that make up a job being considered finished.
+     *
+     * @return Unmodifiable set of all finished statuses
+     */
+    public static Set<JobStatus> getFinishedStatuses() {
+        return FINISHED_STATUSES;
     }
 }

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/JobStatusUnitTests.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/JobStatusUnitTests.java
@@ -19,6 +19,7 @@ package com.netflix.genie.common.dto;
 
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.test.categories.UnitTest;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -90,5 +91,27 @@ public class JobStatusUnitTests {
         Assert.assertTrue(JobStatus.INVALID.isFinished());
         Assert.assertTrue(JobStatus.KILLED.isFinished());
         Assert.assertTrue(JobStatus.SUCCEEDED.isFinished());
+    }
+
+    /**
+     * Make sure all the active statuses are present in the set.
+     */
+    @Test
+    public void testGetActivesStatuses() {
+        Assert.assertThat(JobStatus.getActiveStatuses().size(), Matchers.is(2));
+        Assert.assertTrue(JobStatus.getActiveStatuses().contains(JobStatus.INIT));
+        Assert.assertTrue(JobStatus.getActiveStatuses().contains(JobStatus.RUNNING));
+    }
+
+    /**
+     * Make sure all the finished statuses are present in the set.
+     */
+    @Test
+    public void testGetFinishedStatuses() {
+        Assert.assertThat(JobStatus.getFinishedStatuses().size(), Matchers.is(4));
+        Assert.assertTrue(JobStatus.getFinishedStatuses().contains(JobStatus.INVALID));
+        Assert.assertTrue(JobStatus.getFinishedStatuses().contains(JobStatus.FAILED));
+        Assert.assertTrue(JobStatus.getFinishedStatuses().contains(JobStatus.KILLED));
+        Assert.assertTrue(JobStatus.getFinishedStatuses().contains(JobStatus.SUCCEEDED));
     }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/events/JobFinishedReason.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/events/JobFinishedReason.java
@@ -42,5 +42,10 @@ public enum JobFinishedReason {
     /**
      * The jobs process completed either sucessfully or unsuccessfully. Check job done file.
      */
-    PROCESS_COMPLETED
+    PROCESS_COMPLETED,
+
+    /**
+     * System crash during initialization.
+     */
+    SYSTEM_CRASH
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobExecutionEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobExecutionEntity.java
@@ -61,7 +61,7 @@ public class JobExecutionEntity extends BaseEntity {
 
     @Basic(optional = false)
     @Column(name = "process_id", nullable = false)
-    private int processId;
+    private int processId = JobExecution.DEFAULT_PROCESS_ID;
 
     @Basic(optional = false)
     @Column(name = "check_delay", nullable = false)

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobExecutionRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobExecutionRepository.java
@@ -20,8 +20,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
-import java.util.Set;
-
 /**
  * Job repository.
  *
@@ -30,13 +28,4 @@ import java.util.Set;
  */
 @Repository
 public interface JpaJobExecutionRepository extends JpaRepository<JobExecutionEntity, String>, JpaSpecificationExecutor {
-
-    /**
-     * Get all the job executions which are on the given host with the given exit code.
-     *
-     * @param hostName The hostname to search for
-     * @param exitCode The exit code to search for
-     * @return All the job executions currently running on that host
-     */
-    Set<JobExecutionEntity> findByHostNameAndExitCode(final String hostName, final int exitCode);
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImpl.java
@@ -53,6 +53,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Order;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
@@ -193,12 +194,33 @@ public class JpaJobSearchServiceImpl implements JobSearchService {
      * {@inheritDoc}
      */
     @Override
-    public Set<JobExecution> getAllRunningJobExecutionsOnHost(@NotBlank final String hostname) {
-        log.debug("Called with hostname {}", hostname);
-        return this.jobExecutionRepository
-            .findByHostNameAndExitCode(hostname, JobExecution.DEFAULT_EXIT_CODE)
+    public Set<Job> getAllActiveJobsOnHost(@NotBlank final String hostName) {
+        log.debug("Called with hostname {}", hostName);
+
+        final CriteriaBuilder cb = this.entityManager.getCriteriaBuilder();
+        final CriteriaQuery<JobEntity> query = cb.createQuery(JobEntity.class);
+        final Root<JobEntity> root = query.from(JobEntity.class);
+        final Join<JobEntity, JobExecutionEntity> executions = root.join(JobEntity_.execution);
+
+        final Set<Predicate> statusPredicates = JobStatus
+            .getActiveStatuses()
             .stream()
-            .map(JobExecutionEntity::getDTO)
+            .map(status -> cb.equal(root.get(JobEntity_.status), status))
+            .collect(Collectors.toSet());
+
+        final Predicate statusPredicate = cb.or(statusPredicates.toArray(new Predicate[statusPredicates.size()]));
+
+        final Predicate hostPredicate = cb.equal(executions.get(JobExecutionEntity_.hostName), hostName);
+
+        query
+            .distinct(true)
+            .where(cb.and(statusPredicate, hostPredicate));
+
+        return this.entityManager
+            .createQuery(query)
+            .getResultList()
+            .stream()
+            .map(JobEntity::getDTO)
             .collect(Collectors.toSet());
     }
 
@@ -206,15 +228,24 @@ public class JpaJobSearchServiceImpl implements JobSearchService {
      * {@inheritDoc}
      */
     @Override
-    public List<String> getAllHostsRunningJobs() {
+    public List<String> getAllHostsWithActiveJobs() {
         log.debug("Called");
 
         final CriteriaBuilder cb = this.entityManager.getCriteriaBuilder();
         final CriteriaQuery<String> query = cb.createQuery(String.class);
-        final Root<JobExecutionEntity> root = query.from(JobExecutionEntity.class);
-        final Predicate whereClause = cb.equal(root.get(JobExecutionEntity_.exitCode), JobExecution.DEFAULT_EXIT_CODE);
+        final Root<JobEntity> root = query.from(JobEntity.class);
+        final Join<JobEntity, JobExecutionEntity> executions = root.join(JobEntity_.execution);
 
-        query.select(root.get(JobExecutionEntity_.hostName)).distinct(true).where(whereClause);
+        final Set<Predicate> statusPredicates = JobStatus
+            .getActiveStatuses()
+            .stream()
+            .map(status -> cb.equal(root.get(JobEntity_.status), status))
+            .collect(Collectors.toSet());
+
+        query
+            .select(executions.get(JobExecutionEntity_.hostName))
+            .distinct(true)
+            .where(cb.or(statusPredicates.toArray(new Predicate[statusPredicates.size()])));
 
         return this.entityManager.createQuery(query).getResultList();
     }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobPersistenceService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobPersistenceService.java
@@ -25,6 +25,7 @@ import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieException;
 import org.hibernate.validator.constraints.NotBlank;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.Date;
 import java.util.List;
@@ -38,12 +39,16 @@ import java.util.List;
 public interface JobPersistenceService {
 
     /**
-     * Save the job object in the data store.
+     * Save the job object in the data store. Should also persist job execution information.
      *
-     * @param job the Job object to create
+     * @param job          The Job object to create
+     * @param jobExecution The job execution object to create
      * @throws GenieException if there is an error
      */
-    void createJob(@NotNull final Job job) throws GenieException;
+    void createJobAndJobExecution(
+        @NotNull final Job job,
+        @NotNull final JobExecution jobExecution
+    ) throws GenieException;
 
     /**
      * Update the status and status message of the job.
@@ -89,12 +94,20 @@ public interface JobPersistenceService {
     ) throws GenieException;
 
     /**
-     * Save the jobExecution object in the data store.
+     * Update the job with information for the running job process.
      *
-     * @param jobExecution the Job object to save
+     * @param id         the id of the job to update the process id for
+     * @param processId  The id of the process on the box for this job
+     * @param checkDelay The delay to check the process with
+     * @param timeout    The date at which this job should timeout
      * @throws GenieException if there is an error
      */
-    void createJobExecution(@NotNull final JobExecution jobExecution) throws GenieException;
+    void setJobRunningInformation(
+        @NotBlank final String id,
+        @Min(0) final int processId,
+        @Min(1) final long checkDelay,
+        @NotNull final Date timeout
+    ) throws GenieException;
 
     /**
      * Method to set all job completion information for a job execution.

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobSearchService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobSearchService.java
@@ -80,19 +80,19 @@ public interface JobSearchService {
     );
 
     /**
-     * Given a hostname return a set of all the job executions currently running on that host.
+     * Given a hostname return a set of all the jobs currently active on that host.
      *
-     * @param hostname The host name to search for. Not null or empty.
-     * @return All the jobs running on the host as a set of JobExecution objects
+     * @param hostName The host name to search for. Not null or empty.
+     * @return All the jobs active on the host as a set of Job objects
      */
-    Set<JobExecution> getAllRunningJobExecutionsOnHost(@NotBlank final String hostname);
+    Set<Job> getAllActiveJobsOnHost(@NotBlank final String hostName);
 
     /**
-     * Get a list of host names which are currently running jobs in the Genie system.
+     * Get a list of host names which are currently have active jobs in the Genie cluster.
      *
-     * @return The list of hosts with jobs currently in "RUNNING" state
+     * @return The list of hosts with jobs currently in an active state
      */
-    List<String> getAllHostsRunningJobs();
+    List<String> getAllHostsWithActiveJobs();
 
     /**
      * Get job information for given job id.

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCountServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCountServiceImpl.java
@@ -50,6 +50,6 @@ public class JobCountServiceImpl implements JobCountService {
      */
     @Override
     public int getNumJobs() {
-        return this.jobSearchService.getAllRunningJobExecutionsOnHost(this.hostName).size();
+        return this.jobSearchService.getAllActiveJobsOnHost(this.hostName).size();
     }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
@@ -205,7 +205,12 @@ public class LocalJobRunner implements JobSubmitterService {
                     final long createJobExecutionStart = System.nanoTime();
                     try {
                         log.info("Saving job execution for job {}", jobRequest.getId());
-                        this.jobPersistenceService.createJobExecution(jobExecution);
+                        this.jobPersistenceService.setJobRunningInformation(
+                            jobRequest.getId(),
+                            jobExecution.getProcessId(),
+                            jobExecution.getCheckDelay(),
+                            jobExecution.getTimeout()
+                        );
                     } finally {
                         this.saveJobExecutionTimer
                             .record(System.nanoTime() - createJobExecutionStart, TimeUnit.NANOSECONDS);

--- a/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
@@ -292,6 +292,7 @@ public class ServicesConfigTest {
      * @param maxRunningJobs        The maximum number of running jobs on system
      * @param registry              The registry to use
      * @param eventPublisher        The system event publisher
+     * @param hostName              The host name to use
      * @return An instance of the JobCoordinatorService.
      */
     @Bean
@@ -306,7 +307,8 @@ public class ServicesConfigTest {
         @Value("${genie.jobs.max.running:2}")
         final int maxRunningJobs,
         final Registry registry,
-        final ApplicationEventPublisher eventPublisher
+        final ApplicationEventPublisher eventPublisher,
+        final String hostName
     ) {
         return new JobCoordinatorService(
             taskExecutor,
@@ -317,7 +319,8 @@ public class ServicesConfigTest {
             baseArchiveLocation,
             maxRunningJobs,
             registry,
-            eventPublisher
+            eventPublisher,
+            hostName
         );
     }
 

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplIntegrationTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplIntegrationTests.java
@@ -21,7 +21,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.JobExecution;
+import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.dto.search.JobSearchResult;
 import com.netflix.genie.common.exceptions.GenieException;
@@ -104,14 +104,14 @@ public class JpaJobSearchServiceImplIntegrationTests extends DBUnitTestBase {
                 null,
                 page
             );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(2L));
+        Assert.assertThat(jobs.getTotalElements(), Matchers.is(1L));
         Assert.assertThat(
             jobs
                 .getContent()
                 .stream()
-                .filter(job -> job.getId().equals(JOB_2_ID) || job.getId().equals(JOB_3_ID))
+                .filter(job -> job.getId().equals(JOB_3_ID))
                 .count(),
-            Matchers.is(2L)
+            Matchers.is(1L)
         );
 
         jobs = this.service
@@ -143,43 +143,43 @@ public class JpaJobSearchServiceImplIntegrationTests extends DBUnitTestBase {
     }
 
     /**
-     * Make sure we can get the correct number of job executions which are running on a given host.
+     * Make sure we can get the correct number of jobs which are active on a given host.
      *
      * @throws GenieException on error
      */
     @Test
-    public void canFindRunningJobsByHostName() throws GenieException {
+    public void canFindActiveJobsByHostName() throws GenieException {
         final String hostA = "a.netflix.com";
         final String hostB = "b.netflix.com";
         final String hostC = "c.netflix.com";
 
-        Set<JobExecution> executions = this.service.getAllRunningJobExecutionsOnHost(hostA);
-        Assert.assertThat(executions.size(), Matchers.is(1));
+        Set<Job> jobs = this.service.getAllActiveJobsOnHost(hostA);
+        Assert.assertThat(jobs.size(), Matchers.is(1));
         Assert.assertThat(
-            executions.stream().filter(jobExecution -> JOB_2_ID.equals(jobExecution.getId())).count(),
+            jobs.stream().filter(jobExecution -> JOB_2_ID.equals(jobExecution.getId())).count(),
             Matchers.is(1L)
         );
 
-        executions = this.service.getAllRunningJobExecutionsOnHost(hostB);
-        Assert.assertThat(executions.size(), Matchers.is(1));
+        jobs = this.service.getAllActiveJobsOnHost(hostB);
+        Assert.assertThat(jobs.size(), Matchers.is(1));
         Assert.assertThat(
-            executions.stream().filter(jobExecution -> JOB_3_ID.equals(jobExecution.getId())).count(),
+            jobs.stream().filter(jobExecution -> JOB_3_ID.equals(jobExecution.getId())).count(),
             Matchers.is(1L)
         );
 
-        executions = this.service.getAllRunningJobExecutionsOnHost(hostC);
-        Assert.assertTrue(executions.isEmpty());
+        jobs = this.service.getAllActiveJobsOnHost(hostC);
+        Assert.assertTrue(jobs.isEmpty());
     }
 
     /**
      * Make sure we can get the host names of nodes currently running jobs.
      */
     @Test
-    public void canFindHostnamesOfRunningJobs() {
+    public void canFindHostNamesOfActiveJobs() {
         final String hostA = "a.netflix.com";
         final String hostB = "b.netflix.com";
 
-        final List<String> hostNames = this.service.getAllHostsRunningJobs();
+        final List<String> hostNames = this.service.getAllHostsWithActiveJobs();
         Assert.assertThat(hostNames.size(), Matchers.is(2));
         Assert.assertThat(hostNames, Matchers.hasItem(hostA));
         Assert.assertThat(hostNames, Matchers.hasItem(hostB));
@@ -212,7 +212,7 @@ public class JpaJobSearchServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void canGetJobStatus() throws GenieException {
         Assert.assertThat(this.service.getJobStatus(JOB_1_ID), Matchers.is(JobStatus.SUCCEEDED));
-        Assert.assertThat(this.service.getJobStatus(JOB_2_ID), Matchers.is(JobStatus.RUNNING));
+        Assert.assertThat(this.service.getJobStatus(JOB_2_ID), Matchers.is(JobStatus.INIT));
         Assert.assertThat(this.service.getJobStatus(JOB_3_ID), Matchers.is(JobStatus.RUNNING));
 
         try {

--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/JobCountServiceImplUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/JobCountServiceImplUnitTests.java
@@ -18,7 +18,7 @@
 package com.netflix.genie.core.services.impl;
 
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.JobExecution;
+import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.core.services.JobSearchService;
 import com.netflix.genie.test.categories.UnitTest;
 import org.hamcrest.Matchers;
@@ -56,14 +56,14 @@ public class JobCountServiceImplUnitTests {
      * Test to make sure the method returns the number of running jobs.
      */
     @Test
-    public void canGetNumRunningJobs() {
+    public void canGetNumJobs() {
         Mockito
-            .when(this.jobSearchService.getAllRunningJobExecutionsOnHost(this.hostName))
+            .when(this.jobSearchService.getAllActiveJobsOnHost(this.hostName))
             .thenReturn(
                 Sets.newHashSet(
-                    Mockito.mock(JobExecution.class),
-                    Mockito.mock(JobExecution.class),
-                    Mockito.mock(JobExecution.class)
+                    Mockito.mock(Job.class),
+                    Mockito.mock(Job.class),
+                    Mockito.mock(Job.class)
                 )
             );
 

--- a/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplIntegrationTests/init.xml
+++ b/genie-core/src/test/resources/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplIntegrationTests/init.xml
@@ -198,7 +198,7 @@
         user="tgianos"
         name="testSparkJob1"
         command_args="-f spark.jar"
-        status="RUNNING"
+        status="INIT"
         version="2.4"
         entity_version="0"
         cluster_id="cluster1"

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -328,6 +328,7 @@ public class ServicesConfig {
      * @param maxRunningJobs        The maximum number of jobs that can run on this node
      * @param registry              The metrics registry to use
      * @param eventPublisher        The application event publisher to use
+     * @param hostName              The host this Genie instance is running on
      * @return An instance of the JobCoordinatorService.
      */
     @Bean
@@ -343,7 +344,8 @@ public class ServicesConfig {
         @Value("${genie.jobs.max.running:2}")
         final int maxRunningJobs,
         final Registry registry,
-        final ApplicationEventPublisher eventPublisher
+        final ApplicationEventPublisher eventPublisher,
+        final String hostName
     ) {
         return new JobCoordinatorService(
             taskExecutor,
@@ -354,7 +356,8 @@ public class ServicesConfig {
             baseArchiveLocation,
             maxRunningJobs,
             registry,
-            eventPublisher
+            eventPublisher,
+            hostName
         );
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.tasks.leader;
 
+import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieException;
@@ -109,7 +110,7 @@ public class ClusterCheckerTask extends LeadershipTask {
     public void run() {
         log.info("Checking for cluster node health...");
         final Set<String> badNodes = new HashSet<>();
-        this.jobSearchService.getAllHostsRunningJobs()
+        this.jobSearchService.getAllHostsWithActiveJobs()
             .stream()
             .filter(host -> !this.hostName.equals(host))
             .forEach(
@@ -150,7 +151,7 @@ public class ClusterCheckerTask extends LeadershipTask {
             .forEach(
                 host -> {
                     toRemove.add(host);
-                    final Set<JobExecution> jobs = this.jobSearchService.getAllRunningJobExecutionsOnHost(host);
+                    final Set<Job> jobs = this.jobSearchService.getAllActiveJobsOnHost(host);
                     jobs.forEach(
                         job -> {
                             try {

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -49,6 +49,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Unit Tests for ServicesConfig class.
@@ -245,7 +246,8 @@ public class ServicesConfigUnitTests {
                 "file:///tmp",
                 2,
                 Mockito.mock(Registry.class),
-                Mockito.mock(ApplicationEventPublisher.class)
+                Mockito.mock(ApplicationEventPublisher.class),
+                UUID.randomUUID().toString()
             )
         );
     }

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTaskUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTaskUnitTests.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.tasks.leader;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieException;
@@ -118,26 +119,26 @@ public class ClusterCheckerTaskUnitTests {
             .thenReturn("");
 
         final List<String> hostsRunningJobs = Lists.newArrayList(this.hostName, host1, host2, host3);
-        Mockito.when(this.jobSearchService.getAllHostsRunningJobs()).thenReturn(hostsRunningJobs);
+        Mockito.when(this.jobSearchService.getAllHostsWithActiveJobs()).thenReturn(hostsRunningJobs);
 
-        final JobExecution job1 = Mockito.mock(JobExecution.class);
+        final Job job1 = Mockito.mock(Job.class);
         final String job1Id = UUID.randomUUID().toString();
         Mockito.when(job1.getId()).thenReturn(job1Id);
-        final JobExecution job2 = Mockito.mock(JobExecution.class);
+        final Job job2 = Mockito.mock(Job.class);
         final String job2Id = UUID.randomUUID().toString();
         Mockito.when(job2.getId()).thenReturn(job2Id);
-        final JobExecution job3 = Mockito.mock(JobExecution.class);
+        final Job job3 = Mockito.mock(Job.class);
         final String job3Id = UUID.randomUUID().toString();
         Mockito.when(job3.getId()).thenReturn(job3Id);
-        final JobExecution job4 = Mockito.mock(JobExecution.class);
+        final Job job4 = Mockito.mock(Job.class);
         final String job4Id = UUID.randomUUID().toString();
         Mockito.when(job4.getId()).thenReturn(job4Id);
 
         Mockito
-            .when(this.jobSearchService.getAllRunningJobExecutionsOnHost(host2))
+            .when(this.jobSearchService.getAllActiveJobsOnHost(host2))
             .thenReturn(Sets.newHashSet(job1, job2));
         Mockito
-            .when(this.jobSearchService.getAllRunningJobExecutionsOnHost(host3))
+            .when(this.jobSearchService.getAllActiveJobsOnHost(host3))
             .thenReturn(Sets.newHashSet(job3, job4));
 
         Mockito


### PR DESCRIPTION
PR makes sure jobs that are in the INIT state if a node crashes and comes back are marked failed. Also makes sure if a node completely falls out of the cluster and the jobs are lost they are marked failed by the ClusterCheckerTask along with any jobs thought to be running on that node.