### PR TITLE
Removed the inverse relations in the job entities

### DIFF
--- a/genie-client/src/test/resources/application-integration.yml
+++ b/genie-client/src/test/resources/application-integration.yml
@@ -28,6 +28,10 @@ spring:
     hibernate:
       ddl-auto: update
       naming-strategy: org.hibernate.cfg.ImprovedNamingStrategy
+    properties:
+      hibernate:
+        show_sql: true
+        type: trace
   datasource:
     url: jdbc:hsqldb:mem:genie-int-db;shutdown=true
     username: SA

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobEntity.java
@@ -25,7 +25,6 @@ import org.hibernate.validator.constraints.Length;
 
 import javax.annotation.Nullable;
 import javax.persistence.Basic;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -36,6 +35,8 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
@@ -58,7 +59,17 @@ import java.util.Optional;
 @Setter
 @Entity
 @Table(name = "jobs")
+@NamedQueries({
+    @NamedQuery(
+        name = JobEntity.QUERY_GET_STATUS_BY_ID,
+        query = "select j.status from JobEntity j where j.id = :id"
+    )
+})
 public class JobEntity extends CommonFieldsEntity {
+    /**
+     * Query name to get job status.
+     */
+    public static final String QUERY_GET_STATUS_BY_ID = "getStatusById";
     /**
      * Used as default version when one not entered.
      */
@@ -110,14 +121,6 @@ public class JobEntity extends CommonFieldsEntity {
     @JoinColumn(name = "id")
     @MapsId
     private JobRequestEntity request;
-
-    @OneToOne(
-        mappedBy = "job",
-        fetch = FetchType.LAZY,
-        cascade = CascadeType.ALL,
-        orphanRemoval = true
-    )
-    private JobExecutionEntity execution;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cluster_id")
@@ -278,18 +281,8 @@ public class JobEntity extends CommonFieldsEntity {
      *
      * @param request The job request. Not null.
      */
-    protected void setRequest(final JobRequestEntity request) {
+    public void setRequest(final JobRequestEntity request) {
         this.request = request;
-    }
-
-    /**
-     * Set the job execution for this job.
-     *
-     * @param execution The execution. Not null.
-     */
-    public void setExecution(@NotNull(message = "Execution can't be null") final JobExecutionEntity execution) {
-        this.execution = execution;
-        execution.setJob(this);
     }
 
     /**

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobExecutionEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobExecutionEntity.java
@@ -27,6 +27,8 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapsId;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
@@ -49,8 +51,25 @@ import java.util.TimeZone;
 @Setter
 @Entity
 @Table(name = "job_executions")
+@NamedQueries({
+    @NamedQuery(
+        name = JobExecutionEntity.QUERY_FIND_BY_STATUS_HOST,
+        query = "select e.job from JobExecutionEntity e where e.job.status in :statuses and e.hostName = :hostName"
+    ),
+    @NamedQuery(
+        name = JobExecutionEntity.QUERY_FIND_HOSTS_BY_STATUS,
+        query = "select distinct e.hostName from JobExecutionEntity e where e.job.status in :statuses"
+    )
+})
 public class JobExecutionEntity extends BaseEntity {
-
+    /**
+     * Query name to find jobs by statuses and host.
+     */
+    public static final String QUERY_FIND_BY_STATUS_HOST = "findByStatusHost";
+    /**
+     * Query name to find hosts by statuses.
+     */
+    public static final String QUERY_FIND_HOSTS_BY_STATUS = "findHostsByStatus";
     private static final long serialVersionUID = -5073493356472801960L;
     private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
@@ -154,7 +173,7 @@ public class JobExecutionEntity extends BaseEntity {
      *
      * @param job The job
      */
-    protected void setJob(final JobEntity job) {
+    public void setJob(final JobEntity job) {
         this.job = job;
     }
 

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobRequestEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobRequestEntity.java
@@ -28,14 +28,10 @@ import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.Basic;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.Optional;
@@ -116,22 +112,6 @@ public class JobRequestEntity extends SetupFileEntity {
     @Column(name = "timeout")
     @Min(value = 1)
     private Integer timeout;
-
-    @OneToOne(
-        mappedBy = "request",
-        fetch = FetchType.LAZY,
-        cascade = CascadeType.ALL,
-        orphanRemoval = true
-    )
-    private JobEntity job;
-
-    @OneToOne(
-        mappedBy = "request",
-        fetch = FetchType.LAZY,
-        cascade = CascadeType.ALL,
-        orphanRemoval = true
-    )
-    private JobMetadataEntity jobMetadata;
 
     /**
      * Gets the group name of the user who submitted the job.
@@ -332,35 +312,6 @@ public class JobRequestEntity extends SetupFileEntity {
      */
     protected void setApplications(final String applications) {
         this.applications = applications;
-    }
-
-    /**
-     * Get the job associated with this job request.
-     *
-     * @return The job
-     */
-    public JobEntity getJob() {
-        return this.job;
-    }
-
-    /**
-     * Set the job for this request.
-     *
-     * @param job The job
-     */
-    public void setJob(@NotNull final JobEntity job) {
-        this.job = job;
-        job.setRequest(this);
-    }
-
-    /**
-     * Set the additional metadata for this request.
-     *
-     * @param jobMetadata The metadata
-     */
-    public void setJobMetadata(@NotNull final JobMetadataEntity jobMetadata) {
-        this.jobMetadata = jobMetadata;
-        this.jobMetadata.setRequest(this);
     }
 
     /**

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobExecutionRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobExecutionRepository.java
@@ -20,6 +20,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
 /**
  * Job repository.
  *
@@ -28,4 +31,10 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface JpaJobExecutionRepository extends JpaRepository<JobExecutionEntity, String>, JpaSpecificationExecutor {
+    /**
+     * Deletes all job executions for the given ids.
+     * @param ids list of ids for which the job requests should be deleted
+     * @return no. of executions deleted
+     */
+    Long deleteByIdIn(@NotNull final List<String> ids);
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobMetadataRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobMetadataRepository.java
@@ -20,6 +20,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
 /**
  * Job Metadata repository.
  *
@@ -28,4 +31,10 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface JpaJobMetadataRepository extends JpaRepository<JobMetadataEntity, String>, JpaSpecificationExecutor {
+    /**
+     * Deletes all job metadatas for the given ids.
+     * @param ids list of ids for which the job requests should be deleted
+     * @return no. of metadatas deleted
+     */
+    Long deleteByIdIn(@NotNull final List<String> ids);
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRepository.java
@@ -20,6 +20,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
 /**
  * Job repository.
  *
@@ -27,4 +30,10 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface JpaJobRepository extends JpaRepository<JobEntity, String>, JpaSpecificationExecutor {
+    /**
+     * Deletes all jobs for the given ids.
+     * @param ids list of ids for which the jobs should be deleted
+     * @return no. of jobs deleted
+     */
+    Long deleteByIdIn(@NotNull final List<String> ids);
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRequestRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRequestRepository.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.validation.constraints.NotNull;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Job repository.
@@ -33,10 +34,17 @@ import java.util.Date;
 public interface JpaJobRequestRepository extends JpaRepository<JobRequestEntity, String>, JpaSpecificationExecutor {
 
     /**
-     * Delete all job requests created before the given date.
+     * Returns all job requests created before the given date.
      *
-     * @param date The date before which all job requests should be deleted.
-     * @return The number of deleted records
+     * @param date The date before which all job requests were created.
+     * @return List of job requests
      */
-    Long deleteByCreatedBefore(@NotNull final Date date);
+    List<JobRequestEntity> findByCreatedBefore(@NotNull final Date date);
+
+    /**
+     * Deletes all job requests for the given ids.
+     * @param ids list of ids for which the job requests should be deleted
+     * @return no. of requests deleted
+     */
+    Long deleteByIdIn(@NotNull final List<String> ids);
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
@@ -158,6 +158,7 @@ public class ServicesConfigTest {
      * @param jobRepo               The job repository to use
      * @param jobRequestRepo        The job request repository to use
      * @param jobMetadataRepository The job metadata repository to use
+     * @param jobExecutionRepo      The job execution repository to use
      * @param applicationRepo       The application repository to use
      * @param clusterRepo           The cluster repository to use
      * @param commandRepo           The command repository to use
@@ -168,6 +169,7 @@ public class ServicesConfigTest {
         final JpaJobRepository jobRepo,
         final JpaJobRequestRepository jobRequestRepo,
         final JpaJobMetadataRepository jobMetadataRepository,
+        final JpaJobExecutionRepository jobExecutionRepo,
         final JpaApplicationRepository applicationRepo,
         final JpaClusterRepository clusterRepo,
         final JpaCommandRepository commandRepo
@@ -176,6 +178,7 @@ public class ServicesConfigTest {
             jobRepo,
             jobRequestRepo,
             jobMetadataRepository,
+            jobExecutionRepo,
             applicationRepo,
             clusterRepo,
             commandRepo

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/JobEntityUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/JobEntityUnitTests.java
@@ -315,8 +315,8 @@ public class JobEntityUnitTests extends EntityTestsBase {
     @Test
     public void canSetJobExecution() {
         final JobExecutionEntity entity = new JobExecutionEntity();
-        this.jobEntity.setExecution(entity);
-        Assert.assertThat(this.jobEntity.getExecution(), Matchers.is(entity));
+        entity.setJob(this.jobEntity);
+        Assert.assertThat(this.jobEntity, Matchers.is(entity.getJob()));
     }
 
     /**

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/JobRequestEntityUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/JobRequestEntityUnitTests.java
@@ -84,7 +84,6 @@ public class JobRequestEntityUnitTests {
         Assert.assertThat(this.entity.getDependencies(), Matchers.is(EMPTY_JSON_ARRAY));
         Assert.assertThat(this.entity.getDependenciesAsSet(), Matchers.empty());
         Assert.assertFalse(this.entity.getGroup().isPresent());
-        Assert.assertThat(this.entity.getJob(), Matchers.nullValue());
         Assert.assertFalse(this.entity.getMemory().isPresent());
         Assert.assertFalse(this.entity.getSetupFile().isPresent());
         Assert.assertThat(this.entity.getTags(), Matchers.empty());
@@ -323,8 +322,8 @@ public class JobRequestEntityUnitTests {
     @Test
     public void canSetJob() {
         final JobEntity job = new JobEntity();
-        this.entity.setJob(job);
-        Assert.assertThat(this.entity.getJob(), Matchers.is(job));
+        job.setRequest(this.entity);
+        Assert.assertThat(this.entity, Matchers.is(job.getRequest()));
     }
 
     /**
@@ -332,10 +331,8 @@ public class JobRequestEntityUnitTests {
      */
     @Test
     public void canSetJobMetadata() {
-        Assert.assertThat(this.entity.getJobMetadata(), Matchers.nullValue());
         final JobMetadataEntity metadata = new JobMetadataEntity();
-        this.entity.setJobMetadata(metadata);
-        Assert.assertThat(this.entity.getJobMetadata(), Matchers.is(metadata));
+        metadata.setRequest(entity);
         Assert.assertThat(metadata.getRequest(), Matchers.is(this.entity));
     }
 

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobPersistenceServiceImplUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobPersistenceServiceImplUnitTests.java
@@ -38,6 +38,7 @@ import com.netflix.genie.core.jpa.entities.JobRequestEntity;
 import com.netflix.genie.core.jpa.repositories.JpaApplicationRepository;
 import com.netflix.genie.core.jpa.repositories.JpaClusterRepository;
 import com.netflix.genie.core.jpa.repositories.JpaCommandRepository;
+import com.netflix.genie.core.jpa.repositories.JpaJobExecutionRepository;
 import com.netflix.genie.core.jpa.repositories.JpaJobMetadataRepository;
 import com.netflix.genie.core.jpa.repositories.JpaJobRepository;
 import com.netflix.genie.core.jpa.repositories.JpaJobRequestRepository;
@@ -75,6 +76,7 @@ public class JpaJobPersistenceServiceImplUnitTests {
     private JpaJobRepository jobRepo;
     private JpaJobRequestRepository jobRequestRepo;
     private JpaJobMetadataRepository jobMetadataRepository;
+    private JpaJobExecutionRepository jobExecutionRepo;
     private JpaApplicationRepository applicationRepo;
     private JpaClusterRepository clusterRepo;
     private JpaCommandRepository commandRepo;
@@ -89,6 +91,7 @@ public class JpaJobPersistenceServiceImplUnitTests {
         this.jobRepo = Mockito.mock(JpaJobRepository.class);
         this.jobRequestRepo = Mockito.mock(JpaJobRequestRepository.class);
         this.jobMetadataRepository = Mockito.mock(JpaJobMetadataRepository.class);
+        this.jobExecutionRepo = Mockito.mock(JpaJobExecutionRepository.class);
         this.applicationRepo = Mockito.mock(JpaApplicationRepository.class);
         this.clusterRepo = Mockito.mock(JpaClusterRepository.class);
         this.commandRepo = Mockito.mock(JpaCommandRepository.class);
@@ -97,6 +100,7 @@ public class JpaJobPersistenceServiceImplUnitTests {
             this.jobRepo,
             this.jobRequestRepo,
             this.jobMetadataRepository,
+            this.jobExecutionRepo,
             this.applicationRepo,
             this.clusterRepo,
             this.commandRepo
@@ -180,9 +184,6 @@ public class JpaJobPersistenceServiceImplUnitTests {
             = argument.getValue().getDescription().orElseThrow(IllegalArgumentException::new);
         Assert.assertThat(actualDescription, Matchers.is(description));
         Assert.assertThat(argument.getValue().getApplicationsAsList(), Matchers.empty());
-        Assert.assertThat(argument.getValue().getJob(), Matchers.notNullValue());
-        Assert.assertThat(argument.getValue().getJob().getExecution(), Matchers.notNullValue());
-        Assert.assertThat(argument.getValue().getJobMetadata(), Matchers.notNullValue());
     }
 
     /**
@@ -441,7 +442,7 @@ public class JpaJobPersistenceServiceImplUnitTests {
         final JobEntity jobEntity = Mockito.mock(JobEntity.class);
 
         Mockito.when(this.jobRepo.findOne(id)).thenReturn(jobEntity);
-        Mockito.when(jobEntity.getExecution()).thenReturn(null);
+        Mockito.when(this.jobExecutionRepo.findOne(id)).thenReturn(null);
         this.jobPersistenceService.setJobRunningInformation(id, 1, 1, new Date());
     }
 
@@ -458,7 +459,7 @@ public class JpaJobPersistenceServiceImplUnitTests {
         final Date timeout = new Date();
         final JobExecutionEntity jobExecutionEntity = Mockito.mock(JobExecutionEntity.class);
         final JobEntity jobEntity = Mockito.mock(JobEntity.class);
-        Mockito.when(jobEntity.getExecution()).thenReturn(jobExecutionEntity);
+        Mockito.when(this.jobExecutionRepo.findOne(id)).thenReturn(jobExecutionEntity);
         Mockito.when(jobEntity.getStatus()).thenReturn(JobStatus.INIT);
         Mockito.when(this.jobRepo.findOne(id)).thenReturn(jobEntity);
         this.jobPersistenceService.setJobRunningInformation(id, processId, checkDelay, timeout);
@@ -501,7 +502,7 @@ public class JpaJobPersistenceServiceImplUnitTests {
         final JobEntity jobEntity = Mockito.mock(JobEntity.class);
         final JobExecutionEntity jobExecutionEntity = Mockito.mock(JobExecutionEntity.class);
         Mockito.when(jobEntity.getStatus()).thenReturn(JobStatus.FAILED);
-        Mockito.when(jobEntity.getExecution()).thenReturn(jobExecutionEntity);
+        Mockito.when(this.jobExecutionRepo.findOne(JOB_1_ID)).thenReturn(jobExecutionEntity);
         Mockito.when(this.jobRepo.findOne(JOB_1_ID)).thenReturn(jobEntity);
         Mockito.when(jobExecutionEntity.getExitCode()).thenReturn(Optional.of(1));
         Mockito.when(this.jobMetadataRepository.findOne(JOB_1_ID)).thenReturn(null);
@@ -519,7 +520,7 @@ public class JpaJobPersistenceServiceImplUnitTests {
         final JobEntity jobEntity = Mockito.mock(JobEntity.class);
         final JobExecutionEntity jobExecutionEntity = Mockito.mock(JobExecutionEntity.class);
         Mockito.when(jobEntity.getStatus()).thenReturn(JobStatus.FAILED);
-        Mockito.when(jobEntity.getExecution()).thenReturn(jobExecutionEntity);
+        Mockito.when(this.jobExecutionRepo.findOne(JOB_1_ID)).thenReturn(jobExecutionEntity);
         Mockito.when(this.jobRepo.findOne(JOB_1_ID)).thenReturn(jobEntity);
         Mockito.when(jobExecutionEntity.getExitCode()).thenReturn(Optional.of(1));
 
@@ -537,7 +538,7 @@ public class JpaJobPersistenceServiceImplUnitTests {
         final JobEntity jobEntity = Mockito.mock(JobEntity.class);
         final JobExecutionEntity jobExecutionEntity = Mockito.mock(JobExecutionEntity.class);
         Mockito.when(jobEntity.getStatus()).thenReturn(JobStatus.FAILED);
-        Mockito.when(jobEntity.getExecution()).thenReturn(jobExecutionEntity);
+        Mockito.when(this.jobExecutionRepo.findOne(JOB_1_ID)).thenReturn(jobExecutionEntity);
         Mockito.when(this.jobRepo.findOne(JOB_1_ID)).thenReturn(jobEntity);
         Mockito.when(jobExecutionEntity.getExitCode()).thenReturn(Optional.of(1));
         Mockito.when(this.jobMetadataRepository.findOne(JOB_1_ID)).thenReturn(Mockito.mock(JobMetadataEntity.class));

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -189,6 +189,7 @@ public class ServicesConfig {
      * @param jobRepo               The job repository to use
      * @param jobRequestRepo        The job request repository to use
      * @param jobMetadataRepository The job metadata repository to use
+     * @param jobExecutionRepo      The job execution repository to use
      * @param applicationRepo       The application repository to use
      * @param clusterRepo           The cluster repository to use
      * @param commandRepo           The command repository to use
@@ -199,6 +200,7 @@ public class ServicesConfig {
         final JpaJobRepository jobRepo,
         final JpaJobRequestRepository jobRequestRepo,
         final JpaJobMetadataRepository jobMetadataRepository,
+        final JpaJobExecutionRepository jobExecutionRepo,
         final JpaApplicationRepository applicationRepo,
         final JpaClusterRepository clusterRepo,
         final JpaCommandRepository commandRepo
@@ -207,6 +209,7 @@ public class ServicesConfig {
             jobRepo,
             jobRequestRepo,
             jobMetadataRepository,
+            jobExecutionRepo,
             applicationRepo,
             clusterRepo,
             commandRepo

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -191,6 +191,7 @@ public class ServicesConfigUnitTests {
                 this.jobRepository,
                 this.jobRequestRepository,
                 Mockito.mock(JpaJobMetadataRepository.class),
+                jobExecutionRepository,
                 this.applicationRepository,
                 this.clusterRepository,
                 this.commandRepository

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
@@ -372,10 +372,10 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
 //            )
 //            .andReturn().getResponse().getContentAsString());
 
-        this.jobRequestRepository.deleteAll();
         this.jobRequestMetadataRepository.deleteAll();
-        this.jobRepository.deleteAll();
         this.jobExecutionRepository.deleteAll();
+        this.jobRepository.deleteAll();
+        this.jobRequestRepository.deleteAll();
         this.clusterRepository.deleteAll();
         this.commandRepository.deleteAll();
         this.applicationRepository.deleteAll();


### PR DESCRIPTION
1. Removed the inverse relations in the job entities - JobEntity, JobRequestEntity, JobExecutionEntity and JobMetadataEntity,. This was done to reduce the SQL calls to get the associated entities.
2. Modified certain queries to use named queries.