### PR TITLE
Standardize and improve search functionality

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaApplicationSpecs.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaApplicationSpecs.java
@@ -64,10 +64,14 @@ public final class JpaApplicationSpecs {
         return (final Root<ApplicationEntity> root, final CriteriaQuery<?> cq, final CriteriaBuilder cb) -> {
             final List<Predicate> predicates = new ArrayList<>();
             if (StringUtils.isNotBlank(name)) {
-                predicates.add(cb.equal(root.get(ApplicationEntity_.name), name));
+                predicates.add(
+                    JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(ApplicationEntity_.name), name)
+                );
             }
             if (StringUtils.isNotBlank(user)) {
-                predicates.add(cb.equal(root.get(ApplicationEntity_.user), user));
+                predicates.add(
+                    JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(ApplicationEntity_.user), user)
+                );
             }
             if (statuses != null && !statuses.isEmpty()) {
                 final List<Predicate> orPredicates =
@@ -86,7 +90,9 @@ public final class JpaApplicationSpecs {
                 );
             }
             if (StringUtils.isNotBlank(type)) {
-                predicates.add(cb.equal(root.get(ApplicationEntity_.type), type));
+                predicates.add(
+                    JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(ApplicationEntity_.type), type)
+                );
             }
             return cb.and(predicates.toArray(new Predicate[predicates.size()]));
         };

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaClusterSpecs.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaClusterSpecs.java
@@ -70,7 +70,9 @@ public final class JpaClusterSpecs {
         return (final Root<ClusterEntity> root, final CriteriaQuery<?> cq, final CriteriaBuilder cb) -> {
             final List<Predicate> predicates = new ArrayList<>();
             if (StringUtils.isNotBlank(name)) {
-                predicates.add(cb.like(root.get(ClusterEntity_.name), name));
+                predicates.add(
+                    JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(ClusterEntity_.name), name)
+                );
             }
             if (minUpdateTime != null) {
                 predicates.add(cb.greaterThanOrEqualTo(root.get(ClusterEntity_.updated), minUpdateTime));

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaCommandSpecs.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaCommandSpecs.java
@@ -65,10 +65,14 @@ public final class JpaCommandSpecs {
         return (final Root<CommandEntity> root, final CriteriaQuery<?> cq, final CriteriaBuilder cb) -> {
             final List<Predicate> predicates = new ArrayList<>();
             if (StringUtils.isNotBlank(name)) {
-                predicates.add(cb.equal(root.get(CommandEntity_.name), name));
+                predicates.add(
+                    JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(CommandEntity_.name), name)
+                );
             }
             if (StringUtils.isNotBlank(user)) {
-                predicates.add(cb.equal(root.get(CommandEntity_.user), user));
+                predicates.add(
+                    JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(CommandEntity_.user), user)
+                );
             }
             if (statuses != null && !statuses.isEmpty()) {
                 final List<Predicate> orPredicates =

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaJobSpecs.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaJobSpecs.java
@@ -84,13 +84,13 @@ public final class JpaJobSpecs {
     ) {
         final List<Predicate> predicates = new ArrayList<>();
         if (StringUtils.isNotBlank(id)) {
-            predicates.add(cb.like(root.get(JobEntity_.id), id));
+            predicates.add(JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(JobEntity_.id), id));
         }
         if (StringUtils.isNotBlank(name)) {
-            predicates.add(cb.like(root.get(JobEntity_.name), name));
+            predicates.add(JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(JobEntity_.name), name));
         }
         if (StringUtils.isNotBlank(user)) {
-            predicates.add(cb.equal(root.get(JobEntity_.user), user));
+            predicates.add(JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(JobEntity_.user), user));
         }
         if (statuses != null && !statuses.isEmpty()) {
             final List<Predicate> orPredicates =
@@ -107,13 +107,17 @@ public final class JpaJobSpecs {
             predicates.add(cb.equal(root.get(JobEntity_.cluster), cluster));
         }
         if (StringUtils.isNotBlank(clusterName)) {
-            predicates.add(cb.equal(root.get(JobEntity_.clusterName), clusterName));
+            predicates.add(
+                JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(JobEntity_.clusterName), clusterName)
+            );
         }
         if (command != null) {
             predicates.add(cb.equal(root.get(JobEntity_.command), command));
         }
         if (StringUtils.isNotBlank(commandName)) {
-            predicates.add(cb.equal(root.get(JobEntity_.commandName), commandName));
+            predicates.add(
+                JpaSpecificationUtils.getStringLikeOrEqualPredicate(cb, root.get(JobEntity_.commandName), commandName)
+            );
         }
         if (minStarted != null) {
             predicates.add(cb.greaterThanOrEqualTo(root.get(JobEntity_.started), minStarted));

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaSpecificationUtils.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/specifications/JpaSpecificationUtils.java
@@ -20,6 +20,9 @@ package com.netflix.genie.core.jpa.specifications;
 import com.netflix.genie.core.jpa.entities.CommonFieldsEntity;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Predicate;
 import javax.validation.constraints.NotNull;
 import java.util.Set;
 
@@ -37,6 +40,26 @@ public final class JpaSpecificationUtils {
     }
 
     /**
+     * Create either an equals or like predicate based on the presence of the '%' character in the search value.
+     *
+     * @param cb         The criteria builder to use for predicate creation
+     * @param expression The expression of the field the predicate is acting on
+     * @param value      The value to compare the field to
+     * @return A LIKE predicate if the value contains a '%' otherwise an EQUAL predicate
+     */
+    public static Predicate getStringLikeOrEqualPredicate(
+        @NotNull final CriteriaBuilder cb,
+        @NotNull final Expression<String> expression,
+        @NotNull final String value
+    ) {
+        if (StringUtils.contains(value, PERCENT)) {
+            return cb.like(expression, value);
+        } else {
+            return cb.equal(expression, value);
+        }
+    }
+
+    /**
      * Get the sorted like statement for tags used in specification queries.
      *
      * @param tags The tags to use. Not null.
@@ -45,15 +68,15 @@ public final class JpaSpecificationUtils {
     public static String getTagLikeString(@NotNull final Set<String> tags) {
         final StringBuilder builder = new StringBuilder();
         tags.stream()
-                .filter(StringUtils::isNotBlank)
-                .sorted(String.CASE_INSENSITIVE_ORDER)
-                .forEach(
-                    tag -> builder
-                        .append(PERCENT)
-                        .append(CommonFieldsEntity.TAG_DELIMITER)
-                        .append(tag)
-                        .append(CommonFieldsEntity.TAG_DELIMITER)
-                );
+            .filter(StringUtils::isNotBlank)
+            .sorted(String.CASE_INSENSITIVE_ORDER)
+            .forEach(
+                tag -> builder
+                    .append(PERCENT)
+                    .append(CommonFieldsEntity.TAG_DELIMITER)
+                    .append(tag)
+                    .append(CommonFieldsEntity.TAG_DELIMITER)
+            );
         return builder.append(PERCENT).toString();
     }
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaApplicationSpecsUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaApplicationSpecsUnitTests.java
@@ -15,10 +15,10 @@
  */
 package com.netflix.genie.core.jpa.specifications;
 
-import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.common.dto.ApplicationStatus;
 import com.netflix.genie.core.jpa.entities.ApplicationEntity;
 import com.netflix.genie.core.jpa.entities.ApplicationEntity_;
+import com.netflix.genie.test.categories.UnitTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,32 +78,38 @@ public class JpaApplicationSpecsUnitTests {
 
         final Path<String> namePath = (Path<String>) Mockito.mock(Path.class);
         final Predicate equalNamePredicate = Mockito.mock(Predicate.class);
+        final Predicate likeNamePredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(ApplicationEntity_.name)).thenReturn(namePath);
         Mockito.when(this.cb.equal(namePath, NAME)).thenReturn(equalNamePredicate);
+        Mockito.when(this.cb.like(namePath, NAME)).thenReturn(likeNamePredicate);
 
         final Path<String> userNamePath = (Path<String>) Mockito.mock(Path.class);
         final Predicate equalUserNamePredicate = Mockito.mock(Predicate.class);
+        final Predicate likeUserNamePredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(ApplicationEntity_.user)).thenReturn(userNamePath);
         Mockito.when(this.cb.equal(userNamePath, USER_NAME)).thenReturn(equalUserNamePredicate);
+        Mockito.when(this.cb.like(userNamePath, USER_NAME)).thenReturn(likeUserNamePredicate);
 
         final Path<ApplicationStatus> statusPath = (Path<ApplicationStatus>) Mockito.mock(Path.class);
         final Predicate equalStatusPredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(ApplicationEntity_.status)).thenReturn(statusPath);
         Mockito.when(this.cb.equal(Mockito.eq(statusPath), Mockito.any(ApplicationStatus.class)))
