### PR TITLE
Code and documentation cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,12 +179,12 @@ configure(javaProjects) {
     }
 
     compileJava {
-//        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
         options.incremental = true
     }
 
     compileTestJava {
-//        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
     }
 
     tasks.withType(Test) {

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/S3FileTransferImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/S3FileTransferImpl.java
@@ -17,7 +17,7 @@
  */
 package com.netflix.genie.core.services.impl;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -47,7 +47,7 @@ public class S3FileTransferImpl implements FileTransfer {
 
     private final Pattern s3FilePattern = Pattern.compile("^(s3[n]?://)(.*?)/(.*/.*)");
     private final Pattern s3PrefixPattern = Pattern.compile("^s3[n]?://.*$");
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
     private Timer downloadTimer;
     private Timer uploadTimer;
     private Timer getTimer;
@@ -58,7 +58,7 @@ public class S3FileTransferImpl implements FileTransfer {
      * @param amazonS3Client An amazon s3 client object
      * @param registry       The metrics registry to use
      */
-    public S3FileTransferImpl(@NotNull final AmazonS3Client amazonS3Client, @NotNull final Registry registry) {
+    public S3FileTransferImpl(@NotNull final AmazonS3 amazonS3Client, @NotNull final Registry registry) {
         this.s3Client = amazonS3Client;
         this.downloadTimer = registry.timer("genie.files.s3.download.timer");
         this.uploadTimer = registry.timer("genie.files.s3.upload.timer");

--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/FileSystemAttachmentServiceUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/FileSystemAttachmentServiceUnitTests.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -153,7 +154,11 @@ public class FileSystemAttachmentServiceUnitTests {
         FileInputStream fis = null;
         try {
             final File attachment = this.folder.newFile(UUID.randomUUID().toString() + ".q");
-            FileUtils.write(attachment, "SELECT * FROM my_table WHERE id = '" + UUID.randomUUID().toString() + "';");
+            FileUtils.write(
+                attachment,
+                "SELECT * FROM my_table WHERE id = '" + UUID.randomUUID().toString() + "';",
+                Charset.forName("UTF-8")
+            );
             fis = new FileInputStream(attachment);
             this.service.save(jobId, attachment.getName(), fis);
             return attachment;

--- a/genie-docs/src/docs/asciidoc/concepts/_howItWorks.adoc
+++ b/genie-docs/src/docs/asciidoc/concepts/_howItWorks.adoc
@@ -85,6 +85,9 @@ If no match is found for the first `ClusterCriteria` and `commandCriteria` combi
 and so on until all options are exhausted. This is handy if it is desirable to run a job on some cluster that is only
 up some of the time but other times it isn't and its fine to run it on some other cluster that is always available.
 
+NOTE: Only clusters with status `UP` and commands with status `ACTIVE` will be considered during the selection process
+all others are ignored.
+
 ====== Cluster matching example
 
 Say the following 3 clusters exists tagged as follows:
@@ -128,14 +131,15 @@ HadoopTestCluster:
 
 | `[type:presto, ver:0.150], [type:presto]`
 | PrestoTestCluster
-| The first criteria does not match any cluster, so fallback happens to the second, less restrictive criteria ("any presto cluster").
+| The first criteria does not match any cluster, so fallback happens to the second, less restrictive criteria
+("any presto cluster").
 
 |===
 
 ===== User Submits a Job Request
 
-There are other things a user needs to consider when submitting a job. All dependencies which aren't sent as attachments must
-already be uploaded somewhere Genie can access them. Somewhere like S3, web server, shared disk, etc.
+There are other things a user needs to consider when submitting a job. All dependencies which aren't sent as attachments
+must already be uploaded somewhere Genie can access them. Somewhere like S3, web server, shared disk, etc.
 
 Users should familiarize themselves with whatever the `executable` for their desired command includes. It's possible
 the system admin has setup some default parameters they should know are there so as to avoid duplication or unexpected

--- a/genie-docs/src/docs/asciidoc/concepts/_netflixDeployment.adoc
+++ b/genie-docs/src/docs/asciidoc/concepts/_netflixDeployment.adoc
@@ -77,6 +77,6 @@ See the Spinnaker site for more information.
 
 ==== Wrap Up
 
-This section focussed on how Genie is deployed within Netflix. Hopefully it helps bring clarity to a way that Genie can
+This section focused on how Genie is deployed within Netflix. Hopefully it helps bring clarity to a way that Genie can
 be deployed. Genie certainly is not limited to this deployment model and you are free to come up with your own this
 should only serve as a template or example.

--- a/genie-web/src/docs/asciidoc/api/clusters/_deleteCluster.adoc
+++ b/genie-web/src/docs/asciidoc/api/clusters/_deleteCluster.adoc
@@ -4,6 +4,9 @@
 
 Delete a cluster currently configured in the system.
 
+NOTE: You won't be able to delete a cluster that has run any job that is still in the system to maintain the ability
+for users to look up information about their job (where it ran, etc)
+
 ==== Endpoint
 
 `DELETE /api/v3/clusters/{id}`

--- a/genie-web/src/docs/asciidoc/api/clusters/_deleteClusters.adoc
+++ b/genie-web/src/docs/asciidoc/api/clusters/_deleteClusters.adoc
@@ -4,6 +4,9 @@
 
 Delete all the clusters currently stored in the system.
 
+NOTE: You won't be able to delete any cluster that has run any job that is still in the system to maintain the ability
+for users to look up information about their job (where it ran, etc)
+
 ==== Endpoint
 
 `DELETE /api/v3/clusters`

--- a/genie-web/src/docs/asciidoc/api/commands/_deleteCommand.adoc
+++ b/genie-web/src/docs/asciidoc/api/commands/_deleteCommand.adoc
@@ -4,6 +4,9 @@
 
 Delete a command currently configured in the system.
 
+NOTE: You won't be able to delete a command that has been used by any job that is still in the system to maintain the
+ability for users to look up information about their job (where it ran, what it ran, etc)
+
 ==== Endpoint
 
 `DELETE /api/v3/commands/{id}`

--- a/genie-web/src/docs/asciidoc/api/commands/_deleteCommands.adoc
+++ b/genie-web/src/docs/asciidoc/api/commands/_deleteCommands.adoc
@@ -4,6 +4,9 @@
 
 Delete all the commands currently stored in the system.
 
+NOTE: You won't be able to delete any command that has been used by any job that is still in the system to maintain the
+ability for users to look up information about their job (where it ran, what it ran, etc)
+
 ==== Endpoint
 
 `DELETE /api/v3/commands`

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ApplicationRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ApplicationRestController.java
@@ -41,10 +41,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -94,7 +98,7 @@ public class ApplicationRestController {
      * @return The created application configuration
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> createApplication(@RequestBody final Application app) throws GenieException {
         log.debug("Called to create new application");
@@ -115,7 +119,7 @@ public class ApplicationRestController {
      *
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.DELETE)
+    @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteAllApplications() throws GenieException {
         log.debug("Delete all Applications");
@@ -135,7 +139,7 @@ public class ApplicationRestController {
      * @return All applications matching the criteria
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public PagedResources<ApplicationResource> getApplications(
         @RequestParam(value = "name", required = false) final String name,
@@ -177,7 +181,7 @@ public class ApplicationRestController {
      * @return The application configuration
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public ApplicationResource getApplication(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called to get Application for id {}", id);
@@ -191,7 +195,7 @@ public class ApplicationRestController {
      * @param updateApp contains the application information to update
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateApplication(
         @PathVariable("id") final String id,
@@ -208,7 +212,7 @@ public class ApplicationRestController {
      * @param patch The JSON Patch instructions
      * @throws GenieException On error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.PATCH, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void patchApplication(
         @PathVariable("id") final String id,
@@ -224,7 +228,7 @@ public class ApplicationRestController {
      * @param id unique id of configuration to delete
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteApplication(@PathVariable("id") final String id) throws GenieException {
         log.debug("Delete an application with id {}", id);
@@ -239,7 +243,7 @@ public class ApplicationRestController {
      * @param configs The configuration files to add. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/{id}/configs", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addConfigsToApplication(
         @PathVariable("id") final String id,
@@ -257,7 +261,7 @@ public class ApplicationRestController {
      * @return The active set of configuration files.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{id}/configs", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getConfigsForApplication(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -273,7 +277,7 @@ public class ApplicationRestController {
      *                files with. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}/configs", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateConfigsForApplication(
         @PathVariable("id") final String id,
@@ -290,7 +294,7 @@ public class ApplicationRestController {
      *           from. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/configs")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllConfigsForApplication(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -305,9 +309,7 @@ public class ApplicationRestController {
      * @param dependencies The dependency files to add. Not null.
      * @throws GenieException For any error
      */
-    @RequestMapping(
-        value = "/{id}/dependencies", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE
-    )
+    @PostMapping(value = "/{id}/dependencies", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addDependenciesForApplication(
         @PathVariable("id") final String id,
@@ -325,9 +327,7 @@ public class ApplicationRestController {
      * @return The set of dependency files.
      * @throws GenieException For any error
      */
-    @RequestMapping(
-        value = "/{id}/dependencies", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE
-    )
+    @GetMapping(value = "/{id}/dependencies", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getDependenciesForApplication(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -343,9 +343,7 @@ public class ApplicationRestController {
      *                     null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(
-        value = "/{id}/dependencies", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE
-    )
+    @PutMapping(value = "/{id}/dependencies", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateDependenciesForApplication(
         @PathVariable("id") final String id,
@@ -362,7 +360,7 @@ public class ApplicationRestController {
      *           null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/dependencies", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/dependencies")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllDependenciesForApplication(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -377,7 +375,7 @@ public class ApplicationRestController {
      * @param tags The tags to add. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/{id}/tags", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addTagsForApplication(
         @PathVariable("id") final String id,
@@ -395,7 +393,7 @@ public class ApplicationRestController {
      * @return The active set of tags.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{id}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getTagsForApplication(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -411,7 +409,7 @@ public class ApplicationRestController {
      *             files with. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}/tags", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateTagsForApplication(
         @PathVariable("id") final String id,
@@ -428,7 +426,7 @@ public class ApplicationRestController {
      *           Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/tags")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllTagsForApplication(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -443,7 +441,7 @@ public class ApplicationRestController {
      * @param tag The tag to remove. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags/{tag}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/tags/{tag}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeTagForApplication(
         @PathVariable("id") final String id,
@@ -462,7 +460,7 @@ public class ApplicationRestController {
      * @return The set of commands.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/commands", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}/commands", produces = MediaTypes.HAL_JSON_VALUE)
     public Set<CommandResource> getCommandsForApplication(
         @PathVariable("id") final String id,
         @RequestParam(value = "status", required = false) final Set<String> statuses

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
@@ -41,10 +41,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -97,7 +101,7 @@ ClusterRestController {
      * @return The created cluster
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> createCluster(@RequestBody final Cluster cluster) throws GenieException {
         log.debug("Called to create new cluster {}", cluster);
@@ -120,7 +124,7 @@ ClusterRestController {
      * @return the cluster
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public ClusterResource getCluster(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id: {}", id);
@@ -141,7 +145,7 @@ ClusterRestController {
      * @return the Clusters found matching the criteria
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public PagedResources<ClusterResource> getClusters(
         @RequestParam(value = "name", required = false) final String name,
@@ -200,7 +204,7 @@ ClusterRestController {
      * @param updateCluster contains the cluster information to update
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateCluster(
         @PathVariable("id") final String id,
@@ -215,9 +219,9 @@ ClusterRestController {
      *
      * @param id    The id of the cluster to patch
      * @param patch The JSON Patch instructions
-     * @throws GenieException     On error
+     * @throws GenieException On error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.PATCH, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void patchCluster(
         @PathVariable("id") final String id,
@@ -233,7 +237,7 @@ ClusterRestController {
      * @param id unique id for cluster to delete
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteCluster(@PathVariable("id") final String id) throws GenieException {
         log.debug("Delete called for id: {}", id);
@@ -245,7 +249,7 @@ ClusterRestController {
      *
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.DELETE)
+    @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteAllClusters() throws GenieException {
         log.debug("called");
@@ -260,7 +264,7 @@ ClusterRestController {
      * @param configs The configuration files to add. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/{id}/configs", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addConfigsForCluster(
         @PathVariable("id") final String id,
@@ -278,7 +282,7 @@ ClusterRestController {
      * @return The active set of configuration files.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{id}/configs", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getConfigsForCluster(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -294,7 +298,7 @@ ClusterRestController {
      *                files with. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}/configs", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateConfigsForCluster(
         @PathVariable("id") final String id,
@@ -311,7 +315,7 @@ ClusterRestController {
      *           Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/configs")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllConfigsForCluster(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -326,7 +330,7 @@ ClusterRestController {
      * @param tags The tags to add. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/{id}/tags", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addTagsForCluster(
         @PathVariable("id") final String id,
@@ -344,7 +348,7 @@ ClusterRestController {
      * @return The active set of tags.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{id}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getTagsForCluster(
         @PathVariable("id") final String id
@@ -362,7 +366,7 @@ ClusterRestController {
      *             files with. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}/tags", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateTagsForCluster(
         @PathVariable("id") final String id,
@@ -379,7 +383,7 @@ ClusterRestController {
      *           Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/tags")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllTagsForCluster(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -394,7 +398,7 @@ ClusterRestController {
      * @param tag The tag to remove. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags/{tag}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/tags/{tag}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeTagForCluster(
         @PathVariable("id") final String id,
@@ -412,7 +416,7 @@ ClusterRestController {
      * @param commandIds The ids of the commandIds to add. Not null.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/commands", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/{id}/commands", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addCommandsForCluster(
         @PathVariable("id") final String id,
@@ -431,7 +435,7 @@ ClusterRestController {
      * @return The active set of commandIds for the cluster.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/commands", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}/commands", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public List<CommandResource> getCommandsForCluster(
         @PathVariable("id") final String id,
@@ -462,7 +466,7 @@ ClusterRestController {
      *                   null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/commands", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}/commands", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void setCommandsForCluster(
         @PathVariable("id") final String id,
@@ -479,7 +483,7 @@ ClusterRestController {
      *           null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/commands", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/commands")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllCommandsForCluster(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -494,7 +498,7 @@ ClusterRestController {
      * @param commandId The id of the command to remove. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/commands/{commandId}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/commands/{commandId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeCommandForCluster(
         @PathVariable("id") final String id,

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/CommandRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/CommandRestController.java
@@ -43,10 +43,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -79,7 +83,7 @@ public class CommandRestController {
      *
      * @param commandService               The command configuration service to use.
      * @param commandResourceAssembler     The assembler to use to convert commands to command HAL resources
-     * @param applicationResourceAssembler The assembler to use to convert applicaitons to application HAL resources
+     * @param applicationResourceAssembler The assembler to use to convert applications to application HAL resources
      * @param clusterResourceAssembler     The assembler to use to convert clusters to cluster HAL resources
      */
     @Autowired
@@ -102,7 +106,7 @@ public class CommandRestController {
      * @return The command created
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> createCommand(@RequestBody final Command command) throws GenieException {
         log.debug("called to create new command configuration {}", command);
@@ -125,7 +129,7 @@ public class CommandRestController {
      * @return The command configuration
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public CommandResource getCommand(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called to get command with id {}", id);
@@ -144,7 +148,7 @@ public class CommandRestController {
      * @return All the Commands matching the criteria or all if no criteria
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public PagedResources<CommandResource> getCommands(
         @RequestParam(value = "name", required = false) final String name,
@@ -194,7 +198,7 @@ public class CommandRestController {
      * @param updateCommand the information to update the command with
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateCommand(
         @PathVariable("id") final String id,
@@ -211,7 +215,7 @@ public class CommandRestController {
      * @param patch The JSON Patch instructions
      * @throws GenieException On error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.PATCH, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void patchCommand(
         @PathVariable("id") final String id,
@@ -226,7 +230,7 @@ public class CommandRestController {
      *
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.DELETE)
+    @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteAllCommands() throws GenieException {
         log.debug("called to delete all commands.");
@@ -239,7 +243,7 @@ public class CommandRestController {
      * @param id unique id for configuration to delete
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteCommand(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called to delete command with id {}", id);
@@ -254,7 +258,7 @@ public class CommandRestController {
      * @param configs The configuration files to add. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/{id}/configs", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addConfigsForCommand(
         @PathVariable("id") final String id,
@@ -272,7 +276,7 @@ public class CommandRestController {
      * @return The active set of configuration files.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{id}/configs", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getConfigsForCommand(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -288,7 +292,7 @@ public class CommandRestController {
      *                files with. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}/configs", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateConfigsForCommand(
         @PathVariable("id") final String id,
@@ -305,7 +309,7 @@ public class CommandRestController {
      *           Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/configs", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/configs")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllConfigsForCommand(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -320,7 +324,7 @@ public class CommandRestController {
      * @param tags The tags to add. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/{id}/tags", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addTagsForCommand(
         @PathVariable("id") final String id,
@@ -338,7 +342,7 @@ public class CommandRestController {
      * @return The active set of tags.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{id}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getTagsForCommand(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -354,7 +358,7 @@ public class CommandRestController {
      *             files with. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/{id}/tags", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateTagsForCommand(
         @PathVariable("id") final String id,
@@ -371,7 +375,7 @@ public class CommandRestController {
      *           Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/tags")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllTagsForCommand(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
@@ -386,7 +390,7 @@ public class CommandRestController {
      * @param tag The tag to remove. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/tags/{tag}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/tags/{tag}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeTagForCommand(
         @PathVariable("id") final String id,
@@ -404,9 +408,7 @@ public class CommandRestController {
      * @param applicationIds The ids of the applications to add. Not null.
      * @throws GenieException For any error
      */
-    @RequestMapping(
-        value = "/{id}/applications", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE
-    )
+    @PostMapping(value = "/{id}/applications", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addApplicationsForCommand(
         @PathVariable("id") final String id,
@@ -424,7 +426,7 @@ public class CommandRestController {
      * @return The active applications for the command.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/applications", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}/applications", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public List<ApplicationResource> getApplicationsForCommand(
         @PathVariable("id") final String id
@@ -444,9 +446,7 @@ public class CommandRestController {
      * @param applicationIds The ids of the applications to set in order. Not null.
      * @throws GenieException For any error
      */
-    @RequestMapping(
-        value = "/{id}/applications", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE
-    )
+    @PutMapping(value = "/{id}/applications", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void setApplicationsForCommand(
         @PathVariable("id") final String id,
@@ -463,7 +463,7 @@ public class CommandRestController {
      *           null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/applications", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/applications")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllApplicationsForCommand(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id '{}'.", id);
@@ -478,7 +478,7 @@ public class CommandRestController {
      * @param appId The id of the application to remove from the command. Not null/empty/blank.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/applications/{appId}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}/applications/{appId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeApplicationForCommand(
         @PathVariable("id") final String id,
@@ -497,7 +497,7 @@ public class CommandRestController {
      * @return The list of clusters.
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}/clusters", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}/clusters", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<ClusterResource> getClustersForCommand(
         @PathVariable("id") final String id,

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -69,11 +69,13 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -203,7 +205,7 @@ public class JobRestController {
      * @return The submitted job
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResponseEntity<Void> submitJob(
         @Valid
@@ -231,7 +233,7 @@ public class JobRestController {
      * @return The submitted job
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.POST, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResponseEntity<Void> submitJob(
         @Valid
@@ -349,7 +351,7 @@ public class JobRestController {
      * @return the Job
      * @throws GenieException For any error
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}", produces = MediaTypes.HAL_JSON_VALUE)
     public JobResource getJob(
         @PathVariable("id")
         final String id) throws GenieException {
@@ -364,7 +366,7 @@ public class JobRestController {
      * @return The status of the job as one of: {@link JobStatus}
      * @throws GenieException on error
      */
-    @RequestMapping(value = "/{id}/status", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{id}/status", produces = MediaType.APPLICATION_JSON_VALUE)
     public JsonNode getJobStatus(
         @PathVariable("id")
         final String id) throws GenieException {
@@ -396,7 +398,7 @@ public class JobRestController {
      * @return successful response, or one with HTTP error code
      * @throws GenieException For any error
      */
-    @RequestMapping(method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public PagedResources<JobSearchResultResource> findJobs(
         @RequestParam(value = "id", required = false)
@@ -519,7 +521,7 @@ public class JobRestController {
      * @throws IOException      on redirect error
      * @throws ServletException when trying to handle the request
      */
-    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void killJob(
         @PathVariable("id")
@@ -573,7 +575,7 @@ public class JobRestController {
      * @return The job request
      * @throws GenieException On any internal error
      */
-    @RequestMapping(value = "/{id}/request", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}/request", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public JobRequestResource getJobRequest(
         @PathVariable("id")
@@ -589,7 +591,7 @@ public class JobRestController {
      * @return The job execution
      * @throws GenieException On any internal error
      */
-    @RequestMapping(value = "/{id}/execution", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}/execution", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public JobExecutionResource getJobExecution(
         @PathVariable("id")
@@ -606,7 +608,7 @@ public class JobRestController {
      * @return The cluster
      * @throws GenieException Usually GenieNotFound exception when either the job or the cluster aren't found
      */
-    @RequestMapping(value = "/{id}/cluster", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}/cluster", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public ClusterResource getJobCluster(
         @PathVariable("id")
@@ -623,7 +625,7 @@ public class JobRestController {
      * @return The command
      * @throws GenieException Usually GenieNotFound exception when either the job or the command aren't found
      */
-    @RequestMapping(value = "/{id}/command", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}/command", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public CommandResource getJobCommand(
         @PathVariable("id")
@@ -639,7 +641,7 @@ public class JobRestController {
      * @return The applications
      * @throws GenieException Usually GenieNotFound exception when either the job or the applications aren't found
      */
-    @RequestMapping(value = "/{id}/applications", method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(value = "/{id}/applications", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public List<ApplicationResource> getJobApplications(
         @PathVariable("id")
@@ -664,13 +666,12 @@ public class JobRestController {
      * @throws ServletException when trying to handle the request
      * @throws GenieException   on any Genie internal error
      */
-    @RequestMapping(
+    @GetMapping(
         value = {
             "/{id}/output",
             "/{id}/output/",
             "/{id}/output/**"
         },
-        method = RequestMethod.GET,
         produces = MediaType.ALL_VALUE
     )
     public void getJobOutput(

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/RootRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/RootRestController.java
@@ -25,8 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -58,7 +58,7 @@ public class RootRestController {
      *
      * @return the root resource containing various links to the real APIs
      */
-    @RequestMapping(method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
+    @GetMapping(produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public RootResource getRoot() {
         final JsonNodeFactory factory = JsonNodeFactory.instance;

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/UIController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/UIController.java
@@ -19,9 +19,8 @@ package com.netflix.genie.web.controllers;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.Cookie;
@@ -45,7 +44,7 @@ public class UIController {
      * @param authentication The Spring Security authentication if present
      * @return getIndex
      */
-    @RequestMapping(
+    @GetMapping(
         value = {
             "/",
             "/applications/**",
@@ -53,8 +52,7 @@ public class UIController {
             "/commands/**",
             "/jobs/**",
             "/output/**"
-        },
-        method = RequestMethod.GET
+        }
     )
     public String getIndex(@NotNull final HttpServletResponse response, @Nullable final Authentication authentication) {
         if (authentication != null) {
@@ -72,7 +70,7 @@ public class UIController {
      * @param request the servlet request to get path information from
      * @return The forward address to go to at the API endpoint
      */
-    @RequestMapping(value = "/file/{id}/**", method = RequestMethod.GET)
+    @GetMapping(value = "/file/{id}/**")
     public String getFile(@PathVariable("id") final String id, final HttpServletRequest request) {
         return "forward:/api/v3/jobs/" + id + "/" + ControllerUtils.getRemainingPath(request);
     }


### PR DESCRIPTION
- Update documentation to address #529 
- Clean up deprecation warnings in S3 code
- Move `@RequestMapping(method = RequestMethod.{METHOD}...` to convenience annotations like `@GetMapping`, `@PostMapping` etc for clarity
- Enable unchecked and deprecation warnings into the compiler arguments so we catch them