### PR TITLE
Add simple user job limiting mechanism

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/exceptions/GenieUserLimitExceededException.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/exceptions/GenieUserLimitExceededException.java
@@ -1,0 +1,68 @@
+/*
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.exceptions;
+
+import lombok.Getter;
+
+/**
+ * Extension of a GenieException for a user exceeding some limit (e.g., submitting too many jobs).
+ *
+ * @author mprimi
+ * @since 3.1.0
+ */
+@Getter
+public final class GenieUserLimitExceededException extends GenieException {
+
+    private static final String ACTIVE_JOBS_LIMIT = "activeJobs";
+    private final String user;
+    private final String exceededLimitName;
+
+    private GenieUserLimitExceededException(
+        final String user,
+        final String limitName,
+        final String message
+    ) {
+        super(429, message);
+        this.user = user;
+        this.exceededLimitName = limitName;
+    }
+
+    /**
+     * Static factory method to produce a GenieUserLimitExceededException suitable for when the user exceeded the
+     * maximum number of active jobs and its trying to submit yet another.
+     * @param user the user name
+     * @param activeJobsCount the count of active jobs for this user
+     * @param activeJobsLimit the current limit on active jobs
+     * @return a new GenieUserLimitExceededException
+     */
+    public static GenieUserLimitExceededException createForActiveJobsLimit(
+        final String user,
+        final long activeJobsCount,
+        final long activeJobsLimit
+    ) {
+        return new GenieUserLimitExceededException(
+            user,
+            ACTIVE_JOBS_LIMIT,
+            "User exceeded active jobs limit ("
+                + activeJobsCount
+                + "/"
+                + activeJobsLimit
+                + ")"
+        );
+    }
+}

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRepository.java
@@ -15,12 +15,16 @@
  */
 package com.netflix.genie.core.jpa.repositories;
 
+import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.core.jpa.entities.JobEntity;
+import org.hibernate.validator.constraints.NotBlank;
+import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Job repository.
@@ -35,4 +39,13 @@ public interface JpaJobRepository extends JpaRepository<JobEntity, String>, JpaS
      * @return no. of jobs deleted
      */
     Long deleteByIdIn(@NotNull final List<String> ids);
+
+    /**
+     * Count all jobs that belong to a given user and are in any of the given states.
+     *
+     * @param user the user name
+     * @param statuses the set of statuses
+     * @return the count of jobs matching the search criteria
+     */
+    Long countJobsByUserAndStatusIn(@NotBlank final String user, @NotEmpty final Set<JobStatus> statuses);
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/properties/JobsUsersActiveLimitProperties.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/properties/JobsUsersActiveLimitProperties.java
@@ -20,16 +20,28 @@ package com.netflix.genie.core.properties;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Min;
+
 /**
- * Properties related to users running jobs.
+ * Properties related to user limits in number of active jobs.
  *
- * @author tgianos
- * @since 3.0.0
+ * @author mprimi
+ * @since 3.1.0
  */
 @Getter
 @Setter
