### PR TITLE
Add ScriptLoadBalancer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,13 @@ configure(javaProjects) {
             dependency("org.apache.commons:commons-exec:1.3")
             dependency("org.bitbucket.b_c:jose4j:0.5.4")
             dependency("org.dbunit:dbunit:2.5.3")
+            dependencySet(group: "org.jruby", version:"9.1.12.0") {
+                entry "jruby-complete"
+                entry "jruby-core"
+                entry "jruby-stdlib"
+            }
             dependency("org.opensaml:opensaml:2.6.4")
+            dependency("org.python:jython-standalone:2.7.1")
             dependency("org.springframework.security.extensions:spring-security-saml2-core:1.0.2.RELEASE")
         }
     }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaClusterServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaClusterServiceImpl.java
@@ -153,7 +153,7 @@ public class JpaClusterServiceImpl implements ClusterService {
      * {@inheritDoc}
      */
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public List<Cluster> chooseClusterForJobRequest(
         @NotNull(message = "JobRequest object is null. Unable to continue.")
         final JobRequest jobRequest
@@ -495,12 +495,12 @@ public class JpaClusterServiceImpl implements ClusterService {
         clusterEntity.setUser(updateCluster.getUser());
         clusterEntity.setVersion(updateCluster.getVersion());
         final Optional<String> description = updateCluster.getDescription();
-        clusterEntity.setDescription(description.isPresent() ? description.get() : null);
+        clusterEntity.setDescription(description.orElse(null));
         clusterEntity.setStatus(updateCluster.getStatus());
         clusterEntity.setConfigs(updateCluster.getConfigs());
         clusterEntity.setTags(updateCluster.getTags());
         final Optional<String> setupFile = updateCluster.getSetupFile();
-        clusterEntity.setSetupFile(setupFile.isPresent() ? setupFile.get() : null);
+        clusterEntity.setSetupFile(setupFile.orElse(null));
 
         this.clusterRepo.save(clusterEntity);
     }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/ClusterLoadBalancer.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/ClusterLoadBalancer.java
@@ -18,9 +18,12 @@
 package com.netflix.genie.core.services;
 
 import com.netflix.genie.common.dto.Cluster;
+import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
+import org.springframework.core.Ordered;
 import org.springframework.validation.annotation.Validated;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -30,14 +33,16 @@ import java.util.List;
  * @author tgianos
  */
 @Validated
-public interface ClusterLoadBalancer {
+public interface ClusterLoadBalancer extends Ordered {
 
     /**
      * Return best cluster to run job on.
      *
-     * @param clusters The list of available clusters to choose from
-     * @return the "best" cluster to run job on
+     * @param clusters   The list of available clusters to choose from
+     * @param jobRequest The job request these clusters are being load balanced for
+     * @return the "best" cluster to run job on or null if no cluster selected
      * @throws GenieException if there is any error
      */
-    Cluster selectCluster(final List<Cluster> clusters) throws GenieException;
+    @Nullable
+    Cluster selectCluster(final List<Cluster> clusters, final JobRequest jobRequest) throws GenieException;
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/ClusterLoadBalancer.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/ClusterLoadBalancer.java
@@ -38,7 +38,7 @@ public interface ClusterLoadBalancer extends Ordered {
     /**
      * Return best cluster to run job on.
      *
-     * @param clusters   The list of available clusters to choose from
+     * @param clusters   An immutable, non-empty list of available clusters to choose from
      * @param jobRequest The job request these clusters are being load balanced for
      * @return the "best" cluster to run job on or null if no cluster selected
      * @throws GenieException if there is any error

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobCoordinatorService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobCoordinatorService.java
@@ -44,9 +44,9 @@ public interface JobCoordinatorService {
      * @throws GenieException if there is an error
      */
     String coordinateJob(
-        @NotNull(message = "No job request provided. Unable to submit job for execution.")
+        @NotNull(message = "No job request provided. Unable to execute.")
         @Valid final JobRequest jobRequest,
-        @NotNull(message = "No job metadata provided. Unable to submit job for execution.")
+        @NotNull(message = "No job metadata provided. Unable to execute.")
         @Valid final JobMetadata jobMetadata
     ) throws GenieException;
 

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/RandomizedClusterLoadBalancerImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/RandomizedClusterLoadBalancerImpl.java
@@ -18,10 +18,12 @@
 package com.netflix.genie.core.services.impl;
 
 import com.netflix.genie.common.dto.Cluster;
+import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.core.services.ClusterLoadBalancer;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
 
 import java.util.List;
 import java.util.Random;
@@ -39,7 +41,7 @@ public class RandomizedClusterLoadBalancerImpl implements ClusterLoadBalancer {
      * {@inheritDoc}
      */
     @Override
-    public Cluster selectCluster(final List<Cluster> clusters) throws GenieException {
+    public Cluster selectCluster(final List<Cluster> clusters, final JobRequest jobRequest) throws GenieException {
         log.debug("called");
 
         if (clusters == null || clusters.isEmpty()) {
@@ -51,5 +53,13 @@ public class RandomizedClusterLoadBalancerImpl implements ClusterLoadBalancer {
         // return a random one
         final Random rand = new Random();
         return clusters.get(Math.abs(rand.nextInt(clusters.size())));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
     }
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
@@ -263,8 +263,7 @@ public class ServicesConfigTest {
         final ApplicationEventPublisher eventPublisher,
         final ApplicationEventMulticaster eventMulticaster,
         final List<WorkflowTask> workflowTasks,
-        @Qualifier("jobsDir")
-        final Resource genieWorkingDir,
+        @Qualifier("jobsDir") final Resource genieWorkingDir,
         final Registry registry
     ) {
         return new LocalJobRunner(
@@ -291,6 +290,7 @@ public class ServicesConfigTest {
 
     /**
      * Default task scheduler.
+     *
      * @return task scheduler
      */
     @Bean
@@ -359,7 +359,7 @@ public class ServicesConfigTest {
      * @param applicationService    Implementation of application service interface
      * @param clusterService        Implementation of cluster service interface
      * @param commandService        Implementation of command service interface
-     * @param clusterLoadBalancer   Implementation of the cluster load balancer interface
+     * @param clusterLoadBalancers  Implementations of the cluster load balancer interface
      * @param registry              The registry to use
      * @param hostName              The host name to use
      * @return An instance of the JobCoordinatorService.
@@ -374,7 +374,7 @@ public class ServicesConfigTest {
         final ApplicationService applicationService,
         final ClusterService clusterService,
         final CommandService commandService,
-        final ClusterLoadBalancer clusterLoadBalancer,
+        final List<ClusterLoadBalancer> clusterLoadBalancers,
         final Registry registry,
         final String hostName
     ) {
@@ -387,7 +387,7 @@ public class ServicesConfigTest {
             jobSearchService,
             clusterService,
             commandService,
-            clusterLoadBalancer,
+            clusterLoadBalancers,
             registry,
             hostName
         );

--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/RandomizedClusterLoadBalancerImplUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/RandomizedClusterLoadBalancerImplUnitTests.java
@@ -18,10 +18,11 @@
 package com.netflix.genie.core.services.impl;
 
 import com.google.common.collect.Lists;
-import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.common.dto.Cluster;
+import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
+import com.netflix.genie.test.categories.UnitTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +59,12 @@ public class RandomizedClusterLoadBalancerImplUnitTests {
         final Cluster cluster1 = Mockito.mock(Cluster.class);
         final Cluster cluster2 = Mockito.mock(Cluster.class);
         final Cluster cluster3 = Mockito.mock(Cluster.class);
-        Assert.assertNotNull(this.clb.selectCluster(Lists.newArrayList(cluster1, cluster2, cluster3)));
+        Assert.assertNotNull(
+            this.clb.selectCluster(
+                Lists.newArrayList(cluster1, cluster2, cluster3),
+                Mockito.mock(JobRequest.class)
+            )
+        );
     }
 
     /**
@@ -68,7 +74,7 @@ public class RandomizedClusterLoadBalancerImplUnitTests {
      */
     @Test(expected = GeniePreconditionException.class)
     public void testEmptyList() throws GenieException {
-        this.clb.selectCluster(new ArrayList<>());
+        this.clb.selectCluster(new ArrayList<>(), Mockito.mock(JobRequest.class));
     }
 
     /**
@@ -78,6 +84,6 @@ public class RandomizedClusterLoadBalancerImplUnitTests {
      */
     @Test(expected = GeniePreconditionException.class)
     public void testNullList() throws GenieException {
-        this.clb.selectCluster(null);
+        this.clb.selectCluster(null, Mockito.mock(JobRequest.class));
     }
 }

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -45,6 +45,30 @@ Health of the system is marked unhealthy if the CPU load of a system goes beyond
 |Whether or not to delete the dependencies directories for applications to save disk space after job completion
 |true
 
+|genie.jobs.clusters.loadBalancers.script.destination
+|The location on disk where the script source file should be stored after it is downloaded from
+`genie.jobs.clusters.loadBalancers.script.source`. The file will be given the same name.
+|file:///tmp/genie/loadbalancers/script/destination/
+
+|genie.jobs.clusters.loadBalancers.script.enabled
+|Whether the script based load balancer should be enabled for the system or not.
+See also: `genie.jobs.clusters.loadBalancers.script.source`
+See also: `genie.jobs.clusters.loadBalancers.script.destination`
+|false
+
+|genie.jobs.clusters.loadBalancers.script.refreshRate
+|How frequently to refresh the load balancer script (in milliseconds)
+|300000
+
+|genie.jobs.clusters.loadBalancers.script.source
+|The location of the script the load balancer should load to evaluate which cluster to use for a job request
+|file:///tmp/genie/loadBalancers/script/source/loadBalance.js
+
+|genie.jobs.clusters.loadBalancers.script.timeout
+|The amount of time (in milliseconds) that the system will attempt to run the cluster load balancer script before it
+forces a timeout
+|5000
+
 |genie.jobs.forwarding.enabled
 |Whether or not to attempt to forward kill and get output requests for jobs
 |true

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -10,6 +10,7 @@ property
 * Actuator endpoints secured by default
 ** Follows new Spring default
 ** Turn off by setting `management.security.enabled` to `false`
+* Optional cluster load balancer via Admin supplied script
 
 === Library Upgrades
 
@@ -31,6 +32,30 @@ to Spring Integration Zookeeper. That library is now used.
 
 |===
 |Property |Description| Default Value
+
+|genie.jobs.clusters.loadBalancers.script.destination
+|The location on disk where the script source file should be stored after it is downloaded from
+`genie.jobs.clusters.loadBalancers.script.source`. The file will be given the same name.
+|file:///tmp/genie/loadbalancers/script/destination/
+
+|genie.jobs.clusters.loadBalancers.script.enabled
+|Whether the script based load balancer should be enabled for the system or not.
+See also: `genie.jobs.clusters.loadBalancers.script.source`
+See also: `genie.jobs.clusters.loadBalancers.script.destination`
+|false
+
+|genie.jobs.clusters.loadBalancers.script.refreshRate
+|How frequently to refresh the load balancer script (in milliseconds)
+|300000
+
+|genie.jobs.clusters.loadBalancers.script.source
+|The location of the script the load balancer should load to evaluate which cluster to use for a job request
+|file:///tmp/genie/loadBalancers/script/source/loadBalance.js
+
+|genie.jobs.clusters.loadBalancers.script.timeout
+|The amount of time (in milliseconds) that the system will attempt to run the cluster load balancer script before it
+forces a timeout
+|5000
 
 |management.security.roles
 |The roles a user needs to have in order to access the Actuator endpoints

--- a/genie-docs/src/docs/asciidoc/features/_clusterLoadBalancing.adoc
+++ b/genie-docs/src/docs/asciidoc/features/_clusterLoadBalancing.adoc
@@ -15,7 +15,7 @@ cluster selection. The interface has two methods one from Genie:
 /**
  * Return best cluster to run job on.
  *
- * @param clusters   The list of available clusters to choose from
+ * @param clusters   An immutable, non-empty list of available clusters to choose from
  * @param jobRequest The job request these clusters are being load balanced for
  * @return the "best" cluster to run job on or null if no cluster selected
  * @throws GenieException if there is any error
@@ -112,7 +112,7 @@ The contract between the script and the Java code is as follows:
 |Parameter |Description
 
 |clusters
-|JSON array of cluster objects (serialized as a string) of the clusters to be evaluated
+|Non-empty JSON array of cluster objects (serialized as a string) of the clusters to be evaluated
 
 |jobRequest
 |JSON object (serialized as a string) of the job request that kicked off this evaluation

--- a/genie-docs/src/docs/asciidoc/features/_clusterLoadBalancing.adoc
+++ b/genie-docs/src/docs/asciidoc/features/_clusterLoadBalancing.adoc
@@ -1,0 +1,192 @@
+=== Cluster Load Balancing
+
+Genie allows administrators to tag clusters with multiple tags that could reflect any type of domain modeling the
+admins wish to accomplish. Purpose of the cluster, types of data the cluster can access, workload expected are just
+some examples of ways tags could be used to classify clusters. Users submit jobs with a series of tags that help
+Genie identify which cluster to run a job on. Sometimes the tags submitted by the job match multiple clusters. At this
+point Genie needs a mechanism to chose a final runtime target from the set of clusters selected. This is where the
+cluster load balancing feature of Genie comes into play.
+
+Genie has an interface `ClusterLoadBalancer` which can be implemented to provide plugin functionality of algorithms for
+cluster selection. The interface has two methods one from Genie:
+
+[source,java]
+----
+/**
+ * Return best cluster to run job on.
+ *
+ * @param clusters   The list of available clusters to choose from
+ * @param jobRequest The job request these clusters are being load balanced for
+ * @return the "best" cluster to run job on or null if no cluster selected
+ * @throws GenieException if there is any error
+ */
+@Nullable
+Cluster selectCluster(final List<Cluster> clusters, final JobRequest jobRequest) throws GenieException;
+----
+
+And one inherited from Spring's
+http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/Ordered.html[Ordered]
+interface:
+
+[source,java]
+----
+/**
+ * Get the order value of this object.
+ * <p>Higher values are interpreted as lower priority. As a consequence,
+ * the object with the lowest value has the highest priority (somewhat
+ * analogous to Servlet {@code load-on-startup} values).
+ * <p>Same order values will result in arbitrary sort positions for the
+ * affected objects.
+ * @return the order value
+ * @see #HIGHEST_PRECEDENCE
+ * @see #LOWEST_PRECEDENCE
+ */
+int getOrder();
+----
+
+At startup Genie will collect all beans that implement the `ClusterLoadBalancer` interface and based on their order
+store them in an invocation order list. Meaning that when multiple clusters are selected from the database based on tags
+Genie will send the list of clusters to the implementations in preference order until one of them returns the cluster to
+use.
+
+Genie currently ships with two implementations of this interface which are described below.
+
+==== RandomizedClusterLoadBalancerImpl
+
+As the name indicates this load balancer simply uses a random number generator to select a cluster from the list by
+index. There is no intelligence to this load balancer algorithm but it does provide very close to an equal distribution
+between clusters if the same tags are always used.
+
+This implementation is the "default" implementation. It has the lowest priority order so if all other active
+implementations fail to select a cluster this implementation will be invoked and chose randomly.
+
+==== ScriptLoadBalancer
+
+This implementation, first introduced in 3.1.0, allows administrators to provide a script to be invoked at runtime to
+decide which cluster to select. Currently `JavaScript` and `Groovy` are supported out of the box but others (like
+`Python`, `Ruby`, etc) could be supported by adding their implementations of the
+https://docs.oracle.com/javase/8/docs/api/javax/script/ScriptEngine.html[ScriptEngine] interface to the Genie classpath.
+
+===== Configuration
+
+The script load balancer is disabled by default. To enable it an admin must set the property
+`genie.jobs.clusters.loadBalancers.script.enabled` to true.
+
+Other properties:
+
+|===
+|Property |Description| Default Value
+
+|genie.jobs.clusters.loadBalancers.script.destination
+|The location on disk where the script source file should be stored after it is downloaded from
+`genie.jobs.clusters.loadBalancers.script.source`. The file will be given the same name.
+|file:///tmp/genie/loadbalancers/script/destination/
+
+|genie.jobs.clusters.loadBalancers.script.enabled
+|Whether the script based load balancer should be enabled for the system or not.
+See also: `genie.jobs.clusters.loadBalancers.script.source`
+See also: `genie.jobs.clusters.loadBalancers.script.destination`
+|false
+
+|genie.jobs.clusters.loadBalancers.script.refreshRate
+|How frequently to refresh the load balancer script (in milliseconds)
+|300000
+
+|genie.jobs.clusters.loadBalancers.script.source
+|The location of the script the load balancer should load to evaluate which cluster to use for a job request
+|file:///tmp/genie/loadBalancers/script/source/loadBalance.js
+
+|genie.jobs.clusters.loadBalancers.script.timeout
+|The amount of time (in milliseconds) that the system will attempt to run the cluster load balancer script before it
+forces a timeout
+|5000
+
+|===
+
+===== Script Contract
+
+The contract between the script and the Java code is as follows:
+
+.Script Inputs
+|===
+|Parameter |Description
+
+|clusters
+|JSON array of cluster objects (serialized as a string) of the clusters to be evaluated
+
+|jobRequest
+|JSON object (serialized as a string) of the job request that kicked off this evaluation
+
+|===
+
+.Script Output
+|===
+|Result |Description
+
+|A string
+|The id of the cluster selected by the script algorithm that should be used to run the job
+
+|null
+|No cluster was selected and the evaluation should fall back to another cluster load balancing algorithm
+
+|===
+
+For most of the script engines the last statement will be the return value.
+
+===== Script Examples
+
+Some simple script examples
+
+====== Javascript
+
+[source,javascript]
+----
+var cJson = JSON.parse(clusters);
+var jJson = JSON.parse(jobRequest);
+
+var index;
+for (index = 0; index < cJson.length; index++) {
+    var cluster = cJson[index];
+    if (cluster.user === "h") {
+        break;
+    }
+}
+
+index < cJson.length ? cJson[index].id : null;
+----
+
+====== Groovy
+
+[source,groovy]
+----
+import groovy.json.JsonSlurper
+
+def jsonSlurper = new JsonSlurper()
+def cJson = jsonSlurper.parseText(clusters)
+def jJson = jsonSlurper.parseText(jobRequest)
+
+def index = cJson.findIndexOf {
+    cluster -> cluster.user == "h"
+}
+
+index == -1 ? null : cJson[index].id
+----
+
+===== Caveats
+
+The script load balancer provides great flexibility for system administrators to test algorithms for cluster load
+balancing at runtime. Since the script is refreshed periodically it can even be changed after Genie is running. With
+this flexibility comes the trade off that script evaluation is going to be slower than code running direct JVM byte
+code. The load balancer tries to offset this by compiling and caching the script code in between refresh invocations. It
+is recommended that once an algorithm is well tested it be converted to a true implementation of the
+`ClusterLoadBalancer` interface if performance is desired.
+
+Additionally if a script error is made the `ScriptLoadBalancer` will swallow the exceptions and simply return `null`
+from all calls to `selectCluster` until the script is fixed and `refresh` is invoked again. The metric
+`genie.jobs.clusters.loadBalancers.script.select.timer` with tag `status` and value `failed` can be used to monitor
+this situation.
+
+==== Wrap Up
+
+This section went over the cluster load balancing feature of Genie. This interface provides an extension point for
+administrators of Genie to tweak Genie's runtime behavior to suit their needs.

--- a/genie-docs/src/docs/asciidoc/features/_features.adoc
+++ b/genie-docs/src/docs/asciidoc/features/_features.adoc
@@ -1,0 +1,5 @@
+== Features
+
+This section has documentation pertaining to specific features of Genie that may need specific examples.
+
+include::_clusterLoadBalancing.adoc[]

--- a/genie-docs/src/docs/asciidoc/index.adoc
+++ b/genie-docs/src/docs/asciidoc/index.adoc
@@ -34,6 +34,8 @@ include::_releaseNotes.adoc[]
 
 include::concepts/_concepts.adoc[]
 
+include::features/_features.adoc[]
+
 include::_installation.adoc[]
 
 include::_properties.adoc[]

--- a/genie-web/src/main/java/com/netflix/genie/GenieWeb.java
+++ b/genie-web/src/main/java/com/netflix/genie/GenieWeb.java
@@ -41,8 +41,8 @@ import java.util.Map;
 @EnableAspectJAutoProxy
 public class GenieWeb {
 
-    protected static final String SPRING_CONFIG_LOCATION = "spring.config.location";
-    protected static final String USER_HOME_GENIE = "${user.home}/.genie/";
+    static final String SPRING_CONFIG_LOCATION = "spring.config.location";
+    static final String USER_HOME_GENIE = "${user.home}/.genie/";
 
     /**
      * Protected constructor.
@@ -62,7 +62,7 @@ public class GenieWeb {
         genie.run(args);
     }
 
-    protected static Map<String, Object> getDefaultProperties() {
+    static Map<String, Object> getDefaultProperties() {
         final Map<String, Object> defaultProperties = Maps.newHashMap();
         defaultProperties.put(SPRING_CONFIG_LOCATION, USER_HOME_GENIE);
         return defaultProperties;

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -235,8 +235,7 @@ public class ServicesConfig {
         final Executor executor,
         final JobsProperties jobsProperties,
         final ApplicationEventPublisher eventPublisher,
-        @Qualifier("jobsDir")
-        final Resource genieWorkingDir,
+        @Qualifier("jobsDir") final Resource genieWorkingDir,
         final ObjectMapper objectMapper
     ) {
         return new LocalJobKillServiceImpl(
@@ -286,10 +285,8 @@ public class ServicesConfig {
     @Bean
     public GenieFileTransferService cacheGenieFileTransferService(
         final FileTransferFactory fileTransferFactory,
-        @Value("${genie.file.cache.location}")
-        final String baseCacheLocation,
-        @Qualifier("file.system.file")
-        final FileTransfer localFileTransfer,
+        @Value("${genie.file.cache.location}") final String baseCacheLocation,
+        @Qualifier("file.system.file") final FileTransfer localFileTransfer,
         final Registry registry
     ) throws GenieException {
         return new CacheGenieFileTransferService(fileTransferFactory, baseCacheLocation, localFileTransfer, registry);
@@ -312,8 +309,7 @@ public class ServicesConfig {
         final ApplicationEventPublisher eventPublisher,
         final ApplicationEventMulticaster eventMulticaster,
         final List<WorkflowTask> workflowTasks,
-        @Qualifier("jobsDir")
-        final Resource genieWorkingDir,
+        @Qualifier("jobsDir") final Resource genieWorkingDir,
         final Registry registry
     ) {
         return new LocalJobRunner(
@@ -331,13 +327,13 @@ public class ServicesConfig {
      *
      * @param jobPersistenceService implementation of job persistence service interface
      * @param jobKillService        The job kill service to use
-     * @param jobStateService     The running job metrics service to use
+     * @param jobStateService       The running job metrics service to use
      * @param jobSearchService      Implementation of job search service interface
      * @param jobsProperties        The jobs properties to use
      * @param applicationService    Implementation of application service interface
      * @param clusterService        Implementation of cluster service interface
      * @param commandService        Implementation of command service interface
-     * @param clusterLoadBalancer   Implementation of the cluster load balancer interface
+     * @param clusterLoadBalancers  Implementations of the cluster load balancer interface in invocation order
      * @param registry              The metrics registry to use
      * @param hostName              The host this Genie instance is running on
      * @return An instance of the JobCoordinatorService.
@@ -352,7 +348,7 @@ public class ServicesConfig {
         final ApplicationService applicationService,
         final ClusterService clusterService,
         final CommandService commandService,
-        final ClusterLoadBalancer clusterLoadBalancer,
+        final List<ClusterLoadBalancer> clusterLoadBalancers,
         final Registry registry,
         final String hostName
     ) {
@@ -365,7 +361,7 @@ public class ServicesConfig {
             jobSearchService,
             clusterService,
             commandService,
-            clusterLoadBalancer,
+            clusterLoadBalancers,
             registry,
             hostName
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
@@ -28,6 +28,7 @@ import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
@@ -38,6 +39,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  * @since 3.0.0
  */
 @Configuration
+@EnableScheduling
 public class TaskConfig {
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
@@ -1,0 +1,279 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.loadbalancers.script;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+import com.netflix.genie.common.dto.Cluster;
+import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.core.services.ClusterLoadBalancer;
+import com.netflix.genie.core.services.impl.GenieFileTransferService;
+import com.netflix.spectator.api.Registry;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import javax.script.Bindings;
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * An implementation of the ClusterLoadBalancer interface which uses user a supplied script to make decisions based
+ * on the list of clusters and the job request supplied.
+ *
+ * The contract between the script and the Java code is that the script will be supplied global variables
+ * {@code clusters} and {@code jobRequest} which will be JSON strings representing the list (array) of clusters
+ * matching the cluster criteria tags and the job request that kicked off this evaluation. The code expects the script
+ * to either return the id of the cluster if one is selected or null if none was selected.
+ *
+ * @author tgianos
+ * @since 3.1.0
+ */
+@Component
+@ConditionalOnProperty(value = "genie.jobs.clusters.loadBalancers.script.enabled", havingValue = "true")
+@Slf4j
+public class ScriptLoadBalancer implements ClusterLoadBalancer {
+
+    static final String SCRIPT_TIMEOUT_PROPERTY_KEY = "genie.jobs.clusters.loadBalancers.script.timeout";
+    static final String SCRIPT_FILE_SOURCE_PROPERTY_KEY
+        = "genie.jobs.clusters.loadBalancers.script.source";
+    static final String SCRIPT_FILE_DESTINATION_PROPERTY_KEY
+        = "genie.jobs.clusters.loadBalancers.script.destination";
+    static final String SCRIPT_REFRESH_RATE_PROPERTY_KEY
+        = "genie.jobs.clusters.loadBalancers.script.refreshRate";
+    static final String SELECT_TIMER_NAME = "genie.jobs.clusters.loadBalancers.script.select.timer";
+    static final String UPDATE_TIMER_NAME = "genie.jobs.clusters.loadBalancers.script.update.timer";
+    static final String STATUS_TAG_KEY = "status";
+    static final String STATUS_TAG_OK = "ok";
+    static final String STATUS_TAG_NOT_FOUND = "not found";
+    static final String STATUS_TAG_NOT_CONFIGURED = "not configured";
+    static final String STATUS_TAG_FOUND = "found";
+    static final String STATUS_TAG_FAILED = "failed";
+    static final String EXCEPTION_TAG_KEY = "exception";
+
+    private static final long DEFAULT_TIMEOUT_LENGTH = 5_000L;
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+    private static final String SLASH = "/";
+    private static final String PERIOD = ".";
+    private static final int ORDER = Ordered.LOWEST_PRECEDENCE - 1;
+    private static final String CLUSTERS_BINDING = "clusters";
+    private static final String JOB_REQUEST_BINDING = "jobRequest";
+
+    private final AtomicBoolean isUpdating = new AtomicBoolean();
+    private final AtomicBoolean isConfigured = new AtomicBoolean();
+    private final ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
+
+    private final AsyncTaskExecutor taskExecutor;
+    private final GenieFileTransferService fileTransferService;
+    private final Environment environment;
+    private final ObjectMapper mapper;
+    private final Registry registry;
+
+    private CompiledScript script;
+    private long timeoutLength = DEFAULT_TIMEOUT_LENGTH;
+
+    /**
+     * Constructor.
+     *
+     * @param taskExecutor        The asynchronous task executor to use to run the load balancer script in
+     * @param taskScheduler       The task scheduler to schedule the script refresh task with
+     * @param fileTransferService The file transfer service to use to download the script
+     * @param environment         The program environment to get properties from
+     * @param mapper              The object mapper to use to serialize objects to JSON for binding with scripts
+     * @param registry            The metrics registry to use for collecting metrics
+     */
+    @Autowired
+    public ScriptLoadBalancer(
+        final AsyncTaskExecutor taskExecutor,
+        final TaskScheduler taskScheduler,
+        @Qualifier("cacheGenieFileTransferService") final GenieFileTransferService fileTransferService,
+        final Environment environment,
+        final ObjectMapper mapper,
+        final Registry registry
+    ) {
+        this.taskExecutor = taskExecutor;
+        this.fileTransferService = fileTransferService;
+        this.environment = environment;
+        this.mapper = mapper;
+        this.registry = registry;
+
+        // Schedule the task to run with the configured refresh rate
+        // Task will be stopped when the system stops
+        final long refreshRate = this.environment.getProperty(
+            SCRIPT_REFRESH_RATE_PROPERTY_KEY,
+            Long.class,
+            300_000L
+        );
+        taskScheduler.scheduleWithFixedDelay(this::refresh, refreshRate);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Cluster selectCluster(final List<Cluster> clusters, final JobRequest jobRequest) throws GenieException {
+        final long selectStart = System.nanoTime();
+        final Map<String, String> tags = Maps.newHashMap();
+        try {
+            if (this.isConfigured.get() && this.script != null) {
+                final Bindings bindings = new SimpleBindings();
+                bindings.put(CLUSTERS_BINDING, this.mapper.writeValueAsString(clusters));
+                bindings.put(JOB_REQUEST_BINDING, this.mapper.writeValueAsString(jobRequest));
+
+                // Run as callable and timeout after the configured timeout length
+                final String clusterId = this.taskExecutor
+                    .submit(() -> (String) this.script.eval(bindings))
+                    .get(this.timeoutLength, TimeUnit.MILLISECONDS);
+
+                // Find the cluster if not null
+                if (clusterId != null) {
+                    for (final Cluster cluster : clusters) {
+                        if (cluster.getId().isPresent() && clusterId.equals(cluster.getId().get())) {
+                            tags.put(STATUS_TAG_KEY, STATUS_TAG_FOUND);
+                            return cluster;
+                        }
+                    }
+                }
+            } else {
+                tags.put(STATUS_TAG_KEY, STATUS_TAG_NOT_CONFIGURED);
+                return null;
+            }
+
+            tags.put(STATUS_TAG_KEY, STATUS_TAG_NOT_FOUND);
+            // Defer to any subsequent load balancer in the chain
+            return null;
+        } catch (final Exception e) {
+            tags.put(STATUS_TAG_KEY, STATUS_TAG_FAILED);
+            tags.put(EXCEPTION_TAG_KEY, e.getClass().getName());
+            log.error("Unable to execute script due to", e.getMessage(), e);
+            return null;
+        } finally {
+            this.registry
+                .timer(this.registry.createId(SELECT_TIMER_NAME, tags))
+                .record(System.nanoTime() - selectStart, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getOrder() {
+        return ORDER;
+    }
+
+    /**
+     * Check if the script file needs to be refreshed.
+     */
+    public void refresh() {
+        final long updateStart = System.nanoTime();
+        this.isUpdating.set(true);
+
+        // Update the script timeout
+        this.timeoutLength = this.environment.getProperty(
+            SCRIPT_TIMEOUT_PROPERTY_KEY,
+            Long.class,
+            DEFAULT_TIMEOUT_LENGTH
+        );
+
+        final Map<String, String> tags = Maps.newHashMap();
+        try {
+            final String scriptFileSource = this.environment.getProperty(SCRIPT_FILE_SOURCE_PROPERTY_KEY);
+            if (scriptFileSource == null) {
+                throw new IllegalStateException(
+                    "No script source file found for property " + SCRIPT_FILE_SOURCE_PROPERTY_KEY
+                );
+            }
+            final String scriptDestinationDir = this.environment.getProperty(SCRIPT_FILE_DESTINATION_PROPERTY_KEY);
+            if (scriptDestinationDir == null) {
+                throw new IllegalStateException(
+                    "No script destination directory found for property " + SCRIPT_FILE_DESTINATION_PROPERTY_KEY
+                );
+            }
+            final String fileName = StringUtils.substringAfterLast(scriptFileSource, SLASH);
+            if (StringUtils.isBlank(fileName)) {
+                throw new IllegalStateException("No file name found from " + scriptFileSource);
+            }
+
+            final String scriptExtension = StringUtils.substringAfterLast(fileName, PERIOD);
+            if (StringUtils.isBlank(scriptExtension)) {
+                throw new IllegalStateException("No file extension available in " + fileName);
+            }
+
+            final String scriptFileDestination = scriptDestinationDir.endsWith(SLASH)
+                ? scriptDestinationDir + fileName
+                : scriptDestinationDir + SLASH + fileName;
+
+            // Download and cache the file (if it's not already there)
+            this.fileTransferService.getFile(scriptFileSource, scriptFileDestination);
+
+            final ScriptEngine engine = this.scriptEngineManager.getEngineByExtension(scriptExtension);
+            // We want a compilable engine so we can cache the script
+            if (!(engine instanceof Compilable)) {
+                throw new IllegalArgumentException(
+                    "Script engine must be of type " + Compilable.class.getName()
+                );
+            }
+            final Compilable compilable = (Compilable) engine;
+            try (
+                final FileInputStream fis = new FileInputStream(scriptFileDestination);
+                final InputStreamReader reader = new InputStreamReader(fis, UTF_8)
+            ) {
+                this.script = compilable.compile(reader);
+            }
+
+            tags.put(STATUS_TAG_KEY, STATUS_TAG_OK);
+
+            this.isConfigured.set(true);
+        } catch (final GenieException | IOException | ScriptException | RuntimeException e) {
+            tags.put(STATUS_TAG_KEY, STATUS_TAG_FAILED);
+            tags.put(EXCEPTION_TAG_KEY, e.getClass().getName());
+            log.error(
+                "Refreshing the load balancing script for ScriptLoadBalancer failed due to {}",
+                e.getMessage(),
+                e
+            );
+            this.isConfigured.set(false);
+        } finally {
+            this.isUpdating.set(false);
+            this.registry
+                .timer(this.registry.createId(UPDATE_TIMER_NAME, tags))
+                .record(System.nanoTime() - updateStart, TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Classes related to a JavaScript engine based cluster load balancer.
+ *
+ * @author tgianos
+ * @since 3.1.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.web.services.loadbalancers.script;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -33,6 +33,14 @@ genie:
     cleanup:
       deleteArchiveFile: true
       deleteDependencies: true
+    clusters:
+      loadBalancers:
+        script:
+          destination: file:///tmp/genie/loadbalancers/script/destination/
+          enabled: false
+          refreshRate: 300000
+          source: file:///tmp/genie/loadBalancers/script/source/loadBalance.js
+          timeout: 5000
     forwarding:
       enabled: true
       port: 8080

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
@@ -254,6 +254,5 @@ class ScriptLoadBalancerSpec extends Specification {
         type         | file
         "JavaScript" | this.class.getResource("loadBalance.js").file
         "Groovy"     | this.class.getResource("loadBalance.groovy").file
-//        "Python"     | this.class.getResource("loadBalance.py").file
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
@@ -1,0 +1,258 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.loadbalancers.script
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.google.common.collect.ImmutableMap
+import com.google.common.collect.Lists
+import com.google.common.collect.Sets
+import com.netflix.genie.common.dto.Cluster
+import com.netflix.genie.common.dto.ClusterCriteria
+import com.netflix.genie.common.dto.ClusterStatus
+import com.netflix.genie.common.dto.JobRequest
+import com.netflix.genie.common.util.GenieDateFormat
+import com.netflix.genie.core.services.impl.GenieFileTransferService
+import com.netflix.genie.test.categories.UnitTest
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.Timer
+import org.apache.commons.lang.StringUtils
+import org.junit.experimental.categories.Category
+import org.springframework.core.Ordered
+import org.springframework.core.env.Environment
+import org.springframework.core.task.AsyncTaskExecutor
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Specifications for the ScriptLoadBalancer class.
+ *
+ * @author tgianos
+ * @since 3.1.0
+ */
+@Category(UnitTest.class)
+class ScriptLoadBalancerSpec extends Specification {
+
+    @Shared
+    def mapper = new ObjectMapper().registerModule(new Jdk8Module())
+
+    @Shared
+    def clustersGood = Lists.newArrayList(
+            new Cluster.Builder("a", "b", "c", ClusterStatus.UP).withId("2").build(),
+            new Cluster.Builder("d", "e", "f", ClusterStatus.UP).withId("0").build(),
+            new Cluster.Builder("g", "h", "i", ClusterStatus.UP).withId("1").build()
+    )
+
+    @Shared
+    def clustersBad = Lists.newArrayList(
+            new Cluster.Builder("j", "k", "l", ClusterStatus.UP).withId("3").build(),
+            new Cluster.Builder("m", "n", "o", ClusterStatus.UP).withId("4").build()
+    )
+
+    @Shared
+    def jobRequest = new JobRequest.Builder(
+            "jobName",
+            "jobUser",
+            "jobVersion",
+            "jobCommandAgs",
+            Lists.newArrayList(
+                    new ClusterCriteria(Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString()))
+            ),
+            Sets.newHashSet(UUID.randomUUID().toString())
+    ).build()
+
+    @Shared
+    def executor = new ThreadPoolTaskExecutor()
+
+    def setupSpec() {
+        def iso8601 = new GenieDateFormat()
+        iso8601.setTimeZone(TimeZone.getTimeZone("UTC"))
+        this.mapper.setDateFormat(iso8601)
+
+        this.executor.setCorePoolSize(2)
+        this.executor.initialize()
+    }
+
+    def cleanupSpec() {
+        this.executor.shutdown()
+    }
+
+    def "Order should be before lowest precedence"() {
+        def loadBalancer = new ScriptLoadBalancer(
+                Mock(AsyncTaskExecutor),
+                Mock(TaskScheduler) {
+                    1 * scheduleWithFixedDelay(_ as Runnable, 300_000L)
+                },
+                Mock(GenieFileTransferService),
+                Mock(Environment) {
+                    1 * getProperty(
+                            ScriptLoadBalancer.SCRIPT_REFRESH_RATE_PROPERTY_KEY,
+                            Long.class,
+                            300_000L
+                    ) >> 300_000L
+                },
+                Mock(ObjectMapper),
+                Mock(Registry)
+        )
+
+        when:
+        def order = loadBalancer.getOrder()
+
+        then:
+        order == Ordered.LOWEST_PRECEDENCE - 1
+    }
+
+    @Unroll
+    def "Can select cluster using #type for script #file"() {
+        def scheduler = Mock(TaskScheduler)
+        def environment = Mock(Environment)
+        def fileTransferService = Mock(GenieFileTransferService)
+        def registry = Mock(Registry)
+        def updateId = Mock(Id)
+        def selectId = Mock(Id)
+        def updateTimer = Mock(Timer)
+        def selectTimer = Mock(Timer)
+        def destDir = StringUtils.substringBeforeLast(file, "/")
+
+        when: "Constructed"
+        def loadBalancer = new ScriptLoadBalancer(
+                this.executor,
+                scheduler,
+                fileTransferService,
+                environment,
+                this.mapper,
+                registry
+        )
+
+        then:
+        1 * environment.getProperty(
+                ScriptLoadBalancer.SCRIPT_REFRESH_RATE_PROPERTY_KEY,
+                Long.class,
+                300_000L
+        ) >> 300_000L
+        1 * scheduler.scheduleWithFixedDelay(_ as Runnable, 300_000L)
+
+        when: "Try to select after before update"
+        def cluster = loadBalancer.selectCluster(this.clustersGood, this.jobRequest)
+
+        then: "Should skip running script and do nothing"
+        cluster == null
+        1 * registry.createId(
+                ScriptLoadBalancer.SELECT_TIMER_NAME,
+                ImmutableMap.of(
+                        ScriptLoadBalancer.STATUS_TAG_KEY,
+                        ScriptLoadBalancer.STATUS_TAG_NOT_CONFIGURED
+                )
+        ) >> selectId
+        1 * registry.timer(selectId) >> selectTimer
+        1 * selectTimer.record(_ as Long, TimeUnit.NANOSECONDS)
+
+        when: "refresh is called but fails"
+        loadBalancer.refresh()
+
+        then: "Metrics are recorded"
+        1 * environment.getProperty(ScriptLoadBalancer.SCRIPT_TIMEOUT_PROPERTY_KEY, Long.class, _ as Long) >> 5_000L
+        1 * environment.getProperty(ScriptLoadBalancer.SCRIPT_FILE_SOURCE_PROPERTY_KEY) >> null
+        1 * registry.createId(
+                ScriptLoadBalancer.UPDATE_TIMER_NAME,
+                ImmutableMap.of(
+                        ScriptLoadBalancer.STATUS_TAG_KEY,
+                        ScriptLoadBalancer.STATUS_TAG_FAILED,
+                        ScriptLoadBalancer.EXCEPTION_TAG_KEY,
+                        IllegalStateException.class.getName()
+                )
+        ) >> updateId
+        1 * registry.timer(updateId) >> updateTimer
+        1 * updateTimer.record(_ as Long, TimeUnit.NANOSECONDS)
+
+        when: "Try to select after failed update"
+        cluster = loadBalancer.selectCluster(this.clustersGood, this.jobRequest)
+
+        then: "Should skip running script and do nothing"
+        cluster == null
+        1 * registry.createId(
+                ScriptLoadBalancer.SELECT_TIMER_NAME,
+                ImmutableMap.of(
+                        ScriptLoadBalancer.STATUS_TAG_KEY,
+                        ScriptLoadBalancer.STATUS_TAG_NOT_CONFIGURED
+                )
+        ) >> selectId
+        1 * registry.timer(selectId) >> selectTimer
+        1 * selectTimer.record(_ as Long, TimeUnit.NANOSECONDS)
+
+        when: "Call refresh again"
+        loadBalancer.refresh()
+
+        then: "Refresh successfully configures the script"
+        1 * environment.getProperty(ScriptLoadBalancer.SCRIPT_TIMEOUT_PROPERTY_KEY, Long.class, _ as Long) >> 5_000L
+        1 * environment.getProperty(ScriptLoadBalancer.SCRIPT_FILE_SOURCE_PROPERTY_KEY) >> file
+        1 * environment.getProperty(ScriptLoadBalancer.SCRIPT_FILE_DESTINATION_PROPERTY_KEY) >> destDir
+        1 * fileTransferService.getFile(file, file)
+        1 * registry.createId(
+                ScriptLoadBalancer.UPDATE_TIMER_NAME,
+                ImmutableMap.of(
+                        ScriptLoadBalancer.STATUS_TAG_KEY,
+                        ScriptLoadBalancer.STATUS_TAG_OK
+                )
+        ) >> updateId
+        1 * registry.timer(updateId) >> updateTimer
+        1 * updateTimer.record(_ as Long, TimeUnit.NANOSECONDS)
+
+        when: "Script is compiled after refresh. select is called again"
+        cluster = loadBalancer.selectCluster(this.clustersGood, this.jobRequest)
+
+        then: "Can successfully find a cluster"
+        cluster != null
+        cluster.getId().get() == "1"
+        1 * registry.createId(
+                ScriptLoadBalancer.SELECT_TIMER_NAME,
+                ImmutableMap.of(
+                        ScriptLoadBalancer.STATUS_TAG_KEY,
+                        ScriptLoadBalancer.STATUS_TAG_FOUND
+                )
+        ) >> selectId
+        1 * registry.timer(selectId) >> selectTimer
+        1 * selectTimer.record(_ as Long, TimeUnit.NANOSECONDS)
+
+        when: "Script is called with unhandled clusters"
+        cluster = loadBalancer.selectCluster(this.clustersBad, this.jobRequest)
+
+        then: "Can't find a cluster"
+        cluster == null
+        1 * registry.createId(
+                ScriptLoadBalancer.SELECT_TIMER_NAME,
+                ImmutableMap.of(
+                        ScriptLoadBalancer.STATUS_TAG_KEY,
+                        ScriptLoadBalancer.STATUS_TAG_NOT_FOUND
+                )
+        ) >> selectId
+        1 * registry.timer(selectId) >> selectTimer
+        1 * selectTimer.record(_ as Long, TimeUnit.NANOSECONDS)
+
+        where:
+        type         | file
+        "JavaScript" | this.class.getResource("loadBalance.js").file
+        "Groovy"     | this.class.getResource("loadBalance.groovy").file
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
@@ -254,5 +254,6 @@ class ScriptLoadBalancerSpec extends Specification {
         type         | file
         "JavaScript" | this.class.getResource("loadBalance.js").file
         "Groovy"     | this.class.getResource("loadBalance.groovy").file
+//        "Python"     | this.class.getResource("loadBalance.py").file
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -39,6 +39,7 @@ import com.netflix.genie.core.services.JobStateService;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.spectator.api.Registry;
 import org.apache.commons.exec.Executor;
+import org.assertj.core.util.Lists;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -237,7 +238,7 @@ public class ServicesConfigUnitTests {
                 Mockito.mock(ApplicationService.class),
                 Mockito.mock(ClusterService.class),
                 Mockito.mock(CommandService.class),
-                Mockito.mock(ClusterLoadBalancer.class),
+                Lists.newArrayList(Mockito.mock(ClusterLoadBalancer.class)),
                 Mockito.mock(Registry.class),
                 UUID.randomUUID().toString()
             )

--- a/genie-web/src/test/resources/application-ci.yml
+++ b/genie-web/src/test/resources/application-ci.yml
@@ -30,6 +30,10 @@ genie:
   health:
     maxCpuLoadPercent: 100
   jobs:
+    clusters:
+      loadBalancers:
+        script:
+          enabled: true
     dir:
       location: "file:///tmp/"
 

--- a/genie-web/src/test/resources/application-integration.yml
+++ b/genie-web/src/test/resources/application-integration.yml
@@ -26,6 +26,10 @@ genie:
   health:
     maxCpuLoadPercent: 100
   jobs:
+    clusters:
+      loadBalancers:
+        script:
+          enabled: true
     dir:
       location: "file:///tmp/"
     archive:

--- a/genie-web/src/test/resources/com/netflix/genie/web/services/loadbalancers/script/loadBalance.groovy
+++ b/genie-web/src/test/resources/com/netflix/genie/web/services/loadbalancers/script/loadBalance.groovy
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+import groovy.json.JsonSlurper
+
+def jsonSlurper = new JsonSlurper()
+def cJson = jsonSlurper.parseText(clusters)
+//def jJson = jsonSlurper.parseText(jobRequest)
+
+def index = cJson.findIndexOf {
+    cluster -> cluster.user == "h"
+}
+
+index == -1 ? null : cJson[index].id

--- a/genie-web/src/test/resources/com/netflix/genie/web/services/loadbalancers/script/loadBalance.js
+++ b/genie-web/src/test/resources/com/netflix/genie/web/services/loadbalancers/script/loadBalance.js
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Example load balancer script for JavaScript.
+ * clusters and jobRequest variables passed in via script context.
+ *
+ * @author tgianos
+ * @since 3.1.0
+ */
+
+var cJson = JSON.parse(clusters);
+// var jJson = JSON.parse(jobRequest);
+
+var index;
+for (index = 0; index < cJson.length; index++) {
+    var cluster = cJson[index];
+    if (cluster.user === "h") {
+        break;
+    }
+}
+
+index < cJson.length ? cJson[index].id : null;


### PR DESCRIPTION
This PR includes a new implementation of the `ClusterLoadBalancer` interface which allows system administrators to provide a location for a script which can be downloaded and evaluated within the JVM for selecting a cluster. Currently it supports `JavaScript` and `Groovy` as script languages. More can be added by adding jars to the classpath.

The documentation has been updated with more details.