### PR TITLE
Searching for Jobs by Command or Cluster ID causes server exception

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImpl.java
@@ -36,6 +36,8 @@ import com.netflix.genie.core.jpa.entities.JobEntity_;
 import com.netflix.genie.core.jpa.entities.JobExecutionEntity;
 import com.netflix.genie.core.jpa.entities.JobExecutionEntity_;
 import com.netflix.genie.core.jpa.entities.JobRequestEntity;
+import com.netflix.genie.core.jpa.repositories.JpaClusterRepository;
+import com.netflix.genie.core.jpa.repositories.JpaCommandRepository;
 import com.netflix.genie.core.jpa.repositories.JpaJobExecutionRepository;
 import com.netflix.genie.core.jpa.repositories.JpaJobRepository;
 import com.netflix.genie.core.jpa.repositories.JpaJobRequestRepository;
@@ -77,6 +79,8 @@ public class JpaJobSearchServiceImpl implements JobSearchService {
     private final JpaJobRepository jobRepository;
     private final JpaJobRequestRepository jobRequestRepository;
     private final JpaJobExecutionRepository jobExecutionRepository;
+    private final JpaClusterRepository clusterRepository;
+    private final JpaCommandRepository commandRepository;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -87,15 +91,21 @@ public class JpaJobSearchServiceImpl implements JobSearchService {
      * @param jobRepository          The repository to use for job entities
      * @param jobRequestRepository   The repository to use for job request entities
      * @param jobExecutionRepository The repository to use for job execution entities
+     * @param clusterRepository      The repository to use for cluster entities
+     * @param commandRepository      The repository to use for command entities
      */
     public JpaJobSearchServiceImpl(
         final JpaJobRepository jobRepository,
         final JpaJobRequestRepository jobRequestRepository,
-        final JpaJobExecutionRepository jobExecutionRepository
+        final JpaJobExecutionRepository jobExecutionRepository,
+        final JpaClusterRepository clusterRepository,
+        final JpaCommandRepository commandRepository
     ) {
         this.jobRepository = jobRepository;
         this.jobRequestRepository = jobRequestRepository;
         this.jobExecutionRepository = jobExecutionRepository;
+        this.clusterRepository = clusterRepository;
+        this.commandRepository = commandRepository;
     }
 
     /**
@@ -134,9 +144,9 @@ public class JpaJobSearchServiceImpl implements JobSearchService {
                 statuses,
                 tags,
                 clusterName,
-                clusterId,
+                clusterId == null ? null : this.clusterRepository.findOne(clusterId),
                 commandName,
-                commandId,
+                commandId == null ? null : this.commandRepository.findOne(commandId),
                 minStarted,
                 maxStarted,
                 minFinished,

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaJobSpecs.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaJobSpecs.java
@@ -16,6 +16,8 @@
 package com.netflix.genie.core.jpa.specifications;
 
 import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.core.jpa.entities.ClusterEntity;
+import com.netflix.genie.core.jpa.entities.CommandEntity;
 import com.netflix.genie.core.jpa.entities.JobEntity;
 import com.netflix.genie.core.jpa.entities.JobEntity_;
 import org.apache.commons.lang3.StringUtils;
@@ -54,9 +56,9 @@ public final class JpaJobSpecs {
      * @param statuses    The job statuses
      * @param tags        The tags for the jobs to find
      * @param clusterName The cluster name
-     * @param clusterId   The cluster id
+     * @param cluster     The cluster the job should have been run on
      * @param commandName The command name
-     * @param commandId   The command id
+     * @param command     The command the job should have been run with
      * @param minStarted  The time which the job had to start after in order to be return (inclusive)
      * @param maxStarted  The time which the job had to start before in order to be returned (exclusive)
      * @param minFinished The time which the job had to finish after in order to be return (inclusive)
@@ -72,9 +74,9 @@ public final class JpaJobSpecs {
         final Set<JobStatus> statuses,
         final Set<String> tags,
         final String clusterName,
-        final String clusterId,
+        final ClusterEntity cluster,
         final String commandName,
-        final String commandId,
+        final CommandEntity command,
         final Date minStarted,
         final Date maxStarted,
         final Date minFinished,
@@ -101,14 +103,14 @@ public final class JpaJobSpecs {
         if (tags != null && !tags.isEmpty()) {
             predicates.add(cb.like(root.get(JobEntity_.tags), JpaSpecificationUtils.getTagLikeString(tags)));
         }
-        if (StringUtils.isNotBlank(clusterId)) {
-            predicates.add(cb.equal(root.get(JobEntity_.cluster), clusterId));
+        if (cluster != null) {
+            predicates.add(cb.equal(root.get(JobEntity_.cluster), cluster));
         }
         if (StringUtils.isNotBlank(clusterName)) {
             predicates.add(cb.equal(root.get(JobEntity_.clusterName), clusterName));
         }
-        if (StringUtils.isNotBlank(commandId)) {
-            predicates.add(cb.equal(root.get(JobEntity_.command), commandId));
+        if (command != null) {
+            predicates.add(cb.equal(root.get(JobEntity_.command), command));
         }
         if (StringUtils.isNotBlank(commandName)) {
             predicates.add(cb.equal(root.get(JobEntity_.commandName), commandName));

--- a/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
@@ -130,15 +130,25 @@ public class ServicesConfigTest {
      * @param jobRepository          The repository to use for job entities
      * @param jobRequestRepository   The repository to use for job request entities
      * @param jobExecutionRepository The repository to use for job execution entities
+     * @param clusterRepository      The repository to use for cluster entities
+     * @param commandRepository      The repository to use for command entities
      * @return A job search service instance.
      */
     @Bean
     public JobSearchService jobSearchService(
         final JpaJobRepository jobRepository,
         final JpaJobRequestRepository jobRequestRepository,
-        final JpaJobExecutionRepository jobExecutionRepository
+        final JpaJobExecutionRepository jobExecutionRepository,
+        final JpaClusterRepository clusterRepository,
+        final JpaCommandRepository commandRepository
     ) {
-        return new JpaJobSearchServiceImpl(jobRepository, jobRequestRepository, jobExecutionRepository);
+        return new JpaJobSearchServiceImpl(
+            jobRepository,
+            jobRequestRepository,
+            jobExecutionRepository,
+            clusterRepository,
+            commandRepository
+        );
     }
 
     /**

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplUnitTests.java
@@ -23,6 +23,8 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.core.jpa.entities.JobEntity;
 import com.netflix.genie.core.jpa.entities.JobExecutionEntity;
+import com.netflix.genie.core.jpa.repositories.JpaClusterRepository;
+import com.netflix.genie.core.jpa.repositories.JpaCommandRepository;
 import com.netflix.genie.core.jpa.repositories.JpaJobExecutionRepository;
 import com.netflix.genie.core.jpa.repositories.JpaJobRepository;
 import com.netflix.genie.core.jpa.repositories.JpaJobRequestRepository;
@@ -58,8 +60,13 @@ public class JpaJobSearchServiceImplUnitTests {
         this.jobRepository = Mockito.mock(JpaJobRepository.class);
         this.jobRequestRepository = Mockito.mock(JpaJobRequestRepository.class);
         this.jobExecutionRepository = Mockito.mock(JpaJobExecutionRepository.class);
-        this.service
-            = new JpaJobSearchServiceImpl(this.jobRepository, this.jobRequestRepository, this.jobExecutionRepository);
+        this.service = new JpaJobSearchServiceImpl(
+            this.jobRepository,
+            this.jobRequestRepository,
+            this.jobExecutionRepository,
+            Mockito.mock(JpaClusterRepository.class),
+            Mockito.mock(JpaCommandRepository.class)
+        );
     }
 
     /**

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaJobSpecsUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaJobSpecsUnitTests.java
@@ -48,9 +48,9 @@ public class JpaJobSpecsUnitTests {
     private static final String JOB_NAME = "jobName";
     private static final String USER_NAME = "tgianos";
     private static final String CLUSTER_NAME = "hprod2";
-    private static final String CLUSTER_ID = "prod";
+    private static final ClusterEntity CLUSTER = Mockito.mock(ClusterEntity.class);
     private static final String COMMAND_NAME = "pig";
-    private static final String COMMAND_ID = "pig14";
+    private static final CommandEntity COMMAND = Mockito.mock(CommandEntity.class);
     private static final Set<String> TAGS = new HashSet<>();
     private static final Set<JobStatus> STATUSES = new HashSet<>();
     private static final String TAG = UUID.randomUUID().toString();
@@ -108,7 +108,7 @@ public class JpaJobSpecsUnitTests {
         final Path<ClusterEntity> clusterIdPath = (Path<ClusterEntity>) Mockito.mock(Path.class);
         final Predicate equalClusterIdPredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(JobEntity_.cluster)).thenReturn(clusterIdPath);
-        Mockito.when(this.cb.equal(clusterIdPath, CLUSTER_ID)).thenReturn(equalClusterIdPredicate);
+        Mockito.when(this.cb.equal(clusterIdPath, CLUSTER)).thenReturn(equalClusterIdPredicate);
 
         final Path<String> commandNamePath = (Path<String>) Mockito.mock(Path.class);
         final Predicate equalCommandNamePredicate = Mockito.mock(Predicate.class);
@@ -118,7 +118,7 @@ public class JpaJobSpecsUnitTests {
         final Path<CommandEntity> commandIdPath = (Path<CommandEntity>) Mockito.mock(Path.class);
         final Predicate equalCommandIdPredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(JobEntity_.command)).thenReturn(commandIdPath);
-        Mockito.when(this.cb.equal(clusterIdPath, COMMAND_ID)).thenReturn(equalCommandIdPredicate);
+        Mockito.when(this.cb.equal(clusterIdPath, COMMAND)).thenReturn(equalCommandIdPredicate);
 
         final Path<String> tagPath = (Path<String>) Mockito.mock(Path.class);
         final Predicate likeTagPredicate = Mockito.mock(Predicate.class);
@@ -166,9 +166,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -182,9 +182,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -208,9 +208,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -224,9 +224,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -250,9 +250,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -266,9 +266,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -292,9 +292,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -308,9 +308,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -334,9 +334,9 @@ public class JpaJobSpecsUnitTests {
             null,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -350,9 +350,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -376,9 +376,9 @@ public class JpaJobSpecsUnitTests {
             new HashSet<>(),
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -392,9 +392,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -418,9 +418,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             null,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -434,9 +434,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -462,7 +462,7 @@ public class JpaJobSpecsUnitTests {
             CLUSTER_NAME,
             null,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -476,9 +476,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -502,9 +502,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             null,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -518,9 +518,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -544,7 +544,7 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
             null,
             MIN_STARTED,
@@ -560,9 +560,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -586,9 +586,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             null,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -602,9 +602,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.never()).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -628,9 +628,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             null,
             MAX_STARTED,
             MIN_FINISHED,
@@ -644,9 +644,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.never()).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -670,9 +670,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             null,
             MIN_FINISHED,
@@ -686,9 +686,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.never()).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -712,9 +712,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             null,
@@ -728,9 +728,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -754,9 +754,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -770,9 +770,9 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
@@ -797,9 +797,9 @@ public class JpaJobSpecsUnitTests {
             STATUSES,
             TAGS,
             CLUSTER_NAME,
-            CLUSTER_ID,
+            CLUSTER,
             COMMAND_NAME,
-            COMMAND_ID,
+            COMMAND,
             MIN_STARTED,
             MAX_STARTED,
             MIN_FINISHED,
@@ -813,7 +813,7 @@ public class JpaJobSpecsUnitTests {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
-        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER_ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -171,15 +171,25 @@ public class ServicesConfig {
      * @param jobRepository          The repository to use for job entities
      * @param jobRequestRepository   The repository to use for job request entities
      * @param jobExecutionRepository The repository to use for job execution entities
+     * @param clusterRepository      The repository to use for cluster entities
+     * @param commandRepository      The repository to use for command entities
      * @return A job search service instance.
      */
     @Bean
     public JobSearchService jobSearchService(
         final JpaJobRepository jobRepository,
         final JpaJobRequestRepository jobRequestRepository,
-        final JpaJobExecutionRepository jobExecutionRepository
+        final JpaJobExecutionRepository jobExecutionRepository,
+        final JpaClusterRepository clusterRepository,
+        final JpaCommandRepository commandRepository
     ) {
-        return new JpaJobSearchServiceImpl(jobRepository, jobRequestRepository, jobExecutionRepository);
+        return new JpaJobSearchServiceImpl(
+            jobRepository,
+            jobRequestRepository,
+            jobExecutionRepository,
+            clusterRepository,
+            commandRepository
+        );
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
@@ -149,7 +149,7 @@ ClusterRestController {
         @RequestParam(value = "tag", required = false) final Set<String> tags,
         @RequestParam(value = "minUpdateTime", required = false) final Long minUpdateTime,
         @RequestParam(value = "maxUpdateTime", required = false) final Long maxUpdateTime,
-        @PageableDefault(page = 0, size = 64, sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
+        @PageableDefault(size = 64, sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<Cluster> assembler
     ) throws GenieException {
         log.debug("Called [name | statuses | tags | minUpdateTime | maxUpdateTime | page]");

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/CommandRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/CommandRestController.java
@@ -151,7 +151,7 @@ public class CommandRestController {
         @RequestParam(value = "user", required = false) final String user,
         @RequestParam(value = "status", required = false) final Set<String> statuses,
         @RequestParam(value = "tag", required = false) final Set<String> tags,
-        @PageableDefault(page = 0, size = 64, sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
+        @PageableDefault(size = 64, sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<Command> assembler
     ) throws GenieException {
         log.debug("Called [name | user | status | tags | page]");

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -182,7 +182,9 @@ public class ServicesConfigUnitTests {
             this.servicesConfig.jobSearchService(
                 this.jobRepository,
                 this.jobRequestRepository,
-                this.jobExecutionRepository
+                this.jobExecutionRepository,
+                Mockito.mock(JpaClusterRepository.class),
+                Mockito.mock(JpaCommandRepository.class)
             )
         );
     }


### PR DESCRIPTION
When the user requested to search jobs by cluster and/or command id it will throw a server exception due to incompatible types (string vs. entity) in the JPA specification generation.