### PR TITLE
Fix two SLF4J logger calls

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaCommandServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaCommandServiceImpl.java
@@ -224,7 +224,7 @@ public class JpaCommandServiceImpl implements CommandService {
         @NotBlank(message = "No id entered. Unable to delete.")
         final String id
     ) throws GenieException {
-        log.debug("Called to delete command config with id {}");
+        log.debug("Called to delete command config with id {}", id);
         final CommandEntity commandEntity = this.findCommand(id);
 
         //Remove the command from the associated Application references

--- a/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
@@ -204,7 +204,7 @@ public class ScriptLoadBalancer implements ClusterLoadBalancer {
         } catch (final Exception e) {
             tags.put(STATUS_TAG_KEY, STATUS_TAG_FAILED);
             tags.put(EXCEPTION_TAG_KEY, e.getClass().getName());
-            log.error("Unable to execute script due to", e.getMessage(), e);
+            log.error("Unable to execute script due to {}", e.getMessage(), e);
             return null;
         } finally {
             this.registry


### PR DESCRIPTION
There were an inconsistent number of formatting anchors ('{}') which
can cause information not to be logged as expected.

These issues were identified by SLF4J Helper for NetBeans:
http://plugins.netbeans.org/plugin/72557/