### PR TITLE
Add genie-war project which generates WAR artifact

### DIFF
--- a/genie-war/build.gradle
+++ b/genie-war/build.gradle
@@ -1,0 +1,35 @@
+apply plugin: "war"
+
+dependencies {
+    /*******************************
+     * Compile Dependencies
+     *******************************/
+
+    compile(project(":genie-web"))
+
+    /*******************************
+     * Provided Dependencies
+     *******************************/
+
+    provided("org.springframework.boot:spring-boot-starter-tomcat")
+
+    /*******************************
+     * Optional Dependencies
+     *******************************/
+
+    /*******************************
+     * Runtime Dependencies
+     *******************************/
+
+    /*******************************
+     * Test Dependencies
+     *******************************/
+
+    testCompile(project(":genie-test"))
+}
+
+jar {
+    manifest {
+        attributes("Implementation-Version": version)
+    }
+}

--- a/genie-war/src/main/java/com/netflix/genie/GenieWar.java
+++ b/genie-war/src/main/java/com/netflix/genie/GenieWar.java
@@ -1,0 +1,60 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.retry.annotation.EnableRetry;
+
+/**
+ * A class that serves to set up Spring Boot within a servlet container rather than an embedded one.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@EnableRetry
+@SpringBootApplication(
+    exclude = {
+        SessionAutoConfiguration.class,
+        RedisAutoConfiguration.class
+    }
+)
+public class GenieWar extends SpringBootServletInitializer {
+
+    /**
+     * Spring Boot Main.
+     *
+     * @param args Program arguments
+     * @throws Exception For any failure during program execution
+     */
+    public static void main(final String[] args) throws Exception {
+        SpringApplication.run(GenieWar.class, args);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected SpringApplicationBuilder configure(final SpringApplicationBuilder application) {
+        return application.sources(GenieWar.class);
+    }
+}

--- a/genie-war/src/main/java/com/netflix/genie/package-info.java
+++ b/genie-war/src/main/java/com/netflix/genie/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Main classes for running Genie within a servlet container like Tomcat.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie;

--- a/genie-war/src/test/java/com/netflix/genie/GenieWarUnitTests.java
+++ b/genie-war/src/test/java/com/netflix/genie/GenieWarUnitTests.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie;
+
+import com.netflix.genie.test.categories.UnitTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+/**
+ * Unit tests for the Genie war class.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class GenieWarUnitTests {
+
+    /**
+     * Configure GenieWar.
+     */
+    @Test
+    public void canConfigure() {
+        final SpringApplicationBuilder builder = Mockito.mock(SpringApplicationBuilder.class);
+        final GenieWar war = new GenieWar();
+        war.configure(builder);
+        Mockito.verify(builder, Mockito.times(1)).sources(GenieWar.class);
+    }
+}

--- a/genie-war/src/test/java/com/netflix/genie/package-info.java
+++ b/genie-war/src/test/java/com/netflix/genie/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Tests for classes that drive servlet container configuration.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name='genie'
 
-include 'genie-test', 'genie-common', 'genie-core', 'genie-web', 'genie-app', 'genie-client'
+include 'genie-test', 'genie-common', 'genie-core', 'genie-web', 'genie-app', 'genie-war', 'genie-client'
 


### PR DESCRIPTION
Genie 1.x and 2.x were both only deployed via WAR files. Genie 3 is built on Spring boot so we have been generating an executable jar for OSS via the genie-app project. Internally we still deploy as a war to take advantage of all the infrastructure built up around Tomcat. Others may have this requirement so rather than document the process for how to do that this PR adds a genie-war project which generates a WAR file which can be deployed to a servlet container.

This makes it possible to deploy Genie 3 into a similar environment that users had before if they don't want to use the executable jar.