### PR TITLE
Job failing initialization can get forever stuck in INIT state

### DIFF
--- a/genie-client/src/test/java/com/netflix/genie/client/JobClientIntegrationTests.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/JobClientIntegrationTests.java
@@ -30,7 +30,7 @@ import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
-import com.netflix.genie.common.dto.JobStatusMessage;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.common.dto.search.JobSearchResult;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
@@ -362,7 +362,7 @@ public class JobClientIntegrationTests extends GenieClientsIntegrationTestsBase 
 
         Assert.assertEquals(JobStatus.KILLED, jobStatus);
         Assert.assertEquals(
-            JobStatusMessage.JOB_KILLED_BY_USER,
+            JobStatusMessages.JOB_KILLED_BY_USER,
             jobClient.getJob(jobRequest1.getId().orElseThrow(IllegalArgumentException::new))
                 .getStatusMsg().orElseThrow(IllegalArgumentException::new)
         );

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessage.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessage.java
@@ -67,6 +67,39 @@ public final class JobStatusMessage {
     public static final String JOB_PROCESS_NOT_FOUND = "Couldn't check job process status.";
 
     /**
+     * Job PID terminated, exist status is yet to be verified.
+     */
+    public static final String PROCESS_DETECTED_TO_BE_COMPLETE = "Process detected to be complete";
+
+    /**
+     * Job is undefined intermediate state caused by a crash during setup.
+     */
+    public static final String SYSTEM_CRASHED_WHILE_JOB_STARTING = "System crashed while job starting";
+
+    /**
+     * Job was launched before Genie stopped, and it cannot be re-attached after restart.
+     */
+    public static final String UNABLE_TO_RE_ATTACH_ON_STARTUP = "Unable to re-attach on startup";
+
+    /**
+     * Job was killed by user before even starting.
+     */
+    public static final String USER_REQUESTED_JOB_BE_KILLED_DURING_INITIALIZATION =
+        "User requested job be killed during initialization";
+
+    /**
+     * Job precondition was not satisfied during initialization.
+     */
+    public static final String SUBMIT_PRECONDITION_FAILURE =
+        "Job validation failed, further details available in the job output directory";
+
+    /**
+     * Job failed with unexpected exception during initialization.
+     */
+    public static final String SUBMIT_INIT_FAILURE =
+        "Job initialization failed, further details available in the job output directory";
+
+    /**
      * Private constructor, this class is not meant to be instantiated.
      */
     private JobStatusMessage() {

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessages.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessages.java
@@ -23,7 +23,7 @@ package com.netflix.genie.common.dto;
  * @author mprimi
  * @since 3.0.7
  */
-public final class JobStatusMessage {
+public final class JobStatusMessages {
     //TODO this class could go away and we could fold this into JobStatus
 
     /**
@@ -102,6 +102,6 @@ public final class JobStatusMessage {
     /**
      * Private constructor, this class is not meant to be instantiated.
      */
-    private JobStatusMessage() {
+    private JobStatusMessages() {
     }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/events/JobFinishedEvent.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/events/JobFinishedEvent.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 /**
  * An event thrown when a job is completed.
@@ -45,7 +46,7 @@ public class JobFinishedEvent extends BaseJobEvent {
     public JobFinishedEvent(
         @NotEmpty final String id,
         @NotNull final JobFinishedReason reason,
-        @NotEmpty final String message,
+        @NotEmpty @Size(max = 255, min = 1) final String message,
         @NotNull final Object source
     ) {
         super(id, source);

--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/JobConstants.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/JobConstants.java
@@ -135,6 +135,11 @@ public final class JobConstants {
     public static final String GENIE_KILL_REASON_FILE_NAME = "genie/kill-reason";
 
     /**
+     * File created by Genie with details and trace for a job that failed to initialize.
+     **/
+    public static final String GENIE_INIT_FAILURE_MESSAGE_FILE_NAME = "init-failure-details";
+
+    /**
      * Genie log file path.
      **/
     public static final String GENIE_LOG_PATH = "/genie/logs/genie.log";

--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/JobConstants.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/JobConstants.java
@@ -137,7 +137,7 @@ public final class JobConstants {
     /**
      * File created by Genie with details and trace for a job that failed to initialize.
      **/
-    public static final String GENIE_INIT_FAILURE_MESSAGE_FILE_NAME = "init-failure-details";
+    public static final String GENIE_INIT_FAILURE_MESSAGE_FILE_NAME = "initFailureDetails.txt";
 
     /**
      * Genie log file path.

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobKillServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobKillServiceImpl.java
@@ -20,7 +20,7 @@ package com.netflix.genie.core.services.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobStatus;
-import com.netflix.genie.common.dto.JobStatusMessage;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
@@ -116,7 +116,7 @@ public class LocalJobKillServiceImpl implements JobKillService {
                 new JobFinishedEvent(
                     id,
                     JobFinishedReason.KILLED,
-                    JobStatusMessage.USER_REQUESTED_JOB_BE_KILLED_DURING_INITIALIZATION,
+                    JobStatusMessages.USER_REQUESTED_JOB_BE_KILLED_DURING_INITIALIZATION,
                     this
                 )
             );

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobKillServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobKillServiceImpl.java
@@ -20,6 +20,7 @@ package com.netflix.genie.core.services.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.common.dto.JobStatusMessage;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
@@ -115,7 +116,7 @@ public class LocalJobKillServiceImpl implements JobKillService {
                 new JobFinishedEvent(
                     id,
                     JobFinishedReason.KILLED,
-                    "User requested job be killed during initialization",
+                    JobStatusMessage.USER_REQUESTED_JOB_BE_KILLED_DURING_INITIALIZATION,
                     this
                 )
             );

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
@@ -22,6 +22,7 @@ import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.JobStatusMessage;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
@@ -188,13 +189,17 @@ public class LocalJobRunner implements JobSubmitterService {
             } catch (final GeniePreconditionException gpe) {
                 log.error(gpe.getMessage(), gpe);
                 this.eventMulticaster.multicastEvent(
-                    new JobFinishedEvent(id, JobFinishedReason.INVALID, gpe.getMessage(), this)
+                    new JobFinishedEvent(
+                        id, JobFinishedReason.INVALID, JobStatusMessage.SUBMIT_PRECONDITION_FAILURE, this
+                    )
                 );
                 throw gpe;
             } catch (final Exception e) {
                 log.error(e.getMessage(), e);
                 this.eventMulticaster.multicastEvent(
-                    new JobFinishedEvent(id, JobFinishedReason.FAILED_TO_INIT, e.getMessage(), this)
+                    new JobFinishedEvent(
+                        id, JobFinishedReason.FAILED_TO_INIT, JobStatusMessage.SUBMIT_INIT_FAILURE, this
+                    )
                 );
                 throw e;
             }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
@@ -22,7 +22,7 @@ import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobRequest;
-import com.netflix.genie.common.dto.JobStatusMessage;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
@@ -196,7 +196,7 @@ public class LocalJobRunner implements JobSubmitterService {
                 this.createInitFailureDetailsFile(id, gpe);
                 this.eventMulticaster.multicastEvent(
                     new JobFinishedEvent(
-                        id, JobFinishedReason.INVALID, JobStatusMessage.SUBMIT_PRECONDITION_FAILURE, this
+                        id, JobFinishedReason.INVALID, JobStatusMessages.SUBMIT_PRECONDITION_FAILURE, this
                     )
                 );
                 throw gpe;
@@ -205,7 +205,7 @@ public class LocalJobRunner implements JobSubmitterService {
                 this.createInitFailureDetailsFile(id, e);
                 this.eventMulticaster.multicastEvent(
                     new JobFinishedEvent(
-                        id, JobFinishedReason.FAILED_TO_INIT, JobStatusMessage.SUBMIT_INIT_FAILURE, this
+                        id, JobFinishedReason.FAILED_TO_INIT, JobStatusMessages.SUBMIT_INIT_FAILURE, this
                     )
                 );
                 throw e;

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -227,7 +228,7 @@ public class LocalJobRunner implements JobSubmitterService {
                 }
                 try (
                     final PrintWriter p = new PrintWriter(new OutputStreamWriter(
-                        new FileOutputStream(detailsFile), "UTF-8")
+                        new FileOutputStream(detailsFile), StandardCharsets.UTF_8)
                     )
                 ) {
                     p.format(" *** Initialization failure for job: %s ***%n"
@@ -318,7 +319,7 @@ public class LocalJobRunner implements JobSubmitterService {
 
     private JobExecution executeJob(final Map<String, Object> context, final File runScript) throws GenieException {
         final long start = System.nanoTime();
-        try (final Writer writer = new OutputStreamWriter(new FileOutputStream(runScript), "UTF-8")) {
+        try (final Writer writer = new OutputStreamWriter(new FileOutputStream(runScript), StandardCharsets.UTF_8)) {
             final String jobId = ((JobExecutionEnvironment) context.get(JobConstants.JOB_EXECUTION_ENV_KEY))
                 .getJobRequest()
                 .getId()

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalJobRunner.java
@@ -225,16 +225,17 @@ public class LocalJobRunner implements JobSubmitterService {
                 if (detailsFileExists) {
                     log.warn("Init failure details file exists");
                 }
-                try (final Writer writer = new OutputStreamWriter(new FileOutputStream(detailsFile), "UTF-8")) {
-
-                    writer.write("Job "  + id + " failed initialization due to: " + e.getMessage());
-                    writer.write(System.lineSeparator());
-                    writer.write("Exception: " + e.getClass().getCanonicalName());
-                    writer.write(System.lineSeparator());
-                    writer.write("Trace:");
-                    writer.write(System.lineSeparator());
-                    e.printStackTrace(new PrintWriter(writer));
-                    writer.write(System.lineSeparator());
+                try (
+                    final PrintWriter p = new PrintWriter(new OutputStreamWriter(
+                        new FileOutputStream(detailsFile), "UTF-8")
+                    )
+                ) {
+                    p.format(" *** Initialization failure for job: %s ***%n"
+                            + "%n"
+                            + "Exception: %s - %s%n"
+                            + "Trace:%n",
+                        id, e.getClass().getCanonicalName(), e.getMessage());
+                    e.printStackTrace(p);
                 }
                 log.info("Created init failure details file {}", detailsFile);
             } else {

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -23,7 +23,7 @@ import com.google.common.io.ByteStreams;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
-import com.netflix.genie.common.dto.JobStatusMessage;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.common.dto.search.JobSearchResult;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
@@ -562,7 +562,7 @@ public class JobRestController {
 
         log.info("Job {} is on this node. Attempting to kill.", id);
         // Job is on this node so try to kill it
-        this.jobCoordinatorService.killJob(id, JobStatusMessage.JOB_KILLED_BY_USER);
+        this.jobCoordinatorService.killJob(id, JobStatusMessages.JOB_KILLED_BY_USER);
         response.setStatus(HttpStatus.ACCEPTED.value());
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
@@ -25,7 +25,7 @@ import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
-import com.netflix.genie.common.dto.JobStatusMessage;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.core.events.JobFinishedEvent;
@@ -319,7 +319,7 @@ public class JobCompletionService {
                     JobKillReasonFile.class
                 ).getKillReason();
             } else {
-                 killedStatusMessages = JobStatusMessage.JOB_KILLED_BY_USER;
+                 killedStatusMessages = JobStatusMessages.JOB_KILLED_BY_USER;
             }
             final int exitCode = jobDoneFile.getExitCode();
             // Read the size of STD OUT and STD ERR files
@@ -345,7 +345,7 @@ public class JobCompletionService {
                         id,
                         exitCode,
                         JobStatus.SUCCEEDED,
-                        JobStatusMessage.JOB_FINISHED_SUCCESSFULLY,
+                        JobStatusMessages.JOB_FINISHED_SUCCESSFULLY,
                         stdOutSize,
                         stdErrSize
                     );
@@ -357,7 +357,7 @@ public class JobCompletionService {
                         id,
                         exitCode,
                         JobStatus.FAILED,
-                        JobStatusMessage.JOB_FAILED,
+                        JobStatusMessages.JOB_FAILED,
                         stdOutSize,
                         stdErrSize
                     );
@@ -373,7 +373,7 @@ public class JobCompletionService {
             this.jobPersistenceService.updateJobStatus(
                 id,
                 JobStatus.FAILED,
-                JobStatusMessage.COULD_NOT_LOAD_DONE_FILE
+                JobStatusMessages.COULD_NOT_LOAD_DONE_FILE
             );
             return JobStatus.FAILED;
         }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitor.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitor.java
@@ -166,7 +166,7 @@ public class JobMonitor extends NodeTask {
                 new JobFinishedEvent(
                     this.id,
                     JobFinishedReason.PROCESS_COMPLETED,
-                    "Process detected to be complete",
+                    JobStatusMessage.PROCESS_DETECTED_TO_BE_COMPLETE,
                     this
                 )
             );

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitor.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitor.java
@@ -18,7 +18,7 @@
 package com.netflix.genie.web.tasks.job;
 
 import com.netflix.genie.common.dto.JobExecution;
-import com.netflix.genie.common.dto.JobStatusMessage;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.common.exceptions.GenieTimeoutException;
 import com.netflix.genie.core.events.JobFinishedEvent;
 import com.netflix.genie.core.events.JobFinishedReason;
@@ -140,7 +140,7 @@ public class JobMonitor extends NodeTask {
 
             if (this.stdOut.exists() && this.stdOut.length() > this.maxStdOutLength) {
                 this.publisher.publishEvent(
-                    new KillJobEvent(this.id, JobStatusMessage.JOB_EXCEEDED_STDOUT_LENGTH, this)
+                    new KillJobEvent(this.id, JobStatusMessages.JOB_EXCEEDED_STDOUT_LENGTH, this)
                 );
                 this.stdOutTooLarge.increment();
                 return;
@@ -148,7 +148,7 @@ public class JobMonitor extends NodeTask {
 
             if (this.stdErr.exists() && this.stdErr.length() > this.maxStdErrLength) {
                 this.publisher.publishEvent(
-                    new KillJobEvent(this.id, JobStatusMessage.JOB_EXCEEDED_STDERR_LENGTH, this)
+                    new KillJobEvent(this.id, JobStatusMessages.JOB_EXCEEDED_STDERR_LENGTH, this)
                 );
                 this.stdErrTooLarge.increment();
                 return;
@@ -158,7 +158,7 @@ public class JobMonitor extends NodeTask {
         } catch (final GenieTimeoutException gte) {
             log.info("Job {} has timed out", this.execution.getId(), gte);
             this.timeoutRate.increment();
-            this.publisher.publishEvent(new KillJobEvent(this.id, JobStatusMessage.JOB_EXCEEDED_TIMEOUT, this));
+            this.publisher.publishEvent(new KillJobEvent(this.id, JobStatusMessages.JOB_EXCEEDED_TIMEOUT, this));
         } catch (final ExecuteException ee) {
             log.info("Job {} has finished", this.id);
             this.finishedRate.increment();
@@ -166,7 +166,7 @@ public class JobMonitor extends NodeTask {
                 new JobFinishedEvent(
                     this.id,
                     JobFinishedReason.PROCESS_COMPLETED,
-                    JobStatusMessage.PROCESS_DETECTED_TO_BE_COMPLETE,
+                    JobStatusMessages.PROCESS_DETECTED_TO_BE_COMPLETE,
                     this
                 )
             );
@@ -185,7 +185,7 @@ public class JobMonitor extends NodeTask {
                 this.publisher.publishEvent(
                     new KillJobEvent(
                         this.id,
-                        JobStatusMessage.JOB_PROCESS_NOT_FOUND,
+                        JobStatusMessages.JOB_PROCESS_NOT_FOUND,
                         this
                     )
                 );
@@ -194,7 +194,7 @@ public class JobMonitor extends NodeTask {
                     new JobFinishedEvent(
                         this.id,
                         JobFinishedReason.KILLED,
-                        JobStatusMessage.JOB_PROCESS_NOT_FOUND,
+                        JobStatusMessages.JOB_PROCESS_NOT_FOUND,
                         this
                     )
                 );

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.tasks.job;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.common.dto.JobStatusMessage;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.core.events.JobFinishedEvent;
@@ -163,7 +164,9 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
                 log.info("Job {} is already being tracked. Ignoring.", id);
             } else if (job.getStatus() != JobStatus.RUNNING) {
                 this.eventMulticaster.multicastEvent(
-                    new JobFinishedEvent(id, JobFinishedReason.SYSTEM_CRASH, "System crashed while job starting", this)
+                    new JobFinishedEvent(
+                        id, JobFinishedReason.SYSTEM_CRASH, JobStatusMessage.SYSTEM_CRASHED_WHILE_JOB_STARTING, this
+                    )
                 );
             } else {
                 try {
@@ -174,7 +177,9 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
                 } catch (final GenieException ge) {
                     log.error("Unable to re-attach to job {}.", id);
                     this.eventMulticaster.multicastEvent(
-                        new JobFinishedEvent(id, JobFinishedReason.SYSTEM_CRASH, "Unable to re-attach on startup", this)
+                        new JobFinishedEvent(
+                            id, JobFinishedReason.SYSTEM_CRASH, JobStatusMessage.UNABLE_TO_RE_ATTACH_ON_STARTUP, this
+                        )
                     );
                     this.unableToReAttach.increment();
                 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
@@ -20,7 +20,7 @@ package com.netflix.genie.web.tasks.job;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobStatus;
-import com.netflix.genie.common.dto.JobStatusMessage;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.core.events.JobFinishedEvent;
@@ -165,7 +165,7 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
             } else if (job.getStatus() != JobStatus.RUNNING) {
                 this.eventMulticaster.multicastEvent(
                     new JobFinishedEvent(
-                        id, JobFinishedReason.SYSTEM_CRASH, JobStatusMessage.SYSTEM_CRASHED_WHILE_JOB_STARTING, this
+                        id, JobFinishedReason.SYSTEM_CRASH, JobStatusMessages.SYSTEM_CRASHED_WHILE_JOB_STARTING, this
                     )
                 );
             } else {
@@ -178,7 +178,7 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
                     log.error("Unable to re-attach to job {}.", id);
                     this.eventMulticaster.multicastEvent(
                         new JobFinishedEvent(
-                            id, JobFinishedReason.SYSTEM_CRASH, JobStatusMessage.UNABLE_TO_RE_ATTACH_ON_STARTUP, this
+                            id, JobFinishedReason.SYSTEM_CRASH, JobStatusMessages.UNABLE_TO_RE_ATTACH_ON_STARTUP, this
                         )
                     );
                     this.unableToReAttach.increment();

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
@@ -29,7 +29,7 @@ import com.netflix.genie.common.dto.CommandStatus;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
-import com.netflix.genie.common.dto.JobStatusMessage;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.core.jpa.repositories.JpaApplicationRepository;
 import com.netflix.genie.core.jpa.repositories.JpaClusterRepository;
 import com.netflix.genie.core.jpa.repositories.JpaCommandRepository;
@@ -125,7 +125,7 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
     private static final String JOB_USER = "genie";
     private static final String JOB_VERSION = "1.0";
     private static final String JOB_DESCRIPTION = "Genie 3 Test Job";
-    private static final String JOB_STATUS_MSG = JobStatusMessage.JOB_FINISHED_SUCCESSFULLY;
+    private static final String JOB_STATUS_MSG = JobStatusMessages.JOB_FINISHED_SUCCESSFULLY;
 
     private static final String APP1_ID = "app1";
     private static final String APP1_NAME = "Application 1";
@@ -1140,7 +1140,7 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
             .andExpect(MockMvcResultMatchers.jsonPath(ID_PATH, Matchers.is(jobId)))
             .andExpect(MockMvcResultMatchers.jsonPath(STATUS_PATH, Matchers.is(JobStatus.KILLED.toString())))
             .andExpect(MockMvcResultMatchers.jsonPath(
-                STATUS_MESSAGE_PATH, Matchers.is(JobStatusMessage.JOB_KILLED_BY_USER)
+                STATUS_MESSAGE_PATH, Matchers.is(JobStatusMessages.JOB_KILLED_BY_USER)
             ));
 
         // Kill the job again to make sure it doesn't cause a problem.
@@ -1260,7 +1260,7 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
             .andExpect(MockMvcResultMatchers.content().contentType(MediaTypes.HAL_JSON))
             .andExpect(MockMvcResultMatchers.jsonPath(ID_PATH, Matchers.is(id)))
             .andExpect(MockMvcResultMatchers.jsonPath(STATUS_PATH, Matchers.is(JobStatus.FAILED.toString())))
-            .andExpect(MockMvcResultMatchers.jsonPath(STATUS_MESSAGE_PATH, Matchers.is(JobStatusMessage.JOB_FAILED)));
+            .andExpect(MockMvcResultMatchers.jsonPath(STATUS_MESSAGE_PATH, Matchers.is(JobStatusMessages.JOB_FAILED)));
     }
 
     private String getIdFromLocation(final String location) {

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitorUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitorUnitTests.java
@@ -18,7 +18,7 @@
 package com.netflix.genie.web.tasks.job;
 
 import com.netflix.genie.common.dto.JobExecution;
-import com.netflix.genie.common.dto.JobStatusMessage;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.core.events.JobFinishedEvent;
 import com.netflix.genie.core.events.KillJobEvent;
 import com.netflix.genie.core.jobs.JobConstants;
@@ -302,7 +302,7 @@ public class JobMonitorUnitTests {
             captor.getValue().getId(),
             Matchers.is(jobId)
         );
-        Assert.assertThat(captor.getValue().getReason(), Matchers.is(JobStatusMessage.JOB_EXCEEDED_TIMEOUT));
+        Assert.assertThat(captor.getValue().getReason(), Matchers.is(JobStatusMessages.JOB_EXCEEDED_TIMEOUT));
         Assert.assertThat(captor.getValue().getSource(), Matchers.is(this.monitor));
         Mockito.verify(this.timeoutRate, Mockito.times(1)).increment();
     }


### PR DESCRIPTION
A job failing during initialization can emit a JobFinishedEvent with a 'statusMsg' field exceeding the database 256 character limit for the same field.
This causes the job status change to fail to persist and results in the job being stuck in INIT state forever.

This change consists of the following:
 - Centralize "status messages" used over the project into a static set (in JobStatusMessage)
 - Where applicable, leave behind a file with the detailed trace of the error, for the user to inspect
