### PR TITLE
Throw GenieConflictException if a job request comes in with an id that is already running.

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
@@ -155,7 +155,6 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
         JobStatus jobStatus = JobStatus.FAILED;
         try {
             log.info("Called to schedule job launch for job {}", jobId);
-            jobStateService.init(jobId);
             // create the job object in the database with status INIT
             final Job.Builder jobBuilder = new Job.Builder(
                 jobRequest.getName(),
@@ -184,7 +183,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
 
             // Log all the job initial job information
             this.jobPersistenceService.createJob(jobRequest, jobMetadata, jobBuilder.build(), jobExecution);
-
+            jobStateService.init(jobId);
             //TODO: Combine the cluster and command selection into a single method/database query for efficiency
             // Resolve the cluster for the job request based on the tags specified
             final Cluster cluster = this.getCluster(jobRequest);
@@ -242,15 +241,18 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
                 }
             }
         } catch (GenieConflictException e) {
-            jobStateService.done(jobId);
             throw e;
         } catch (GenieException e) {
-            jobStateService.done(jobId);
-            jobPersistenceService.updateJobStatus(jobId, jobStatus, e.getMessage());
+            if (jobStateService.jobExists(jobId)) {
+                jobStateService.done(jobId);
+                jobPersistenceService.updateJobStatus(jobId, jobStatus, e.getMessage());
+            }
             throw e;
         } catch (Exception e) {
-            jobStateService.done(jobId);
-            jobPersistenceService.updateJobStatus(jobId, jobStatus, e.getMessage());
+            if (jobStateService.jobExists(jobId)) {
+                jobStateService.done(jobId);
+                jobPersistenceService.updateJobStatus(jobId, jobStatus, e.getMessage());
+            }
             throw new GenieServerException(e);
         } finally {
             this.coordinationTimer.record(System.nanoTime() - coordinationStart, TimeUnit.MILLISECONDS);

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
@@ -241,14 +241,23 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
                 }
             }
         } catch (GenieConflictException e) {
+            // Job has not been initiated so we don't have to call JobStateService.done()
             throw e;
         } catch (GenieException e) {
+            //
+            // Need to check if the job exists in the JobStateService
+            // because this error can happen before the job is initiated.
+            //
             if (jobStateService.jobExists(jobId)) {
                 jobStateService.done(jobId);
                 jobPersistenceService.updateJobStatus(jobId, jobStatus, e.getMessage());
             }
             throw e;
         } catch (Exception e) {
+            //
+            // Need to check if the job exists in the JobStateService
+            // because this error can happen before the job is initiated.
+            //
             if (jobStateService.jobExists(jobId)) {
                 jobStateService.done(jobId);
                 jobPersistenceService.updateJobStatus(jobId, jobStatus, e.getMessage());

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
@@ -26,6 +26,7 @@ import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.common.exceptions.GenieConflictException;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
@@ -240,6 +241,9 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
                     );
                 }
             }
+        } catch (GenieConflictException e) {
+            jobStateService.done(jobId);
+            throw e;
         } catch (GenieException e) {
             jobStateService.done(jobId);
             jobPersistenceService.updateJobStatus(jobId, jobStatus, e.getMessage());

--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImplUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImplUnitTests.java
@@ -28,6 +28,7 @@ import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.common.exceptions.GenieConflictException;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
@@ -476,6 +477,22 @@ public class JobCoordinatorServiceImplUnitTests {
         final JobRequest request = Mockito.mock(JobRequest.class);
         Mockito.when(request.getId()).thenReturn(Optional.empty());
         this.jobCoordinatorService.coordinateJob(request, Mockito.mock(JobMetadata.class));
+    }
+
+    /**
+     * Make sure if the job with id already exists.
+     *
+     * @throws GenieException On error
+     */
+    @Test(expected = GenieConflictException.class)
+    public void cantCoordinateIfJobAlreadyExists() throws GenieException {
+        final JobRequest request = getJobRequest(false, null, null, null);
+        final JobMetadata metadata = Mockito.mock(JobMetadata.class);
+        Mockito.doThrow(GenieConflictException.class).when(jobPersistenceService)
+            .createJob(Mockito.eq(request), Mockito.eq(metadata),
+                Mockito.any(Job.class),
+                Mockito.any(JobExecution.class));
+        this.jobCoordinatorService.coordinateJob(request, metadata);
     }
 
     /**


### PR DESCRIPTION
Previous change had opened this bug where the JobCoordinator was updating the job that is already running with a failed status. Made changes to reject a job request if a job is submitted with an id that is already running.