### PR TITLE
Make job finished events asynchronous

### DIFF
--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/LocalJobRunnerUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/LocalJobRunnerUnitTests.java
@@ -48,6 +48,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.core.io.Resource;
 
 import java.io.File;
@@ -103,7 +104,8 @@ public class LocalJobRunnerUnitTests {
         this.clusterService = Mockito.mock(ClusterService.class);
         final CommandService commandService = Mockito.mock(CommandService.class);
         this.clusterLoadBalancer = Mockito.mock(ClusterLoadBalancer.class);
-        final ApplicationEventPublisher applicationEventPublisher = Mockito.mock(ApplicationEventPublisher.class);
+        final ApplicationEventPublisher eventPublisher = Mockito.mock(ApplicationEventPublisher.class);
+        final ApplicationEventMulticaster eventMulticaster = Mockito.mock(ApplicationEventMulticaster.class);
         final WorkflowTask task1 = Mockito.mock(WorkflowTask.class);
         this.task2 = Mockito.mock(WorkflowTask.class);
 
@@ -124,7 +126,8 @@ public class LocalJobRunnerUnitTests {
             this.clusterService,
             commandService,
             this.clusterLoadBalancer,
-            applicationEventPublisher,
+            eventPublisher,
+            eventMulticaster,
             jobWorkflowTasks,
             baseWorkingDirResource,
             registry

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -65,6 +65,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.core.io.Resource;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -186,7 +187,6 @@ public class ServicesConfig {
      *
      * @param jobRepo               The job repository to use
      * @param jobRequestRepo        The job request repository to use
-     * @param jobExecutionRepo      The jobExecution Repository to use
      * @param jobMetadataRepository The job metadata repository to use
      * @param applicationRepo       The application repository to use
      * @param clusterRepo           The cluster repository to use
@@ -197,7 +197,6 @@ public class ServicesConfig {
     public JobPersistenceService jobPersistenceService(
         final JpaJobRepository jobRepo,
         final JpaJobRequestRepository jobRequestRepo,
-        final JpaJobExecutionRepository jobExecutionRepo,
         final JpaJobMetadataRepository jobMetadataRepository,
         final JpaApplicationRepository applicationRepo,
         final JpaClusterRepository clusterRepo,
@@ -206,7 +205,6 @@ public class ServicesConfig {
         return new JpaJobPersistenceServiceImpl(
             jobRepo,
             jobRequestRepo,
-            jobExecutionRepo,
             jobMetadataRepository,
             applicationRepo,
             clusterRepo,
@@ -290,7 +288,8 @@ public class ServicesConfig {
      * @param clusterService      Implementation of cluster service interface.
      * @param commandService      Implementation of command service interface.
      * @param clusterLoadBalancer Implementation of the cluster load balancer interface.
-     * @param aep                 Instance of the event publisher.
+     * @param eventPublisher      Instance of the synchronous event publisher.
+     * @param eventMulticaster    Instance of the asynchronous event publisher.
      * @param workflowTasks       List of all the workflow tasks to be executed.
      * @param genieWorkingDir     Working directory for genie where it creates jobs directories.
      * @param registry            The metrics registry to use
@@ -303,7 +302,8 @@ public class ServicesConfig {
         final ClusterService clusterService,
         final CommandService commandService,
         final ClusterLoadBalancer clusterLoadBalancer,
-        final ApplicationEventPublisher aep,
+        final ApplicationEventPublisher eventPublisher,
+        final ApplicationEventMulticaster eventMulticaster,
         final List<WorkflowTask> workflowTasks,
         final Resource genieWorkingDir,
         final Registry registry
@@ -314,7 +314,8 @@ public class ServicesConfig {
             clusterService,
             commandService,
             clusterLoadBalancer,
-            aep,
+            eventPublisher,
+            eventMulticaster,
             workflowTasks,
             genieWorkingDir,
             registry

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
@@ -29,7 +29,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -55,6 +58,19 @@ public class TaskConfig {
         final Executor executor = new DefaultExecutor();
         executor.setStreamHandler(new PumpStreamHandler(null, null));
         return executor;
+    }
+
+    /**
+     * A multicast (async) event publisher to replace the synchronous one used by Spring via the ApplicationContext.
+     *
+     * @param taskExecutor The task executor to use
+     * @return The application event multicaster to use
+     */
+    @Bean
+    public ApplicationEventMulticaster applicationEventMulticaster(final TaskExecutor taskExecutor) {
+        final SimpleApplicationEventMulticaster applicationEventMulticaster = new SimpleApplicationEventMulticaster();
+        applicationEventMulticaster.setTaskExecutor(taskExecutor);
+        return applicationEventMulticaster;
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.core.io.Resource;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -195,7 +196,6 @@ public class ServicesConfigUnitTests {
             this.servicesConfig.jobPersistenceService(
                 this.jobRepository,
                 this.jobRequestRepository,
-                this.jobExecutionRepository,
                 Mockito.mock(JpaJobMetadataRepository.class),
                 this.applicationRepository,
                 this.clusterRepository,
@@ -214,7 +214,8 @@ public class ServicesConfigUnitTests {
         final ClusterService clusterService = Mockito.mock(ClusterService.class);
         final CommandService commandService = Mockito.mock(CommandService.class);
         final ClusterLoadBalancer clusterLoadBalancer = Mockito.mock(ClusterLoadBalancer.class);
-        final ApplicationEventPublisher applicationEventPublisher = Mockito.mock(ApplicationEventPublisher.class);
+        final ApplicationEventPublisher eventPublisher = Mockito.mock(ApplicationEventPublisher.class);
+        final ApplicationEventMulticaster eventMulticaster = Mockito.mock(ApplicationEventMulticaster.class);
         final Resource resource = Mockito.mock(Resource.class);
         final List<WorkflowTask> workflowTasks = new ArrayList<>();
 
@@ -225,7 +226,8 @@ public class ServicesConfigUnitTests {
                 clusterService,
                 commandService,
                 clusterLoadBalancer,
-                applicationEventPublisher,
+                eventPublisher,
+                eventMulticaster,
                 workflowTasks,
                 resource,
                 Mockito.mock(Registry.class)


### PR DESCRIPTION
This PR makes job finished events asynchronous instead of synchronous. This disconnects the thread throwing the events from the handling of the events and freeing up the threads to act on each other. Also should improve performance as all event handlers are independent.