### PR TITLE
Fix handling of Optional job 'description' in email notification

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
@@ -537,8 +537,8 @@ public class JobCompletionService {
                 .append("Name: [" + jobRequest.getName() + "]\n")
                 .append("Status: [" + status + "]\n")
                 .append("User: [" + jobRequest.getUser() + "]\n")
-                .append("Description: [" + jobRequest.getDescription() + "]\n")
                 .append("Tags: " + jobRequest.getTags() + "\n");
+            jobRequest.getDescription().ifPresent(description -> body.append("[" + description + "]"));
 
             this.mailServiceImpl.sendEmail(
                 email.get(),


### PR DESCRIPTION
The optional 'description' attribute of a job is being serialized as "Optional[...]" in email notifications body.
Strip the Optional box when composing the message.