### PR TITLE
Modified CPU health indicator to be more reliable.

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/properties/HealthProperties.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/properties/HealthProperties.java
@@ -33,4 +33,8 @@ public class HealthProperties {
      * Default to 80 percentage.
      */
     private double maxCpuLoadPercent = 80;
+    /**
+     * Default to 3.
+     */
+    private int maxCpuLoadConsecutiveOccurrences = 3;
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/properties/HealthProperties.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/properties/HealthProperties.java
@@ -30,10 +30,16 @@ import lombok.Setter;
 @Setter
 public class HealthProperties {
     /**
+     * Defines the threshold for the maximum CPU load percentage. Health of the system is marked OUT_OF_SERVICE if
+     * the CPU load of a system goes beyond this threshold for <code>maxCpuLoadConsecutiveOccurrences</code>
+     * consecutive times.
      * Default to 80 percentage.
      */
     private double maxCpuLoadPercent = 80;
     /**
+     * Defines the threshold of consecutive occurrences of CPU load crossing the <code>maxCpuLoadPercent</code>.
+     * Health of the system is marked OUT_OF_SERVICE if the CPU load of a system goes beyond the threshold
+     * <code>maxCpuLoadPercent</code> for <code>maxCpuLoadConsecutiveOccurrences</code> consecutive times.
      * Default to 3.
      */
     private int maxCpuLoadConsecutiveOccurrences = 3;

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -16,8 +16,16 @@ Spring properties described here are ones that we have overridden from Spring de
 |Where to store cached files on local disk
 |file:///tmp/genie/cache
 
+|genie.health.maxCpuLoadConsecutiveOccurrences
+|Defines the threshold of consecutive occurrences of CPU load crossing the <maxCpuLoadPercent>.
+Health of the system is marked unhealthy if the CPU load of a system goes beyond the threshold 'maxCpuLoadPercent'
+for 'maxCpuLoadConsecutiveOccurrences' consecutive times.
+|3
+
 |genie.health.maxCpuLoadPercent
-|How high the CPU usage needs to get before the node is marked unhealthy
+|Defines the threshold for the maximum CPU load percentage to consider for an instance to be unhealthy.
+Health of the system is marked unhealthy if the CPU load of a system goes beyond this threshold for
+'maxCpuLoadConsecutiveOccurrences' consecutive times.
 |80
 
 |genie.http.connect.timeout

--- a/genie-web/src/main/java/com/netflix/genie/web/health/GenieCpuHealthIndicator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/health/GenieCpuHealthIndicator.java
@@ -18,11 +18,14 @@
 package com.netflix.genie.web.health;
 
 import com.netflix.genie.core.properties.HealthProperties;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Registry;
 import com.sun.management.OperatingSystemMXBean;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
 import javax.validation.constraints.NotNull;
@@ -38,36 +41,58 @@ import java.lang.management.ManagementFactory;
 public class GenieCpuHealthIndicator implements HealthIndicator {
     private static final String CPU_LOAD = "cpuLoad";
     private final double maxCpuLoadPercent;
-    private final OperatingSystemMXBean operatingSystemMXBean;
+    private final int maxCpuLoadConsecutiveOccurrences;
+    private final DistributionSummary summaryCpuMetric;
+    private int cpuLoadConsecutiveOccurrences;
     /**
      * Constructor.
      *
      * @param healthProperties The maximum physical memory threshold
+     * @param registry         Registry
+     * @param taskScheduler    task scheduler
      */
     @Autowired
     public GenieCpuHealthIndicator(
-        @NotNull final HealthProperties healthProperties
-        ) {
+        @NotNull final HealthProperties healthProperties,
+        @NotNull final Registry registry,
+        @NotNull final TaskScheduler taskScheduler
+    ) {
         this(healthProperties.getMaxCpuLoadPercent(),
-            (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean());
+            healthProperties.getMaxCpuLoadConsecutiveOccurrences(),
+            (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean(),
+            registry.distributionSummary("genie.cpuLoad"),
+            taskScheduler);
     }
 
     GenieCpuHealthIndicator(final double maxCpuLoadPercent,
-                            final OperatingSystemMXBean operatingSystemMXBean) {
+        final int maxCpuLoadConsecutiveOccurrences,
+        final OperatingSystemMXBean operatingSystemMXBean,
+        final DistributionSummary summaryCpuMetric,
+        final TaskScheduler taskScheduler) {
         this.maxCpuLoadPercent = maxCpuLoadPercent;
-        this.operatingSystemMXBean = operatingSystemMXBean;
+        this.maxCpuLoadConsecutiveOccurrences = maxCpuLoadConsecutiveOccurrences;
+        this.summaryCpuMetric = summaryCpuMetric;
+        this.summaryCpuMetric.record((long) (operatingSystemMXBean.getSystemCpuLoad() * 100));
+        taskScheduler.scheduleAtFixedRate(() -> this.summaryCpuMetric
+            .record((long) (operatingSystemMXBean.getSystemCpuLoad() * 100)), 5000);
     }
 
     @Override
     public Health health() {
-        final double currentCpuLoadPercent = operatingSystemMXBean.getSystemCpuLoad() * 100;
+        final long cpuCount = summaryCpuMetric.count();
+        final long cpuTotal = summaryCpuMetric.totalAmount();
+        final double currentCpuLoadPercent = cpuCount == 0 ? 0 : (cpuTotal / (double) cpuCount);
         if (currentCpuLoadPercent > maxCpuLoadPercent) {
+            cpuLoadConsecutiveOccurrences++;
+        }
+        if (cpuLoadConsecutiveOccurrences >= maxCpuLoadConsecutiveOccurrences) {
             log.warn("CPU usage {} crossed the threshold of {}", currentCpuLoadPercent, maxCpuLoadPercent);
             return Health
                 .outOfService()
                 .withDetail(CPU_LOAD, currentCpuLoadPercent)
                 .build();
         } else {
+            cpuLoadConsecutiveOccurrences = 0;
             return Health
                 .up()
                 .withDetail(CPU_LOAD, currentCpuLoadPercent)

--- a/genie-web/src/main/java/com/netflix/genie/web/health/GenieCpuHealthIndicator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/health/GenieCpuHealthIndicator.java
@@ -79,12 +79,14 @@ public class GenieCpuHealthIndicator implements HealthIndicator {
 
     @Override
     public Health health() {
+        // Use the distribution summary to get an average of the cpu metrics.
         final long cpuCount = summaryCpuMetric.count();
         final long cpuTotal = summaryCpuMetric.totalAmount();
         final double currentCpuLoadPercent = cpuCount == 0 ? 0 : (cpuTotal / (double) cpuCount);
         if (currentCpuLoadPercent > maxCpuLoadPercent) {
             cpuLoadConsecutiveOccurrences++;
         }
+        // Mark the service down only after a consecutive number of cpu load occurrences.
         if (cpuLoadConsecutiveOccurrences >= maxCpuLoadConsecutiveOccurrences) {
             log.warn("CPU usage {} crossed the threshold of {}", currentCpuLoadPercent, maxCpuLoadPercent);
             return Health

--- a/genie-web/src/test/groovy/com/netflix/genie/web/health/GenieCpuHealthIndicatorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/health/GenieCpuHealthIndicatorSpec.groovy
@@ -1,8 +1,11 @@
 package com.netflix.genie.web.health
 
 import com.netflix.genie.web.configs.PropertiesConfig
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.DistributionSummary
 import com.sun.management.OperatingSystemMXBean
 import org.springframework.boot.actuate.health.Status
+import org.springframework.scheduling.concurrent.DefaultManagedTaskScheduler
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -16,26 +19,52 @@ import spock.lang.Unroll
 class GenieCpuHealthIndicatorSpec extends Specification{
     OperatingSystemMXBean operatingSystemMXBean
     GenieCpuHealthIndicator cpuHealthIndicator;
+    DistributionSummary summary;
 
     def setup(){
         operatingSystemMXBean = Mock(OperatingSystemMXBean)
+        summary = Mock(DistributionSummary)
+        def props = new PropertiesConfig().healthProperties()
         cpuHealthIndicator = new GenieCpuHealthIndicator(
-                new PropertiesConfig().healthProperties().getMaxCpuLoadPercent(), operatingSystemMXBean)
+                props.getMaxCpuLoadPercent(),
+                1,
+                operatingSystemMXBean,
+                summary,
+                new DefaultManagedTaskScheduler())
     }
 
-    def 'Health should be #status when free memory is #freeMemory and totla is #totalMemory'(){
+    def 'Health should be #status when totalCpuLoad is #cpuLoad'(){
         given:
-        1 * operatingSystemMXBean.getSystemCpuLoad() >> cpuLoad
+        1 * summary.totalAmount() >> cpuLoad
+        1 * summary.count() >> count
         expect:
         cpuHealthIndicator.health().getStatus() == status
         where:
-        cpuLoad     | status
-        0.90        | Status.OUT_OF_SERVICE
-        0.81        | Status.OUT_OF_SERVICE
-        0.801       | Status.OUT_OF_SERVICE
-        0.80        | Status.UP
-        0.202       | Status.UP
-        0.30        | Status.UP
-        0.10        | Status.UP
+        cpuLoad  | count    | status
+        90       | 1        | Status.OUT_OF_SERVICE
+        171      | 2        | Status.OUT_OF_SERVICE
+        81.1     | 1        | Status.OUT_OF_SERVICE
+        80.1     | 0        | Status.UP
+        80       | 5        | Status.UP
+        20.2     | 1        | Status.UP
+        60       | 2        | Status.UP
+        50       | 5        | Status.UP
+    }
+
+    def checkHealth(){
+        when:
+        def okOperatingSystemMXBean = Mock(OperatingSystemMXBean)
+        okOperatingSystemMXBean.getSystemCpuLoad() >> 0.75 >> 0.78
+        def indicator = new GenieCpuHealthIndicator( 80, 1, okOperatingSystemMXBean,
+                new DefaultRegistry().distributionSummary('s'), new DefaultManagedTaskScheduler())
+        then:
+        indicator.health().getStatus() == Status.UP
+        when:
+        def outOperatingSystemMXBean = Mock(OperatingSystemMXBean)
+        outOperatingSystemMXBean.getSystemCpuLoad() >> 0.85 >> 0.88
+        indicator = new GenieCpuHealthIndicator( 80, 1, outOperatingSystemMXBean,
+                new DefaultRegistry().distributionSummary('s'), new DefaultManagedTaskScheduler())
+        then:
+        indicator.health().getStatus() == Status.OUT_OF_SERVICE
     }
 }


### PR DESCRIPTION
Earlier the CPU health indicator was erratic because of the erratic nature of cpu metric. Added two strategies to reduce it.
1. Take an average of the CPU metric instead of the current value.
2. Mark the service down only if the CPU metric crosses the threshold for a number of times (configured by a property. Default is 3)