### PR TITLE
add more info to warning error when making requests in Python client

### DIFF
--- a/genie-client/src/main/python/pygenie/utils.py
+++ b/genie-client/src/main/python/pygenie/utils.py
@@ -107,7 +107,11 @@ def call(url, method='get', headers=None, raise_not_status=None, none_on_404=Fal
         if i < attempts - 1:
             msg = ''
             if resp is not None:
-                msg = '-> {}: {}'.format(resp.status_code, resp.text)
+                msg = '-> {method} {url} ({code}): {text}'\
+                    .format(method=resp.request.method,
+                            url=resp.url,
+                            code=resp.status_code,
+                            text=resp.text)
             logger.warning('attempt %s %s', i + 1, msg)
             time.sleep(i * backoff)
 

--- a/genie-client/src/main/python/setup.py
+++ b/genie-client/src/main/python/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='nflx-genie-client',
-    version='3.3.2',
+    version='3.3.3',
     author='Netflix Inc.',
     author_email='genieoss@googlegroups.com',
     keywords='genie hadoop cloud netflix client bigdata presto',

--- a/genie-client/src/main/python/tests/utils.py
+++ b/genie-client/src/main/python/tests/utils.py
@@ -6,10 +6,14 @@ import requests
 import uuid
 
 
-def fake_response(content, status_code=200):
+def fake_response(content, status_code=200, method='GET'):
     response = requests.Response()
+    response.request = requests.Request()
+
     response.status_code = status_code
     response._content = json.dumps(content)
+    response.request.method = method
+
     return response
 
 


### PR DESCRIPTION
When the Python client makes a HTTP request to the server and it fails, the client logs a message with attempt, etc. Add request URL and method to this message.