### PR TITLE
Cache webpack builds and show spinner on search click

### DIFF
--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -117,6 +117,8 @@ node {
 }
 
 task bundle(type: NpmTask) {
+    inputs.files(fileTree("${project.projectDir}/src/main/resources/static"))
+    outputs.dir("${project.projectDir}/src/main/resources/static/build")
     args = ["run", "bundle"]
 }
 

--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -116,9 +116,16 @@ node {
     download = true
 }
 
+def static_build_dir = new File(project.projectDir, "/src/main/resources/static/build")
+def static_project_dir = new File(project.projectDir, "/src/main/resources/static")
+
+clean {
+    delete static_build_dir
+}
+
 task bundle(type: NpmTask) {
-    inputs.files(fileTree("${project.projectDir}/src/main/resources/static"))
-    outputs.dir("${project.projectDir}/src/main/resources/static/build")
+    inputs.dir static_project_dir
+    outputs.dir static_build_dir
     args = ["run", "bundle"]
 }
 
@@ -131,7 +138,7 @@ jar {
         attributes("Implementation-Version": genieVersion)
     }
 
-    from("${project.projectDir}/src/main/resources/static/build") {
+    from(static_build_dir) {
         into "static"
     }
 }

--- a/genie-web/src/main/resources/static/scripts/OutputDirectory.js
+++ b/genie-web/src/main/resources/static/scripts/OutputDirectory.js
@@ -80,7 +80,11 @@ export default class OutputDirectory extends React.Component {
           infos={this.state.infos}
         />
         {this.state.error ?
-          <div className="container job-output-directory"> Output not found </div> :
+          <div className="container job-output-directory"> Output not found
+            <div>
+              <Link to="/jobs">&larr; back</Link>
+            </div>
+          </div> :
           <div className="container job-output-directory">
             {
               this.state.fetching && !this.state.error ?

--- a/genie-web/src/main/resources/static/scripts/Page.js
+++ b/genie-web/src/main/resources/static/scripts/Page.js
@@ -63,6 +63,7 @@ export default class Page extends React.Component {
       query = { size: 25 };
     }
     const { rowId = null, showSearchForm = 'true' } = query;
+    this.setState({query, data: []}); //Loading state
 
     fetch(this.url, query)
     .done(data => {
@@ -130,7 +131,7 @@ export default class Page extends React.Component {
         </div> :
         this.state.noSearchResult ?
           <NoSearchResult /> :
-          <Loading />;
+          <Loading />; //Default to loading...
     }
 
     return (

--- a/genie-web/src/main/resources/static/scripts/components/JobDetails.js
+++ b/genie-web/src/main/resources/static/scripts/components/JobDetails.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 
 import { momentFormat, fetch } from '../utils';
 import Modal from 'react-modal';
+import Error from './Error';
 
 export default class JobDetails extends React.Component {
 
@@ -49,8 +50,12 @@ export default class JobDetails extends React.Component {
     const { row } = props;
     const url = row._links.self.href;
     fetch(url).done(job => {
+      this.setState({ job });
       fetch(job._links.command.href).done(command => {
-        this.setState({ job, command });
+        this.setState({ command });
+      })
+      .fail(xhr => {
+        this.setState({error: xhr.responseJSON});
       });
     });
   }
@@ -237,6 +242,15 @@ export default class JobDetails extends React.Component {
                 <div><small>*Request failed. Please refresh the page and try again.</small></div>
                 <div><small><code>{this.state.killRequestError.message}.</code></small></div>
               </div> : null
+            }
+            {this.state.error ?
+              <div>
+                <div>
+                  <span>Failed to load Command details:</span>
+                </div>
+                <Error error={this.state.error} />
+              </div>
+             : null
             }
           </div>
         </td>


### PR DESCRIPTION
- Cache webpack build via gradle
- Handle errors gracefully on JobDetails page
- Show loading spinner when search button is clicked
- Explicit back link when output directory empty
