### PR TITLE
Fix ScriptLoadBalancer directory not existing copy error

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/GenieFileTransferService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/GenieFileTransferService.java
@@ -46,10 +46,7 @@ public class GenieFileTransferService {
      * @param fileTransferFactory file transfer implementation factory
      * @throws GenieException If there is any problem
      */
-    public GenieFileTransferService(
-            @NotNull
-            final FileTransferFactory fileTransferFactory
-    ) throws GenieException {
+    public GenieFileTransferService(@NotNull final FileTransferFactory fileTransferFactory) throws GenieException {
         this.fileTransferFactory = fileTransferFactory;
     }
 
@@ -61,14 +58,12 @@ public class GenieFileTransferService {
      * @throws GenieException If there is any problem
      */
     public void getFile(
-            @NotBlank(message = "Source file path cannot be empty.")
-            final String srcRemotePath,
-            @NotBlank(message = "Destination local path cannot be empty")
-            final String dstLocalPath
+        @NotBlank(message = "Source file path cannot be empty.") final String srcRemotePath,
+        @NotBlank(message = "Destination local path cannot be empty") final String dstLocalPath
     ) throws GenieException {
         log.debug("Called with src path {} and destination path {}", srcRemotePath, dstLocalPath);
 
-        getFileTransfer(srcRemotePath).getFile(srcRemotePath, dstLocalPath);
+        this.getFileTransfer(srcRemotePath).getFile(srcRemotePath, dstLocalPath);
     }
 
     /**
@@ -79,14 +74,12 @@ public class GenieFileTransferService {
      * @throws GenieException If there is any problem
      */
     public void putFile(
-            @NotBlank(message = "Source local path cannot be empty.")
-            final String srcLocalPath,
-            @NotBlank(message = "Destination remote path cannot be empty")
-            final String dstRemotePath
+        @NotBlank(message = "Source local path cannot be empty.") final String srcLocalPath,
+        @NotBlank(message = "Destination remote path cannot be empty") final String dstRemotePath
     ) throws GenieException {
         log.debug("Called with src path {} and destination path {}", srcLocalPath, dstRemotePath);
 
-        getFileTransfer(dstRemotePath).putFile(srcLocalPath, dstRemotePath);
+        this.getFileTransfer(dstRemotePath).putFile(srcLocalPath, dstRemotePath);
     }
 
     protected FileTransfer getFileTransfer(final String path) throws GenieNotFoundException {
@@ -99,7 +92,7 @@ public class GenieFileTransferService {
         }
         if (result == null) {
             throw new GenieNotFoundException("Failed getting the appropriate FileTransfer implementation to get file: "
-                    + path);
+                + path);
         }
         return result;
     }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalFileTransferImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/LocalFileTransferImpl.java
@@ -53,24 +53,11 @@ public class LocalFileTransferImpl implements FileTransfer {
      */
     @Override
     public void getFile(
-        @NotBlank(message = "Source file path cannot be empty.")
-        final String srcRemotePath,
-        @NotBlank(message = "Destination local path cannot be empty")
-        final String dstLocalPath
+        @NotBlank(message = "Source file path cannot be empty.") final String srcRemotePath,
+        @NotBlank(message = "Destination local path cannot be empty") final String dstLocalPath
     ) throws GenieException {
         log.debug("Called with src path {} and destination path {}", srcRemotePath, dstLocalPath);
-        try {
-            final File src = new File(srcRemotePath);
-            final File dest = new File(dstLocalPath);
-            Files.copy(src.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException ioe) {
-            log.error("Got error while copying remote file {} to local path {}", srcRemotePath, dstLocalPath);
-            throw new GenieServerException(
-                "Got error while copying remote file "
-                    + srcRemotePath
-                    + " to local path "
-                    + dstLocalPath, ioe);
-        }
+        this.copy(srcRemotePath, dstLocalPath);
     }
 
     /**
@@ -78,24 +65,11 @@ public class LocalFileTransferImpl implements FileTransfer {
      */
     @Override
     public void putFile(
-        @NotBlank(message = "Source local path cannot be empty.")
-        final String srcLocalPath,
-        @NotBlank(message = "Destination remote path cannot be empty")
-        final String dstRemotePath
+        @NotBlank(message = "Source local path cannot be empty.") final String srcLocalPath,
+        @NotBlank(message = "Destination remote path cannot be empty") final String dstRemotePath
     ) throws GenieException {
         log.debug("Called with src path {} and destination path {}", srcLocalPath, dstRemotePath);
-        try {
-            final File src = new File(srcLocalPath);
-            final File dest = new File(dstRemotePath);
-            Files.copy(src.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException ioe) {
-            log.error("Got error while copying local file {} to remote path {}", srcLocalPath, dstRemotePath);
-            throw new GenieServerException(
-                "Got error while copying local file "
-                    + srcLocalPath
-                    + " to remote path "
-                    + dstRemotePath, ioe);
-        }
+        this.copy(srcLocalPath, dstRemotePath);
     }
 
     /**
@@ -107,8 +81,28 @@ public class LocalFileTransferImpl implements FileTransfer {
             return new File(path).lastModified();
         } catch (Exception e) {
             final String message = String.format("Failed getting the last modified time for file with path %s", path);
-            log.error(message);
+            log.error(message, e);
             throw new GenieServerException(message, e);
+        }
+    }
+
+    private void copy(final String srcPath, final String dstPath) throws GenieServerException {
+        try {
+            final File src = new File(srcPath);
+            final File dest = new File(dstPath);
+            if (!dest.getParentFile().exists()) {
+                Files.createDirectories(dest.getParentFile().toPath());
+            }
+            Files.copy(src.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (final IOException ioe) {
+            log.error("Got error while copying file {} to {}", srcPath, dstPath, ioe);
+            throw new GenieServerException(
+                "Got error while copying file "
+                    + srcPath
+                    + " to "
+                    + dstPath,
+                ioe
+            );
         }
     }
 }

--- a/genie-core/src/test/groovy/com/netflix/genie/core/services/impl/CacheGenieFileTransferServiceSpec.groovy
+++ b/genie-core/src/test/groovy/com/netflix/genie/core/services/impl/CacheGenieFileTransferServiceSpec.groovy
@@ -19,7 +19,6 @@ import com.netflix.genie.core.services.FileTransferFactory
 import com.netflix.spectator.api.Registry
 import spock.lang.Specification
 import spock.lang.Unroll
-
 /**
  * Unit tests for CacheGenieFileTransferService.
  * Created by amajumdar on 7/26/16.

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
@@ -34,7 +34,9 @@ import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.Timer
 import org.apache.commons.lang.StringUtils
+import org.junit.Rule
 import org.junit.experimental.categories.Category
+import org.junit.rules.TemporaryFolder
 import org.springframework.core.env.Environment
 import org.springframework.core.task.AsyncTaskExecutor
 import org.springframework.scheduling.TaskScheduler
@@ -44,7 +46,6 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.util.concurrent.TimeUnit
-
 /**
  * Specifications for the ScriptLoadBalancer class.
  *
@@ -53,6 +54,9 @@ import java.util.concurrent.TimeUnit
  */
 @Category(UnitTest.class)
 class ScriptLoadBalancerSpec extends Specification {
+
+    @Rule
+    TemporaryFolder temporaryFolder
 
     @Shared
     def mapper = new ObjectMapper().registerModule(new Jdk8Module())


### PR DESCRIPTION
This PR fixes an issue where if the destination directory for load balancer scripts (#552) didn't already exist the copy would fail and cause the entire script refresh to fail.

This PR does four things:

1. Attempts to create the script destination directory if it doesn't exist
2. Verifies the directory is truly a directory
3. Modifies the `LocalFileTransferImpl` to attempt to create the directories of a destination if they don't exist as a catch all for any place in the code where local file system to l local file system copies are used
4. Adds missing tests for the `LocalFileTransferImpl` class to verify expected behavior