### PR TITLE
Cluster Checker no longer ignores genieMemory health key

### DIFF
--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -229,7 +229,7 @@ determined by Zookeeper or other mechanism via Spring
 |genie.tasks.clusterChecker.healthIndicatorsToIgnore
 |The health indicator groups from the actuator /health endpoint to ignore when determining if a node is lost or not as
 a comma separated list
-|memory,genie,discoveryComposite
+|memory,genieMemory,discoveryComposite
 
 |genie.tasks.clusterChecker.lostThreshold
 |The number of times a Genie nodes need to fail health check in order for jobs running on that node to be marked as

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -40,12 +40,23 @@ for more information. Currently on classpath only none, hash_map, redis and jdbc
 
 |===
 
+==== Changed Default Value
+
+|===
+|Property |Old Default| New Default
+
+|genie.tasks.clusterChecker.healthIndicatorsToIgnore
+|memory,genie,discoveryComposite
+|memory,genieMemory,discoveryComposite
+
+|===
+
 ==== Removed
 
 ==== Renamed
 
 |===
-|Old |New
+|Old Name |New Name
 
 |multipart.max-file-size
 |spring.http.multipart.max-file-size

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/ClusterCheckerProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/ClusterCheckerProperties.java
@@ -37,4 +37,5 @@ public class ClusterCheckerProperties {
     private int port = 8080;
     private long rate = 300_000L;
     private int lostThreshold = 3;
+    private String healthIndicatorsToIgnore = "memory,genieMemory,discoveryComposite";
 }

--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -81,6 +81,7 @@ genie:
       port: 8080
       rate: 300000
       lostThreshold: 3
+      healthIndicatorsToIgnore: memory,genieMemory,discoveryComposite
     databaseCleanup:
       enabled: true
       expression: 0 0 0 * * *

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTaskUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTaskUnitTests.java
@@ -73,6 +73,7 @@ public class ClusterCheckerTaskUnitTests {
     public void setup() {
         this.hostName = UUID.randomUUID().toString();
         final ClusterCheckerProperties properties = new ClusterCheckerProperties();
+        properties.setHealthIndicatorsToIgnore("memory,genie ");
         this.jobSearchService = Mockito.mock(JobSearchService.class);
         this.jobPersistenceService = Mockito.mock(JobPersistenceService.class);
         this.restTemplate = Mockito.mock(RestTemplate.class);
@@ -92,7 +93,6 @@ public class ClusterCheckerTaskUnitTests {
             this.jobPersistenceService,
             this.restTemplate,
             serverProperties,
-            "memory,genie ",
             registry
         );
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@
 
 # Used in documentation and for including the Gradle plugin
 spring_boot_version=1.4.3.RELEASE
-spring_cloud_version=Camden.SR3
+spring_cloud_version=Camden.SR4
 spring_platform_version=Athens-SR2
 
 ## Override Spring Platform IO Versions


### PR DESCRIPTION
Genie health check was renamed to genieMemory and it was no longer excluded from cluster check health indicators causing jobs running on nodes "OUT_OF_SERVICE" due to lack of available memory to be marked as failed assuming node was lost from cluster.

Putting fix into 3.1.0 as for 3.0.0 users they can override property `genie.tasks.clusterChecker.healthIndicatorsToIgnore` to be `memory,genieMemory,discoveryComposite` and get the same result.