### PR TITLE
add more specific interfaces for jobs for Python client

### DIFF
--- a/genie-client/src/main/python/pygenie/jobs/core.py
+++ b/genie-client/src/main/python/pygenie/jobs/core.py
@@ -168,7 +168,7 @@ class GenieJob(object):
 
         #initialize repr
         self.repr_obj.append('job_id', (self._job_id,))
-        self.repr_obj.append('username', (self._username,))
+        self.repr_obj.append('genie_username', (self._username,))
 
         #initialize cluster tags with default set of tags
         self._cluster_tag_mapping['default'] = self.default_cluster_tags
@@ -400,25 +400,6 @@ class GenieJob(object):
 
         return self.archive(False)
 
-    @unicodify
-    @arg_string
-    @add_to_repr('overwrite')
-    def email(self, _email):
-        """
-        Sets an email address for Genie to send a notification to after the job
-        is done.
-
-        Example:
-            >>> job = GenieJob() \\
-            ...     .email('jdoe@domain.com')
-
-        Args:
-            email_addr (str): The email address.
-
-        Returns:
-            :py:class:`GenieJob`: self
-        """
-
     def execute(self, retry=False, force=False, catch_signal=False):
         """
         Send the job to Genie and execute.
@@ -483,6 +464,97 @@ class GenieJob(object):
         running_job = execute_job(self)
         return running_job
 
+    @unicodify
+    @arg_string
+    @add_to_repr('overwrite')
+    def genie_email(self, _email):
+        """
+        Sets an email address for Genie to send a notification to after the job
+        is done.
+
+        Example:
+            >>> job = GenieJob() \\
+            ...     .genie_email('jdoe@domain.com')
+
+        Args:
+            email_addr (str): The email address.
+
+        Returns:
+            :py:class:`GenieJob`: self
+        """
+
+    def email(self, email):
+        # TODO: for legacy support (need to remove) - should use .genie_timeout()
+        logger.warning("Use .genie_email('%s') to set Genie email.", email)
+        return self.genie_email(email)
+
+    @unicodify
+    @add_to_repr('overwrite')
+    def genie_setup_file(self, setup_file):
+        """
+        Sets a Bash file to source before the job is executed.
+
+        Genie will source the Bash file before executing the job. This can be
+        used to set environment variables before the job is run, etc. This
+        should not be used to set job configuration properties via a file (job's
+        should have separate interfaces for setting property files).
+
+        The file must be stored externally, or available on the Genie nodes.
+
+        Example:
+            >>> job = GenieJob() \\
+            ...     .genie_setup_file('/Users/jdoe/my_setup_file.sh')
+
+        Args:
+            setup_file (str): The local path to the Bash file to use for setup.
+
+        Returns:
+            :py:class:`GenieJob`: self
+        """
+
+        assert setup_file is not None and is_file(setup_file), \
+            "setup file '{}' does not exist".format(setup_file)
+
+        self._setup_file = setup_file
+
+        return self
+
+    def setup_file(self, setup_file):
+        # TODO: for legacy support (need to remove) - should use .genie_timeout()
+        logger.warning("Use .genie_setup_file('%s') to set Genie setup file.", setup_file)
+        return self.genie_setup_file(setup_file)
+
+    @add_to_repr('overwrite')
+    def genie_timeout(self, timeout):
+        """
+        Sets a Genie job timeout (in seconds) for the job.
+
+        If the job does not finish within the specified timeout, Genie will kill
+        the job.
+
+        Example:
+            >>> job = GenieJob() \\
+            ...     .genie_timeout(3600)
+
+        Args:
+            timeout (int): The timeout for the job in seconds.
+
+        Returns:
+            :py:class:`GenieJob`: self
+        """
+
+        assert timeout is not None, \
+            'timeout cannot None and should be an int (number of seconds)'
+
+        self._timeout = int(timeout)
+
+        return self
+
+    def timeout(self, timeout):
+        # TODO: for legacy support (need to remove) - should use .genie_timeout()
+        logger.warning("Use .genie_timeout(%s) to set Genie timeout.", timeout)
+        return self.genie_timeout(timeout)
+
     @add_to_repr('overwrite')
     def genie_url(self, url):
         """
@@ -502,6 +574,29 @@ class GenieJob(object):
         self._conf.genie.url = url
 
         return self
+
+    @unicodify
+    @arg_string
+    @add_to_repr('overwrite')
+    def genie_username(self, _username):
+        """
+        Sets the Genie username to use when executing the job.
+
+        Example:
+            >>> job = GenieJob() \\
+            ...     .genie_username('jdoe')
+
+        Args:
+            username (str): The username.
+
+        Returns:
+            :py:class:`GenieJob`: self
+        """
+
+    def username(self, username):
+        # TODO: for legacy support (need to remove) - should use .genie_username()
+        logger.warning("Use .genie_username('%s') to set Genie user.", username)
+        return self.genie_username(username)
 
     def get(self, attr, default=None):
         """
@@ -656,37 +751,6 @@ class GenieJob(object):
         return self
 
     @unicodify
-    @add_to_repr('overwrite')
-    def setup_file(self, setup_file):
-        """
-        Sets a Bash file to source before the job is executed.
-
-        Genie will source the Bash file before executing the job. This can be
-        used to set environment variables before the job is run, etc. This
-        should not be used to set job configuration properties via a file (job's
-        should have separate interfaces for setting property files).
-
-        The file must be stored externally, or available on the Genie nodes.
-
-        Example:
-            >>> job = GenieJob() \\
-            ...     .setup_file('/Users/jdoe/my_setup_file.sh')
-
-        Args:
-            setup_file (str): The local path to the Bash file to use for setup.
-
-        Returns:
-            :py:class:`GenieJob`: self
-        """
-
-        assert setup_file is not None and is_file(setup_file), \
-            "setup file '{}' does not exist".format(setup_file)
-
-        self._setup_file = setup_file
-
-        return self
-
-    @unicodify
     @arg_list
     @add_to_repr('append')
     def tags(self, _tags):
@@ -708,30 +772,6 @@ class GenieJob(object):
             :py:class:`GenieJob`: self
         """
 
