### PR TITLE
Test improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,12 @@ configure(javaProjects) {
         }
     }
 
+    test {
+        testLogging {
+            events "passed", "skipped", "failed"
+        }
+    }
+
     ext {
         generatedSourcesDir = new File("${projectDir}/src/generated")
         generatedSourcesJavaDir = new File(generatedSourcesDir, "/java")

--- a/genie-client/src/test/java/com/netflix/genie/client/JobClientIntegrationTests.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/JobClientIntegrationTests.java
@@ -589,7 +589,7 @@ public class JobClientIntegrationTests extends GenieClientsIntegrationTestsBase 
         reader1.close();
         inputStream1.close();
 
-        Assert.assertEquals("ls: foo: No such file or directory", sb.toString());
+        Assert.assertTrue(sb.toString().contains("No such file or directory"));
     }
 
     /**


### PR DESCRIPTION
JobClientIntegrationTests:
  * Remove flaky test that relies on timing (killing a job before it gets to RUNNING state).
  * Fix a job looking for a non-portable stderr message
  * Re-enable this class (removing `@Ignore` annotation)

Gradle:
  * Increase verbosity, list tests as they are executed
