### PR TITLE
Create the std out and std err files during job setup

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/InitialSetupTask.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/InitialSetupTask.java
@@ -144,7 +144,7 @@ public class InitialSetupTask extends GenieBaseTask {
         }
         final File stderr = new File(jobWorkingDirectory, JobConstants.STDERR_LOG_FILE_NAME);
         if (!stderr.exists() && !stderr.createNewFile()) {
-            throw new GenieServerException("Unable to create std err file at " + stdout);
+            throw new GenieServerException("Unable to create std err file at " + stderr);
         }
     }
 

--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/InitialSetupTask.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/InitialSetupTask.java
@@ -29,6 +29,7 @@ import com.netflix.spectator.api.Timer;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.validation.constraints.NotNull;
+import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Map;
@@ -102,7 +103,7 @@ public class InitialSetupTask extends GenieBaseTask {
         }
     }
 
-    private void createJobDirStructure(final String jobWorkingDirectory) throws GenieException {
+    private void createJobDirStructure(final String jobWorkingDirectory) throws GenieException, IOException {
         // create top level directory structure for the job
 
         // Genie Directory {basedir/genie}
@@ -135,6 +136,16 @@ public class InitialSetupTask extends GenieBaseTask {
             + JobConstants.GENIE_PATH_VAR
             + JobConstants.FILE_PATH_DELIMITER
             + JobConstants.CLUSTER_PATH_VAR);
+
+        // Create std out file
+        final File stdout = new File(jobWorkingDirectory, JobConstants.STDOUT_LOG_FILE_NAME);
+        if (!stdout.exists() && !stdout.createNewFile()) {
+            throw new GenieServerException("Unable to create std out file at " + stdout);
+        }
+        final File stderr = new File(jobWorkingDirectory, JobConstants.STDERR_LOG_FILE_NAME);
+        if (!stderr.exists() && !stderr.createNewFile()) {
+            throw new GenieServerException("Unable to create std err file at " + stdout);
+        }
     }
 
     private void createJobDirEnvironmentVariables(final Writer writer, final String jobWorkingDirectory)


### PR DESCRIPTION
Avoid edge case where one of the files is requested immediately once job is marked running and they don't yet exist causing an exception. The files currently aren't created until the actual client command is invoked and output is redirected. In this case there will be empty files there at least to return to users during the time the run script is building up to invoking the client command.