### PR TITLE
Renamed jobs variables not being picked up

### DIFF
--- a/genie-app/build.gradle
+++ b/genie-app/build.gradle
@@ -1,3 +1,7 @@
+//plugins {
+//    id "com.palantir.docker" version "0.9.1"
+//}
+
 apply plugin: "spring-boot"
 
 dependencies {

--- a/genie-core/src/main/java/com/netflix/genie/core/properties/JobsCleanupProperties.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/properties/JobsCleanupProperties.java
@@ -20,32 +20,15 @@ package com.netflix.genie.core.properties;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
-
 /**
- * All properties related to jobs in Genie.
+ * Properties related to cleanup for jobs.
  *
  * @author tgianos
  * @since 3.0.0
  */
 @Getter
 @Setter
-public class JobsProperties {
-    @NotNull
-    private JobsCleanupProperties cleanup = new JobsCleanupProperties();
-
-    @NotNull
-    private JobsForwardingProperties forwarding = new JobsForwardingProperties();
-
-    @NotNull
-    private JobsLocationsProperties locations = new JobsLocationsProperties();
-
-    @NotNull
-    private JobsMaxProperties max = new JobsMaxProperties();
-
-    @NotNull
-    private JobsMemoryProperties memory = new JobsMemoryProperties();
-
-    @NotNull
-    private JobsUsersProperties users = new JobsUsersProperties();
+public class JobsCleanupProperties {
+    private boolean deleteArchiveFile = true;
+    private boolean deleteDependencies = true;
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/properties/JobsCleanupPropertiesUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/properties/JobsCleanupPropertiesUnitTests.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.properties;
+
+import com.netflix.genie.test.categories.UnitTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Unit tests for the cleanup properties.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class JobsCleanupPropertiesUnitTests {
+
+    private JobsCleanupProperties properties;
+
+    /**
+     * Setup for tests.
+     */
+    @Before
+    public void setup() {
+        this.properties = new JobsCleanupProperties();
+    }
+
+    /**
+     * Make sure properties are true by default.
+     */
+    @Test
+    public void canConstruct() {
+        Assert.assertTrue(this.properties.isDeleteArchiveFile());
+        Assert.assertTrue(this.properties.isDeleteDependencies());
+    }
+
+    /**
+     * Make sure can set whether to delete the archive file.
+     */
+    @Test
+    public void canSetDeleteArchiveFile() {
+        this.properties.setDeleteArchiveFile(false);
+        Assert.assertFalse(this.properties.isDeleteArchiveFile());
+    }
+
+    /**
+     * Make sure can set whether to delete the delete the dependencies.
+     */
+    @Test
+    public void canSetDeleteDependencies() {
+        this.properties.setDeleteDependencies(false);
+        Assert.assertFalse(this.properties.isDeleteDependencies());
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -222,7 +222,7 @@ public class ServicesConfig {
      * @param hostName         The name of the host this Genie node is running on.
      * @param jobSearchService The job search service to use to locate job information.
      * @param executor         The executor to use to run system processes.
-     * @param runAsUser        Whether jobs on this instance are run as the user or not
+     * @param jobsProperties   The jobs properties to use
      * @param eventPublisher   The application event publisher to use to publish system wide events
      * @return A job kill service instance.
      */
@@ -231,11 +231,16 @@ public class ServicesConfig {
         final String hostName,
         final JobSearchService jobSearchService,
         final Executor executor,
-        @Value("${genie.jobs.runAsUser.enabled:false}")
-        final boolean runAsUser,
+        final JobsProperties jobsProperties,
         final ApplicationEventPublisher eventPublisher
     ) {
-        return new LocalJobKillServiceImpl(hostName, jobSearchService, executor, runAsUser, eventPublisher);
+        return new LocalJobKillServiceImpl(
+            hostName,
+            jobSearchService,
+            executor,
+            jobsProperties.getUsers().isRunAsUserEnabled(),
+            eventPublisher
+        );
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/GenieExceptionMapper.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/GenieExceptionMapper.java
@@ -28,6 +28,7 @@ import com.netflix.genie.common.exceptions.GenieTimeoutException;
 import com.netflix.genie.core.util.MetricsConstants;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -44,6 +45,7 @@ import java.io.IOException;
  * @author tgianos
  * @since 3.0.0
  */
+@Slf4j
 @ControllerAdvice
 public class GenieExceptionMapper {
 
@@ -106,6 +108,7 @@ public class GenieExceptionMapper {
         } else {
             this.genieRate.increment();
         }
+        log.error(e.getLocalizedMessage(), e);
         response.sendError(e.getErrorCode(), e.getLocalizedMessage());
     }
 
@@ -131,6 +134,7 @@ public class GenieExceptionMapper {
             }
         }
         this.constraintViolationRate.increment();
+        log.error(cve.getLocalizedMessage(), cve);
         response.sendError(HttpStatus.PRECONDITION_FAILED.value(), builder.toString());
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/node/DiskCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/node/DiskCleanupTask.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.tasks.node;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.core.jobs.JobConstants;
+import com.netflix.genie.core.properties.JobsProperties;
 import com.netflix.genie.core.services.JobSearchService;
 import com.netflix.genie.web.properties.DiskCleanupProperties;
 import com.netflix.genie.web.tasks.TaskUtils;
@@ -31,7 +32,6 @@ import org.apache.commons.exec.Executor;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.io.Resource;
 import org.springframework.scheduling.TaskScheduler;
@@ -73,7 +73,7 @@ public class DiskCleanupTask implements Runnable {
      * @param scheduler        The scheduler to use to schedule the cron trigger.
      * @param jobsDir          The resource representing the location of the job directory
      * @param jobSearchService The service to find jobs with
-     * @param runAsUser        If jobs are run as the user (and thus ownership of directories is changed)
+     * @param jobsProperties   The jobs properties to use
      * @param processExecutor  The process executor to use to delete directories
      * @param registry         The metrics registry
      * @throws IOException When it is unable to open a file reference to the job directory
@@ -84,7 +84,7 @@ public class DiskCleanupTask implements Runnable {
         @NotNull final TaskScheduler scheduler,
         @NotNull final Resource jobsDir,
         @NotNull final JobSearchService jobSearchService,
-        @Value("${genie.jobs.runAsUser.enabled:false}") final boolean runAsUser,
+        @NotNull final JobsProperties jobsProperties,
         @NotNull final Executor processExecutor,
         @NotNull final Registry registry
     ) throws IOException {
@@ -96,7 +96,7 @@ public class DiskCleanupTask implements Runnable {
         this.properties = properties;
         this.jobsDir = jobsDir.getFile();
         this.jobSearchService = jobSearchService;
-        this.runAsUser = runAsUser;
+        this.runAsUser = jobsProperties.getUsers().isRunAsUserEnabled();
         this.processExecutor = processExecutor;
 
         this.numberOfDeletedJobDirs

--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -28,6 +28,9 @@ genie:
     cache:
       location: file:///tmp/genie/cache
   jobs:
+    cleanup:
+      deleteArchiveFile: true
+      deleteDependencies: true
     forwarding:
       enabled: true
       port: 8080

--- a/genie-web/src/test/groovy/com/netflix/genie/web/tasks/job/JobCompletionServiceSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/tasks/job/JobCompletionServiceSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.genie.common.dto.JobStatus
 import com.netflix.genie.common.exceptions.GenieServerException
 import com.netflix.genie.core.events.JobFinishedEvent
 import com.netflix.genie.core.events.JobFinishedReason
+import com.netflix.genie.core.properties.JobsProperties
 import com.netflix.genie.core.services.JobPersistenceService
 import com.netflix.genie.core.services.JobSearchService
 import com.netflix.genie.core.services.MailService
@@ -51,15 +52,20 @@ class JobCompletionServiceSpec extends Specification{
     JobCompletionService jobCompletionService;
     MailService mailService;
     GenieFileTransferService genieFileTransferService;
+    JobsProperties jobsProperties;
 
     def setup(){
         jobPersistenceService = Mock(JobPersistenceService.class)
         jobSearchService = Mock(JobSearchService.class)
         mailService = Mock(MailService.class)
         genieFileTransferService = Mock(GenieFileTransferService.class)
+        jobsProperties = new JobsProperties()
+        jobsProperties.cleanup.deleteArchiveFile = false
+        jobsProperties.cleanup.deleteDependencies = false
+        jobsProperties.users.runAsUserEnabled = false
         jobCompletionService = new JobCompletionService( jobPersistenceService, jobSearchService,
                 genieFileTransferService, new FileSystemResource("/tmp"), mailService, new NoopRegistry(),
-                false, false, false, new RetryTemplate())
+                jobsProperties, new RetryTemplate())
     }
 
     def handleJobCompletion() throws Exception{

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -256,7 +256,7 @@ public class ServicesConfigUnitTests {
                 "localhost",
                 this.jobSearchService,
                 Mockito.mock(Executor.class),
-                true,
+                new JobsProperties(),
                 Mockito.mock(ApplicationEventPublisher.class)
             )
         );

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/node/DiskCleanupTaskUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/node/DiskCleanupTaskUnitTests.java
@@ -21,6 +21,7 @@ import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.core.properties.JobsProperties;
 import com.netflix.genie.core.services.JobSearchService;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.web.properties.DiskCleanupProperties;
@@ -71,6 +72,8 @@ public class DiskCleanupTaskUnitTests {
      */
     @Test(expected = IOException.class)
     public void cantConstruct() throws IOException {
+        final JobsProperties properties = new JobsProperties();
+        properties.getUsers().setRunAsUserEnabled(false);
         final Resource jobsDir = Mockito.mock(Resource.class);
         Mockito.when(jobsDir.exists()).thenReturn(false);
         Assert.assertNotNull(
@@ -79,7 +82,7 @@ public class DiskCleanupTaskUnitTests {
                 Mockito.mock(TaskScheduler.class),
                 jobsDir,
                 Mockito.mock(JobSearchService.class),
-                false,
+                properties,
                 Mockito.mock(Executor.class),
                 Mockito.mock(Registry.class)
             )
@@ -103,7 +106,7 @@ public class DiskCleanupTaskUnitTests {
                 scheduler,
                 jobsDir,
                 Mockito.mock(JobSearchService.class),
-                true,
+                new JobsProperties(),
                 Mockito.mock(Executor.class),
                 Mockito.mock(Registry.class)
             )
@@ -128,7 +131,7 @@ public class DiskCleanupTaskUnitTests {
                 scheduler,
                 jobsDir,
                 Mockito.mock(JobSearchService.class),
-                true,
+                new JobsProperties(),
                 Mockito.mock(Executor.class),
                 Mockito.mock(Registry.class)
             )
@@ -143,6 +146,8 @@ public class DiskCleanupTaskUnitTests {
      */
     @Test
     public void willScheduleOnUnixWithoutSudo() throws IOException {
+        final JobsProperties properties = new JobsProperties();
+        properties.getUsers().setRunAsUserEnabled(false);
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
         final TaskScheduler scheduler = Mockito.mock(TaskScheduler.class);
         final Resource jobsDir = Mockito.mock(Resource.class);
@@ -153,7 +158,7 @@ public class DiskCleanupTaskUnitTests {
                 scheduler,
                 jobsDir,
                 Mockito.mock(JobSearchService.class),
-                false,
+                properties,
                 Mockito.mock(Executor.class),
                 Mockito.mock(Registry.class)
             )
@@ -169,6 +174,9 @@ public class DiskCleanupTaskUnitTests {
      */
     @Test
     public void canRunWithoutSudo() throws IOException, GenieException {
+        final JobsProperties jobsProperties = new JobsProperties();
+        jobsProperties.getUsers().setRunAsUserEnabled(false);
+
         // Create some random junk file that should be ignored
         this.tmpJobDir.newFile(UUID.randomUUID().toString());
         final DiskCleanupProperties properties = new DiskCleanupProperties();
@@ -239,7 +247,7 @@ public class DiskCleanupTaskUnitTests {
             scheduler,
             jobDir,
             jobSearchService,
-            false,
+            jobsProperties,
             Mockito.mock(Executor.class),
             registry
         );

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -6,15 +6,15 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   ./gradlew build coveralls --info
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build snapshot coveralls publishGhPages --info
+  ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build snapshot coveralls publishGhPages
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in
   *-rc\.*)
-    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" candidate coveralls publishGhPages --info
+    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" candidate coveralls publishGhPages
     ;;
   *)
-    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" final coveralls publishGhPages --info
+    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" final coveralls publishGhPages
     ;;
   esac
 else

--- a/gradle/buildViaTravis.sh
+++ b/gradle/buildViaTravis.sh
@@ -3,7 +3,7 @@
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
-  ./gradlew build coveralls --info
+  ./gradlew build coveralls
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
   ./gradlew -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" build snapshot coveralls publishGhPages
@@ -19,5 +19,5 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   esac
 else
   echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
-  ./gradlew build coveralls --info
+  ./gradlew build coveralls
 fi


### PR DESCRIPTION
```@Value``` strings aren't compile time checked so they were using their default values instead of our actual values in the properties file for runAsUser and others