-    @add_to_repr('overwrite')
-    def timeout(self, timeout):
-        """
-        Sets a job timeout (in seconds) for the job.
-
-        If the job does not finish within the specified timeout, Genie will kill
-        the job.
-
-        Example:
-            >>> job = GenieJob() \\
-            ...     .timeout(3600)
-
-        Args:
-            timeout (int): The timeout for the job in seconds.
-
-        Returns:
-            :py:class:`GenieJob`: self
-        """
-
-        assert timeout is not None, \
-            'timeout cannot None and should be an int (number of seconds)'
-
-        self._timeout = int(timeout)
-        return self
 
     def to_dict(self):
         """
@@ -768,21 +808,3 @@ class GenieJob(object):
         """
 
         return json.dumps(self.to_dict(), sort_keys=True, indent=4)
-
-    @unicodify
-    @arg_string
-    @add_to_repr('overwrite')
-    def username(self, _username):
-        """
-        Sets the username to use when executing the job.
-
-        Example:
-            >>> job = GenieJob() \\
-            ...     .username('jdoe')
-
-        Args:
-            username (str): The username.
-
-        Returns:
-            :py:class:`GenieJob`: self
-        """

--- a/genie-client/src/main/python/pygenie/jobs/sqoop.py
+++ b/genie-client/src/main/python/pygenie/jobs/sqoop.py
@@ -192,7 +192,7 @@ class SqoopJob(GenieJob):
         Example:
             >>> # sqoop --password passw0rd
             >>> job = SqoopJob() \\
-            ...     .username('passw0rd')
+            ...     .password('passw0rd')
 
         Args:
             value (str): The value to set the '--password' option to.
