### PR TITLE
Normalize file paths in LocalFileTransferImpl to all start with file://

### DIFF
--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/LocalFileTransferImplUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/LocalFileTransferImplUnitTests.java
@@ -99,6 +99,18 @@ public class LocalFileTransferImplUnitTests {
         Assert.assertFalse(dstFile3.exists());
         this.localFileTransfer.getFile(srcFile, dstFile3.getAbsolutePath());
         Assert.assertTrue(dstFile3.exists());
+
+        // Normalize for case where input is file:
+        final File dstFile4 = new File(folder.getAbsolutePath(), UUID.randomUUID().toString());
+        Assert.assertFalse(dstFile4.exists());
+        this.localFileTransfer.getFile("file:" + srcFile, dstFile4.getAbsolutePath());
+        Assert.assertTrue(dstFile4.exists());
+
+        // Normalize for case where input is file://
+        final File dstFile5 = new File(folder.getAbsolutePath(), UUID.randomUUID().toString());
+        Assert.assertFalse(dstFile5.exists());
+        this.localFileTransfer.getFile("file://" + srcFile, dstFile5.getAbsolutePath());
+        Assert.assertTrue(dstFile5.exists());
     }
 
     /**


### PR DESCRIPTION
Ensure that the paths passed to URI and `java.nio.file.Path` are full valid file URI's starting with `file://` and not nothing or or only `file:` which could cause issues.