### PR TITLE
Leadership tasks cleanup logic

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
@@ -234,11 +234,19 @@ public class ClusterCheckerTask extends LeadershipTask {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void cleanup() {
+        this.errorCounts.clear();
+    }
+
+    /**
      * Get the current size of error counts. Mainly used for testing.
      *
      * @return Number of nodes currently in an error state
      */
-    protected int getErrorCountsSize() {
+    int getErrorCountsSize() {
         return this.errorCounts.size();
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
@@ -103,4 +103,12 @@ public class DatabaseCleanupTask extends LeadershipTask {
         log.info("Deleted {} jobs from before {}", numberDeletedJobs, this.dateFormat.format(retentionLimit));
         this.numDeletedJobs.set(numberDeletedJobs);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void cleanup() {
+        this.numDeletedJobs.set(0L);
+    }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeadershipTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeadershipTask.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.tasks.leader;
 
 import com.netflix.genie.web.tasks.GenieTask;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Interface for any task that a node elected as the leader of a Genie cluster should run.
@@ -25,5 +26,13 @@ import com.netflix.genie.web.tasks.GenieTask;
  * @author tgianos
  * @since 3.0.0
  */
+@Slf4j
 public abstract class LeadershipTask extends GenieTask {
+
+    /**
+     * Any cleanup that needs to be performed when this task is stopped due to leadership being revoked.
+     */
+    public void cleanup() {
+        log.info("Task cleanup called. Nothing to do.");
+    }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeadershipTasksCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeadershipTasksCoordinator.java
@@ -87,7 +87,7 @@ public class LeadershipTasksCoordinator {
             }
             log.info("Leadership granted.");
             this.isRunning = true;
-            this.tasks.stream().forEach(
+            this.tasks.forEach(
                 task -> {
                     switch (task.getScheduleType()) {
                         case TRIGGER:
@@ -146,5 +146,6 @@ public class LeadershipTasksCoordinator {
 
         // Clear out the tasks
         this.futures.clear();
+        this.tasks.forEach(LeadershipTask::cleanup);
     }
 }


### PR DESCRIPTION
When leadership was revoked from a node the singletons representing the leadership tasks maintained some state. Particularly for metrics. This PR adds a cleanup method to the `LeadershipTask` interface which is called when Leadership is revoked in the coordinator. All state cleanup should be done within these methods.