### PR TITLE
Added retries to service level methods that make persistence calls.

### DIFF
--- a/codequality/checkstyle/checkstyle.xml
+++ b/codequality/checkstyle/checkstyle.xml
@@ -33,6 +33,8 @@
          consistency regarding their keys. -->
     <module name="Translation"/>
 
+    <module name="SuppressWarningsFilter" />
+
     <module name="TreeWalker">
         <!-- Checks the style of array type definitions. -->
         <module name="ArrayTypeStyle"/>
@@ -282,6 +284,8 @@
 
         <!-- Checks that a token is surrounded by whitespace. -->
         <module name="WhitespaceAround"/>
+
+        <module name="SuppressWarningsHolder" />
     </module>
 
     <!-- Enable suppression comments -->

--- a/genie-core/src/main/java/com/netflix/genie/core/properties/DataServiceRetryProperties.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/properties/DataServiceRetryProperties.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * All properties related to data service retry template in Genie.
+ *
+ * @author amajumdar
+ * @since 3.0.0
+ */
+@Getter
+@Setter
+public class DataServiceRetryProperties {
+    /**
+     * Default to 5 retries.
+     */
+    private int noOfRetries = 5;
+
+    /**
+     * Default to 100 ms.
+     */
+    private long initialInterval = 100L;
+
+    /**
+     * Defaults to 30000 ms.
+     */
+    private long maxInterval = 30000L;
+}

--- a/genie-war/src/main/java/com/netflix/genie/GenieWar.java
+++ b/genie-war/src/main/java/com/netflix/genie/GenieWar.java
@@ -23,7 +23,6 @@ import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.web.SpringBootServletInitializer;
-import org.springframework.retry.annotation.EnableRetry;
 
 /**
  * A class that serves to set up Spring Boot within a servlet container rather than an embedded one.
@@ -31,7 +30,6 @@ import org.springframework.retry.annotation.EnableRetry;
  * @author tgianos
  * @since 3.0.0
  */