-                .thenReturn(equalStatusPredicate);
+            .thenReturn(equalStatusPredicate);
 
         final Path<String> tagPath = (Path<String>) Mockito.mock(Path.class);
         final Predicate likeTagPredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(ApplicationEntity_.tags)).thenReturn(tagPath);
         Mockito.when(this.cb.like(Mockito.eq(tagPath), Mockito.any(String.class)))
-                .thenReturn(likeTagPredicate);
+            .thenReturn(likeTagPredicate);
 
         this.tagLikeStatement = JpaSpecificationUtils.getTagLikeString(TAGS);
 
         final Path<String> typePath = (Path<String>) Mockito.mock(Path.class);
-        final Predicate typePredicate = Mockito.mock(Predicate.class);
+        final Predicate equalTypePredicate = Mockito.mock(Predicate.class);
+        final Predicate likeTypePredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(ApplicationEntity_.type)).thenReturn(typePath);
-        Mockito.when(this.cb.equal(typePath, TYPE)).thenReturn(typePredicate);
+        Mockito.when(this.cb.equal(typePath, TYPE)).thenReturn(equalTypePredicate);
+        Mockito.when(this.cb.like(typePath, TYPE)).thenReturn(likeTypePredicate);
     }
 
     /**
@@ -121,6 +127,27 @@ public class JpaApplicationSpecsUnitTests {
         }
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(ApplicationEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(ApplicationEntity_.type), TYPE);
+    }
+
+    /**
+     * Test the find specification.
+     */
+    @Test
+    public void testFindAllLike() {
+        final String newName = NAME + "%";
+        final String newUser = USER_NAME + "%";
+        final String newType = TYPE + "%";
+        final Specification<ApplicationEntity> spec
+            = JpaApplicationSpecs.find(newName, newUser, STATUSES, TAGS, newType);
+
+        spec.toPredicate(this.root, this.cq, this.cb);
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(ApplicationEntity_.name), newName);
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(ApplicationEntity_.user), newUser);
+        for (final ApplicationStatus status : STATUSES) {
+            Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(ApplicationEntity_.status), status);
+        }
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(ApplicationEntity_.tags), this.tagLikeStatement);
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(ApplicationEntity_.type), newType);
     }
 
     /**

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaClusterSpecsUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaClusterSpecsUnitTests.java
@@ -109,9 +109,10 @@ public class JpaClusterSpecsUnitTests {
 
         final Path<String> clusterNamePath = (Path<String>) Mockito.mock(Path.class);
         final Predicate likeNamePredicate = Mockito.mock(Predicate.class);
+        final Predicate equalNamePredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(ClusterEntity_.name)).thenReturn(clusterNamePath);
-        Mockito.when(this.cb.like(clusterNamePath, NAME))
-            .thenReturn(likeNamePredicate);
+        Mockito.when(this.cb.like(clusterNamePath, NAME)).thenReturn(likeNamePredicate);
+        Mockito.when(this.cb.equal(clusterNamePath, NAME)).thenReturn(equalNamePredicate);
 
         final Path<Date> minUpdatePath = (Path<Date>) Mockito.mock(Path.class);
         final Predicate greaterThanOrEqualToPredicate = Mockito.mock(Predicate.class);
@@ -161,7 +162,36 @@ public class JpaClusterSpecsUnitTests {
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-            .like(this.root.get(ClusterEntity_.name), NAME);
+            .equal(this.root.get(ClusterEntity_.name), NAME);
+        Mockito.verify(this.cb, Mockito.times(1))
+            .greaterThanOrEqualTo(this.root.get(ClusterEntity_.updated), MIN_UPDATE_TIME);
+        Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(ClusterEntity_.updated), MAX_UPDATE_TIME);
+        Mockito.verify(this.cb, Mockito.times(1))
+            .like(this.root.get(ClusterEntity_.tags), this.tagLikeStatement);
+        for (final ClusterStatus status : STATUSES) {
+            Mockito.verify(this.cb, Mockito.times(1))
+                .equal(this.root.get(ClusterEntity_.status), status);
+        }
+    }
+
+    /**
+     * Test the find specification.
+     */
+    @Test
+    public void testFindAllLike() {
+        final String newName = NAME + "%";
+        final Specification<ClusterEntity> spec = JpaClusterSpecs
+            .find(
+                newName,
+                STATUSES,
+                TAGS,
+                MIN_UPDATE_TIME,
+                MAX_UPDATE_TIME
+            );
+
+        spec.toPredicate(this.root, this.cq, this.cb);
+        Mockito.verify(this.cb, Mockito.times(1))
+            .like(this.root.get(ClusterEntity_.name), newName);
         Mockito.verify(this.cb, Mockito.times(1))
             .greaterThanOrEqualTo(this.root.get(ClusterEntity_.updated), MIN_UPDATE_TIME);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(ClusterEntity_.updated), MAX_UPDATE_TIME);
