### PR TITLE
Also log the IOException

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTask.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTask.java
@@ -241,7 +241,7 @@ public class JobKickoffTask extends GenieBaseTask {
                     log.debug("Running command to create group:  [" + groupCreateCommandLine.toString() + "]");
                     this.executor.execute(groupCreateCommandLine);
                 } catch (IOException ioexception) {
-                    log.debug("Group creation threw an error as it might already exist");
+                    log.debug("Group creation threw an error as it might already exist", ioexception);
                 }
             }
 


### PR DESCRIPTION
SLF4J has special support for the last argument to a logger call being
an instance of Throwable: https://www.slf4j.org/faq.html#string_or_object