-public class JobsUsersProperties {
-    private boolean creationEnabled;
-    private boolean runAsUserEnabled;
-    private JobsUsersActiveLimitProperties activeLimit = new JobsUsersActiveLimitProperties();
+public class JobsUsersActiveLimitProperties {
+    /**
+     * Default value for active user job limit enabled.
+     */
+    public static final boolean DEFAULT_ENABLED = false;
+
+    /**
+     * Default value for active user job limit count.
+     */
+    public static final int DEFAULT_COUNT = 100;
+
+    private boolean enabled = DEFAULT_ENABLED;
+    @Min(value = 1)
+    private int count = DEFAULT_COUNT;
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/properties/JobsUsersProperties.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/properties/JobsUsersProperties.java
@@ -31,4 +31,6 @@ import lombok.Setter;
 public class JobsUsersProperties {
     private boolean creationEnabled;
     private boolean runAsUserEnabled;
+    private boolean activeJobsLimitEnabled;
+    private int activeJobsLimit;
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobSearchService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobSearchService.java
@@ -167,4 +167,13 @@ public interface JobSearchService {
      * @throws GenieException If the job isn't found or any other error
      */
     String getJobHost(@NotBlank final String jobId) throws GenieException;
+
+    /**
+     * Get the count of 'active' jobs for a given user across all instances.
+     *
+     * @param user The user name
+     * @return the number of active jobs for a given user
+     * @throws GenieException If any error occurs
+     */
+    long getActiveJobCountForUser(@NotBlank final String user) throws GenieException;
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
@@ -31,6 +31,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
+import com.netflix.genie.common.exceptions.GenieUserLimitExceededException;
 import com.netflix.genie.core.jobs.JobConstants;
 import com.netflix.genie.core.properties.JobsProperties;
 import com.netflix.genie.core.services.ApplicationService;
@@ -40,6 +41,7 @@ import com.netflix.genie.core.services.CommandService;
 import com.netflix.genie.core.services.JobCoordinatorService;
 import com.netflix.genie.core.services.JobKillService;
 import com.netflix.genie.core.services.JobPersistenceService;
+import com.netflix.genie.core.services.JobSearchService;
 import com.netflix.genie.core.services.JobStateService;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
@@ -71,6 +73,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
     private final JobKillService jobKillService;
     private final JobStateService jobStateService;
     private final ApplicationService applicationService;
+    private final JobSearchService jobSearchService;
     private final ClusterService clusterService;
     private final CommandService commandService;
     private final ClusterLoadBalancer clusterLoadBalancer;
@@ -96,6 +99,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
      *                              jobs currently running
      * @param jobsProperties        The jobs properties to use
      * @param applicationService    Implementation of application service interface
+     * @param jobSearchService      Implementation of job search service
      * @param clusterService        Implementation of cluster service interface
      * @param commandService        Implementation of command service interface
      * @param clusterLoadBalancer   Implementation of the cluster load balancer interface
@@ -108,6 +112,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
         @NotNull final JobStateService jobStateService,
         @NotNull final JobsProperties jobsProperties,
         @NotNull final ApplicationService applicationService,
+        @NotNull final JobSearchService jobSearchService,
         @NotNull final ClusterService clusterService,
         @NotNull final CommandService commandService,
         @NotNull final ClusterLoadBalancer clusterLoadBalancer,
@@ -118,6 +123,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
         this.jobKillService = jobKillService;
         this.jobStateService = jobStateService;
         this.applicationService = applicationService;
+        this.jobSearchService = jobSearchService;
         this.clusterService = clusterService;
         this.commandService = commandService;
         this.clusterLoadBalancer = clusterLoadBalancer;

--- a/genie-core/src/main/java/com/netflix/genie/core/util/MetricsConstants.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/util/MetricsConstants.java
@@ -71,6 +71,11 @@ public final class MetricsConstants {
     public static final String GENIE_EXCEPTIONS_CONSTRAINT_VIOLATION_RATE = "genie.exceptions.constraintViolation.rate";
 
     /**
+     * For counting how often requests are rejected due to user exceeding limits.
+     */
+    public static final String GENIE_EXCEPTIONS_USER_LIMIT_EXCEEDED_RATE = "genie.exceptions.userLimitExceeded.rate";
+
+    /**
      * Utility class protected constructor.
      */
     protected MetricsConstants() {

--- a/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
@@ -352,8 +352,9 @@ public class ServicesConfigTest {
      * Get an instance of the JobCoordinatorService.
      *
      * @param jobPersistenceService implementation of job persistence service interface.
-     * @param jobStateService       implementation of job state service interface
      * @param jobKillService        The job kill service to use.
+     * @param jobStateService       implementation of job state service interface
+     * @param jobSearchService      implementation of job search service interface
      * @param jobsProperties        The jobs properties to use
      * @param applicationService    Implementation of application service interface
      * @param clusterService        Implementation of cluster service interface
@@ -368,6 +369,7 @@ public class ServicesConfigTest {
         final JobPersistenceService jobPersistenceService,
         final JobKillService jobKillService,
         final JobStateService jobStateService,
+        final JobSearchService jobSearchService,
         final JobsProperties jobsProperties,
         final ApplicationService applicationService,
         final ClusterService clusterService,
@@ -382,6 +384,7 @@ public class ServicesConfigTest {
             jobStateService,
             jobsProperties,
             applicationService,
+            jobSearchService,
             clusterService,
             commandService,
             clusterLoadBalancer,

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplIntegrationTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobSearchServiceImplIntegrationTests.java
@@ -324,4 +324,15 @@ public class JpaJobSearchServiceImplIntegrationTests extends DBUnitTestBase {
         Assert.assertThat(applications.get(0).getId().orElseGet(RandomSuppliers.STRING), Matchers.is("app1"));
         Assert.assertThat(applications.get(1).getId().orElseGet(RandomSuppliers.STRING), Matchers.is("app2"));
     }
+
+    /**
+     * Make sure we can get the correct number of jobs which are active for a given user.
+     *
+     * @throws GenieException on error
+     */
+    @Test
+    public void canGetActiveJobCountForUser() throws GenieException {
+        Assert.assertThat(this.service.getActiveJobCountForUser("nobody"), Matchers.is(0L));
+        Assert.assertThat(this.service.getActiveJobCountForUser("tgianos"), Matchers.is(2L));
+    }
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/properties/JobsUsersActiveLimitPropertiesUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/properties/JobsUsersActiveLimitPropertiesUnitTests.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.properties;
+
+import com.netflix.genie.test.categories.UnitTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Unit tests for JobsUsersActiveLimitProperties.
+ *
+ * @author mprimi
+ * @since 3.1.0
+ */
+@Category(UnitTest.class)
+public class JobsUsersActiveLimitPropertiesUnitTests {
+    private JobsUsersActiveLimitProperties properties;
+
+    /**
+     * Setup for the tests.
+     */
+    @Before
+    public void setup() {
+        this.properties = new JobsUsersActiveLimitProperties();
+    }
+
+    /**
+     * Make sure the constructor sets defaults.
+     */
+    @Test
+    public void canConstruct() {
+        Assert.assertEquals(JobsUsersActiveLimitProperties.DEFAULT_ENABLED, this.properties.isEnabled());
+        Assert.assertEquals(JobsUsersActiveLimitProperties.DEFAULT_COUNT, this.properties.getCount());
+    }
+
+    /**
+     * Make sure we can set the enabled field.
+     */
+    @Test
+    public void canSetEnabled() {
+        final boolean newEnabledValue = !this.properties.isEnabled();
+        this.properties.setEnabled(newEnabledValue);
+        Assert.assertEquals(newEnabledValue, this.properties.isEnabled());
+    }
+
+    /**
+     * Make sure we can set the count field.
+     */
+    @Test
+    public void canSetRunAsEnabled() {
+        final int newCountValue = 2 * this.properties.getCount();
+        this.properties.setCount(newCountValue);
+        Assert.assertEquals(newCountValue, this.properties.getCount());
+    }
+}

--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImplUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImplUnitTests.java
@@ -40,6 +40,7 @@ import com.netflix.genie.core.services.ClusterService;
 import com.netflix.genie.core.services.CommandService;
 import com.netflix.genie.core.services.JobKillService;
 import com.netflix.genie.core.services.JobPersistenceService;
+import com.netflix.genie.core.services.JobSearchService;
 import com.netflix.genie.core.services.JobStateService;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.spectator.api.Registry;
@@ -47,6 +48,7 @@ import com.netflix.spectator.api.Timer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.HashSet;
@@ -77,6 +79,7 @@ public class JobCoordinatorServiceImplUnitTests {
     private JobPersistenceService jobPersistenceService;
     private JobKillService jobKillService;
     private JobStateService jobStateService;
+    private JobSearchService jobSearchService;
     private ApplicationService applicationService;
     private ClusterService clusterService;
     private CommandService commandService;
@@ -91,6 +94,7 @@ public class JobCoordinatorServiceImplUnitTests {
         this.jobPersistenceService = Mockito.mock(JobPersistenceService.class);
         this.jobKillService = Mockito.mock(JobKillService.class);
         this.jobStateService = Mockito.mock(JobStateService.class);
+        this.jobSearchService = Mockito.mock(JobSearchService.class);
         this.jobsProperties = new JobsProperties();
         this.jobsProperties.getLocations().setArchives(BASE_ARCHIVE_LOCATION);
         this.jobsProperties.getMemory().setDefaultJobMemory(MEMORY);
@@ -108,6 +112,7 @@ public class JobCoordinatorServiceImplUnitTests {
             this.jobStateService,
             jobsProperties,
             this.applicationService,
+            this.jobSearchService,
             this.clusterService,
             this.commandService,
             this.clusterLoadBalancer,

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -100,13 +100,13 @@ rights for this to work.
 to work.
 |false
 
-|genie.jobs.users.activeJobsLimitEnabled
-|Enables the per-user active job limit. The number of jobs is controlled by the `genie.jobs.users.activeJobsLimit` property.
+|genie.jobs.users.activeLimit.enabled
+|Enables the per-user active job limit. The number of jobs is controlled by the `genie.jobs.users.activeLimit.count` property.
 |false
 
-|genie.jobs.users.activeJobsLimit
-|The maximum number of active jobs a user is allowed to have. Once a user hits this limit, jobs submitted are rejected. This is property is ignored unless `genie.jobs.users.activeJobsLimitEnabled` is set to true.
-|0
+|genie.jobs.users.activeLimit.count
+|The maximum number of active jobs a user is allowed to have. Once a user hits this limit, jobs submitted are rejected. This is property is ignored unless `genie.jobs.users.activeLimit.enabled` is set to true.
+|100
 
 |genie.leader.enabled
 |Whether this node should be the leader of the cluster or not. Should only be used if leadership is not being

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -100,6 +100,14 @@ rights for this to work.
 to work.
 |false
 
+|genie.jobs.users.activeJobsLimitEnabled
+|Enables the per-user active job limit. The number of jobs is controlled by the `genie.jobs.users.activeJobsLimit` property.
+|false
+
+|genie.jobs.users.activeJobsLimit
+|The maximum number of active jobs a user is allowed to have. Once a user hits this limit, jobs submitted are rejected. This is property is ignored unless `genie.jobs.users.activeJobsLimitEnabled` is set to true.
+|0
+
 |genie.leader.enabled
 |Whether this node should be the leader of the cluster or not. Should only be used if leadership is not being
 determined by Zookeeper or other mechanism via Spring

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -332,6 +332,7 @@ public class ServicesConfig {
      * @param jobPersistenceService implementation of job persistence service interface
      * @param jobKillService        The job kill service to use
      * @param jobStateService     The running job metrics service to use
+     * @param jobSearchService      Implementation of job search service interface
      * @param jobsProperties        The jobs properties to use
      * @param applicationService    Implementation of application service interface
      * @param clusterService        Implementation of cluster service interface
@@ -345,8 +346,8 @@ public class ServicesConfig {
     public JobCoordinatorService jobCoordinatorService(
         final JobPersistenceService jobPersistenceService,
         final JobKillService jobKillService,
-        @Qualifier("jobMonitoringCoordinator")
-        final JobStateService jobStateService,
+        @Qualifier("jobMonitoringCoordinator") final JobStateService jobStateService,
+        final JobSearchService jobSearchService,
         final JobsProperties jobsProperties,
         final ApplicationService applicationService,
         final ClusterService clusterService,
@@ -361,6 +362,7 @@ public class ServicesConfig {
             jobStateService,
             jobsProperties,
             applicationService,
+            jobSearchService,
             clusterService,
             commandService,
             clusterLoadBalancer,

--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -51,6 +51,8 @@ genie:
     users:
       creationEnabled: false
       runAsUserEnabled: false
+      activeJobsLimitEnabled: false
+      activeJobsLimit: 100 # Ignored unless enabled via activeJobsLimitEnabled
   leader:
     enabled: false
   mail:

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/PropertiesConfigIntegrationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/PropertiesConfigIntegrationTest.java
@@ -66,6 +66,8 @@ public class PropertiesConfigIntegrationTest {
         Assert.assertThat(jobsProperties.getMax().getStdOutSize(), Matchers.is(512L));
         Assert.assertThat(jobsProperties.getMemory().getMaxSystemMemory(), Matchers.is(1024));
         Assert.assertThat(jobsProperties.getUsers().isCreationEnabled(), Matchers.is(true));
+        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().isEnabled(), Matchers.is(true));
+        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getCount(), Matchers.is(15));
 
         Assert.assertNotNull(dataServiceRetryProperties);
         Assert.assertThat(dataServiceRetryProperties.getInitialInterval(), Matchers.is(200L));

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -232,6 +232,7 @@ public class ServicesConfigUnitTests {
                 Mockito.mock(JobPersistenceService.class),
                 Mockito.mock(JobKillService.class),
                 Mockito.mock(JobStateService.class),
+                Mockito.mock(JobSearchService.class),
                 new JobsProperties(),
                 Mockito.mock(ApplicationService.class),
                 Mockito.mock(ClusterService.class),

--- a/genie-web/src/test/resources/PropertiesConfigIntegrationTest.properties
+++ b/genie-web/src/test/resources/PropertiesConfigIntegrationTest.properties
@@ -19,6 +19,10 @@ genie.jobs.memory.maxSystemMemory = 1024
 # Jobs users properties
 genie.jobs.users.creationEnabled = true
 
+# Jobs users active limit properties
+genie.jobs.users.activeLimit.enabled = true
+genie.jobs.users.activeLimit.count = 15
+
 # Data service retry properties
 genie.data.service.retry.initialInterval = 200
 


### PR DESCRIPTION
Motivation:
Introduce a simple mechanism that allows administrators to set a upper limit to the number of jobs  users are allowed to concurrently run. The limit, if enabled, is applied to all users.
This mechanism is designed as a first line of defense against a user issuing an avalanche of job submissions (either maliciously (i.e. to cause denial of service), or unintentionally (i.e. client-side bug).

Change:
 * Implement database query that returns the number of active jobs for a given user (in `JPAJobSearchService`)
 * Introduce new properties to toggle and configure the per-user active jobs limit
 * Introduce new `GenieException` to model a user limit exceeded
 * Reject job submissions (in `JobCoordinationService`) if a user exceeded the limit

Note:
It is still possible for a user to issue more jobs than the limit.
For example, by issuing two jobs on two genie instances at exactly the same time, both of them will check the limit and let a job through, even if one one of them should have.