### PR TITLE
Http File Transfer Service Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Genie builds are run on Travis CI [here](https://travis-ci.org/Netflix/genie).
 |  Master | [![Build Status](https://travis-ci.org/Netflix/genie.svg?branch=master)](https://travis-ci.org/Netflix/genie) |  [![Coverage Status](https://coveralls.io/repos/github/Netflix/genie/badge.svg?branch=master)](https://coveralls.io/github/Netflix/genie?branch=master)  |
 | Develop | [![Build Status](https://travis-ci.org/Netflix/genie.svg?branch=master)](https://travis-ci.org/Netflix/genie) | [![Coverage Status](https://coveralls.io/repos/github/Netflix/genie/badge.svg?branch=develop)](https://coveralls.io/github/Netflix/genie?branch=develop) |
 
+## Docker
+
+[![Docker Example](https://img.shields.io/docker/pulls/netflixoss/genie-app.svg)](https://hub.docker.com/r/netflixoss/genie-app/)
+
+Successful builds which generate SNAPSHOT, release candidate (rc) or final artifacts also generate a docker container 
+which is published to Docker Hub. You can use `docker pull netflixoss/genie-app:{version}` to test the one you want.
+ 
+You can run via `docker run -t --rm -p 8080:8080 netflixoss/genie-app:{version}`
+
 ## Documentation
 
 * Netflix Tech Blog Posts

--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/GenieBaseTask.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/GenieBaseTask.java
@@ -116,8 +116,6 @@ public abstract class GenieBaseTask implements WorkflowTask {
         localPath.append(JobConstants.FILE_PATH_DELIMITER).append(fileName);
 
         return localPath.toString();
-
-
     }
 
     /**

--- a/genie-core/src/main/java/com/netflix/genie/core/services/FileTransferFactory.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/FileTransferFactory.java
@@ -16,7 +16,8 @@ package com.netflix.genie.core.services;
 /**
  * Factory for FileTransfer implementation based on the scheme.
  *
- * Created by amajumdar on 7/21/16.
+ * @author amajumdar
+ * @since 3.0.0
  */
 public interface FileTransferFactory {
     /**

--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     // Commons
     compile("org.apache.commons:commons-exec:${commons_exec_version}")
     compile("org.apache.httpcomponents:httpclient")
+    compile("commons-validator:commons-validator:${commons_validator_version}")
 
     // JWT JOSE implementation lib
     compile("org.bitbucket.b_c:jose4j:${jose4j_version}")

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/JobConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/JobConfig.java
@@ -31,6 +31,7 @@ import com.netflix.genie.core.services.AttachmentService;
 import com.netflix.genie.core.services.FileTransfer;
 import com.netflix.genie.core.services.impl.GenieFileTransferService;
 import com.netflix.genie.core.services.impl.LocalFileTransferImpl;
+import com.netflix.genie.web.services.impl.HttpFileTransferImpl;
 import com.netflix.spectator.api.Registry;
 import org.apache.commons.exec.Executor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Configuration for Jobs Setup and Run.
@@ -56,6 +58,19 @@ public class JobConfig {
     @Order(value = 2)
     public FileTransfer localFileTransfer() {
         return new LocalFileTransferImpl();
+    }
+
+    /**
+     * Bean to create a http[s] file transfer object.
+     *
+     * @param restTemplate The rest template to use
+     * @param registry     The registry to use for metrics
+     * @return A http implementation of the FileTransferService.
+     */
+    @Bean(name = {"file.system.http", "file.system.https"})
+    @Order(value = 3)
+    public FileTransfer httpFileTransfer(final RestTemplate restTemplate, final Registry registry) {
+        return new HttpFileTransferImpl(restTemplate, registry);
     }
 
 

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsS3Config.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsS3Config.java
@@ -83,7 +83,7 @@ public class AwsS3Config {
     /**
      * A bean providing a client to work with S3.
      *
-     * @param noOfS3Retries No. of S3 request retries
+     * @param noOfS3Retries          No. of S3 request retries
      * @param awsCredentialsProvider A credentials provider used to instantiate the client.
      * @return An amazon s3 client object
      */
@@ -106,12 +106,12 @@ public class AwsS3Config {
      * @return An s3 implementation of the FileTransfer interface
      * @throws GenieException if there is any problem
      */
-    @Bean(name = { "file.system.s3", "file.system.s3n", "file.system.s3a" })
+    @Bean(name = {"file.system.s3", "file.system.s3n", "file.system.s3a"})
     @Order(value = 1)
     @ConditionalOnBean(AmazonS3Client.class)
     public FileTransfer s3FileTransferImpl(
-            final AmazonS3Client s3Client,
-            final Registry registry
+        final AmazonS3Client s3Client,
+        final Registry registry
     ) throws GenieException {
         return new S3FileTransferImpl(s3Client, registry);
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -694,7 +694,7 @@ public class JobRestController {
                 log.info("Job {} is not or was not run on this node. Forwarding to {}", id, jobHostname);
                 final String forwardUrl = buildForwardURL(request, jobHostname);
                 try {
-                    restTemplate.execute(forwardUrl, HttpMethod.GET,
+                    this.restTemplate.execute(forwardUrl, HttpMethod.GET,
                         forwardRequest -> copyRequestHeaders(request, forwardRequest),
                         new ResponseExtractor<Void>() {
                             @Override

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/HttpFileTransferImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/HttpFileTransferImpl.java
@@ -1,0 +1,159 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl;
+
+import com.google.common.collect.Lists;
+import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.core.services.FileTransfer;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.validator.routines.UrlValidator;
+import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseExtractor;
+import org.springframework.web.client.RestTemplate;
+
+import javax.validation.constraints.NotNull;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An implementation of the FileTransferService interface in which the remote locations are available via http[s].
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Slf4j
+public class HttpFileTransferImpl implements FileTransfer {
+
+    private final UrlValidator validator
+        = new UrlValidator(new String[]{"http", "https"}, UrlValidator.ALLOW_LOCAL_URLS);
+    private final RestTemplate restTemplate;
+    private final Timer downloadTimer;
+    private final Timer uploadTimer;
+    private final Timer getLastModifiedTimer;
+
+    /**
+     * Constructor.
+     *
+     * @param restTemplate The rest template to use
+     * @param registry     The metrics registry to use
+     */
+    public HttpFileTransferImpl(@NotNull final RestTemplate restTemplate, @NotNull final Registry registry) {
+        this.restTemplate = restTemplate;
+        this.downloadTimer = registry.timer("genie.files.http.download.timer");
+        this.uploadTimer = registry.timer("genie.files.http.upload.timer");
+        this.getLastModifiedTimer = registry.timer("genie.files.http.getLastModified.timer");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isValid(final String fileName) throws GenieException {
+        log.debug("Called with file name {}", fileName);
+        return this.validator.isValid(fileName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void getFile(
+        @NotBlank(message = "Source file path cannot be empty.")
+        final String srcRemotePath,
+        @NotBlank(message = "Destination local path cannot be empty")
+        final String dstLocalPath
+    ) throws GenieException {
+        final long start = System.nanoTime();
+        log.debug("Called with src path {} and destination path {}", srcRemotePath, dstLocalPath);
+
+        try {
+            final File outputFile = new File(dstLocalPath);
+            if (!this.isValid(srcRemotePath)) {
+                throw new GenieServerException("Unable to download " + srcRemotePath + " not a valid URL");
+            }
+            this.restTemplate.execute(
+                srcRemotePath,
+                HttpMethod.GET,
+                requestEntity ->
+                    requestEntity.getHeaders().setAccept(Lists.newArrayList(MediaType.ALL)),
+                new ResponseExtractor<Void>() {
+                    @Override
+                    public Void extractData(final ClientHttpResponse response) throws IOException {
+                        // Documentation I could find pointed to the HttpEntity reading the bytes off
+                        // the stream so this should resolve memory problems if the file returned is large
+                        FileUtils.copyInputStreamToFile(response.getBody(), outputFile);
+                        return null;
+                    }
+                }
+            );
+        } finally {
+            this.downloadTimer.record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void putFile(
+        @NotBlank(message = "Source local path cannot be empty.")
+        final String srcLocalPath,
+        @NotBlank(message = "Destination remote path cannot be empty")
+        final String dstRemotePath
+    ) throws GenieException {
+        final long start = System.nanoTime();
+        try {
+            throw new UnsupportedOperationException(
+                "Saving a file to an HttpEndpoint isn't implemented in this version"
+            );
+        } finally {
+            this.uploadTimer.record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getLastModifiedTime(final String path) throws GenieException {
+        final long start = System.nanoTime();
+        try {
+            final URL url = new URL(path);
+            final long time = this.restTemplate.headForHeaders(url.toURI()).getLastModified();
+            // Returns now if there was no last modified header as best we can do is assume file is brand new
+            return time != -1 ? time : Instant.now().toEpochMilli();
+        } catch (final MalformedURLException | URISyntaxException e) {
+            log.error(e.getLocalizedMessage(), e);
+            throw new GenieServerException(e);
+        } finally {
+            this.getLastModifiedTimer.record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Implementations of services specific to a web application.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie.web.services.impl;

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/HttpFileTransferImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/HttpFileTransferImplTest.java
@@ -1,0 +1,237 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl;
+
+import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.test.categories.UnitTest;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.charset.Charset;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for the HttpFileTransferImpl class.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@Category(UnitTest.class)
+public class HttpFileTransferImplTest {
+
+    private static final String TEST_URL = "http://localhost/myFile.txt";
+
+    /**
+     * Used for reading and writing files during tests. Cleaned up at end.
+     */
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private MockRestServiceServer server;
+    private HttpFileTransferImpl httpFileTransfer;
+
+    private Timer downloadTimer;
+    private Timer uploadTimer;
+    private Timer metadataTimer;
+
+    /**
+     * Setup for the tests.
+     */
+    @Before
+    public void setup() {
+        final RestTemplate restTemplate = new RestTemplate();
+        this.server = MockRestServiceServer.createServer(restTemplate);
+        this.downloadTimer = Mockito.mock(Timer.class);
+        this.uploadTimer = Mockito.mock(Timer.class);
+        this.metadataTimer = Mockito.mock(Timer.class);
+        final Registry registry = Mockito.mock(Registry.class);
+        Mockito.when(registry.timer("genie.files.http.download.timer")).thenReturn(this.downloadTimer);
+        Mockito.when(registry.timer("genie.files.http.upload.timer")).thenReturn(this.uploadTimer);
+        Mockito.when(registry.timer("genie.files.http.getLastModified.timer")).thenReturn(this.metadataTimer);
+        this.httpFileTransfer = new HttpFileTransferImpl(restTemplate, registry);
+    }
+
+    /**
+     * Make sure valid url's return true.
+     *
+     * @throws GenieException On error
+     */
+    @Test
+    public void canValidate() throws GenieException {
+        Assert.assertTrue(this.httpFileTransfer.isValid("http://netflix.github.io/genie"));
+        Assert.assertTrue(this.httpFileTransfer.isValid("https://netflix.github.io/genie"));
+        Assert.assertFalse(this.httpFileTransfer.isValid("ftp://netflix.github.io/genie"));
+        Assert.assertFalse(this.httpFileTransfer.isValid("file:///tmp/blah"));
+        Assert.assertTrue(this.httpFileTransfer.isValid("http://localhost/someFile.txt"));
+        Assert.assertTrue(this.httpFileTransfer.isValid("https://localhost:8080/someFile.txt"));
+    }
+
+    /**
+     * Make sure we can actually get a file.
+     *
+     * @throws GenieException On error
+     * @throws IOException On error
+     */
+    @Test
+    public void canGet() throws GenieException, IOException {
+        final File output = this.temporaryFolder.newFile();
+        final String contents = UUID.randomUUID().toString();
+
+        this.server
+            .expect(MockRestRequestMatchers.requestTo(TEST_URL))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
+            .andRespond(
+                MockRestResponseCreators
+                    .withSuccess(contents.getBytes(Charset.forName("UTF-8")), MediaType.APPLICATION_OCTET_STREAM)
+            );
+
+        this.httpFileTransfer.getFile(TEST_URL, output.getCanonicalPath());
+
+        this.server.verify();
+        Mockito
+            .verify(this.downloadTimer, Mockito.times(1))
+            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Make sure can't get a file if the intput isn't a valid url.
+     *
+     * @throws GenieException On Error
+     * @throws IOException On Error
+     */
+    @Test(expected = GenieServerException.class)
+    public void cantGetWithInvalidUrl() throws GenieException, IOException {
+        this.httpFileTransfer.getFile(UUID.randomUUID().toString(), this.temporaryFolder.getRoot().getCanonicalPath());
+    }
+
+    /**
+     * Make sure can't get a file if the output location is a directory.
+     *
+     * @throws GenieException On Error
+     * @throws IOException On Error
+     */
+    @Test(expected = ResourceAccessException.class)
+    public void cantGetWithDirectoryAsOutput() throws GenieException, IOException {
+        this.server
+            .expect(MockRestRequestMatchers.requestTo(TEST_URL))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
+            .andRespond(
+                MockRestResponseCreators
+                    .withSuccess("junk".getBytes(Charset.forName("UTF-8")), MediaType.APPLICATION_OCTET_STREAM)
+            );
+        this.httpFileTransfer.getFile(TEST_URL, this.temporaryFolder.getRoot().getCanonicalPath());
+    }
+
+    /**
+     * Make sure that there is no implementation of the putFile method.
+     *
+     * @throws GenieException on error
+     */
+    @Test
+    public void cantPutFile() throws GenieException {
+        try {
+            final String file = UUID.randomUUID().toString();
+            this.httpFileTransfer.putFile(file, file);
+            Assert.fail();
+        } catch (final UnsupportedOperationException e) {
+            Mockito
+                .verify(this.uploadTimer, Mockito.times(1))
+                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
+        }
+    }
+
+    /**
+     * Make sure can get the last update time of a file.
+     *
+     * @throws GenieException On error
+     */
+    @Test
+    public void canGetLastModifiedTime() throws GenieException {
+        final long lastModified = 28424323000L;
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setLastModified(lastModified);
+        this.server
+            .expect(MockRestRequestMatchers.requestTo(TEST_URL))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.HEAD))
+            .andRespond(MockRestResponseCreators.withSuccess().headers(headers));
+
+        Assert.assertThat(this.httpFileTransfer.getLastModifiedTime(TEST_URL), Matchers.is(lastModified));
+        this.server.verify();
+        Mockito
+            .verify(this.metadataTimer, Mockito.times(1))
+            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Make sure can get the last update time of a file.
+     *
+     * @throws GenieException On error
+     */
+    @Test
+    public void canGetLastModifiedTimeIfNoHeader() throws GenieException {
+        final long time = Instant.now().toEpochMilli() - 1;
+        this.server
+            .expect(MockRestRequestMatchers.requestTo(TEST_URL))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.HEAD))
+            .andRespond(MockRestResponseCreators.withSuccess());
+        Assert.assertTrue(this.httpFileTransfer.getLastModifiedTime(TEST_URL) > time);
+        Mockito
+            .verify(this.metadataTimer, Mockito.times(1))
+            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Make sure can get the last update time of a file.
+     *
+     * @throws GenieException On error
+     */
+    @Test
+    public void cantGetLastModifiedTimeIfNotURL() throws GenieException {
+        try {
+            this.httpFileTransfer.getLastModifiedTime(UUID.randomUUID().toString());
+            Assert.fail();
+        } catch (final GenieServerException e) {
+            Assert.assertTrue(e.getCause() instanceof MalformedURLException);
+            Mockito
+                .verify(this.metadataTimer, Mockito.times(1))
+                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
+        }
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/package-info.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Tests for implementations of services specific to a web application.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+package com.netflix.genie.web.services.impl;

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@
 
 commons_exec_version=1.3
 commons_configuration2_version=2.0
+commons_validator_version=1.5.1
 
 # JWT Related Libraries
 jose4j_version=0.5.2


### PR DESCRIPTION
There was a local file transfer implementation and a S3 file transfer implementation but were missing an obvious Http file transfer implementation.

There is no implementation of the putFile method in this implementation as it doesn't seem to make sense given we have no idea what is on the other end of the http connection. Could accept any type of PUT/POST/etc. Could revisit later or have people extend the class as they want.

Getting the update time relies on the ```Last-Modified``` header. If that header isn't present it just assumes the file is last modified at the instant in time the method request was made.