### PR TITLE
remove trailing slash when setting genie url in python client

### DIFF
--- a/genie-client/src/main/python/pygenie/jobs/core.py
+++ b/genie-client/src/main/python/pygenie/jobs/core.py
@@ -626,7 +626,7 @@ class GenieJob(object):
             :py:class:`GenieJob`: self
         """
 
-        self._conf.genie.url = url
+        self._conf.genie.url = url[:-1] if url.endswith('/') else url
 
         return self
 

--- a/genie-client/src/main/python/setup.py
+++ b/genie-client/src/main/python/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='nflx-genie-client',
-    version='3.3.3',
+    version='3.4.0',
     author='Netflix Inc.',
     author_email='genieoss@googlegroups.com',
     keywords='genie hadoop cloud netflix client bigdata presto',

--- a/genie-client/src/main/python/tests/job_tests/test_geniejob.py
+++ b/genie-client/src/main/python/tests/job_tests/test_geniejob.py
@@ -364,3 +364,35 @@ class TestingSetJobName(unittest.TestCase):
             set_jobname(pygenie.jobs.PrestoJob() \
                 .script("min(\"values\") r = 'foo' order by date, hour;"))
         )
+
+
+@patch.dict('os.environ', {'GENIE_BYPASS_HOME_CONFIG': '1'})
+class TestingSetGenieUrl(unittest.TestCase):
+    """Test setting genie url."""
+
+    def test_set_genie_url(self):
+        """Test setting genie url."""
+
+        url = 'http://www.test-genie-url.com:7001'
+
+        job = pygenie.jobs.GenieJob() \
+            .genie_url(url)
+
+        assert_equals(
+            url,
+            job._conf.genie.url
+        )
+
+    def test_set_genie_url_trailing_slash(self):
+        """Test setting genie url with trailing slash."""
+
+        url = 'http://www.test-genie-url.com:7001/'
+        url_clean = url.rstrip('/')
+
+        job = pygenie.jobs.GenieJob() \
+            .genie_url(url)
+
+        assert_equals(
+            url_clean,
+            job._conf.genie.url
+        )


### PR DESCRIPTION
For a GenieJob, when setting the Genie URL to use via `.genie_url()`, if there is a trailing slash remove it so constructing URLs will not contain extra slashes.