### PR TITLE
Handle empty columns commandCriteria and clusterCriterias

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobRequestEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobRequestEntity.java
@@ -24,7 +24,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.util.JsonUtils;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.validator.constraints.NotBlank;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.Basic;
@@ -159,8 +159,8 @@ public class JobRequestEntity extends SetupFileEntity {
      *
      * @param clusterCriterias The cluster criterias.
      */
-    protected void setClusterCriterias(@NotBlank final String clusterCriterias) {
-        this.clusterCriterias = clusterCriterias;
+    protected void setClusterCriterias(final String clusterCriterias) {
+        this.clusterCriterias = StringUtils.isBlank(clusterCriterias) ? EMPTY_JSON_ARRAY : clusterCriterias;
     }
 
     /**
@@ -246,7 +246,7 @@ public class JobRequestEntity extends SetupFileEntity {
      * @param commandCriteria A set of command criteria tags as a JSON array
      */
     protected void setCommandCriteria(final String commandCriteria) {
-        this.commandCriteria = commandCriteria;
+        this.commandCriteria = StringUtils.isBlank(commandCriteria) ? EMPTY_JSON_ARRAY : commandCriteria;
     }
 
     /**

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/JobRequestEntityUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/entities/JobRequestEntityUnitTests.java
@@ -161,6 +161,15 @@ public class JobRequestEntityUnitTests {
     }
 
     /**
+     * Make sure the setter for the entity class works for JPA for null cluster criterias.
+     */
+    @Test
+    public void canSetNullClusterCriterias() {
+        this.entity.setClusterCriterias(null);
+        Assert.assertThat(this.entity.getClusterCriterias(), Matchers.is(EMPTY_JSON_ARRAY));
+    }
+
+    /**
      * Make sure can set the command args for the job.
      */
     @Test
@@ -262,6 +271,15 @@ public class JobRequestEntityUnitTests {
         final String commandCriteria = UUID.randomUUID().toString();
         this.entity.setCommandCriteria(commandCriteria);
         Assert.assertThat(this.entity.getCommandCriteria(), Matchers.is(commandCriteria));
+    }
+
+    /**
+     * Make sure the setter for the entity class works for JPA for null command criteria.
+     */
+    @Test
+    public void canSetNullCommandCriteria() {
+        this.entity.setCommandCriteria(null);
+        Assert.assertThat(this.entity.getCommandCriteria(), Matchers.is(EMPTY_JSON_ARRAY));
     }
 
     /**


### PR DESCRIPTION
In an upcoming upgrade to the database schema, the columns will be migrated to TEXT, which does not support default value (currently '[]').
This change ensure the code is forward compatible with the new schema, by providing the expected default value via setter