### PR TITLE
Test improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,8 @@ configure(javaProjects) {
         testLogging {
             events "passed", "skipped", "failed"
         }
+        forkEvery 1
+        maxParallelForks 4
     }
 
     ext {

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,12 @@ configure(javaProjects) {
         }
     }
 
+    test {
+        testLogging {
+            events "passed", "skipped", "failed"
+        }
+    }
+
     ext {
         generatedSourcesDir = new File("${projectDir}/src/generated")
         generatedSourcesJavaDir = new File(generatedSourcesDir, "/java")


### PR DESCRIPTION
* Remove flaky test that relies on timing (JobClientIntegrationTests::submitAndKillJob)
* Fix failing test that relies on platform-specific output (JobClientIntegrationTests:: testCanGetJobStderr)
* Increase Gradle verbosity to see each test name and outcome as they are executed
* Re-enable JobClientIntegrationTests class
* Change Gradle settings for better test isolation