### PR TITLE
Return text/plain as content type for job output files without known extension

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/resources/handlers/GenieResourceHttpRequestHandler.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/resources/handlers/GenieResourceHttpRequestHandler.java
@@ -166,4 +166,15 @@ public class GenieResourceHttpRequestHandler extends ResourceHttpRequestHandler 
         }
         response.setHeader(HttpHeaders.ACCEPT_RANGES, BYTES);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Overriding to handle case where media type was unknown to default to Text
+     */
+    @Override
+    protected MediaType getMediaType(final HttpServletRequest request, final Resource resource) {
+        final MediaType mediaType = super.getMediaType(request, resource);
+        return mediaType == null ? MediaType.TEXT_PLAIN : mediaType;
+    }
 }


### PR DESCRIPTION
Previous versions of Spring Framework would read the file contents to determine a MimeType to return if no extension was present. Current version has changed this and now job output files without extensions like `run`, `stdout`, `stderr` are coming back with MimeType `octet-stream` causing browser to auto download the file instead of displaying it in the browser (desired behavior)

This change overrides the `getMediaType` method to provide a catch all where if a content type can't be determined by the default mechanisms provided by framework it defaults to `text/plain`. On a grand scale this would be problematic if we did it server wide however this resource handler is only used by job output which we know really only contains text files for files without extensions. All other files have extensions. If this breaks something in the browser the user can always go back right-click and download.