@@ -256,3 +256,21 @@ class SqoopJob(GenieJob):
         """
 
         return self.option('target-dir', value)
+
+    def username(self, value):
+        """
+        Set the '--username' parameter for the Sqoop command.
+
+        Example:
+            >>> # sqoop --username jsmith
+            >>> job = SqoopJob() \\
+            ...     .username('jsmith')
+
+        Args:
+            value (str): The value to set the '--username' option to.
+
+        Returns:
+            :py:class:`SqoopJob`: self
+        """
+
+        return self.option('username', value)

--- a/genie-client/src/main/python/setup.py
+++ b/genie-client/src/main/python/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='nflx-genie-client',
-    version='3.0.40',
+    version='3.0.41',
     author='Netflix Inc.',
     author_email='genieoss@googlegroups.com',
     keywords='genie hadoop cloud netflix client bigdata presto',

--- a/genie-client/src/main/python/tests/job_tests/test_geniejob.py
+++ b/genie-client/src/main/python/tests/job_tests/test_geniejob.py
@@ -69,8 +69,11 @@ class TestingGenieJobRepr(unittest.TestCase):
             .dependencies('/dep2') \
             .description('description') \
             .disable_archive() \
-            .email('jsmith@email.com') \
+            .genie_email('jsmith@email.com') \
+            .genie_setup_file('/setup.sh') \
+            .genie_timeout(999) \
             .genie_url('http://asdfasdf') \
+            .genie_username('jsmith') \
             .group('group1') \
             .job_id('geniejob_repr') \
             .job_name('geniejob_repr') \
@@ -78,11 +81,8 @@ class TestingGenieJobRepr(unittest.TestCase):
             .parameter('param1', 'pval1') \
             .parameter('param2', 'pval2') \
             .parameters(param3='pval3', param4='pval4') \
-            .setup_file('/setup.sh') \
             .tags('tag1') \
-            .tags('tag2') \
-            .timeout(999) \
-            .username('jsmith')
+            .tags('tag2')
 
         assert_equals(
             str(job),
@@ -99,8 +99,11 @@ class TestingGenieJobRepr(unittest.TestCase):
                 u'dependencies("/dep1")',
                 u'dependencies("/dep2")',
                 u'description("description")',
-                u'email("jsmith@email.com")',
+                u'genie_email("jsmith@email.com")',
+                u'genie_setup_file("/setup.sh")',
+                u'genie_timeout(999)',
                 u'genie_url("http://asdfasdf")',
+                u'genie_username("jsmith")',
                 u'group("group1")',
                 u'job_id("geniejob_repr")',
                 u'job_name("geniejob_repr")',
@@ -109,11 +112,8 @@ class TestingGenieJobRepr(unittest.TestCase):
                 u'parameter("param2", "pval2")',
                 u'parameter("param3", "pval3")',
                 u'parameter("param4", "pval4")',
-                u'setup_file("/setup.sh")',
                 u'tags("tag1")',
-                u'tags("tag2")',
-                u'timeout(999)',
-                u'username("jsmith")'
+                u'tags("tag2")'
             ])
         )
 
@@ -140,14 +140,14 @@ class TestingGenieJobAdapters(unittest.TestCase):
             .dependencies(['/file1', '/file2']) \
             .description('this job is to test geniejob adapter') \
             .archive(False) \
-            .email('jdoe@email.com') \
+            .genie_email('jdoe@email.com') \
+            .genie_timeout(100) \
             .genie_url('http://fdsafdsa') \
+            .genie_username('jdoe') \
             .group('geniegroup1') \
             .job_id('geniejob1') \
             .job_name('testing_adapting_geniejob') \
             .tags('tag1, tag2') \
-            .timeout(100) \
-            .username('jdoe') \
             .job_version('0.0.1alpha')
 
         assert_equals(
@@ -189,7 +189,7 @@ class TestingJobExecute(unittest.TestCase):
 
         job = pygenie.jobs.HiveJob() \
             .job_id('exec') \
-            .username('exectester') \
+            .genie_username('exectester') \
             .script('select * from db.table')
 
         job.execute()
@@ -212,7 +212,7 @@ class TestingJobExecute(unittest.TestCase):
 
         job = pygenie.jobs.HiveJob() \
             .job_id(job_id) \
-            .username('exectester') \
+            .genie_username('exectester') \
             .script('select * from db.table')
 
         job.execute(retry=True)
@@ -238,7 +238,7 @@ class TestingJobExecute(unittest.TestCase):
 
         job = pygenie.jobs.HiveJob() \
             .job_id(job_id) \
-            .username('exectester') \
+            .genie_username('exectester') \
             .script('select * from db.table')
 
         job.execute(retry=True, force=True)

--- a/genie-client/src/main/python/tests/job_tests/test_hadoopjob.py
+++ b/genie-client/src/main/python/tests/job_tests/test_hadoopjob.py
@@ -85,16 +85,16 @@ class TestingHadoopJobRepr(unittest.TestCase):
             .dependencies('/Users/hadoop/dep2') \
             .description('"test hadoop desc"') \
             .disable_archive() \
-            .email('hadoop@email.com') \
+            .genie_email('hadoop@email.com') \
+            .genie_setup_file('/hadoop_setup.sh') \
+            .genie_timeout(5) \
+            .genie_username('jhadoop') \
             .group('hadoopgroup') \
             .job_id('hadoopjob_repr_id') \
             .job_name('hadoopjob_repr') \
             .job_version('0.0.0') \
-            .setup_file('/hadoop_setup.sh') \
             .tags('hadoop_tag_1') \
-            .tags('hadoop_tag_2') \
-            .timeout(5) \
-            .username('jhadoop')
+            .tags('hadoop_tag_2')
         job \
             .property('mapred.1', 'p1') \
             .property('mapred.2', 'p2') \
@@ -103,31 +103,33 @@ class TestingHadoopJobRepr(unittest.TestCase):
 
         assert_equals(
             str(job),
-            u'HadoopJob()' \
-            u'.applications("hadoop_app_1")' \
-            u'.applications("hadoop_app_2")' \
-            u'.archive(False)' \
-            u'.cluster_tags("hadoop_cluster_1")' \
-            u'.cluster_tags("hadoop_cluster_2")' \
-            u'.command_tags("hadoop_cmd_1")' \
-            u'.command_tags("hadoop_cmd_2")' \
-            u'.dependencies("/Users/hadoop/dep1")' \
-            u'.dependencies("/Users/hadoop/dep2")' \
-            u".description('\"test hadoop desc\"')" \
-            u'.email("hadoop@email.com")' \
-            u'.group("hadoopgroup")' \
-            u'.job_id("hadoopjob_repr_id")' \
-            u'.job_name("hadoopjob_repr")' \
-            u'.job_version("0.0.0")' \
-            u'.property("mapred.1", "p1")' \
-            u'.property("mapred.2", "p2")' \
-            u'.property_file("/Users/hadoop/test.conf")' \
-            u'.script("jar testing.jar")' \
-            u'.setup_file("/hadoop_setup.sh")' \
-            u'.tags("hadoop_tag_1")' \
-            u'.tags("hadoop_tag_2")' \
-            u'.timeout(5)' \
-            u'.username("jhadoop")'
+            '.'.join([
+                'HadoopJob()',
+                'applications("hadoop_app_1")',
+                'applications("hadoop_app_2")',
+                'archive(False)',
+                'cluster_tags("hadoop_cluster_1")',
+                'cluster_tags("hadoop_cluster_2")',
+                'command_tags("hadoop_cmd_1")',
+                'command_tags("hadoop_cmd_2")',
+                'dependencies("/Users/hadoop/dep1")',
+                'dependencies("/Users/hadoop/dep2")',
+                "description('\"test hadoop desc\"')",
+                'genie_email("hadoop@email.com")',
+                'genie_setup_file("/hadoop_setup.sh")',
+                'genie_timeout(5)',
+                'genie_username("jhadoop")',
+                'group("hadoopgroup")',
+                'job_id("hadoopjob_repr_id")',
+                'job_name("hadoopjob_repr")',
+                'job_version("0.0.0")',
+                'property("mapred.1", "p1")',
+                'property("mapred.2", "p2")',
+                'property_file("/Users/hadoop/test.conf")',
+                'script("jar testing.jar")',
+                'tags("hadoop_tag_1")',
+                'tags("hadoop_tag_2")'
+            ])
         )
 
 
@@ -160,14 +162,14 @@ class TestingHadoopJobAdapters(unittest.TestCase):
             .dependencies(['/hadoopfile1']) \
             .description('this job is to test hadoopjob adapter') \
             .archive(False) \
-            .email('jhadoop@email.com') \
+            .genie_email('jhadoop@email.com') \
+            .genie_timeout(7) \
+            .genie_username('jhadoop') \
             .group('hadoopgroup') \
             .job_id('hadoopjob1') \
             .job_name('testing_adapting_hadoopjob') \
             .script('fs -ls /testing/adapter') \
             .tags('hadooptag') \
-            .timeout(7) \
-            .username('jhadoop') \
             .job_version('0.0.hadoop-alpha')
 
         assert_equals(
@@ -213,14 +215,14 @@ class TestingHadoopJobAdapters(unittest.TestCase):
             .dependencies(['/hadoop.file1']) \
             .description('this job is to test hadoopjob adapter') \
             .archive(False) \
-            .email('jhadoop@email.com') \
+            .genie_email('jhadoop@email.com') \
+            .genie_timeout(7) \
+            .genie_username('jhadoop') \
             .group('hadoop-group') \
             .job_id('hadoop-job1') \
             .job_name('testing_adapting_hadoopjob') \
             .script('jar jar jar') \
             .tags('hadoop.tag') \
-            .timeout(7) \
-            .username('jhadoop') \
             .job_version('0.0.hadoop')
 
         assert_equals(

--- a/genie-client/src/main/python/tests/job_tests/test_hivejob.py
+++ b/genie-client/src/main/python/tests/job_tests/test_hivejob.py
@@ -135,18 +135,18 @@ class TestingHiveJobRepr(unittest.TestCase):
             .dependencies('/hive/dep2') \
             .description('hive description') \
             .disable_archive() \
-            .email('jhive@email.com') \
+            .genie_email('jhive@email.com') \
+            .genie_setup_file('/hive.setup.sh') \
+            .genie_timeout(1) \
+            .genie_username('jhive') \
             .group('hive-group') \
             .job_id('hivejob_repr') \
             .job_name('hivejob_repr') \
             .job_version('1.1.5') \
             .parameter('param1', 'pval1') \
             .parameter('param2', 'pval2') \
-            .setup_file('/hive.setup.sh') \
             .tags('hive.tag.1') \
-            .tags('hive.tag.2') \
-            .timeout(1) \
-            .username('jhive')
+            .tags('hive.tag.2')
 
         job \
             .hiveconf('hconf1', '1') \
@@ -158,35 +158,37 @@ class TestingHiveJobRepr(unittest.TestCase):
 
         assert_equals(
             str(job),
-            u'HiveJob()'
-            u'.applications("hive.app.1")'
-            u'.applications("hive.app.2")'
-            u'.archive(False)'
-            u'.cluster_tags("hive.cluster1")'
-            u'.cluster_tags("hive.cluster2")'
-            u'.command_tags("hive.cmd1")'
-            u'.command_tags("hive.cmd2")'
-            u'.dependencies("/hive/dep1")'
-            u'.dependencies("/hive/dep2")'
-            u'.description("hive description")'
-            u'.email("jhive@email.com")'
-            u'.group("hive-group")'
-            u'.hiveconf("hconf1", "1")'
-            u'.hiveconf("hconf2", "2")'
-            u'.hiveconf("prop1", "1")'
-            u'.hiveconf("prop2", "2")'
-            u'.job_id("hivejob_repr")'
-            u'.job_name("hivejob_repr")'
-            u'.job_version("1.1.5")'
-            u'.parameter("param1", "pval1")'
-            u'.parameter("param2", "pval2")'
-            u'.property_file("/hive/conf.prop")'
-            u'.script("SELECT * FROM TEST")'
-            u'.setup_file("/hive.setup.sh")'
-            u'.tags("hive.tag.1")'
-            u'.tags("hive.tag.2")'
-            u'.timeout(1)'
-            u'.username("jhive")'
+            '.'.join([
+                'HiveJob()',
+                'applications("hive.app.1")',
+                'applications("hive.app.2")',
+                'archive(False)',
+                'cluster_tags("hive.cluster1")',
+                'cluster_tags("hive.cluster2")',
+                'command_tags("hive.cmd1")',
+                'command_tags("hive.cmd2")',
+                'dependencies("/hive/dep1")',
+                'dependencies("/hive/dep2")',
+                'description("hive description")',
+                'genie_email("jhive@email.com")',
+                'genie_setup_file("/hive.setup.sh")',
+                'genie_timeout(1)',
+                'genie_username("jhive")',
+                'group("hive-group")',
+                'hiveconf("hconf1", "1")',
+                'hiveconf("hconf2", "2")',
+                'hiveconf("prop1", "1")',
+                'hiveconf("prop2", "2")',
+                'job_id("hivejob_repr")',
+                'job_name("hivejob_repr")',
+                'job_version("1.1.5")',
+                'parameter("param1", "pval1")',
+                'parameter("param2", "pval2")',
+                'property_file("/hive/conf.prop")',
+                'script("SELECT * FROM TEST")',
+                'tags("hive.tag.1")',
+                'tags("hive.tag.2")'
+            ])
         )
 
 
@@ -218,16 +220,16 @@ class TestingHiveJobAdapters(unittest.TestCase):
             .command_tags('type:hive.cmd') \
             .dependencies(['/hive.file1', '/hive.file2']) \
             .description('this job is to test hivejob adapter') \
-            .email('jhive@email.com') \
+            .genie_email('jhive@email.com') \
+            .genie_setup_file('/hive/setup.sh') \
+            .genie_timeout(7) \
+            .genie_username('jhive') \
             .group('hive-group') \
             .job_id('hive-job1') \
             .job_name('testing_adapting_hivejob') \
             .job_version('0.0.hive') \
             .parameter('a', 'b') \
-            .setup_file('/hive/setup.sh') \
             .tags('hive.tag1, hive.tag2') \
-            .timeout(7) \
-            .username('jhive') \
             .script('SELECT * FROM DUAL')
 
         assert_equals(
@@ -275,17 +277,17 @@ class TestingHiveJobAdapters(unittest.TestCase):
             .command_tags('type:hive.cmd.2') \
             .dependencies(['/hive.file1', '/hive.file2']) \
             .description('this job is to test hivejob adapter') \
-            .email('hive@email.com') \
+            .genie_email('hive@email.com') \
+            .genie_setup_file('/hive/setup.sh') \
+            .genie_timeout(9) \
+            .genie_username('hive') \
             .group('hive-group') \
             .job_id('hive-job-2') \
             .job_name('testing_adapting_hivejob') \
             .job_version('0.0.hive-alpha') \
             .parameter('a', '1') \
             .parameter('b', '2') \
-            .setup_file('/hive/setup.sh') \
             .tags('hive.tag1, hive.tag2') \
-            .timeout(9) \
-            .username('hive') \
             .script('/hive/script.hql')
 
         assert_equals(
@@ -333,17 +335,17 @@ class TestingHiveJobAdapters(unittest.TestCase):
             .command_tags('type:hive.cmd.2') \
             .dependencies(['/hive.file1', '/hive.file2']) \
             .description('this job is to test hivejob adapter') \
-            .email('hive@email.com') \
+            .genie_email('hive@email.com') \
+            .genie_setup_file('/hive/setup.sh') \
+            .genie_timeout(9) \
+            .genie_username('hive') \
             .group('hive-group') \
             .job_id('hive-job-1') \
             .job_name('testing_adapting_hivejob') \
             .job_version('0.0.-0') \
             .parameter('a', 'a') \
             .parameter('b', 'b') \
-            .setup_file('/hive/setup.sh') \
             .tags('hive.tag.1, hive.tag.2') \
-            .timeout(9) \
-            .username('hive') \
             .property_file('x://properties.conf') \
             .script('SELECT * FROM DUAL')
 
@@ -396,17 +398,17 @@ class TestingHiveJobAdapters(unittest.TestCase):
             .command_tags('type:hive.cmd.2') \
             .dependencies(['/hive.file1', '/hive.file2']) \
             .description('this job is to test hivejob adapter') \
-            .email('hive@email.com') \
+            .genie_email('hive@email.com') \
+            .genie_setup_file('/hive/setup.sh') \
+            .genie_timeout(9) \
+            .genie_username('hive') \
             .group('hive-group') \
             .job_id('hive-job-1') \
             .job_name('testing_adapting_hivejob') \
             .job_version('0.0.-0') \
             .parameter('a', 'a') \
             .parameter('b', 'b') \
-            .setup_file('/hive/setup.sh') \
             .tags('hive.tag.1, hive.tag.2') \
-            .timeout(9) \
-            .username('hive') \
             .property_file('/properties.conf') \
             .script('/script.hql')
 

--- a/genie-client/src/main/python/tests/job_tests/test_pigjob.py
+++ b/genie-client/src/main/python/tests/job_tests/test_pigjob.py
@@ -154,7 +154,10 @@ class TestingPigJobRepr(unittest.TestCase):
             .dependencies('/Users/pig/dep2') \
             .description('"test pig desc"') \
             .disable_archive() \
-            .email('pig@email.com') \
+            .genie_email('pig@email.com') \
+            .genie_setup_file('/pig_setup.sh') \
+            .genie_timeout(5) \
+            .genie_username('jpig') \
             .group('piggroup') \
             .job_id('pigjob_repr_id') \
             .job_name('pigjob_repr') \
@@ -167,43 +170,42 @@ class TestingPigJobRepr(unittest.TestCase):
             .property('mapred.pig.2', 'p2') \
             .property_file('/Users/pig/test.conf') \
             .script('/Users/pig/testscript.pig') \
-            .setup_file('/pig_setup.sh') \
             .tags('pig_tag_1') \
-            .tags('pig_tag_2') \
-            .timeout(5) \
-            .username('jpig')
+            .tags('pig_tag_2')
 
         assert_equals(
             str(job),
-            u'PigJob()' \
-            u'.applications("pig_app_1")' \
-            u'.applications("pig_app_2")' \
-            u'.archive(False)' \
-            u'.cluster_tags("pig_cluster_1")' \
-            u'.cluster_tags("pig_cluster_2")' \
-            u'.command_tags("pig_cmd_1")' \
-            u'.command_tags("pig_cmd_2")' \
-            u'.dependencies("/Users/pig/dep1")' \
-            u'.dependencies("/Users/pig/dep2")' \
-            u".description('\"test pig desc\"')" \
-            u'.email("pig@email.com")' \
-            u'.group("piggroup")' \
-            u'.job_id("pigjob_repr_id")' \
-            u'.job_name("pigjob_repr")' \
-            u'.job_version("0.0.0")' \
-            u'.parameter("pig_param_1", "1")' \
-            u'.parameter("pig_param_2", "2")' \
-            u'.parameter_file("/Users/pig/param_1.params")' \
-            u'.parameter_file("/Users/pig/param_2.params")' \
-            u'.property("mapred.pig.1", "p1")' \
-            u'.property("mapred.pig.2", "p2")' \
-            u'.property_file("/Users/pig/test.conf")' \
-            u'.script("/Users/pig/testscript.pig")' \
-            u'.setup_file("/pig_setup.sh")' \
-            u'.tags("pig_tag_1")' \
-            u'.tags("pig_tag_2")' \
-            u'.timeout(5)' \
-            u'.username("jpig")'
+            '.'.join([
+                'PigJob()',
+                'applications("pig_app_1")',
+                'applications("pig_app_2")',
+                'archive(False)',
+                'cluster_tags("pig_cluster_1")',
+                'cluster_tags("pig_cluster_2")',
+                'command_tags("pig_cmd_1")',
+                'command_tags("pig_cmd_2")',
+                'dependencies("/Users/pig/dep1")',
+                'dependencies("/Users/pig/dep2")',
+                "description('\"test pig desc\"')",
+                'genie_email("pig@email.com")',
+                'genie_setup_file("/pig_setup.sh")',
+                'genie_timeout(5)',
+                'genie_username("jpig")',
+                'group("piggroup")',
+                'job_id("pigjob_repr_id")',
+                'job_name("pigjob_repr")',
+                'job_version("0.0.0")',
+                'parameter("pig_param_1", "1")',
+                'parameter("pig_param_2", "2")',
+                'parameter_file("/Users/pig/param_1.params")',
+                'parameter_file("/Users/pig/param_2.params")',
+                'property("mapred.pig.1", "p1")',
+                'property("mapred.pig.2", "p2")',
+                'property_file("/Users/pig/test.conf")',
+                'script("/Users/pig/testscript.pig")',
+                'tags("pig_tag_1")',
+                'tags("pig_tag_2")'
+            ])
         )
 
 
@@ -235,7 +237,9 @@ class TestingPigJobAdapters(unittest.TestCase):
             .dependencies('x://externalfile') \
             .description('this job is to test pigjob adapter') \
             .archive(False) \
-            .email('pig@email.com') \
+            .genie_email('pig@email.com') \
+            .genie_timeout(1) \
+            .genie_username('jpig') \
             .group('piggroup') \
             .job_id('pig_job_id_1') \
             .job_name('testing_adapting_pigjob') \
@@ -248,8 +252,6 @@ class TestingPigJobAdapters(unittest.TestCase):
             .property_file('x://external/my_properties.conf') \
             .script("""A = LOAD;""") \
             .tags('pigtag1, pigtag2') \
-            .timeout(1) \
-            .username('jpig') \
             .job_version('0.0.1pig')
 
         assert_equals(
@@ -309,14 +311,14 @@ class TestingPigJobAdapters(unittest.TestCase):
             .dependencies(['/pigfile1']) \
             .description('this job is to test pigjob adapter') \
             .archive(False) \
-            .email('jpig@email.com') \
+            .genie_email('jpig@email.com') \
+            .genie_timeout(7) \
+            .genie_username('jpig') \
             .group('piggroup') \
             .job_id('pigjob1') \
             .job_name('testing_adapting_pigjob') \
             .script('/path/to/test/script.pig') \
             .tags('pigtag') \
-            .timeout(7) \
-            .username('jpig') \
             .job_version('0.0.pig')
 
         assert_equals(
@@ -362,7 +364,9 @@ class TestingPigJobAdapters(unittest.TestCase):
             .dependencies('x://externalfile') \
             .description('this job is to test pigjob adapter') \
             .archive(False) \
-            .email('pig@email.com') \
+            .genie_email('pig@email.com') \
+            .genie_timeout(1) \
+            .genie_username('jpig') \
             .group('piggroup') \
             .job_id('pig_job_id_1') \
             .job_name('testing_adapting_pigjob') \
@@ -375,8 +379,6 @@ class TestingPigJobAdapters(unittest.TestCase):
             .property_file('x://external/my_properties.conf') \
             .script("""A = LOAD;""") \
             .tags('pigtag1, pigtag2') \
-            .timeout(1) \
-            .username('jpig') \
             .job_version('0.0.1pig')
 
         assert_equals(
@@ -439,14 +441,14 @@ class TestingPigJobAdapters(unittest.TestCase):
             .dependencies(['/pigfile1']) \
             .description('this job is to test pigjob adapter') \
             .archive(False) \
-            .email('jpig@email.com') \
+            .genie_email('jpig@email.com') \
+            .genie_timeout(7) \
+            .genie_username('jpig') \
             .group('piggroup') \
             .job_id('pigjob1') \
             .job_name('testing_adapting_pigjob') \
             .script('/path/to/test/script.pig') \
             .tags('pigtag') \
-            .timeout(7) \
-            .username('jpig') \
             .job_version('0.0.pig')
 
         assert_equals(

--- a/genie-client/src/main/python/tests/job_tests/test_prestojob.py
+++ b/genie-client/src/main/python/tests/job_tests/test_prestojob.py
@@ -104,7 +104,10 @@ class TestingPrestoJobRepr(unittest.TestCase):
             .dependencies('/prestodep2') \
             .description('presto description') \
             .disable_archive() \
-            .email('jpresto@email.com') \
+            .genie_email('jpresto@email.com') \
+            .genie_setup_file('/prestosetup.sh') \
+            .genie_timeout(1) \
+            .genie_username('jpresto') \
             .group('prestogroup') \
             .headers() \
             .job_id('prestojob_repr') \
@@ -117,42 +120,41 @@ class TestingPrestoJobRepr(unittest.TestCase):
             """) \
             .session('session1', 'value1') \
             .session('session2', 'value2') \
