### PR TITLE
Expose FileTransfer beans as concrete types

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/CacheGenieFileTransferService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/CacheGenieFileTransferService.java
@@ -18,7 +18,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
-import com.netflix.genie.core.services.FileTransfer;
 import com.netflix.genie.core.services.FileTransferFactory;
 import com.netflix.spectator.api.Registry;
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +42,7 @@ public class CacheGenieFileTransferService extends GenieFileTransferService {
     //File cache location
     private final String baseCacheLocation;
     //File transfer service to get/put files on a local system
-    private final FileTransfer localFileTransfer;
+    private final LocalFileTransferImpl localFileTransfer;
     //File cache
     private final LoadingCache<String, File> fileCache = CacheBuilder.newBuilder()
         .recordStats()
@@ -67,7 +66,7 @@ public class CacheGenieFileTransferService extends GenieFileTransferService {
     public CacheGenieFileTransferService(
         @NotNull final FileTransferFactory fileTransferFactory,
         @NotNull final String baseCacheLocation,
-        @NotNull final FileTransfer localFileTransfer, // TODO: I think this should be instance of LocalFileTransferImpl
+        @NotNull final LocalFileTransferImpl localFileTransfer,
         @NotNull final Registry registry
     ) throws GenieException {
         super(fileTransferFactory);

--- a/genie-core/src/test/groovy/com/netflix/genie/core/services/impl/CacheGenieFileTransferServiceSpec.groovy
+++ b/genie-core/src/test/groovy/com/netflix/genie/core/services/impl/CacheGenieFileTransferServiceSpec.groovy
@@ -14,7 +14,6 @@
 package com.netflix.genie.core.services.impl
 
 import com.netflix.genie.common.exceptions.GenieServerException
-import com.netflix.genie.core.services.FileTransfer
 import com.netflix.genie.core.services.FileTransferFactory
 import com.netflix.spectator.api.Registry
 import spock.lang.Specification
@@ -25,7 +24,7 @@ import spock.lang.Unroll
  */
 @Unroll
 class CacheGenieFileTransferServiceSpec extends Specification{
-    FileTransfer localFileTransfer = Mock(FileTransfer)
+    LocalFileTransferImpl localFileTransfer = Mock(LocalFileTransferImpl)
     FileTransferFactory fileTransferFactory = Mock(FileTransferFactory){
         get(_) >> localFileTransfer
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/JobConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/JobConfig.java
@@ -28,7 +28,6 @@ import com.netflix.genie.core.jobs.workflow.impl.JobKickoffTask;
 import com.netflix.genie.core.jobs.workflow.impl.JobTask;
 import com.netflix.genie.core.properties.JobsProperties;
 import com.netflix.genie.core.services.AttachmentService;
-import com.netflix.genie.core.services.FileTransfer;
 import com.netflix.genie.core.services.impl.GenieFileTransferService;
 import com.netflix.genie.core.services.impl.LocalFileTransferImpl;
 import com.netflix.genie.web.services.impl.HttpFileTransferImpl;
@@ -56,7 +55,7 @@ public class JobConfig {
      */
     @Bean(name = {"file.system.file", "file.system.null"})
     @Order(value = 2)
-    public FileTransfer localFileTransfer() {
+    public LocalFileTransferImpl localFileTransfer() {
         return new LocalFileTransferImpl();
     }
 
@@ -69,7 +68,7 @@ public class JobConfig {
      */
     @Bean(name = {"file.system.http", "file.system.https"})
     @Order(value = 3)
-    public FileTransfer httpFileTransfer(final RestTemplate restTemplate, final Registry registry) {
+    public HttpFileTransferImpl httpFileTransfer(final RestTemplate restTemplate, final Registry registry) {
         return new HttpFileTransferImpl(restTemplate, registry);
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -38,7 +38,6 @@ import com.netflix.genie.core.services.AttachmentService;
 import com.netflix.genie.core.services.ClusterLoadBalancer;
 import com.netflix.genie.core.services.ClusterService;
 import com.netflix.genie.core.services.CommandService;
-import com.netflix.genie.core.services.FileTransfer;
 import com.netflix.genie.core.services.FileTransferFactory;
 import com.netflix.genie.core.services.JobCoordinatorService;
 import com.netflix.genie.core.services.JobKillService;
@@ -52,6 +51,7 @@ import com.netflix.genie.core.services.impl.DefaultMailServiceImpl;
 import com.netflix.genie.core.services.impl.FileSystemAttachmentService;
 import com.netflix.genie.core.services.impl.GenieFileTransferService;
 import com.netflix.genie.core.services.impl.JobCoordinatorServiceImpl;
+import com.netflix.genie.core.services.impl.LocalFileTransferImpl;
 import com.netflix.genie.core.services.impl.LocalJobKillServiceImpl;
 import com.netflix.genie.core.services.impl.LocalJobRunner;
 import com.netflix.genie.core.services.impl.MailServiceImpl;
@@ -286,7 +286,7 @@ public class ServicesConfig {
     public GenieFileTransferService cacheGenieFileTransferService(
         final FileTransferFactory fileTransferFactory,
         @Value("${genie.file.cache.location}") final String baseCacheLocation,
-        @Qualifier("file.system.file") final FileTransfer localFileTransfer,
+        final LocalFileTransferImpl localFileTransfer,
         final Registry registry
     ) throws GenieException {
         return new CacheGenieFileTransferService(fileTransferFactory, baseCacheLocation, localFileTransfer, registry);

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsS3Config.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsS3Config.java
@@ -25,7 +25,6 @@ import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.netflix.genie.common.exceptions.GenieException;
-import com.netflix.genie.core.services.FileTransfer;
 import com.netflix.genie.core.services.impl.S3FileTransferImpl;
 import com.netflix.spectator.api.Registry;
 import lombok.extern.slf4j.Slf4j;
@@ -112,7 +111,10 @@ public class AwsS3Config {
     @Bean(name = {"file.system.s3", "file.system.s3n", "file.system.s3a"})
     @Order(value = 1)
     @ConditionalOnBean(AmazonS3.class)
-    public FileTransfer s3FileTransferImpl(final AmazonS3 s3Client, final Registry registry) throws GenieException {
+    public S3FileTransferImpl s3FileTransferImpl(
+        final AmazonS3 s3Client,
+        final Registry registry
+    ) throws GenieException {
         return new S3FileTransferImpl(s3Client, registry);
     }
 }


### PR DESCRIPTION
Remove loose coupling in times when a specific type is required. Particularly when the cached file transfer service needs a local transfer it no longer takes a `FileTransfer` instance it now takes a `LocalFileTransferImpl` to be certain we're getting what we expect.