@@ -190,6 +220,8 @@ public class JpaClusterSpecsUnitTests {
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.never())
             .like(this.root.get(ClusterEntity_.name), NAME);
+        Mockito.verify(this.cb, Mockito.never())
+            .equal(this.root.get(ClusterEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
             .greaterThanOrEqualTo(this.root.get(ClusterEntity_.updated), MIN_UPDATE_TIME);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(ClusterEntity_.updated), MAX_UPDATE_TIME);
@@ -217,7 +249,7 @@ public class JpaClusterSpecsUnitTests {
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-            .like(this.root.get(ClusterEntity_.name), NAME);
+            .equal(this.root.get(ClusterEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
             .greaterThanOrEqualTo(this.root.get(ClusterEntity_.updated), MIN_UPDATE_TIME);
         Mockito.verify(this.cb, Mockito.times(1)).lessThan(
@@ -246,7 +278,7 @@ public class JpaClusterSpecsUnitTests {
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-            .like(this.root.get(ClusterEntity_.name), NAME);
+            .equal(this.root.get(ClusterEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
             .greaterThanOrEqualTo(this.root.get(ClusterEntity_.updated), MIN_UPDATE_TIME);
         Mockito.verify(this.cb, Mockito.times(1))
@@ -275,7 +307,7 @@ public class JpaClusterSpecsUnitTests {
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-            .like(this.root.get(ClusterEntity_.name), NAME);
+            .equal(this.root.get(ClusterEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
             .greaterThanOrEqualTo(this.root.get(ClusterEntity_.updated), MIN_UPDATE_TIME);
         Mockito.verify(this.cb, Mockito.times(1))
@@ -304,7 +336,7 @@ public class JpaClusterSpecsUnitTests {
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-            .like(this.root.get(ClusterEntity_.name), NAME);
+            .equal(this.root.get(ClusterEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.never())
             .greaterThanOrEqualTo(this.root.get(ClusterEntity_.updated), MIN_UPDATE_TIME);
         Mockito.verify(this.cb, Mockito.times(1))
@@ -333,7 +365,7 @@ public class JpaClusterSpecsUnitTests {
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-            .like(this.root.get(ClusterEntity_.name), NAME);
+            .equal(this.root.get(ClusterEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
             .greaterThanOrEqualTo(this.root.get(ClusterEntity_.updated), MIN_UPDATE_TIME);
         Mockito.verify(this.cb, Mockito.never())
@@ -363,7 +395,7 @@ public class JpaClusterSpecsUnitTests {
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-            .like(this.root.get(ClusterEntity_.name), NAME);
+            .equal(this.root.get(ClusterEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
             .greaterThanOrEqualTo(this.root.get(ClusterEntity_.updated), MIN_UPDATE_TIME);
         Mockito.verify(this.cb, Mockito.never())

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaCommandSpecsUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaCommandSpecsUnitTests.java
@@ -15,10 +15,10 @@
  */
 package com.netflix.genie.core.jpa.specifications;
 
-import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.common.dto.CommandStatus;
 import com.netflix.genie.core.jpa.entities.CommandEntity;
 import com.netflix.genie.core.jpa.entities.CommandEntity_;
+import com.netflix.genie.test.categories.UnitTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,21 +76,23 @@ public class JpaCommandSpecsUnitTests {
 
         final Path<String> commandNamePath = (Path<String>) Mockito.mock(Path.class);
         final Predicate equalNamePredicate = Mockito.mock(Predicate.class);
+        final Predicate likeNamePredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(CommandEntity_.name)).thenReturn(commandNamePath);
-        Mockito.when(this.cb.equal(commandNamePath, NAME))
-                .thenReturn(equalNamePredicate);
+        Mockito.when(this.cb.equal(commandNamePath, NAME)).thenReturn(equalNamePredicate);
+        Mockito.when(this.cb.like(commandNamePath, NAME)).thenReturn(likeNamePredicate);
 
         final Path<String> userNamePath = (Path<String>) Mockito.mock(Path.class);
         final Predicate equalUserNamePredicate = Mockito.mock(Predicate.class);
+        final Predicate likeUserNamePredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(CommandEntity_.user)).thenReturn(userNamePath);
-        Mockito.when(this.cb.equal(userNamePath, USER_NAME))
-                .thenReturn(equalUserNamePredicate);
+        Mockito.when(this.cb.equal(userNamePath, USER_NAME)).thenReturn(equalUserNamePredicate);
+        Mockito.when(this.cb.like(userNamePath, USER_NAME)).thenReturn(likeUserNamePredicate);
 
         final Path<CommandStatus> statusPath = (Path<CommandStatus>) Mockito.mock(Path.class);
         final Predicate equalStatusPredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(CommandEntity_.status)).thenReturn(statusPath);
         Mockito.when(this.cb.equal(Mockito.eq(statusPath), Mockito.any(CommandStatus.class)))
-                .thenReturn(equalStatusPredicate);
+            .thenReturn(equalStatusPredicate);
 
         final Path<String> tagPath = (Path<String>) Mockito.mock(Path.class);
         final Predicate likeTagPredicate = Mockito.mock(Predicate.class);
@@ -106,20 +108,44 @@ public class JpaCommandSpecsUnitTests {
     @Test
     public void testFindAll() {
         final Specification<CommandEntity> spec = JpaCommandSpecs.find(
-                NAME, USER_NAME, STATUSES, TAGS
+            NAME, USER_NAME, STATUSES, TAGS
         );
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.name), NAME);
+            .equal(this.root.get(CommandEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.user), USER_NAME);
+            .equal(this.root.get(CommandEntity_.user), USER_NAME);
         for (final CommandStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1))
-                    .equal(this.root.get(CommandEntity_.status), status);
+                .equal(this.root.get(CommandEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1))
-                .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
+            .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
+    }
+
+    /**
+     * Test the find specification.
+     */
+    @Test
+    public void testFindAllLike() {
+        final String newName = NAME + "%";
+        final String newUser = USER_NAME + "%";
+        final Specification<CommandEntity> spec = JpaCommandSpecs.find(
+            newName, newUser, STATUSES, TAGS
+        );
+
+        spec.toPredicate(this.root, this.cq, this.cb);
+        Mockito.verify(this.cb, Mockito.times(1))
+            .like(this.root.get(CommandEntity_.name), newName);
+        Mockito.verify(this.cb, Mockito.times(1))
+            .like(this.root.get(CommandEntity_.user), newUser);
+        for (final CommandStatus status : STATUSES) {
+            Mockito.verify(this.cb, Mockito.times(1))
+                .equal(this.root.get(CommandEntity_.status), status);
+        }
+        Mockito.verify(this.cb, Mockito.times(1))
+            .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
     }
 
     /**
@@ -128,20 +154,20 @@ public class JpaCommandSpecsUnitTests {
     @Test
     public void testFindNoName() {
         final Specification<CommandEntity> spec = JpaCommandSpecs.find(
-                null, USER_NAME, STATUSES, TAGS
+            null, USER_NAME, STATUSES, TAGS
         );
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.never())
-                .equal(this.root.get(CommandEntity_.name), NAME);
+            .equal(this.root.get(CommandEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.user), USER_NAME);
+            .equal(this.root.get(CommandEntity_.user), USER_NAME);
         for (final CommandStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1))
-                    .equal(this.root.get(CommandEntity_.status), status);
+                .equal(this.root.get(CommandEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1))
-                .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
+            .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
     }
 
     /**
@@ -150,20 +176,20 @@ public class JpaCommandSpecsUnitTests {
     @Test
     public void testFindNoUserName() {
         final Specification<CommandEntity> spec = JpaCommandSpecs.find(
-                NAME, null, STATUSES, TAGS
+            NAME, null, STATUSES, TAGS
         );
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.name), NAME);
+            .equal(this.root.get(CommandEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.never())
-                .equal(this.root.get(CommandEntity_.user), USER_NAME);
+            .equal(this.root.get(CommandEntity_.user), USER_NAME);
         for (final CommandStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1))
-                    .equal(this.root.get(CommandEntity_.status), status);
+                .equal(this.root.get(CommandEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1))
-                .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
+            .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
     }
 
     /**
@@ -172,20 +198,20 @@ public class JpaCommandSpecsUnitTests {
     @Test
     public void testFindNoTags() {
         final Specification<CommandEntity> spec = JpaCommandSpecs.find(
-                NAME, USER_NAME, STATUSES, null
+            NAME, USER_NAME, STATUSES, null
         );
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.name), NAME);
+            .equal(this.root.get(CommandEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.user), USER_NAME);
+            .equal(this.root.get(CommandEntity_.user), USER_NAME);
         for (final CommandStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1))
-                    .equal(this.root.get(CommandEntity_.status), status);
+                .equal(this.root.get(CommandEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.never())
-                .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
+            .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
     }
 
     /**
@@ -195,20 +221,20 @@ public class JpaCommandSpecsUnitTests {
     public void testFindEmptyTag() {
         TAGS.add("");
         final Specification<CommandEntity> spec = JpaCommandSpecs.find(
-                NAME, USER_NAME, STATUSES, TAGS
+            NAME, USER_NAME, STATUSES, TAGS
         );
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.name), NAME);
+            .equal(this.root.get(CommandEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.user), USER_NAME);
+            .equal(this.root.get(CommandEntity_.user), USER_NAME);
         for (final CommandStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1))
-                    .equal(this.root.get(CommandEntity_.status), status);
+                .equal(this.root.get(CommandEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1))
-                .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
+            .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
     }
 
     /**
@@ -217,19 +243,19 @@ public class JpaCommandSpecsUnitTests {
     @Test
     public void testFindNoStatuses() {
         final Specification<CommandEntity> spec = JpaCommandSpecs
-                .find(NAME, USER_NAME, null, TAGS);
+            .find(NAME, USER_NAME, null, TAGS);
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.name), NAME);
+            .equal(this.root.get(CommandEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.user), USER_NAME);
+            .equal(this.root.get(CommandEntity_.user), USER_NAME);
         for (final CommandStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.never())
-                    .equal(this.root.get(CommandEntity_.status), status);
+                .equal(this.root.get(CommandEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1))
-                .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
+            .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
     }
 
     /**
@@ -238,19 +264,19 @@ public class JpaCommandSpecsUnitTests {
     @Test
     public void testFindEmptyStatuses() {
         final Specification<CommandEntity> spec = JpaCommandSpecs
-                .find(NAME, USER_NAME, new HashSet<>(), TAGS);
+            .find(NAME, USER_NAME, new HashSet<>(), TAGS);
 
         spec.toPredicate(this.root, this.cq, this.cb);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.name), NAME);
+            .equal(this.root.get(CommandEntity_.name), NAME);
         Mockito.verify(this.cb, Mockito.times(1))
-                .equal(this.root.get(CommandEntity_.user), USER_NAME);
+            .equal(this.root.get(CommandEntity_.user), USER_NAME);
         for (final CommandStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.never())
-                    .equal(this.root.get(CommandEntity_.status), status);
+                .equal(this.root.get(CommandEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.times(1))
-                .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
+            .like(this.root.get(CommandEntity_.tags), this.tagLikeStatement);
     }
 
     /**

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaJobSpecsUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/specifications/JpaJobSpecsUnitTests.java
@@ -81,13 +81,17 @@ public class JpaJobSpecsUnitTests {
 
         final Path<String> idPath = (Path<String>) Mockito.mock(Path.class);
         final Predicate likeIdPredicate = Mockito.mock(Predicate.class);
+        final Predicate equalIdPredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(JobEntity_.id)).thenReturn(idPath);
         Mockito.when(this.cb.like(idPath, ID)).thenReturn(likeIdPredicate);
+        Mockito.when(this.cb.equal(idPath, ID)).thenReturn(equalIdPredicate);
 
         final Path<String> jobNamePath = (Path<String>) Mockito.mock(Path.class);
         final Predicate likeJobNamePredicate = Mockito.mock(Predicate.class);
+        final Predicate equalJobNamePredicate = Mockito.mock(Predicate.class);
         Mockito.when(this.root.get(JobEntity_.name)).thenReturn(jobNamePath);
         Mockito.when(this.cb.like(jobNamePath, JOB_NAME)).thenReturn(likeJobNamePredicate);
+        Mockito.when(this.cb.equal(jobNamePath, JOB_NAME)).thenReturn(equalJobNamePredicate);
 
         final Path<String> userNamePath = (Path<String>) Mockito.mock(Path.class);
         final Predicate equalUserNamePredicate = Mockito.mock(Predicate.class);
@@ -175,8 +179,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -184,6 +188,53 @@ public class JpaJobSpecsUnitTests {
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
+        Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
+        Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.started), MAX_STARTED);
+        Mockito
+            .verify(this.cb, Mockito.times(1))
+            .greaterThanOrEqualTo(this.root.get(JobEntity_.finished), MIN_FINISHED);
+        Mockito.verify(this.cb, Mockito.times(1)).lessThan(this.root.get(JobEntity_.finished), MAX_FINISHED);
+    }
+
+    /**
+     * Test the find specification.
+     */
+    @Test
+    public void testFindWithAllLikes() {
+        final String newId = ID + "%";
+        final String newName = JOB_NAME + "%";
+        final String newUserName = USER_NAME + "%";
+        final String newClusterName = CLUSTER_NAME + "%";
+        final String newCommandName = COMMAND_NAME + "%";
+        JpaJobSpecs.getFindPredicate(
+            this.root,
+            this.cb,
+            newId,
+            newName,
+            newUserName,
+            STATUSES,
+            TAGS,
+            newClusterName,
+            CLUSTER,
+            newCommandName,
+            COMMAND,
+            MIN_STARTED,
+            MAX_STARTED,
+            MIN_FINISHED,
+            MAX_FINISHED
+        );
+
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), newId);
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), newName);
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.user), newUserName);
+        for (final JobStatus status : STATUSES) {
+            Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
+        }
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.clusterName), newClusterName);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
+        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.commandName), newCommandName);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
@@ -218,7 +269,8 @@ public class JpaJobSpecsUnitTests {
         );
 
         Mockito.verify(this.cb, Mockito.never()).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -259,8 +311,9 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
         Mockito.verify(this.cb, Mockito.never()).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -301,9 +354,10 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.user), USER_NAME);
+        Mockito.verify(this.cb, Mockito.never()).like(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
@@ -343,8 +397,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.status), status);
@@ -385,8 +439,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.status), status);
@@ -427,13 +481,14 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
         }
         Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
