### PR TITLE
Modify job cleanup query to limit amount of data via id projection

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaApplicationRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaApplicationRepository.java
@@ -18,13 +18,11 @@ package com.netflix.genie.core.jpa.repositories;
 import com.netflix.genie.core.jpa.entities.ApplicationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
 
 /**
  * Application repository.
  *
  * @author tgianos
  */
-@Repository
 public interface JpaApplicationRepository extends JpaRepository<ApplicationEntity, String>, JpaSpecificationExecutor {
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaClusterRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaClusterRepository.java
@@ -18,13 +18,11 @@ package com.netflix.genie.core.jpa.repositories;
 import com.netflix.genie.core.jpa.entities.ClusterEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
 
 /**
  * Cluster repository.
  *
  * @author tgianos
  */
-@Repository
 public interface JpaClusterRepository extends JpaRepository<ClusterEntity, String>, JpaSpecificationExecutor {
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaCommandRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaCommandRepository.java
@@ -18,13 +18,11 @@ package com.netflix.genie.core.jpa.repositories;
 import com.netflix.genie.core.jpa.entities.CommandEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
 
 /**
  * Command repository.
  *
  * @author tgianos
  */
-@Repository
 public interface JpaCommandRepository extends JpaRepository<CommandEntity, String>, JpaSpecificationExecutor {
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobExecutionRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobExecutionRepository.java
@@ -18,7 +18,6 @@ package com.netflix.genie.core.jpa.repositories;
 import com.netflix.genie.core.jpa.entities.JobExecutionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
@@ -29,10 +28,10 @@ import java.util.List;
  * @author tgianos
  * @since 3.0.0
  */
-@Repository
 public interface JpaJobExecutionRepository extends JpaRepository<JobExecutionEntity, String>, JpaSpecificationExecutor {
     /**
      * Deletes all job executions for the given ids.
+     *
      * @param ids list of ids for which the job requests should be deleted
      * @return no. of executions deleted
      */

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobMetadataRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobMetadataRepository.java
@@ -18,7 +18,6 @@ package com.netflix.genie.core.jpa.repositories;
 import com.netflix.genie.core.jpa.entities.JobMetadataEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
@@ -29,10 +28,10 @@ import java.util.List;
  * @author tgianos
  * @since 3.0.0
  */
-@Repository
 public interface JpaJobMetadataRepository extends JpaRepository<JobMetadataEntity, String>, JpaSpecificationExecutor {
     /**
      * Deletes all job metadatas for the given ids.
+     *
      * @param ids list of ids for which the job requests should be deleted
      * @return no. of metadatas deleted
      */

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRepository.java
@@ -18,7 +18,6 @@ package com.netflix.genie.core.jpa.repositories;
 import com.netflix.genie.core.jpa.entities.JobEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
@@ -28,10 +27,10 @@ import java.util.List;
  *
  * @author tgianos
  */
-@Repository
 public interface JpaJobRepository extends JpaRepository<JobEntity, String>, JpaSpecificationExecutor {
     /**
      * Deletes all jobs for the given ids.
+     *
      * @param ids list of ids for which the jobs should be deleted
      * @return no. of jobs deleted
      */

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRequestRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRequestRepository.java
@@ -18,7 +18,8 @@ package com.netflix.genie.core.jpa.repositories;
 import com.netflix.genie.core.jpa.entities.JobRequestEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import javax.validation.constraints.NotNull;
 import java.util.Date;
@@ -30,7 +31,6 @@ import java.util.List;
  * @author tgianos
  * @since 3.0.0
  */
-@Repository
 public interface JpaJobRequestRepository extends JpaRepository<JobRequestEntity, String>, JpaSpecificationExecutor {
 
     /**
@@ -39,10 +39,12 @@ public interface JpaJobRequestRepository extends JpaRepository<JobRequestEntity,
      * @param date The date before which all job requests were created.
      * @return List of job requests
      */
-    List<JobRequestEntity> findByCreatedBefore(@NotNull final Date date);
+    @Query("SELECT e.id FROM JobRequestEntity e WHERE e.created < :date")
+    List<String> findByCreatedBefore(@NotNull @Param("date") final Date date);
 
     /**
      * Deletes all job requests for the given ids.
+     *
      * @param ids list of ids for which the job requests should be deleted
      * @return no. of requests deleted
      */

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaJobPersistenceServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaJobPersistenceServiceImpl.java
@@ -28,7 +28,6 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.core.jpa.entities.ApplicationEntity;
-import com.netflix.genie.core.jpa.entities.BaseEntity;
 import com.netflix.genie.core.jpa.entities.ClusterEntity;
 import com.netflix.genie.core.jpa.entities.CommandEntity;
 import com.netflix.genie.core.jpa.entities.JobEntity;
@@ -53,7 +52,6 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * JPA implementation of the job persistence service.
@@ -297,11 +295,10 @@ public class JpaJobPersistenceServiceImpl implements JobPersistenceService {
      */
     @Override
     public long deleteAllJobsCreatedBeforeDate(@NotNull final Date date) {
-        final List<JobRequestEntity> requests = jobRequestRepo.findByCreatedBefore(date);
-        final List<String> ids = requests.stream().map(BaseEntity::getId).collect(Collectors.toList());
-        jobExecutionRepo.deleteByIdIn(ids);
-        jobMetadataRepository.deleteByIdIn(ids);
-        jobRepo.deleteByIdIn(ids);
+        final List<String> ids = this.jobRequestRepo.findByCreatedBefore(date);
+        this.jobExecutionRepo.deleteByIdIn(ids);
+        this.jobMetadataRepository.deleteByIdIn(ids);
+        this.jobRepo.deleteByIdIn(ids);
         return jobRequestRepo.deleteByIdIn(ids);
     }
 

--- a/genie-core/src/test/java/com/netflix/genie/GenieCoreTestApplication.java
+++ b/genie-core/src/test/java/com/netflix/genie/GenieCoreTestApplication.java
@@ -91,7 +91,7 @@ public class GenieCoreTestApplication {
      * Get the jobs dir as a Spring Resource. Will create if it doesn't exist.
      *
      * @return The job dir as a resource
-     * @throws IOException on error reading or creading the directory
+     * @throws IOException on error reading or creating the directory
      */
     @Bean
     @ConditionalOnMissingBean


### PR DESCRIPTION
Current implementation pulls back far too much data causing potential for OOM on large queries.

This can be further improved in future releases with improved paging logic if necessary.