### PR TITLE
Remove filter restrictions for jobs.

### DIFF
--- a/genie-client/src/main/python/pygenie/client.py
+++ b/genie-client/src/main/python/pygenie/client.py
@@ -1469,8 +1469,6 @@ class Genie(object):
 
         """
         params = filters or {}
-        _verify_filters(params, ['id', 'clusterName', 'user', 'size', 'status'
-                                 'tag'])
 
         # Iterate through any responses until we get to the end
         params['page'] = 0


### PR DESCRIPTION
Removes the restrictions on filters passed to the ```get_jobs``` method. This was originally introduced to cope with vague error messages returned by the genie masters. It's overly restrictive and no longer necessary.