### PR TITLE
Utilize parameterized logging and remove calls to toString()

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTask.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTask.java
@@ -197,7 +197,7 @@ public class JobKickoffTask extends GenieBaseTask {
 
     // Helper method to add write permissions to a directory for the group owner
     private void makeDirGroupWritable(final String dir) throws GenieServerException {
-        log.debug("Adding write permissions for the directory " + dir + " for the group.");
+        log.debug("Adding write permissions for the directory {} for the group.", dir);
         final CommandLine commandLIne = new CommandLine("sudo").addArgument("chmod").addArgument("g+w")
             .addArgument(dir);
 
@@ -238,7 +238,7 @@ public class JobKickoffTask extends GenieBaseTask {
                 // We create the group and ignore the error as it will fail if group already exists.
                 // If the failure is due to some other reason, then user creation will fail and we catch that.
                 try {
-                    log.debug("Running command to create group:  [" + groupCreateCommandLine.toString() + "]");
+                    log.debug("Running command to create group:  [{}]", groupCreateCommandLine);
                     this.executor.execute(groupCreateCommandLine);
                 } catch (IOException ioexception) {
                     log.debug("Group creation threw an error as it might already exist");
@@ -252,7 +252,7 @@ public class JobKickoffTask extends GenieBaseTask {
             userCreateCommandLine.addArgument("-M");
 
             try {
-                log.debug("Running command to create user: [" + userCreateCommandLine.toString() + "]");
+                log.debug("Running command to create user: [{}]", userCreateCommandLine);
                 this.executor.execute(userCreateCommandLine);
             } catch (IOException ioexception) {
                 throw new GenieServerException("Could not create user " + user + " with exception " + ioexception);

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaApplicationServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaApplicationServiceImpl.java
@@ -99,7 +99,7 @@ public class JpaApplicationServiceImpl implements ApplicationService {
         @Valid
         final Application app
     ) throws GenieException {
-        log.debug("Called with application: {}", app.toString());
+        log.debug("Called with application: {}", app);
         final Optional<String> appId = app.getId();
         if (appId.isPresent() && this.applicationRepo.exists(appId.get())) {
             throw new GenieConflictException("An application with id " + appId.get() + " already exists");
@@ -165,7 +165,7 @@ public class JpaApplicationServiceImpl implements ApplicationService {
             throw new GenieBadRequestException("Application id inconsistent with id passed in.");
         }
 
-        log.debug("Called with app {}", updateApp.toString());
+        log.debug("Called with app {}", updateApp);
         this.updateAndSaveApplicationEntity(this.findApplication(id), updateApp);
     }
 

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/FileSystemAttachmentService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/FileSystemAttachmentService.java
@@ -63,7 +63,7 @@ public class FileSystemAttachmentService implements AttachmentService {
         final File attachment = new File(attachmentDirectory, jobId + "/" + filename);
         try {
             FileUtils.copyInputStreamToFile(content, attachment);
-            log.info("Saved " + filename + " to " + attachment.getAbsolutePath());
+            log.info("Saved {} to {}", filename, attachment.getAbsolutePath());
         } catch (final IOException ioe) {
             throw new GenieServerException(ioe);
         }

--- a/genie-web/src/main/java/com/netflix/genie/web/security/SecurityConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configureGlobal(final AuthenticationManagerBuilder auth) throws Exception {
         if (this.providers != null) {
             for (final AuthenticationProvider provider : this.providers) {
-                log.debug("Adding authentication provider {} to authentication provider.", provider.toString());
+                log.debug("Adding authentication provider {} to authentication provider.", provider);
                 auth.authenticationProvider(provider);
             }
         } else {

--- a/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
@@ -172,7 +172,7 @@ public class ScriptLoadBalancer implements ClusterLoadBalancer {
         final Map<String, String> tags = Maps.newHashMap();
         try {
             if (this.isConfigured.get() && this.script != null && this.script.get() != null) {
-                log.debug("Evaluating script for job " + jobRequest.getId().orElse("without id"));
+                log.debug("Evaluating script for job {}", jobRequest.getId().orElse("without id"));
                 final Bindings bindings = new SimpleBindings();
                 bindings.put(CLUSTERS_BINDING, this.mapper.writeValueAsString(clusters));
                 bindings.put(JOB_REQUEST_BINDING, this.mapper.writeValueAsString(jobRequest));
@@ -191,7 +191,7 @@ public class ScriptLoadBalancer implements ClusterLoadBalancer {
                         }
                     }
                 }
-                log.warn("Script returned a cluster not in the input list: " + clusterId);
+                log.warn("Script returned a cluster not in the input list: {}", clusterId);
             } else {
                 log.debug("Script returned null");
                 tags.put(STATUS_TAG_KEY, STATUS_TAG_NOT_CONFIGURED);
@@ -294,7 +294,7 @@ public class ScriptLoadBalancer implements ClusterLoadBalancer {
                 final InputStream fis = Files.newInputStream(scriptDestinationPath);
                 final InputStreamReader reader = new InputStreamReader(fis, UTF_8)
             ) {
-                log.debug("Compiling " + scriptFileSource);
+                log.debug("Compiling {}", scriptFileSource);
                 this.script.set(compilable.compile(reader));
             }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
@@ -287,7 +287,7 @@ public class JobCompletionService {
                 });
             }
         } catch (final GenieException ge) {
-            log.error("Unable to cleanup process for job due to exception. " + jobId, ge);
+            log.error("Unable to cleanup process for job due to exception. {}", jobId, ge);
             this.processGroupCleanupFailureRate.increment();
         }
     }
@@ -463,7 +463,7 @@ public class JobCompletionService {
                 deleteCommand.addArgument("rm");
                 deleteCommand.addArgument("-rf");
                 deleteCommand.addArgument(dependencyDirectory.getCanonicalPath());
-                log.debug("Delete command is {}", deleteCommand.toString());
+                log.debug("Delete command is {}", deleteCommand);
                 this.executor.execute(deleteCommand);
             } else {
                 FileUtils.deleteDirectory(dependencyDirectory);
@@ -514,7 +514,7 @@ public class JobCompletionService {
 
                     this.executor.setWorkingDirectory(jobDir);
 
-                    log.debug("Archive command : {}", commandLine.toString());
+                    log.debug("Archive command : {}", commandLine);
                     this.executor.execute(commandLine);
 
                     // Upload the tar file to remote location
@@ -532,7 +532,7 @@ public class JobCompletionService {
                                 deleteCommand.addArgument(localArchiveFile.getCanonicalPath());
 
                                 this.executor.setWorkingDirectory(jobDir);
-                                log.debug("Delete command: {}", deleteCommand.toString());
+                                log.debug("Delete command: {}", deleteCommand);
                                 this.executor.execute(deleteCommand);
                             } else if (!localArchiveFile.delete()) {
                                 log.error("Failed to delete archive file for job: {}", jobId);

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeadershipTasksCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeadershipTasksCoordinator.java
@@ -136,7 +136,7 @@ public class LeadershipTasksCoordinator {
 
     private void cancelTasks() {
         for (final ScheduledFuture<?> future : this.futures) {
-            log.info("Attempting to cancel thread {}", future.toString());
+            log.info("Attempting to cancel thread {}", future);
             if (future.cancel(true)) {
                 log.info("Successfully cancelled.");
             } else {

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LocalLeader.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LocalLeader.java
@@ -62,7 +62,7 @@ public class LocalLeader {
     @EventListener
     public void startLeadership(final ContextRefreshedEvent event) {
         if (this.isLeader) {
-            log.debug("Starting Leadership due to " + event);
+            log.debug("Starting Leadership due to {}", event);
             this.publisher.publishEvent(new OnGrantedEvent(this, null, "leader"));
         }
     }
@@ -75,7 +75,7 @@ public class LocalLeader {
     @EventListener
     public void stopLeadership(final ContextClosedEvent event) {
         if (this.isLeader) {
-            log.debug("Stopping Leadership due to " + event);
+            log.debug("Stopping Leadership due to {}", event);
             this.publisher.publishEvent(new OnRevokedEvent(this, null, "leader"));
         }
     }


### PR DESCRIPTION
As suggested in the SLF4J FAQ: https://www.slf4j.org/faq.html#logging_performance
parameterized logging can improve the efficiency of logging calls when
logging at the specified level is disabled.

In addition, per the FAQ: https://www.slf4j.org/faq.html#string_contents
toString() is called automatically.

These changes were suggested and automatically made by SLF4J Helper:
http://plugins.netbeans.org/plugin/72557/