### PR TITLE
Add groovy-all to runtime class path for script load balancer

### DIFF
--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -67,6 +67,8 @@ dependencies {
      * Runtime Dependencies
      *******************************/
 
+    runtime("org.codehaus.groovy:groovy-all")
+
     /*******************************
      * Test Dependencies
      *******************************/


### PR DESCRIPTION
This relates to #552 in that the Groovy tests were working because `groovy-all` was being pulled in by Spock to test class path however only the regular `groovy` jar was on the actual runtime class path.

This caused the system to be unable to find the JSR-223 Groovy implementation at runtime failing the script refresh module.

Adding `groovy-all` to runtime class path will resolve this.