### PR TITLE
Precondition failed when no valid (non-blank) Cluster Criteria or Command Criteria submitted

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/dto/ClusterCriteria.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/ClusterCriteria.java
@@ -20,6 +20,7 @@ package com.netflix.genie.common.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import java.io.Serializable;
@@ -39,13 +40,13 @@ public class ClusterCriteria implements Serializable {
 
     private static final long serialVersionUID = 1782794735938665541L;
 
-    @NotEmpty(message = "No tags passed in to set and are required")
+    @NotEmpty(message = "No valid (e.g. non-blank) tags present")
     private Set<String> tags = new HashSet<>();
 
     /**
      * Create a cluster criteria object with the included tags.
      *
-     * @param tags The tags to add. Not null or empty.
+     * @param tags The tags to add. Not null or empty and must have at least one non-empty tag.
      */
     @JsonCreator
     public ClusterCriteria(
@@ -53,7 +54,13 @@ public class ClusterCriteria implements Serializable {
         final Set<String> tags
     ) {
         if (tags != null) {
-            this.tags.addAll(tags);
+            tags.forEach(
+                tag -> {
+                    if (StringUtils.isNotBlank(tag)) {
+                        this.tags.add(tag);
+                    }
+                }
+            );
         }
     }
 

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
@@ -20,6 +20,7 @@ package com.netflix.genie.common.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -54,9 +55,10 @@ public class JobRequest extends SetupFileDTO {
     @NotNull
     @Size(min = 1, max = 10000, message = "Command arguments are required and max at 10000 characters")
     private final String commandArgs;
+    @Valid
     @NotEmpty(message = "At least one cluster criteria is required")
     private final List<ClusterCriteria> clusterCriterias = new ArrayList<>();
-    @NotEmpty(message = "At least one command criteria is required")
+    @NotEmpty(message = "At least one valid (e.g. non-blank) command criteria is required")
     private final Set<String> commandCriteria = new HashSet<>();
     @Size(max = 255, message = "Max length of the group is 255 characters")
     private final String group;
@@ -225,7 +227,13 @@ public class JobRequest extends SetupFileDTO {
                 this.bClusterCriterias.addAll(clusterCriterias);
             }
             if (commandCriteria != null) {
-                this.bCommandCriteria.addAll(commandCriteria);
+                commandCriteria.forEach(
+                    criteria -> {
+                        if (StringUtils.isNotBlank(criteria)) {
+                            this.bCommandCriteria.add(criteria);
+                        }
+                    }
+                );
             }
         }
 

--- a/genie-core/src/main/java/com/netflix/genie/core/util/MetricsConstants.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/util/MetricsConstants.java
@@ -71,6 +71,12 @@ public final class MetricsConstants {
     public static final String GENIE_EXCEPTIONS_CONSTRAINT_VIOLATION_RATE = "genie.exceptions.constraintViolation.rate";
 
     /**
+     * For counting how often method argument not valid exceptions happen in the system.
+     */
+    public static final String GENIE_EXCEPTIONS_METHOD_ARGUMENT_NOT_VALID_RATE
+        = "genie.exceptions.methodArgumentNotValid.rate";
+
+    /**
      * Utility class protected constructor.
      */
     protected MetricsConstants() {

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/GenieExceptionMapper.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/GenieExceptionMapper.java
@@ -31,6 +31,7 @@ import com.netflix.spectator.api.Registry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -60,6 +61,7 @@ public class GenieExceptionMapper {
     private final Counter timeoutRate;
     private final Counter genieRate;
     private final Counter constraintViolationRate;
+    private final Counter methodArgumentNotValidRate;
 
     /**
      * Constructor.
@@ -77,6 +79,8 @@ public class GenieExceptionMapper {
         this.timeoutRate = registry.counter(MetricsConstants.GENIE_EXCEPTIONS_TIMEOUT_RATE);
         this.genieRate = registry.counter(MetricsConstants.GENIE_EXCEPTIONS_OTHER_RATE);
         this.constraintViolationRate = registry.counter(MetricsConstants.GENIE_EXCEPTIONS_CONSTRAINT_VIOLATION_RATE);
+        this.methodArgumentNotValidRate
+            = registry.counter(MetricsConstants.GENIE_EXCEPTIONS_METHOD_ARGUMENT_NOT_VALID_RATE);
     }
 
     /**
@@ -136,5 +140,22 @@ public class GenieExceptionMapper {
         this.constraintViolationRate.increment();
         log.error(cve.getLocalizedMessage(), cve);
         response.sendError(HttpStatus.PRECONDITION_FAILED.value(), builder.toString());
+    }
+
+    /**
+     * Handle MethodArgumentNotValid  exceptions.
+     *
+     * @param response The HTTP response
+     * @param e        The exception to handle
+     * @throws IOException on error in sending error
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public void handleMethodArgumentNotValidException(
+        final HttpServletResponse response,
+        final MethodArgumentNotValidException e
+    ) throws IOException {
+        this.methodArgumentNotValidRate.increment();
+        log.error(e.getMessage(), e);
+        response.sendError(HttpStatus.PRECONDITION_FAILED.value(), e.getMessage());
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/GenieExceptionMapperUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/GenieExceptionMapperUnitTests.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.controllers;
 
+import com.google.common.collect.Lists;
 import com.netflix.genie.common.exceptions.GenieBadRequestException;
 import com.netflix.genie.common.exceptions.GenieConflictException;
 import com.netflix.genie.common.exceptions.GenieException;
@@ -25,18 +26,24 @@ import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
 import com.netflix.genie.common.exceptions.GenieTimeoutException;
+import com.netflix.genie.core.util.MetricsConstants;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.ConstraintViolationException;
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 /**
  * Tests for the exception mapper.
@@ -56,6 +63,7 @@ public class GenieExceptionMapperUnitTests {
     private Counter timeoutRate;
     private Counter genieRate;
     private Counter constraintViolationRate;
+    private Counter methodArgumentNotValidRate;
 
     private HttpServletResponse response;
     private GenieExceptionMapper mapper;
@@ -74,21 +82,39 @@ public class GenieExceptionMapperUnitTests {
         this.timeoutRate = Mockito.mock(Counter.class);
         this.genieRate = Mockito.mock(Counter.class);
         this.constraintViolationRate = Mockito.mock(Counter.class);
+        this.methodArgumentNotValidRate = Mockito.mock(Counter.class);
 
         final Registry registry = Mockito.mock(Registry.class);
-        Mockito.when(registry.counter("genie.exceptions.badRequest.rate")).thenReturn(this.badRequestRate);
-        Mockito.when(registry.counter("genie.exceptions.conflict.rate")).thenReturn(this.conflictRate);
-        Mockito.when(registry.counter("genie.exceptions.notFound.rate")).thenReturn(this.notFoundRate);
-        Mockito.when(registry.counter("genie.exceptions.precondition.rate")).thenReturn(this.preconditionRate);
-        Mockito.when(registry.counter("genie.exceptions.server.rate")).thenReturn(this.serverRate);
         Mockito
-            .when(registry.counter("genie.exceptions.serverUnavailable.rate"))
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_BAD_REQUEST_RATE))
+            .thenReturn(this.badRequestRate);
+        Mockito
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_CONFLICT_RATE))
+            .thenReturn(this.conflictRate);
+        Mockito
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_NOT_FOUND_RATE))
+            .thenReturn(this.notFoundRate);
+        Mockito
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_PRECONDITION_RATE))
+            .thenReturn(this.preconditionRate);
+        Mockito
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_SERVER_RATE))
+            .thenReturn(this.serverRate);
+        Mockito
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_SERVER_UNAVAILABLE_RATE))
             .thenReturn(this.serverUnavailableRate);
-        Mockito.when(registry.counter("genie.exceptions.timeout.rate")).thenReturn(this.timeoutRate);
-        Mockito.when(registry.counter("genie.exceptions.other.rate")).thenReturn(this.genieRate);
         Mockito
-            .when(registry.counter("genie.exceptions.constraintViolation.rate"))
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_TIMEOUT_RATE))
+            .thenReturn(this.timeoutRate);
+        Mockito
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_OTHER_RATE))
+            .thenReturn(this.genieRate);
+        Mockito
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_CONSTRAINT_VIOLATION_RATE))
             .thenReturn(this.constraintViolationRate);
+        Mockito
+            .when(registry.counter(MetricsConstants.GENIE_EXCEPTIONS_METHOD_ARGUMENT_NOT_VALID_RATE))
+            .thenReturn(this.methodArgumentNotValidRate);
 
         this.response = Mockito.mock(HttpServletResponse.class);
         this.mapper = new GenieExceptionMapper(registry);
@@ -101,14 +127,14 @@ public class GenieExceptionMapperUnitTests {
      */
     @Test
     public void canHandleGenieExceptions() throws IOException {
-        this.mapper.handleGenieException(response, new GenieBadRequestException("bad"));
-        this.mapper.handleGenieException(response, new GenieConflictException("conflict"));
-        this.mapper.handleGenieException(response, new GenieNotFoundException("Not Found"));
-        this.mapper.handleGenieException(response, new GeniePreconditionException("Precondition"));
-        this.mapper.handleGenieException(response, new GenieServerException("server"));
-        this.mapper.handleGenieException(response, new GenieServerUnavailableException("Server Unavailable"));
-        this.mapper.handleGenieException(response, new GenieTimeoutException("Timeout"));
-        this.mapper.handleGenieException(response, new GenieException(568, "Other"));
+        this.mapper.handleGenieException(this.response, new GenieBadRequestException("bad"));
+        this.mapper.handleGenieException(this.response, new GenieConflictException("conflict"));
+        this.mapper.handleGenieException(this.response, new GenieNotFoundException("Not Found"));
+        this.mapper.handleGenieException(this.response, new GeniePreconditionException("Precondition"));
+        this.mapper.handleGenieException(this.response, new GenieServerException("server"));
+        this.mapper.handleGenieException(this.response, new GenieServerUnavailableException("Server Unavailable"));
+        this.mapper.handleGenieException(this.response, new GenieTimeoutException("Timeout"));
+        this.mapper.handleGenieException(this.response, new GenieException(568, "Other"));
 
         Mockito.verify(this.badRequestRate, Mockito.times(1)).increment();
         Mockito.verify(this.conflictRate, Mockito.times(1)).increment();
@@ -128,9 +154,41 @@ public class GenieExceptionMapperUnitTests {
      */
     @Test
     public void canHandleConstraintViolationExceptions() throws IOException {
-        this.mapper.handleConstraintViolation(response, new ConstraintViolationException("cve", null));
+        this.mapper.handleConstraintViolation(this.response, new ConstraintViolationException("cve", null));
         Mockito.verify(this.constraintViolationRate, Mockito.times(1)).increment();
         Mockito.verify(this.response, Mockito.times(1))
+            .sendError(Mockito.eq(HttpStatus.PRECONDITION_FAILED.value()), Mockito.anyString());
+    }
+
+    /**
+     * Test method argument not valid exceptions.
+     *
+     * @throws IOException on error
+     */
+    @Test
+    @SuppressFBWarnings(value = "DM_NEW_FOR_GETCLASS", justification = "It's needed for the test")
+    public void canHandleMethodArgumentNotValidExceptions() throws IOException {
+        // Method is a final class so can't mock it. Just use the current method.
+        final Method method = new Object() {
+        }.getClass().getEnclosingMethod();
+        final MethodParameter parameter = Mockito.mock(MethodParameter.class);
+        Mockito.when(parameter.getMethod()).thenReturn(method);
+
+        final BindingResult bindingResult = Mockito.mock(BindingResult.class);
+        Mockito.when(bindingResult.getAllErrors()).thenReturn(Lists.newArrayList());
+
+        this.mapper.handleMethodArgumentNotValidException(
+            this.response,
+            new MethodArgumentNotValidException(
+                parameter,
+                bindingResult
+            )
+        );
+        Mockito
+            .verify(this.methodArgumentNotValidRate, Mockito.times(1))
+            .increment();
+        Mockito
+            .verify(this.response, Mockito.times(1))
             .sendError(Mockito.eq(HttpStatus.PRECONDITION_FAILED.value()), Mockito.anyString());
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTests.java
@@ -1030,6 +1030,91 @@ public class JobRestControllerIntegrationTests extends RestControllerIntegration
     }
 
     /**
+     * Test the job submit method for incorrect cluster criteria.
+     *
+     * @throws Exception If there is a problem.
+     */
+    @Test
+    public void testSubmitJobMethodInvalidClusterCriteria() throws Exception {
+        Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
+        final String commandArgs = "-c 'echo hello world'";
+
+        final List<ClusterCriteria> clusterCriteriaList
+            = Lists.newArrayList(new ClusterCriteria(Sets.newHashSet(" ", "", null)));
+
+        final String jobId = UUID.randomUUID().toString();
+
+        final Set<String> commandCriteria = Sets.newHashSet("bash");
+        final JobRequest jobRequest = new JobRequest.Builder(
+            JOB_NAME,
+            JOB_USER,
+            JOB_VERSION,
+            commandArgs,
+            clusterCriteriaList,
+            commandCriteria
+        )
+            .withId(jobId)
+            .withDisableLogArchival(true)
+            .build();
+
+        this.mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post(JOBS_API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(this.objectMapper.writeValueAsBytes(jobRequest))
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(MockMvcResultMatchers.status().isPreconditionFailed());
+
+        this.mvc
+            .perform(MockMvcRequestBuilders.get(JOBS_API + "/{id}/status", jobId))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    /**
+     * Test the job submit method for incorrect cluster criteria.
+     *
+     * @throws Exception If there is a problem.
+     */
+    @Test
+    public void testSubmitJobMethodInvalidCommandCriteria() throws Exception {
+        Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
+        final String commandArgs = "-c 'echo hello world'";
+
+        final List<ClusterCriteria> clusterCriteriaList
+            = Lists.newArrayList(new ClusterCriteria(Sets.newHashSet("ok")));
+
+        final String jobId = UUID.randomUUID().toString();
+
+        final Set<String> commandCriteria = Sets.newHashSet(" ", "", null);
+        final JobRequest jobRequest = new JobRequest.Builder(
+            JOB_NAME,
+            JOB_USER,
+            JOB_VERSION,
+            commandArgs,
+            clusterCriteriaList,
+            commandCriteria
+        )
+            .withId(jobId)
+            .withDisableLogArchival(true)
+            .build();
+
+        this.mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post(JOBS_API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(this.objectMapper.writeValueAsBytes(jobRequest))
+                    .accept(MediaType.APPLICATION_JSON)
+            ).andExpect(MockMvcResultMatchers.status().isPreconditionFailed());
+
+        this.mvc
+            .perform(MockMvcRequestBuilders.get(JOBS_API + "/{id}/status", jobId))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    /**
      * Test the job submit method for incorrect command resolved.
      *
      * @throws Exception If there is a problem.

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/Snippets.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/Snippets.java
@@ -683,13 +683,16 @@ final class Snippets {
                 .fieldWithPath("clusterCriterias")
                 .attributes(getConstraintsForField(JOB_REQUEST_CONSTRAINTS, "clusterCriterias"))
                 .description(
-                    "List of cluster criteria's for which a match will be attempted with register cluster tags"
+                    "List of cluster criteria's for which a match will be attempted with register cluster tags."
+                        + " Each set of tags within a given cluster criteria must have at least one non-blank "
+                        + "(e.g. ' ', '    ', null) tag."
                 ),
             PayloadDocumentation
                 .fieldWithPath("commandCriteria")
                 .attributes(getConstraintsForField(JOB_REQUEST_CONSTRAINTS, "commandCriteria"))
                 .description(
-                    "List of tags which will attempt to match against the commands linked to selected cluster"
+                    "Set of tags which will attempt to match against the commands linked to selected cluster."
+                     + " There must be at least one non-blank (e.g. ' ', '   ', null) criteria within the set"
                 ),
             PayloadDocumentation
                 .fieldWithPath("group")


### PR DESCRIPTION
This PR modifies the bean validation on `JobRequest` payloads to ensure that there is at least one non-blank tag in both one of the `ClusterCriteria` and the `CommandCriteria`. This prevents the job request from getting through and causing non-deterministic behavior in the DB query as `""` tags will match every cluster or command in DB.

Now when a job request is made with this precondition violated the entire request fails and returns a 412 HTTP status code to the user. The job request is NOT saved to the database since it was invalid anyway.