### PR TITLE
Fix for handling lists of dicts in attributes.

### DIFF
--- a/genie-client/src/main/python/pygenie/utils.py
+++ b/genie-client/src/main/python/pygenie/utils.py
@@ -9,6 +9,7 @@ This module contains utility functions.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
+import json
 import logging
 import pkg_resources
 import six
@@ -144,7 +145,7 @@ def convert_to_unicode(value):
 def normalize_list(l):
     if not l:
         return ''
-    return "['{}']".format("', '".join(l))
+    return json.dumps(l)
 
 def unicodify(func):
     """

--- a/genie-client/src/main/python/setup.py
+++ b/genie-client/src/main/python/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='nflx-genie-client',
-    version='3.4.0',
+    version='3.4.1',
     author='Netflix Inc.',
     author_email='genieoss@googlegroups.com',
     keywords='genie hadoop cloud netflix client bigdata presto',

--- a/genie-client/src/main/python/tests/job_tests/test_geniejob.py
+++ b/genie-client/src/main/python/tests/job_tests/test_geniejob.py
@@ -121,10 +121,10 @@ class TestingGenieJobRepr(unittest.TestCase):
                 'parameter("param3", "pval3")',
                 'parameter("param4", "pval4")',
                 'post_cmd_args("post1")',
-                "post_cmd_args(['post2', 'post3'])",
+                'post_cmd_args(["post2", "post3"])',
                 'tags("tag1")',
                 'tags("tag2")',
-                "tags(['tag3', 'tag4'])"
+                'tags(["tag3", "tag4"])'
             ])
         )
 

--- a/genie-client/src/main/python/tests/job_tests/test_prestojob.py
+++ b/genie-client/src/main/python/tests/job_tests/test_prestojob.py
@@ -108,6 +108,22 @@ class TestingPrestoJob(unittest.TestCase):
 class TestingPrestoJobRepr(unittest.TestCase):
     """Test PrestoJob repr."""
 
+    def test_attachment_repr(self):
+        job = pygenie.jobs.PrestoJob() \
+            .dependencies([{"data": "blah", "name": "blah"}]) \
+            .job_id('prestojob_repr') \
+            .genie_username('testuser')
+
+        assert_equals(
+            str(job),
+            '.'.join([
+                'PrestoJob()',
+                'dependencies([{"data": "blah", "name": "blah"}])',
+                'genie_username("testuser")',
+                'job_id("prestojob_repr")'
+                ])
+        )
+
     @patch('pygenie.jobs.core.is_file')
     def test_repr(self, is_file):
         """Test PrestoJob repr."""


### PR DESCRIPTION
Handled this case:

```
pygenie.jobs.PrestoJob() \
    .dependencies([{"data": "blah", "name": "blah"}])
```

Which failed due to the list normalization.