-            .setup_file('/prestosetup.sh') \
             .tags('prestotag1') \
-            .tags('prestotag2') \
-            .timeout(1) \
-            .username('jpresto')
+            .tags('prestotag2')
 
         assert_equals(
             str(job),
-            u'PrestoJob()'
-            u'.applications("prestoapp1")'
-            u'.applications("prestoapp2")'
-            u'.archive(False)'
-            u'.cluster_tags("prestocluster1")'
-            u'.cluster_tags("prestocluster2")'
-            u'.command_tags("prestocmd1")'
-            u'.command_tags("prestocmd2")'
-            u'.dependencies("/prestodep1")'
-            u'.dependencies("/prestodep2")'
-            u'.description("presto description")'
-            u'.email("jpresto@email.com")'
-            u'.group("prestogroup")'
-            u'.job_id("prestojob_repr")'
-            u'.job_name("prestojob_repr")'
-            u'.job_version("1.1.1")'
-            u'.option("debug", None)'
-            u'.option("output-format", "CSV_HEADER")'
-            u'.option("source", "testrepr")'
-            u'.script("""\n            SELECT * FROM TEST\n            """)'
-            u'.session("session1", "value1")'
-            u'.session("session2", "value2")'
-            u'.setup_file("/prestosetup.sh")'
-            u'.tags("headers")'
-            u'.tags("prestotag1")'
-            u'.tags("prestotag2")'
-            u'.timeout(1)'
-            u'.username("jpresto")'
+            '.'.join([
+                'PrestoJob()',
+                'applications("prestoapp1")',
+                'applications("prestoapp2")',
+                'archive(False)',
+                'cluster_tags("prestocluster1")',
+                'cluster_tags("prestocluster2")',
+                'command_tags("prestocmd1")',
+                'command_tags("prestocmd2")',
+                'dependencies("/prestodep1")',
+                'dependencies("/prestodep2")',
+                'description("presto description")',
+                'genie_email("jpresto@email.com")',
+                'genie_setup_file("/prestosetup.sh")',
+                'genie_timeout(1)',
+                'genie_username("jpresto")',
+                'group("prestogroup")',
+                'job_id("prestojob_repr")',
+                'job_name("prestojob_repr")',
+                'job_version("1.1.1")',
+                'option("debug", None)',
+                'option("output-format", "CSV_HEADER")',
+                'option("source", "testrepr")',
+                'script("""\n            SELECT * FROM TEST\n            """)',
+                'session("session1", "value1")',
+                'session("session2", "value2")',
+                'tags("headers")',
+                'tags("prestotag1")',
+                'tags("prestotag2")'
+            ])
         )
 
 
