### PR TITLE
Fix missing validation on Job input

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaJobPersistenceServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaJobPersistenceServiceImpl.java
@@ -109,10 +109,8 @@ public class JpaJobPersistenceServiceImpl implements JobPersistenceService {
      */
     @Override
     public void createJobAndJobExecution(
-        @NotNull(message = "No Job provided to create")
-        final Job job,
-        @NotNull(message = "No Job execution information provided. Unable to create.")
-        final JobExecution jobExecution
+        @NotNull(message = "No Job provided to create") final Job job,
+        @NotNull(message = "No Job execution information provided. Unable to create.") final JobExecution jobExecution
     ) throws GenieException {
         log.debug("Called with job: {}", job);
 
@@ -162,12 +160,9 @@ public class JpaJobPersistenceServiceImpl implements JobPersistenceService {
      */
     @Override
     public void updateJobStatus(
-        @NotBlank(message = "No job id entered. Unable to update.")
-        final String id,
-        @NotNull(message = "Status cannot be null.")
-        final JobStatus jobStatus,
-        @NotBlank(message = "Status message cannot be empty.")
-        final String statusMsg
+        @NotBlank(message = "No job id entered. Unable to update.") final String id,
+        @NotNull(message = "Status cannot be null.") final JobStatus jobStatus,
+        @NotBlank(message = "Status message cannot be empty.") final String statusMsg
     ) throws GenieException {
         log.debug("Called to update job with id {}, status {} and statusMsg \"{}\"", id, jobStatus, statusMsg);
 

--- a/genie-core/src/main/java/com/netflix/genie/core/services/AttachmentService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/AttachmentService.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.core.services;
 
 import com.netflix.genie.common.exceptions.GenieException;
+import org.springframework.validation.annotation.Validated;
 
 import java.io.File;
 import java.io.InputStream;
@@ -29,6 +30,7 @@ import java.io.InputStream;
  * @author tgianos
  * @since 3.0.0
  */
+@Validated
 public interface AttachmentService {
 
     /**

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobCoordinatorService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobCoordinatorService.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 Netflix, Inc.
+ *  Copyright 2016 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -17,87 +17,23 @@
  */
 package com.netflix.genie.core.services;
 
-import com.netflix.genie.common.dto.Job;
-import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
-import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieException;
-import com.netflix.genie.common.exceptions.GenieServerException;
-import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
-import com.netflix.genie.core.events.JobScheduledEvent;
-import com.netflix.genie.core.jobs.JobConstants;
-import com.netflix.genie.core.jobs.JobLauncher;
-import com.netflix.spectator.api.Registry;
-import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.NotBlank;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.core.task.AsyncTaskExecutor;
-import org.springframework.core.task.TaskRejectedException;
+import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.util.concurrent.Future;
-
 
 /**
- * Implementation of the JobService APIs.
+ * Job Coordination APIs.
  *
- * @author amsharma
  * @author tgianos
  * @since 3.0.0
  */
-@Slf4j
-public class JobCoordinatorService {
-
-    private final AsyncTaskExecutor taskExecutor;
-    private final JobPersistenceService jobPersistenceService;
-    private final JobSubmitterService jobSubmitterService;
-    private final JobKillService jobKillService;
-    private final JobCountService jobCountService;
-    private final int maxRunningJobs;
-    private final String baseArchiveLocation;
-    private final Registry registry;
-    private final ApplicationEventPublisher eventPublisher;
-    private final String hostName;
-
-    /**
-     * Constructor.
-     *
-     * @param taskExecutor          The executor to use to launch jobs
-     * @param jobPersistenceService implementation of job persistence service interface
-     * @param jobSubmitterService   implementation of the job submitter service
-     * @param jobKillService        The job kill service to use
-     * @param jobCountService       The service which will return the number of running jobs on this host
-     * @param baseArchiveLocation   The base directory location of where the job dir should be archived
-     * @param maxRunningJobs        The maximum number of jobs that can run on this host at any time
-     * @param registry              The registry to use for metrics
-     * @param eventPublisher        The application event publisher to use
-     * @param hostName              The name of the host this Genie instance is running on
-     */
-    public JobCoordinatorService(
-        @NotNull final AsyncTaskExecutor taskExecutor,
-        @NotNull final JobPersistenceService jobPersistenceService,
-        @NotNull final JobSubmitterService jobSubmitterService,
-        @NotNull final JobKillService jobKillService,
-        @NotNull final JobCountService jobCountService,
-        @NotNull final String baseArchiveLocation,
-        final int maxRunningJobs,
-        @NotNull final Registry registry,
-        @NotNull final ApplicationEventPublisher eventPublisher,
-        @NotBlank final String hostName
-    ) {
-        this.taskExecutor = taskExecutor;
-        this.jobPersistenceService = jobPersistenceService;
-        this.jobSubmitterService = jobSubmitterService;
-        this.jobKillService = jobKillService;
-        this.jobCountService = jobCountService;
-        this.baseArchiveLocation = baseArchiveLocation;
-        this.maxRunningJobs = maxRunningJobs;
-        this.registry = registry;
-        this.eventPublisher = eventPublisher;
-        this.hostName = hostName;
-    }
+@Validated
+public interface JobCoordinatorService {
 
     /**
      * Takes in a Job Request object and does necessary preparation for execution.
@@ -107,94 +43,12 @@ public class JobCoordinatorService {
      * @return the id of the job run
      * @throws GenieException if there is an error
      */
-    public String coordinateJob(
-        @NotNull(message = "No jobRequest provided. Unable to submit job for execution.")
-        @Valid
-        final JobRequest jobRequest,
-        @NotNull
-        @Valid
-        final JobMetadata jobMetadata
-    ) throws GenieException {
-        final String jobId = jobRequest
-            .getId()
-            .orElseThrow(() -> new GenieServerException("Id of the jobRequest cannot be null"));
-        log.info("Called to schedule job launch for job {}", jobId);
-
-        // Log the job request and optionally the client host
-        this.jobPersistenceService.createJobRequest(jobRequest, jobMetadata);
-
-        String archiveLocation = null;
-        if (!jobRequest.isDisableLogArchival()) {
-            archiveLocation = this.baseArchiveLocation
-                + JobConstants.FILE_PATH_DELIMITER
-                + jobId
-                + ".tar.gz";
-        }
-
-        // create the job object in the database with status INIT
-        final Job.Builder jobBuilder = new Job.Builder(
-            jobRequest.getName(),
-            jobRequest.getUser(),
-            jobRequest.getVersion(),
-            jobRequest.getCommandArgs()
-        )
-            .withId(jobId)
-            .withArchiveLocation(archiveLocation)
-            .withTags(jobRequest.getTags());
-
-        jobRequest.getDescription().ifPresent(jobBuilder::withDescription);
-
-        final JobExecution jobExecution = new JobExecution.Builder(
-            this.hostName
-        )
-            .withId(jobId)
-            .build();
-
-        synchronized (this) {
-            log.info("Checking if can run job {} on this node", jobRequest.getId());
-            final int numActiveJobs = this.jobCountService.getNumJobs();
-            if (numActiveJobs < this.maxRunningJobs) {
-                log.info(
-                    "Job {} can run on this node as only {}/{} jobs are active",
-                    jobRequest.getId(),
-                    numActiveJobs,
-                    this.maxRunningJobs
-                );
-                jobBuilder
-                    .withStatus(JobStatus.INIT)
-                    .withStatusMsg("Job Accepted and in initialization phase.");
-                // TODO: if this throws exception the job will never be marked failed
-                this.jobPersistenceService.createJobAndJobExecution(jobBuilder.build(), jobExecution);
-                try {
-                    log.info("Scheduling job {} for submission", jobRequest.getId());
-                    final Future<?> task = this.taskExecutor.submit(
-                        new JobLauncher(this.jobSubmitterService, jobRequest, this.registry)
-                    );
-
-                    // Tell the system a new job has been scheduled so any actions can be taken
-                    log.info("Publishing job scheduled event for job {}", jobId);
-                    this.eventPublisher.publishEvent(new JobScheduledEvent(jobId, task, this));
-                } catch (final TaskRejectedException e) {
-                    final String errorMsg = "Unable to launch job due to exception: " + e.getMessage();
-                    this.jobPersistenceService.updateJobStatus(jobId, JobStatus.FAILED, errorMsg);
-                    throw new GenieServerException(errorMsg, e);
-                }
-                return jobId;
-            } else {
-                jobBuilder
-                    .withStatus(JobStatus.FAILED)
-                    .withStatusMsg("Unable to run job due to host being too busy during request.");
-                this.jobPersistenceService.createJobAndJobExecution(jobBuilder.build(), jobExecution);
-                throw new GenieServerUnavailableException(
-                    "Running ("
-                        + numActiveJobs
-                        + ") when max running jobs is ("
-                        + this.maxRunningJobs
-                        + ") on this host. Unable to run job."
-                );
-            }
-        }
-    }
+    String coordinateJob(
+        @NotNull(message = "No job request provided. Unable to submit job for execution.")
+        @Valid final JobRequest jobRequest,
+        @NotNull(message = "No job metadata provided. Unable to submit job for execution.")
+        @Valid final JobMetadata jobMetadata
+    ) throws GenieException;
 
     /**
      * Kill the job identified by the given id.
@@ -202,7 +56,5 @@ public class JobCoordinatorService {
      * @param jobId id of the job to kill
      * @throws GenieException if there is an error
      */
-    public void killJob(@NotBlank final String jobId) throws GenieException {
-        this.jobKillService.killJob(jobId);
-    }
+    void killJob(@NotBlank final String jobId) throws GenieException;
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobKillService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobKillService.java
@@ -21,6 +21,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.core.events.KillJobEvent;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.context.event.EventListener;
+import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotNull;
 
@@ -30,6 +31,7 @@ import javax.validation.constraints.NotNull;
  * @author tgianos
  * @since 3.0.0
  */
+@Validated
 public interface JobKillService {
 
     /**

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobPersistenceService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobPersistenceService.java
@@ -24,6 +24,7 @@ import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieException;
 import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.validation.annotation.Validated;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
@@ -37,6 +38,7 @@ import java.util.List;
  * @author tgianos
  * @since 3.0.0
  */
+@Validated
 public interface JobPersistenceService {
 
     /**
@@ -47,8 +49,8 @@ public interface JobPersistenceService {
      * @throws GenieException if there is an error
      */
     void createJobAndJobExecution(
-        @NotNull final Job job,
-        @NotNull final JobExecution jobExecution
+        @NotNull(message = "No Job provided to create") final Job job,
+        @NotNull(message = "No Job execution information provided. Unable to create.") final JobExecution jobExecution
     ) throws GenieException;
 
     /**
@@ -60,9 +62,9 @@ public interface JobPersistenceService {
      * @throws GenieException if there is an error
      */
     void updateJobStatus(
-        @NotBlank final String id,
-        @NotNull final JobStatus jobStatus,
-        @NotBlank final String statusMsg
+        @NotBlank(message = "No job id entered. Unable to update.") final String id,
+        @NotNull(message = "Status cannot be null.") final JobStatus jobStatus,
+        @NotBlank(message = "Status message cannot be empty.") final String statusMsg
     ) throws GenieException;
 
     /**
@@ -105,8 +107,8 @@ public interface JobPersistenceService {
      */
     void setJobRunningInformation(
         @NotBlank final String id,
-        @Min(0) final int processId,
-        @Min(1) final long checkDelay,
+        @Min(value = 0, message = "Must be no lower than zero") final int processId,
+        @Min(value = 1, message = "Must be at least 1 millisecond, preferably much more") final long checkDelay,
         @NotNull final Date timeout
     ) throws GenieException;
 
@@ -122,10 +124,10 @@ public interface JobPersistenceService {
      * @throws GenieException if there is an error
      */
     void setJobCompletionInformation(
-        @NotBlank final String id,
+        @NotBlank(message = "No job id entered. Unable to update.") final String id,
         final int exitCode,
-        @NotNull final JobStatus status,
-        @NotBlank final String statusMessage,
+        @NotNull(message = "No job status entered. Unable to update") final JobStatus status,
+        @NotBlank(message = "Status message can't be blank. Unable to update") final String statusMessage,
         @Nullable final Long stdOutSize,
         @Nullable final Long stdErrSize
     ) throws GenieException;

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobSearchService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobSearchService.java
@@ -29,6 +29,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotNull;
 import java.util.Date;
@@ -41,6 +42,7 @@ import java.util.Set;
  * @author amsharma
  * @since 3.0.0
  */
+@Validated
 public interface JobSearchService {
 
     /**
@@ -101,7 +103,7 @@ public interface JobSearchService {
      * @return the job
      * @throws GenieException if there is an error
      */
-    Job getJob(@NotBlank final String id) throws GenieException;
+    Job getJob(@NotBlank(message = "No id entered. Unable to get job.") final String id) throws GenieException;
 
     /**
      * Get the status of the job with the given id.

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobSubmitterService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobSubmitterService.java
@@ -20,6 +20,7 @@ package com.netflix.genie.core.services;
 
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
+import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -30,6 +31,7 @@ import javax.validation.constraints.NotNull;
  * @author amsharma
  * @since 3.0.0
  */
+@Validated
 public interface  JobSubmitterService {
 
     /**

--- a/genie-core/src/main/java/com/netflix/genie/core/services/MailService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/MailService.java
@@ -19,6 +19,7 @@ package com.netflix.genie.core.services;
 
 import com.netflix.genie.common.exceptions.GenieException;
 import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * An interface for sending emails.
@@ -26,6 +27,7 @@ import org.hibernate.validator.constraints.NotBlank;
  * @author amsharma
  * @since 3.0.0
  */
+@Validated
 public interface MailService {
 
     /**

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
@@ -1,0 +1,207 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.services.impl;
+
+import com.netflix.genie.common.dto.Job;
+import com.netflix.genie.common.dto.JobExecution;
+import com.netflix.genie.common.dto.JobMetadata;
+import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
+import com.netflix.genie.core.events.JobScheduledEvent;
+import com.netflix.genie.core.jobs.JobConstants;
+import com.netflix.genie.core.jobs.JobLauncher;
+import com.netflix.genie.core.services.JobCoordinatorService;
+import com.netflix.genie.core.services.JobCountService;
+import com.netflix.genie.core.services.JobKillService;
+import com.netflix.genie.core.services.JobPersistenceService;
+import com.netflix.genie.core.services.JobSubmitterService;
+import com.netflix.spectator.api.Registry;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.TaskRejectedException;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.concurrent.Future;
+
+
+/**
+ * Implementation of the JobCoordinationService APIs.
+ *
+ * @author amsharma
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Slf4j
+public class JobCoordinatorServiceImpl implements JobCoordinatorService {
+
+    private final AsyncTaskExecutor taskExecutor;
+    private final JobPersistenceService jobPersistenceService;
+    private final JobSubmitterService jobSubmitterService;
+    private final JobKillService jobKillService;
+    private final JobCountService jobCountService;
+    private final int maxRunningJobs;
+    private final String baseArchiveLocation;
+    private final Registry registry;
+    private final ApplicationEventPublisher eventPublisher;
+    private final String hostName;
+
+    /**
+     * Constructor.
+     *
+     * @param taskExecutor          The executor to use to launch jobs
+     * @param jobPersistenceService implementation of job persistence service interface
+     * @param jobSubmitterService   implementation of the job submitter service
+     * @param jobKillService        The job kill service to use
+     * @param jobCountService       The service which will return the number of running jobs on this host
+     * @param baseArchiveLocation   The base directory location of where the job dir should be archived
+     * @param maxRunningJobs        The maximum number of jobs that can run on this host at any time
+     * @param registry              The registry to use for metrics
+     * @param eventPublisher        The application event publisher to use
+     * @param hostName              The name of the host this Genie instance is running on
+     */
+    public JobCoordinatorServiceImpl(
+        @NotNull final AsyncTaskExecutor taskExecutor,
+        @NotNull final JobPersistenceService jobPersistenceService,
+        @NotNull final JobSubmitterService jobSubmitterService,
+        @NotNull final JobKillService jobKillService,
+        @NotNull final JobCountService jobCountService,
+        @NotNull final String baseArchiveLocation,
+        final int maxRunningJobs,
+        @NotNull final Registry registry,
+        @NotNull final ApplicationEventPublisher eventPublisher,
+        @NotBlank final String hostName
+    ) {
+        this.taskExecutor = taskExecutor;
+        this.jobPersistenceService = jobPersistenceService;
+        this.jobSubmitterService = jobSubmitterService;
+        this.jobKillService = jobKillService;
+        this.jobCountService = jobCountService;
+        this.baseArchiveLocation = baseArchiveLocation;
+        this.maxRunningJobs = maxRunningJobs;
+        this.registry = registry;
+        this.eventPublisher = eventPublisher;
+        this.hostName = hostName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String coordinateJob(
+        @NotNull(message = "No job request provided. Unable to submit job for execution.")
+        @Valid
+        final JobRequest jobRequest,
+        @NotNull(message = "No job metadata provided. Unable to submit job for execution.")
+        @Valid
+        final JobMetadata jobMetadata
+    ) throws GenieException {
+        final String jobId = jobRequest
+            .getId()
+            .orElseThrow(() -> new GenieServerException("Id of the jobRequest cannot be null"));
+        log.info("Called to schedule job launch for job {}", jobId);
+
+        // Log the job request and optionally the client host
+        this.jobPersistenceService.createJobRequest(jobRequest, jobMetadata);
+
+        String archiveLocation = null;
+        if (!jobRequest.isDisableLogArchival()) {
+            archiveLocation = this.baseArchiveLocation
+                + JobConstants.FILE_PATH_DELIMITER
+                + jobId
+                + ".tar.gz";
+        }
+
+        // create the job object in the database with status INIT
+        final Job.Builder jobBuilder = new Job.Builder(
+            jobRequest.getName(),
+            jobRequest.getUser(),
+            jobRequest.getVersion(),
+            jobRequest.getCommandArgs()
+        )
+            .withId(jobId)
+            .withArchiveLocation(archiveLocation)
+            .withTags(jobRequest.getTags());
+
+        jobRequest.getDescription().ifPresent(jobBuilder::withDescription);
+
+        final JobExecution jobExecution = new JobExecution.Builder(
+            this.hostName
+        )
+            .withId(jobId)
+            .build();
+
+        synchronized (this) {
+            log.info("Checking if can run job {} on this node", jobRequest.getId());
+            final int numActiveJobs = this.jobCountService.getNumJobs();
+            if (numActiveJobs < this.maxRunningJobs) {
+                log.info(
+                    "Job {} can run on this node as only {}/{} jobs are active",
+                    jobRequest.getId(),
+                    numActiveJobs,
+                    this.maxRunningJobs
+                );
+                jobBuilder
+                    .withStatus(JobStatus.INIT)
+                    .withStatusMsg("Job Accepted and in initialization phase.");
+                // TODO: if this throws exception the job will never be marked failed
+                this.jobPersistenceService.createJobAndJobExecution(jobBuilder.build(), jobExecution);
+                try {
+                    log.info("Scheduling job {} for submission", jobRequest.getId());
+                    final Future<?> task = this.taskExecutor.submit(
+                        new JobLauncher(this.jobSubmitterService, jobRequest, this.registry)
+                    );
+
+                    // Tell the system a new job has been scheduled so any actions can be taken
+                    log.info("Publishing job scheduled event for job {}", jobId);
+                    this.eventPublisher.publishEvent(new JobScheduledEvent(jobId, task, this));
+                } catch (final TaskRejectedException e) {
+                    final String errorMsg = "Unable to launch job due to exception: " + e.getMessage();
+                    this.jobPersistenceService.updateJobStatus(jobId, JobStatus.FAILED, errorMsg);
+                    throw new GenieServerException(errorMsg, e);
+                }
+                return jobId;
+            } else {
+                jobBuilder
+                    .withStatus(JobStatus.FAILED)
+                    .withStatusMsg("Unable to run job due to host being too busy during request.");
+                this.jobPersistenceService.createJobAndJobExecution(jobBuilder.build(), jobExecution);
+                throw new GenieServerUnavailableException(
+                    "Running ("
+                        + numActiveJobs
+                        + ") when max running jobs is ("
+                        + this.maxRunningJobs
+                        + ") on this host. Unable to run job."
+                );
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void killJob(@NotBlank final String jobId) throws GenieException {
+        this.jobKillService.killJob(jobId);
+    }
+}

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobKillServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobKillServiceImpl.java
@@ -85,7 +85,9 @@ public class LocalJobKillServiceImpl implements JobKillService {
      * {@inheritDoc}
      */
     @Override
-    public void killJob(@NotBlank final String id) throws GenieException {
+    public void killJob(
+        @NotBlank(message = "No id entered. Unable to kill job.") final String id
+    ) throws GenieException {
         // Will throw exception if not found
         // TODO: Could instead check JobMonitorCoordinator eventually for in memory check
         final JobStatus jobStatus = this.jobSearchService.getJobStatus(id);

--- a/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
@@ -45,6 +45,7 @@ import com.netflix.genie.core.services.JobSearchService;
 import com.netflix.genie.core.services.JobSubmitterService;
 import com.netflix.genie.core.services.impl.FileSystemAttachmentService;
 import com.netflix.genie.core.services.impl.GenieFileTransferService;
+import com.netflix.genie.core.services.impl.JobCoordinatorServiceImpl;
 import com.netflix.genie.core.services.impl.JobCountServiceImpl;
 import com.netflix.genie.core.services.impl.LocalJobKillServiceImpl;
 import com.netflix.genie.core.services.impl.LocalJobRunner;
@@ -314,7 +315,7 @@ public class ServicesConfigTest {
         final ApplicationEventPublisher eventPublisher,
         final String hostName
     ) {
-        return new JobCoordinatorService(
+        return new JobCoordinatorServiceImpl(
             taskExecutor,
             jobPersistenceService,
             jobSubmitterService,

--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImplUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImplUnitTests.java
@@ -15,7 +15,7 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.core.services;
+package com.netflix.genie.core.services.impl;
 
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
@@ -26,6 +26,10 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
 import com.netflix.genie.core.events.JobScheduledEvent;
 import com.netflix.genie.core.jobs.JobLauncher;
+import com.netflix.genie.core.services.JobCountService;
+import com.netflix.genie.core.services.JobKillService;
+import com.netflix.genie.core.services.JobPersistenceService;
+import com.netflix.genie.core.services.JobSubmitterService;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.spectator.api.Registry;
 import org.hamcrest.Matchers;
@@ -50,7 +54,7 @@ import java.util.concurrent.Future;
  * @since 3.0.0
  */
 @Category(UnitTest.class)
-public class JobCoordinatorServiceUnitTests {
+public class JobCoordinatorServiceImplUnitTests {
 
     private static final int MAX_RUNNING_JOBS = 2;
     private static final String JOB_1_ID = "job1";
@@ -61,7 +65,7 @@ public class JobCoordinatorServiceUnitTests {
     private static final String HOST_NAME = UUID.randomUUID().toString();
 
     private AsyncTaskExecutor taskExecutor;
-    private JobCoordinatorService jobCoordinatorService;
+    private JobCoordinatorServiceImpl jobCoordinatorService;
     private JobPersistenceService jobPersistenceService;
     private JobKillService jobKillService;
     private JobCountService jobCountService;
@@ -78,7 +82,7 @@ public class JobCoordinatorServiceUnitTests {
         this.jobCountService = Mockito.mock(JobCountService.class);
         this.eventPublisher = Mockito.mock(ApplicationEventPublisher.class);
 
-        this.jobCoordinatorService = new JobCoordinatorService(
+        this.jobCoordinatorService = new JobCoordinatorServiceImpl(
             this.taskExecutor,
             this.jobPersistenceService,
             Mockito.mock(JobSubmitterService.class),

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -49,6 +49,7 @@ import com.netflix.genie.core.services.impl.CacheGenieFileTransferService;
 import com.netflix.genie.core.services.impl.DefaultMailServiceImpl;
 import com.netflix.genie.core.services.impl.FileSystemAttachmentService;
 import com.netflix.genie.core.services.impl.GenieFileTransferService;
+import com.netflix.genie.core.services.impl.JobCoordinatorServiceImpl;
 import com.netflix.genie.core.services.impl.LocalJobKillServiceImpl;
 import com.netflix.genie.core.services.impl.LocalJobRunner;
 import com.netflix.genie.core.services.impl.MailServiceImpl;
@@ -351,7 +352,7 @@ public class ServicesConfig {
         final ApplicationEventPublisher eventPublisher,
         final String hostName
     ) {
-        return new JobCoordinatorService(
+        return new JobCoordinatorServiceImpl(
             taskExecutor,
             jobPersistenceService,
             jobSubmitterService,

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -88,6 +88,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 import java.io.IOException;
 import java.util.Date;
 import java.util.EnumSet;
@@ -204,6 +205,7 @@ public class JobRestController {
     @RequestMapping(method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResponseEntity<Void> submitJob(
+        @Valid
         @RequestBody
         final JobRequest jobRequest,
         @RequestHeader(value = FORWARDED_FOR_HEADER, required = false)
@@ -231,6 +233,7 @@ public class JobRestController {
     @RequestMapping(method = RequestMethod.POST, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResponseEntity<Void> submitJob(
+        @Valid
         @RequestPart("request")
         final JobRequest jobRequest,
         @RequestPart("attachment")


### PR DESCRIPTION
Bean validation on job requests and other beans wasn't happening due to services not being interfaces so no proxies could be created. Also some of them weren't annotated with validated.