-@EnableRetry
 @SpringBootApplication(
     exclude = {
         SessionAutoConfiguration.class,

--- a/genie-web/src/main/java/com/netflix/genie/GenieWeb.java
+++ b/genie-web/src/main/java/com/netflix/genie/GenieWeb.java
@@ -22,7 +22,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
-import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 import java.util.Map;
 
@@ -32,8 +32,8 @@ import java.util.Map;
  * @author tgianos
  * @since 3.0.0
  */
-@EnableRetry
 @SpringBootApplication(exclude = {SessionAutoConfiguration.class, RedisAutoConfiguration.class})
+@EnableAspectJAutoProxy
 public class GenieWeb {
 
     protected static final String SPRING_CONFIG_LOCATION = "spring.config.location";

--- a/genie-web/src/main/java/com/netflix/genie/web/aspect/DataServiceRetryAspect.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/aspect/DataServiceRetryAspect.java
@@ -1,0 +1,115 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.aspect;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.common.exceptions.GenieServerException;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.dao.TransientDataAccessResourceException;
+import org.springframework.jdbc.CannotGetJdbcConnectionException;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+
+import javax.validation.ConstraintViolationException;
+
+/**
+ * Aspect implementation of retrying the data service methods on certain failures.
+ * @author amajumdar
+ * @since 3.0.0
+ */
+@Aspect
+@Component
+@Slf4j
+public class DataServiceRetryAspect implements Ordered {
+    private final RetryTemplate retryTemplate;
+
+    /**
+     * Constructor.
+     * @param noOfRetries number of retries
+     * @param initialInterval initial interval in milliseconds before retrying the first attempt
+     * @param maxInterval maximum interval in milliseconds
+     */
+    @Autowired
+    public DataServiceRetryAspect(
+        @Value("${genie.data.service.retry.noOfRetries:5}") final int noOfRetries,
+        @Value("${genie.data.service.retry.initialInterval:100}") final int initialInterval,
+        @Value("${genie.data.service.retry.maxInterval:30000}") final int maxInterval) {
+        retryTemplate = new RetryTemplate();
+        retryTemplate.setRetryPolicy(new SimpleRetryPolicy(noOfRetries,
+            new ImmutableMap.Builder<Class<? extends Throwable>, Boolean>()
+                .put(CannotGetJdbcConnectionException.class, true)
+                .put(CannotAcquireLockException.class, true)
+                .put(DeadlockLoserDataAccessException.class, true)
+                .put(OptimisticLockingFailureException.class, true)
+                .put(PessimisticLockingFailureException.class, true)
+                .put(ConcurrencyFailureException.class, true)
+                .put(QueryTimeoutException.class, true)
+                .put(TransientDataAccessResourceException.class, true)
+                .build()));
+        final ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+        backOffPolicy.setInitialInterval(initialInterval);
+        backOffPolicy.setMaxInterval(maxInterval);
+        retryTemplate.setBackOffPolicy(backOffPolicy);
+    }
+
+    /**
+     * Sets the retry listeners for the retry template in use.
+     * @param retryListeners retry listeners
+     */
+    public void setRetryListeners(final RetryListener[] retryListeners) {
+        retryTemplate.setListeners(retryListeners);
+    }
+
+    /**
+     * Aspect implementation method of retrying the data service method on certain failures.
+     * @param pjp join point
+     * @return return the data method response
+     * @throws GenieException any exception thrown by the data service method
+     */
+    @Around("com.netflix.genie.web.aspect.SystemArchitecture.dataOperation()")
+    public Object profile(final ProceedingJoinPoint pjp) throws GenieException {
+        try {
+            return retryTemplate.execute(context -> pjp.proceed());
+        } catch (GenieException | ConstraintViolationException e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new GenieServerException(e);
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/aspect/DataServiceRetryAspect.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/aspect/DataServiceRetryAspect.java
@@ -35,6 +35,7 @@ import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.dao.QueryTimeoutException;
 import org.springframework.dao.TransientDataAccessResourceException;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
+import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.retry.RetryListener;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
@@ -72,6 +73,7 @@ public class DataServiceRetryAspect implements Ordered {
                 // Will this work for cases where the write queries timeout on the client?
                 .put(QueryTimeoutException.class, true)
                 .put(TransientDataAccessResourceException.class, true)
+                .put(JpaSystemException.class, true)
                 .build()));
         final ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
         backOffPolicy.setInitialInterval(dataServiceRetryProperties.getInitialInterval());

--- a/genie-web/src/main/java/com/netflix/genie/web/aspect/SystemArchitecture.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/aspect/SystemArchitecture.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.aspect;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+/**
+ * Application pointcut expressions.
+ * @author amajumdar
+ * @since 3.0.0
+ */
+@Aspect
+@Component
+public class SystemArchitecture {
+    /**
+     * A join point is in the resource layer if the method is defined
+     * in a type in the com.netflix.genie.web.controllers package or any sub-package
+     * under that.
+     */
+    @Pointcut("within(com.netflix.genie.web.controllers..*)")
+    public void inResourceLayer() { }
+
+    /**
+     * A join point is in the service layer if the method is defined
+     * in a type in the com.netflix.genie.core.services package or any sub-package
+     * under that.
+     */
+    @Pointcut("within(com.netflix.genie.core.services..*)")
+    public void inServiceLayer() { }
+
+    /**
+     * A join point is in the data service layer if the method is defined
+     * in a type in the com.netflix.genie.core.jpa.services package or any sub-package
+     * under that.
+     */
+    @Pointcut("within(com.netflix.genie.core.jpa.services..*)")
+    public void inDataLayer() { }
+
+    /**
+     * A resource service is the execution of any method defined on a controller.
+     * This definition assumes that interfaces are placed in the
+     * "resources" package, and that implementation types are in sub-packages.
+     */
+    @Pointcut("execution(* com.netflix.genie.web.controllers.*.*(..))")
+    public void resourceOperation() { }
+
+    /**
+     * A service operation is the execution of any method defined on a
+     * service class/interface. This definition assumes that interfaces are placed in the
+     * "service" package, and that implementation types are in sub-packages.
+     */
+    @Pointcut("execution(* com.netflix.genie.core.services.*.*(..))")
+    public void serviceOperation() { }
+
+    /**
+     * A data service operation is the execution of any method defined on a
+     * dao interface. This definition assumes that interfaces are placed in the
+     * "dao" package, and that implementation types are in sub-packages.
+     */
+    @Pointcut("execution(* com.netflix.genie.core.jpa.services.*.*(..))")
+    public void dataOperation() { }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/aspect/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/aspect/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Various Spring aspects for Genie web.
+ *
+ * @author amajumdar
+ * @since 3.0.0
+ */
+package com.netflix.genie.web.aspect;

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/PropertiesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/PropertiesConfig.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.configs;
 
+import com.netflix.genie.core.properties.DataServiceRetryProperties;
 import com.netflix.genie.core.properties.JobsProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -40,5 +41,16 @@ public class PropertiesConfig {
     @ConfigurationProperties("genie.jobs")
     public JobsProperties jobsProperties() {
         return new JobsProperties();
+    }
+
+    /**
+     * All the properties related to configuring data service retries.
+     *
+     * @return The data service retry properties structure
+     */
+    @Bean
+    @ConfigurationProperties("genie.data.service.retry")
+    public DataServiceRetryProperties dataServiceRetryProperties() {
+        return new DataServiceRetryProperties();
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/aspect/DataServiceRetryAspectSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/aspect/DataServiceRetryAspectSpec.groovy
@@ -3,6 +3,7 @@ package com.netflix.genie.web.aspect
 import com.netflix.genie.common.exceptions.GenieException
 import com.netflix.genie.common.exceptions.GenieServerException
 import com.netflix.genie.core.jpa.services.JpaJobSearchServiceImpl
+import com.netflix.genie.core.properties.DataServiceRetryProperties
 import com.netflix.genie.test.categories.UnitTest
 import org.aspectj.lang.ProceedingJoinPoint
 import org.junit.experimental.categories.Category
@@ -19,7 +20,16 @@ import spock.lang.Specification
  */
 @Category(UnitTest.class)
 class DataServiceRetryAspectSpec extends Specification{
-    @Shared dataServiceRetryAspect = new DataServiceRetryAspect(2,10,10)
+    def dataServiceRetryAspect
+
+    def setup(){
+        def dataServiceRetryProperties = new DataServiceRetryProperties()
+        dataServiceRetryProperties.setNoOfRetries(2)
+        dataServiceRetryProperties.setMaxInterval(10)
+        dataServiceRetryProperties.setInitialInterval(10)
+        dataServiceRetryAspect = new DataServiceRetryAspect(dataServiceRetryProperties);
+    }
+
     def testProfile(){
         given:
         def ProceedingJoinPoint joinPoint = Mock(ProceedingJoinPoint.class)

--- a/genie-web/src/test/groovy/com/netflix/genie/web/aspect/DataServiceRetryAspectSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/aspect/DataServiceRetryAspectSpec.groovy
@@ -1,0 +1,90 @@
+package com.netflix.genie.web.aspect
+
+import com.netflix.genie.common.exceptions.GenieException
+import com.netflix.genie.common.exceptions.GenieServerException
+import com.netflix.genie.core.jpa.services.JpaJobSearchServiceImpl
+import com.netflix.genie.test.categories.UnitTest
+import org.aspectj.lang.ProceedingJoinPoint
+import org.junit.experimental.categories.Category
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
+import org.springframework.dao.QueryTimeoutException
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Unit tests for DataServiceRetryAspect
+ *
+ * @author amajumdar
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+class DataServiceRetryAspectSpec extends Specification{
+    @Shared dataServiceRetryAspect = new DataServiceRetryAspect(2,10,10)
+    def testProfile(){
+        given:
+        def ProceedingJoinPoint joinPoint = Mock(ProceedingJoinPoint.class)
+        when:
+        dataServiceRetryAspect.profile(joinPoint)
+        then:
+        thrown(GenieException.class)
+        1 * joinPoint.proceed() >> { throw new GenieException(1,"")}
+        when:
+        dataServiceRetryAspect.profile(joinPoint)
+        then:
+        thrown(GenieServerException.class)
+        2 * joinPoint.proceed() >> { throw new QueryTimeoutException(null, null)}
+        when:
+        dataServiceRetryAspect.profile(joinPoint)
+        then:
+        noExceptionThrown()
+        1 * joinPoint.proceed() >> null
+        when:
+        dataServiceRetryAspect.profile(joinPoint)
+        then:
+        noExceptionThrown()
+        2 * joinPoint.proceed() >> { throw new QueryTimeoutException(null, null)} >> null
+        when:
+        dataServiceRetryAspect.profile(joinPoint)
+        then:
+        thrown(GenieServerException.class)
+        2 * joinPoint.proceed() >>
+                { throw new QueryTimeoutException(null, null)} >>
+                { throw new QueryTimeoutException(null, null)} >> null
+    }
+
+    def testDataServiceMethod(){
+        given:
+        def id = '1'
+        def dataService = Mock(JpaJobSearchServiceImpl.class)
+        AspectJProxyFactory factory = new AspectJProxyFactory(dataService);
+        factory.addAspect(dataServiceRetryAspect)
+        def dataServiceProxy = factory.getProxy()
+        when:
+        dataServiceProxy.getJob(id)
+        then:
+        thrown(GenieException.class)
+        1 * dataService.getJob(id) >> { throw new GenieException(1,"")}
+        when:
+        dataServiceProxy.getJob(id)
+        then:
+        thrown(GenieServerException.class)
+        2 * dataService.getJob(id) >> { throw new QueryTimeoutException(null, null)}
+        when:
+        dataServiceProxy.getJob(id)
+        then:
+        noExceptionThrown()
+        1 * dataService.getJob(id) >> null
+        when:
+        dataServiceProxy.getJob(id)
+        then:
+        noExceptionThrown()
+        2 * dataService.getJob(id) >> { throw new QueryTimeoutException(null, null)} >> null
+        when:
+        dataServiceProxy.getJob(id)
+        then:
+        thrown(GenieServerException.class)
+        2 * dataService.getJob(id) >>
+                { throw new QueryTimeoutException(null, null)} >>
+                { throw new QueryTimeoutException(null, null)} >> null
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/ClusterRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/ClusterRestControllerIntegrationTests.java
@@ -380,7 +380,7 @@ public class ClusterRestControllerIntegrationTests extends RestControllerIntegra
             Assert.assertThat(this.jpaClusterRepository.count(), Matchers.is(0L));
             this.createConfigResource(new Cluster.Builder(NAME, USER, VERSION, ClusterStatus.UP).build(), null);
             conn.setAutoCommit(false);
-            stmt.execute("LOCK TABLE clusters WRITE");
+            stmt.execute("select * from clusters for update");
             this.mvc
                 .perform(MockMvcRequestBuilders.delete(CLUSTERS_API))
                 .andExpect(MockMvcResultMatchers.status().is5xxServerError());

--- a/genie-web/src/test/resources/application-ci.yml
+++ b/genie-web/src/test/resources/application-ci.yml
@@ -43,3 +43,4 @@ spring:
     test-while-idle: true
     min-evictable-idle-time-millis: 60000
     time-between-eviction-runs-millis: 10000
+    jdbc-interceptors: org.apache.tomcat.jdbc.pool.interceptor.QueryTimeoutInterceptor

--- a/genie-web/src/test/resources/application-ci.yml
+++ b/genie-web/src/test/resources/application-ci.yml
@@ -21,6 +21,12 @@ endpoints:
     time-to-live: 1
 
 genie:
+  data:
+    service:
+      retry:
+        noOfRetries: 2
+        initialInterval: 10
+        maxInterval: 10
   health:
     memory:
       usedPhysicalMemoryPercent: 100

--- a/genie-web/src/test/resources/application-integration.yml
+++ b/genie-web/src/test/resources/application-integration.yml
@@ -17,6 +17,12 @@
 ##
 
 genie:
+  data:
+    service:
+      retry:
+        noOfRetries: 2
+        initialInterval: 10
+        maxInterval: 10
   health:
     memory:
       usedPhysicalMemoryPercent: 100
@@ -35,3 +41,5 @@ spring:
     url: jdbc:hsqldb:mem:genie-int-db;shutdown=true
     username: SA
     password:
+    max-active: 5
+    jdbc-interceptors: org.apache.tomcat.jdbc.pool.interceptor.QueryTimeoutInterceptor


### PR DESCRIPTION
Using spring AOP, added a retry aspect for service methods that make persistence calls. Retries happen on exceptions - CannotGetJdbcConnectionException, CannotAcquireLockException, DeadlockLoserDataAccessException, OptimisticLockingFailureException, PessimisticLockingFailureException, ConcurrencyFailureException, QueryTimeoutException, TransientDataAccessResourceException