### PR TITLE
URL-encode job ID when forwarding from UIController

### DIFF
--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/UIControllerUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/UIControllerUnitTests.java
@@ -31,6 +31,7 @@ import org.springframework.web.servlet.HandlerMapping;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.net.URLEncoder;
 import java.util.UUID;
 
 /**
@@ -75,9 +76,10 @@ public class UIControllerUnitTests {
 
     /**
      * Make sure the getFile method returns the right forward command.
+     * @throws Exception if an error occurs
      */
     @Test
-    public void canGetFile() {
+    public void canGetFile() throws Exception {
         final String id = UUID.randomUUID().toString();
         final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 
@@ -88,9 +90,12 @@ public class UIControllerUnitTests {
             .when(request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
             .thenReturn("/file/{id}/**");
 
+        final String encodedId = URLEncoder.encode(id, "UTF-8");
+        final String expectedPath = "/api/v3/jobs/" + encodedId + "/output/genie/log.out";
+
         Assert.assertThat(
             this.controller.getFile(id, request),
-            Matchers.is("forward:/api/v3/jobs/" + id + "/output/genie/log.out")
+            Matchers.is("forward:" + expectedPath)
         );
     }
 }


### PR DESCRIPTION
Motivation:
Download of files from the web UI fails if the job ID contains certain characters (such as '+').
This is due to URL decoding performed on the "forward URL" string returned by UIController (before passing the URL to JobRestController).

Change:
URL-encode the ID contained in the forward string.
This results in the ID being decoded back by Spring MVC to it's original format, and passed intact to the downstream JobRestController.