### PR TITLE
Ability to set cluster load balancer order via properties

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/services/ClusterLoadBalancer.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/ClusterLoadBalancer.java
@@ -20,9 +20,12 @@ package com.netflix.genie.core.services;
 import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
+import lombok.NonNull;
+import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.core.Ordered;
 import org.springframework.validation.annotation.Validated;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -31,9 +34,18 @@ import java.util.List;
  * run job on from an array of candidates.
  *
  * @author tgianos
+ * @since 2.0.0
  */
 @Validated
 public interface ClusterLoadBalancer extends Ordered {
+
+    /**
+     * The default order to apply to any implementation that doesn't explicitly set one.
+     *
+     * @see org.springframework.core.Ordered
+     * @see org.springframework.core.OrderComparator
+     */
+    int DEFAULT_ORDER = Ordered.LOWEST_PRECEDENCE - 1;
 
     /**
      * Return best cluster to run job on.
@@ -44,5 +56,16 @@ public interface ClusterLoadBalancer extends Ordered {
      * @throws GenieException if there is any error
      */
     @Nullable
-    Cluster selectCluster(final List<Cluster> clusters, final JobRequest jobRequest) throws GenieException;
+    Cluster selectCluster(
+        @Nonnull @NonNull @NotEmpty final List<Cluster> clusters,
+        @Nonnull @NonNull final JobRequest jobRequest
+    ) throws GenieException;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default int getOrder() {
+        return DEFAULT_ORDER;
+    }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/RandomizedClusterLoadBalancerImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/RandomizedClusterLoadBalancerImpl.java
@@ -20,11 +20,13 @@ package com.netflix.genie.core.services.impl;
 import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
-import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.core.services.ClusterLoadBalancer;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.core.Ordered;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Random;
 
@@ -41,14 +43,11 @@ public class RandomizedClusterLoadBalancerImpl implements ClusterLoadBalancer {
      * {@inheritDoc}
      */
     @Override
-    public Cluster selectCluster(final List<Cluster> clusters, final JobRequest jobRequest) throws GenieException {
+    public Cluster selectCluster(
+        @Nonnull @NonNull @NotEmpty final List<Cluster> clusters,
+        @Nonnull @NonNull final JobRequest jobRequest
+    ) throws GenieException {
         log.debug("called");
-
-        if (clusters == null || clusters.isEmpty()) {
-            final String msg = "No cluster configuration found for supplied cluster criteria";
-            log.error(msg);
-            throw new GeniePreconditionException(msg);
-        }
 
         // return a random one
         final Random rand = new Random();

--- a/genie-core/src/test/groovy/com/netflix/genie/core/services/ClusterLoadBalancerSpec.groovy
+++ b/genie-core/src/test/groovy/com/netflix/genie/core/services/ClusterLoadBalancerSpec.groovy
@@ -1,0 +1,59 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.services
+
+import com.netflix.genie.common.dto.Cluster
+import com.netflix.genie.common.dto.JobRequest
+import com.netflix.genie.common.exceptions.GenieException
+import lombok.NonNull
+import org.hibernate.validator.constraints.NotEmpty
+import org.springframework.core.Ordered
+import spock.lang.Specification
+
+import javax.annotation.Nonnull
+
+/**
+ * Specifications for the ClusterLoadBalancer interface.
+ *
+ * @author tgianos
+ * @since 3.1.0
+ */
+class ClusterLoadBalancerSpec extends Specification {
+
+    def "The default order variable is the expected value"() {
+        expect:
+        assert ClusterLoadBalancer.DEFAULT_ORDER == Ordered.LOWEST_PRECEDENCE - 1
+    }
+
+    def "The default interface implementation returns the default order value"() {
+        def loadBalancer = new ClusterLoadBalancer() {
+            @Override
+            Cluster selectCluster(
+                    @Nonnull @NonNull @NotEmpty List<Cluster> clusters,
+                    @Nonnull @NonNull JobRequest jobRequest) throws GenieException {
+                return null
+            }
+        }
+
+        when:
+        def order = loadBalancer.getOrder()
+
+        then:
+        order == ClusterLoadBalancer.DEFAULT_ORDER
+    }
+}

--- a/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
@@ -378,6 +378,9 @@ public class ServicesConfigTest {
         final Registry registry,
         final String hostName
     ) {
+        if (clusterLoadBalancers.isEmpty()) {
+            throw new IllegalStateException("Must have at least one active implementation of ClusterLoadBalancer");
+        }
         return new JobCoordinatorServiceImpl(
             jobPersistenceService,
             jobKillService,

--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/RandomizedClusterLoadBalancerImplUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/RandomizedClusterLoadBalancerImplUnitTests.java
@@ -21,15 +21,13 @@ import com.google.common.collect.Lists;
 import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
-import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.test.categories.UnitTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
-
-import java.util.ArrayList;
+import org.springframework.core.Ordered;
 
 /**
  * Test for the cluster load balancer.
@@ -55,7 +53,7 @@ public class RandomizedClusterLoadBalancerImplUnitTests {
      * @throws GenieException For any problem if anything went wrong with the test.
      */
     @Test
-    public void testValidCluster() throws GenieException {
+    public void testValidClusterList() throws GenieException {
         final Cluster cluster1 = Mockito.mock(Cluster.class);
         final Cluster cluster2 = Mockito.mock(Cluster.class);
         final Cluster cluster3 = Mockito.mock(Cluster.class);
@@ -68,22 +66,28 @@ public class RandomizedClusterLoadBalancerImplUnitTests {
     }
 
     /**
-     * Ensure exception is thrown if no cluster is found.
+     * Test whether a cluster is returned from a set of candidates.
      *
-     * @throws GenieException For any problem
+     * @throws GenieException For any problem if anything went wrong with the test.
      */
-    @Test(expected = GeniePreconditionException.class)
-    public void testEmptyList() throws GenieException {
-        this.clb.selectCluster(new ArrayList<>(), Mockito.mock(JobRequest.class));
+    @Test
+    public void testValidClusterListOfOne() throws GenieException {
+        final Cluster cluster1 = Mockito.mock(Cluster.class);
+        Assert.assertEquals(
+            cluster1,
+            this.clb.selectCluster(
+                Lists.newArrayList(cluster1),
+                Mockito.mock(JobRequest.class)
+            )
+        );
     }
 
     /**
-     * Ensure exception is thrown if no cluster is found.
-     *
-     * @throws GenieException For any problem
+     * Make sure the order for the RandomizedLoadBalancer is the lowest precedence as the fallback for all other
+     * options.
      */
-    @Test(expected = GeniePreconditionException.class)
-    public void testNullList() throws GenieException {
-        this.clb.selectCluster(null, Mockito.mock(JobRequest.class));
+    @Test
+    public void testOrderIsLowestPrecedence() {
+        Assert.assertEquals(this.clb.getOrder(), Ordered.LOWEST_PRECEDENCE);
     }
 }

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -56,6 +56,12 @@ See also: `genie.jobs.clusters.loadBalancers.script.source`
 See also: `genie.jobs.clusters.loadBalancers.script.destination`
 |false
 
+|genie.jobs.clusters.loadBalancers.script.order
+|The order which the script load balancer should be evaluated. The lower this number the sooner it is evaluated. 0
+would be the first thing evaluated if nothing else is set to 0 as well. Must be < 2147483647 (Integer.MAX_VALUE). If
+no value set will be given Integer.MAX_VALUE - 1 (default).
+|2147483646
+
 |genie.jobs.clusters.loadBalancers.script.refreshRate
 |How frequently to refresh the load balancer script (in milliseconds)
 |300000

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -44,6 +44,12 @@ See also: `genie.jobs.clusters.loadBalancers.script.source`
 See also: `genie.jobs.clusters.loadBalancers.script.destination`
 |false
 
+|genie.jobs.clusters.loadBalancers.script.order
+|The order which the script load balancer should be evaluated. The lower this number the sooner it is evaluated. 0
+would be the first thing evaluated if nothing else is set to 0 as well. Must be < 2147483647 (Integer.MAX_VALUE). If
+no value set will be given Integer.MAX_VALUE - 1 (default).
+|2147483646
+
 |genie.jobs.clusters.loadBalancers.script.refreshRate
 |How frequently to refresh the load balancer script (in milliseconds)
 |300000

--- a/genie-docs/src/docs/asciidoc/features/_clusterLoadBalancing.adoc
+++ b/genie-docs/src/docs/asciidoc/features/_clusterLoadBalancing.adoc
@@ -88,6 +88,12 @@ See also: `genie.jobs.clusters.loadBalancers.script.source`
 See also: `genie.jobs.clusters.loadBalancers.script.destination`
 |false
 
+|genie.jobs.clusters.loadBalancers.script.order
+|The order which the script load balancer should be evaluated. The lower this number the sooner it is evaluated. 0
+would be the first thing evaluated if nothing else is set to 0 as well. Must be < 2147483647 (Integer.MAX_VALUE). If
+no value set will be given Integer.MAX_VALUE - 1 (default).
+|2147483646
+
 |genie.jobs.clusters.loadBalancers.script.refreshRate
 |How frequently to refresh the load balancer script (in milliseconds)
 |300000

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -352,6 +352,9 @@ public class ServicesConfig {
         final Registry registry,
         final String hostName
     ) {
+        if (clusterLoadBalancers.isEmpty()) {
+            throw new IllegalStateException("Must have at least one active implementation of ClusterLoadBalancer");
+        }
         return new JobCoordinatorServiceImpl(
             jobPersistenceService,
             jobKillService,

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -246,6 +246,28 @@ public class ServicesConfigUnitTests {
     }
 
     /**
+     * Can't get a bean for Job Coordinator Service.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void cantGetJobCoordinatorServiceBeanWhenNoClusterLoadBalancers() {
+        Assert.assertNotNull(
+            this.servicesConfig.jobCoordinatorService(
+                Mockito.mock(JobPersistenceService.class),
+                Mockito.mock(JobKillService.class),
+                Mockito.mock(JobStateService.class),
+                Mockito.mock(JobSearchService.class),
+                new JobsProperties(),
+                Mockito.mock(ApplicationService.class),
+                Mockito.mock(ClusterService.class),
+                Mockito.mock(CommandService.class),
+                Lists.newArrayList(),
+                Mockito.mock(Registry.class),
+                UUID.randomUUID().toString()
+            )
+        );
+    }
+
+    /**
      * Can get a bean for Job Kill Service.
      */
     @Test


### PR DESCRIPTION
This PR allows admins to reset the `ScriptLoadBalancer` order from its default (second to last which is the `Randomized` one) to another priority if they wish to provide other `ClusterLoadBalancer` implementations in between