+        Mockito.verify(this.cb, Mockito.never()).like(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
@@ -469,8 +524,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -511,8 +566,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -520,6 +575,7 @@ public class JpaJobSpecsUnitTests {
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.clusterName), CLUSTER_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.cluster), CLUSTER);
         Mockito.verify(this.cb, Mockito.never()).equal(this.root.get(JobEntity_.commandName), COMMAND_NAME);
+        Mockito.verify(this.cb, Mockito.never()).like(this.root.get(JobEntity_.commandName), COMMAND_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.command), COMMAND);
         Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.tags), this.tagLikeStatement);
         Mockito.verify(this.cb, Mockito.times(1)).greaterThanOrEqualTo(this.root.get(JobEntity_.started), MIN_STARTED);
@@ -553,8 +609,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -595,8 +651,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -637,8 +693,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -679,8 +735,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -721,8 +777,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -763,8 +819,8 @@ public class JpaJobSpecsUnitTests {
             null
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);
@@ -806,8 +862,8 @@ public class JpaJobSpecsUnitTests {
             MAX_FINISHED
         );
 
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.id), ID);
-        Mockito.verify(this.cb, Mockito.times(1)).like(this.root.get(JobEntity_.name), JOB_NAME);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.id), ID);
+        Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.name), JOB_NAME);
         Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.user), USER_NAME);
         for (final JobStatus status : STATUSES) {
             Mockito.verify(this.cb, Mockito.times(1)).equal(this.root.get(JobEntity_.status), status);


### PR DESCRIPTION
This PR addresses two issues:

1. Job search by id and name was degrading at large job database size. It was performing a `LIKE` no matter what string was passed in. Now the code searches for the presence of the `%` character and if it's not present it switches that predicate to be an `EQUAL`

2. String fields across resources were treated differently. Some were defaulting to `EQUAL` predicates and some to `LIKE` predicates. Now all string fields supported by the API for search will use `EQUAL` by default and switch to `LIKE` if a `%` is present