@@ -184,14 +186,14 @@ class TestingPrestoJobAdapters(unittest.TestCase):
             .dependencies(['/prestofile1', '/prestofile2']) \
             .description('this job is to test prestojob adapter') \
             .archive(False) \
-            .email('jpresto@email.com') \
+            .genie_email('jpresto@email.com') \
+            .genie_timeout(7) \
+            .genie_username('jpresto') \
             .group('prestogroup') \
             .job_id('prestojob1') \
             .job_name('testing_adapting_prestojob') \
             .script('SELECT * FROM DUAL') \
             .tags('prestotag1, prestotag2') \
-            .timeout(7) \
-            .username('jpresto') \
             .job_version('0.0.1presto')
 
         assert_equals(
@@ -239,14 +241,14 @@ class TestingPrestoJobAdapters(unittest.TestCase):
             .dependencies(['/prestofile1', '/prestofile2']) \
             .description('this job is to test prestojob adapter') \
             .archive(False) \
-            .email('jpresto@email.com') \
+            .genie_email('jpresto@email.com') \
+            .genie_timeout(7) \
+            .genie_username('jpresto') \
             .group('prestogroup') \
             .job_id('prestojob1') \
             .job_name('testing_adapting_prestojob') \
             .script('/path/to/test/file.presto') \
             .tags('prestotag1, prestotag2') \
-            .timeout(7) \
-            .username('jpresto') \
             .job_version('0.0.1presto')
 
         assert_equals(
@@ -292,14 +294,14 @@ class TestingPrestoJobAdapters(unittest.TestCase):
             .dependencies(['/prestofile1', '/prestofile2']) \
             .description('this job is to test prestojob adapter') \
             .archive(False) \
-            .email('jpresto@email.com') \
+            .genie_email('jpresto@email.com') \
+            .genie_timeout(7) \
+            .genie_username('jpresto') \
             .group('prestogroup') \
             .job_id('prestojob1') \
             .job_name('testing_adapting_prestojob') \
             .script('SELECT * FROM DUAL') \
             .tags('prestotag1, prestotag2') \
-            .timeout(7) \
-            .username('jpresto') \
             .job_version('0.0.1presto')
 
         assert_equals(
@@ -349,14 +351,14 @@ class TestingPrestoJobAdapters(unittest.TestCase):
             .dependencies(['/prestofile1', '/prestofile2']) \
             .description('this job is to test prestojob adapter') \
             .archive(False) \
-            .email('jpresto@email.com') \
+            .genie_email('jpresto@email.com') \
+            .genie_timeout(7) \
+            .genie_username('jpresto') \
             .group('prestogroup') \
             .job_id('prestojob1') \
             .job_name('testing_adapting_prestojob') \
             .script('/path/to/test/file.presto') \
             .tags('prestotag1, prestotag2') \
-            .timeout(7) \
-            .username('jpresto') \
             .job_version('0.0.1presto')
 
         assert_equals(

--- a/genie-client/src/main/python/tests/job_tests/test_sqoopjob.py
+++ b/genie-client/src/main/python/tests/job_tests/test_sqoopjob.py
@@ -98,22 +98,24 @@ class TestingSqoopJobRepr(unittest.TestCase):
 
         assert_equals(
             str(job),
-            u'SqoopJob()'
-            u'.cmd("importtest")'
-            u'.job_id("1234-abcd")'
-            u'.option("bar", "buzz")'
-            u'.option("connect", "jdbc://")'
-            u'.option("debug", None)'
-            u'.option("foo", "fizz")'
-            u'.option("hello", "world")'
-            u'.option("password", "1234")'
-            u'.option("split-by", "col_a")'
-            u'.option("table", "test_table")'
-            u'.option("target-dir", "/path/to/test/output")'
-            u'.option("verbose", None)'
-            u'.property("p1", "v1", "-D")'
-            u'.property("p2", "v2", "-f")'
-            u'.username("user_ini")'
+            '.'.join([
+                'SqoopJob()',
+                'cmd("importtest")',
+                'genie_username("user_ini")',
+                'job_id("1234-abcd")',
+                'option("bar", "buzz")',
+                'option("connect", "jdbc://")',
+                'option("debug", None)',
+                'option("foo", "fizz")',
+                'option("hello", "world")',
+                'option("password", "1234")',
+                'option("split-by", "col_a")',
+                'option("table", "test_table")',
+                'option("target-dir", "/path/to/test/output")',
+                'option("verbose", None)',
+                'property("p1", "v1", "-D")',
+                'property("p2", "v2", "-f")'
+            ])
         )
 
 
@@ -209,14 +211,15 @@ class TestingSqoopJobAdapters(unittest.TestCase):
             .dependencies(['/sqoopfile1', '/sqoopfile2']) \
             .description('this job is to test sqoopjob adapter') \
             .archive(False) \
-            .email('jsqoop@email.com') \
+            .genie_email('jsqoop@email.com') \
+            .genie_timeout(58) \
+            .genie_username('jsqoop-genie') \
             .group('sqoopgroup') \
             .job_id('sqoopjob1') \
             .job_name('testing_adapting_sqoopjob') \
             .job_version('0.0.1sqoop') \
             .setup_file('/path/to/testsetup.sh') \
             .tags('sqooptag1, sqooptag2') \
-            .timeout(58) \
             .username('jsqoop') \
             .cmd('test-export') \
             .option('opt1', 'val1') \
@@ -251,7 +254,7 @@ class TestingSqoopJobAdapters(unittest.TestCase):
                 u'id': u'sqoopjob1',
                 u'name': u'testing_adapting_sqoopjob',
                 u'tags': [u'sqooptag1', u'sqooptag2'],
-                u'user': u'jsqoop',
+                u'user': u'jsqoop-genie',
                 u'version': u'0.0.1sqoop'
             }
         )
@@ -271,14 +274,15 @@ class TestingSqoopJobAdapters(unittest.TestCase):
             .dependencies(['/sqoopfile1a', '/sqoopfile2b']) \
             .description('this job is to test sqoopjob adapter for genie 3') \
             .archive(False) \
-            .email('jsqoop-g3@email.com') \
+            .genie_email('jsqoop-g3@email.com') \
+            .genie_timeout(5) \
+            .genie_username('jsqoop-genie3') \
             .group('sqoopgroup-g3') \
             .job_id('sqoopjob1-g3') \
             .job_name('testing_adapting_sqoopjob-g3') \
             .job_version('0.0.1sqoop-g3') \
             .setup_file('/path/to/testsetup.sh-g3') \
             .tags('sqooptag1-g3, sqooptag2-g3') \
-            .timeout(5) \
             .username('jsqoop-g3') \
             .cmd('test-export-g3') \
             .option('opt1-g3', 'val1-g3') \
@@ -312,7 +316,7 @@ class TestingSqoopJobAdapters(unittest.TestCase):
                 u'setupFile': u'/path/to/testsetup.sh-g3',
                 u'tags': [u'sqooptag1-g3', u'sqooptag2-g3'],
                 u'timeout': 5,
-                u'user': u'jsqoop-g3',
+                u'user': u'jsqoop-genie3',
                 u'version': u'0.0.1sqoop-g3'
             }
         )


### PR DESCRIPTION
Added more specific interfaces like ".genie_username()" for jobs because
other jobs may require those interface names to set things on the
command-line, etc. The old interface is still there but logs a warning
message.