### PR TITLE
Modify database cleanup task to delete jobs in configurable batches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,14 @@ configure(javaProjects) {
                 entry "retrofit"
                 entry "converter-jackson"
             }
-            dependency("com.netflix.spectator:spectator-api:0.55.0")
+            dependencySet(group: "com.netflix.servo", version: "0.12.17") {
+                entry "servo-core"
+                entry "servo-internal"
+            }
+            dependencySet(group: "com.netflix.spectator", version: "0.56.0") {
+                entry "spectator-api"
+                entry "spectator-reg-servo"
+            }
             dependencySet(group: "io.springfox", version: "2.7.0") {
                 entry "springfox-swagger2"
                 entry "springfox-swagger-ui"

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/projections/IdProjection.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/projections/IdProjection.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Netflix, Inc.
+ *  Copyright 2017 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -15,26 +15,20 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.web.properties;
-
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
+package com.netflix.genie.core.jpa.entities.projections;
 
 /**
- * Properties controlling the behavior of the database cleanup leadership task.
+ * A projection just for returning the id field of a given entity.
  *
  * @author tgianos
- * @since 3.0.0
+ * @since 3.1.0
  */
-@ConfigurationProperties(prefix = "genie.tasks.databaseCleanup")
-@Component
-@Getter
-@Setter
-public class DatabaseCleanupProperties {
-    private boolean enabled;
-    private String expression = "0 0 0 * * *";
-    private int retention = 90;
-    private int batchSize = 10_000;
+public interface IdProjection {
+
+    /**
+     * Get the id from the projection.
+     *
+     * @return The id
+     */
+    String getId();
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/projections/package-info.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/projections/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Netflix, Inc.
+ *  Copyright 2017 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -15,26 +15,14 @@
  *     limitations under the License.
  *
  */
-package com.netflix.genie.web.properties;
-
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 /**
- * Properties controlling the behavior of the database cleanup leadership task.
+ * A package containing projection interfaces for Spring Data JPA.
  *
  * @author tgianos
- * @since 3.0.0
+ * @since 3.1.0
  */
-@ConfigurationProperties(prefix = "genie.tasks.databaseCleanup")
-@Component
-@Getter
-@Setter
-public class DatabaseCleanupProperties {
-    private boolean enabled;
-    private String expression = "0 0 0 * * *";
-    private int retention = 90;
-    private int batchSize = 10_000;
-}
+@ParametersAreNonnullByDefault
+package com.netflix.genie.core.jpa.entities.projections;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRequestRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaJobRequestRepository.java
@@ -16,10 +16,11 @@
 package com.netflix.genie.core.jpa.repositories;
 
 import com.netflix.genie.core.jpa.entities.JobRequestEntity;
+import com.netflix.genie.core.jpa.entities.projections.IdProjection;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import javax.validation.constraints.NotNull;
 import java.util.Date;
@@ -34,13 +35,13 @@ import java.util.List;
 public interface JpaJobRequestRepository extends JpaRepository<JobRequestEntity, String>, JpaSpecificationExecutor {
 
     /**
-     * Returns all job requests created before the given date.
+     * Returns the slice of ids for job requests created before the given date.
      *
-     * @param date The date before which all job requests were created.
-     * @return List of job requests
+     * @param date     The date before which the job requests were created
+     * @param pageable The page of data to get
+     * @return List of job request ids
      */
-    @Query("SELECT e.id FROM JobRequestEntity e WHERE e.created < :date")
-    List<String> findByCreatedBefore(@NotNull @Param("date") final Date date);
+    Slice<IdProjection> findByCreatedBefore(@NotNull final Date date, @NotNull Pageable pageable);
 
     /**
      * Deletes all job requests for the given ids.

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobPersistenceService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobPersistenceService.java
@@ -128,8 +128,9 @@ public interface JobPersistenceService {
     /**
      * This method will delete all jobs whose created time is less than date.
      *
-     * @param date The date before which all jobs should be deleted
+     * @param date      The date before which all jobs should be deleted
+     * @param batchSize The maximum number of jobs that should be deleted per iteration
      * @return the number of deleted jobs
      */
-    long deleteAllJobsCreatedBeforeDate(@NotNull final Date date);
+    long deleteAllJobsCreatedBeforeDate(@NotNull final Date date, @Min(1) final int batchSize);
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobPersistenceImplIntegrationTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaJobPersistenceImplIntegrationTests.java
@@ -62,7 +62,7 @@ public class JpaJobPersistenceImplIntegrationTests extends DBUnitTestBase {
      * Make sure we can delete jobs that were created before a given date.
      */
     @Test
-    public void canDeleteJobsCreatedBeforeDate() {
+    public void canDeleteJobsCreatedBeforeDateWithMinimumBatchSize() {
         Assert.assertThat(this.jobExecutionRepository.count(), Matchers.is(3L));
         Assert.assertThat(this.jobRequestRepository.count(), Matchers.is(3L));
         Assert.assertThat(this.jobRequestMetadataRepository.count(), Matchers.is(3L));
@@ -73,7 +73,35 @@ public class JpaJobPersistenceImplIntegrationTests extends DBUnitTestBase {
         cal.set(2016, Calendar.JANUARY, 1, 0, 0, 0);
         cal.set(Calendar.MILLISECOND, 0);
 
-        final long deleted = this.jobPersistenceService.deleteAllJobsCreatedBeforeDate(cal.getTime());
+        final long deleted = this.jobPersistenceService.deleteAllJobsCreatedBeforeDate(cal.getTime(), 1);
+
+        Assert.assertThat(deleted, Matchers.is(2L));
+        Assert.assertThat(this.jobExecutionRepository.count(), Matchers.is(1L));
+        Assert.assertThat(this.jobRequestRepository.count(), Matchers.is(1L));
+        Assert.assertThat(this.jobRequestMetadataRepository.count(), Matchers.is(1L));
+        Assert.assertThat(this.jobRepository.count(), Matchers.is(1L));
+        Assert.assertNotNull(this.jobExecutionRepository.getOne(JOB_3_ID));
+        Assert.assertNotNull(this.jobRequestRepository.getOne(JOB_3_ID));
+        Assert.assertNotNull(this.jobRequestMetadataRepository.getOne(JOB_3_ID));
+        Assert.assertNotNull(this.jobRepository.getOne(JOB_3_ID));
+    }
+
+    /**
+     * Make sure we can delete jobs that were created before a given date.
+     */
+    @Test
+    public void canDeleteJobsCreatedBeforeDateWithLargeBatchSize() {
+        Assert.assertThat(this.jobExecutionRepository.count(), Matchers.is(3L));
+        Assert.assertThat(this.jobRequestRepository.count(), Matchers.is(3L));
+        Assert.assertThat(this.jobRequestMetadataRepository.count(), Matchers.is(3L));
+        Assert.assertThat(this.jobRepository.count(), Matchers.is(3L));
+
+        // Try to delete all jobs before Jan 1, 2016
+        final Calendar cal = Calendar.getInstance(JobConstants.UTC);
+        cal.set(2016, Calendar.JANUARY, 1, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+
+        final long deleted = this.jobPersistenceService.deleteAllJobsCreatedBeforeDate(cal.getTime(), 10_000);
 
         Assert.assertThat(deleted, Matchers.is(2L));
         Assert.assertThat(this.jobExecutionRepository.count(), Matchers.is(1L));

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -290,6 +290,11 @@ lost and failed by the Genie leader
 |Whether or not to delete old job records from the database
 |true
 
+|genie.tasks.databaseCleanup.batchSize
+|The number of jobs to delete from the database at a time. Genie will loop until all jobs older than the retention
+time are deleted.
+|10000
+
 |genie.tasks.databaseCleanup.expression
 |The cron expression for how often to run the database cleanup task
 |0 0 0 * * *

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -65,6 +65,11 @@ no value set will be given Integer.MAX_VALUE - 1 (default).
 forces a timeout
 |5000
 
+|genie.tasks.databaseCleanup.batchSize
+|The number of jobs to delete from the database at a time. Genie will loop until all jobs older than the retention
+time are deleted.
+|10000
+
 |management.security.roles
 |The roles a user needs to have in order to access the Actuator endpoints
 |ADMIN


### PR DESCRIPTION
This PR adds the ability for system admins to configure the number of jobs deleted by the `DatabaseCleanupTask` at a time. The system will loop deleting that many jobs per iteration until all the jobs that were created before the configured retention time are deleted.

This will prevent the system from being overwhelmed when large numbers of jobs are present for given dates. In Netflix when we would have 250k+ jobs per day sometimes this task would fail.

Effectively pages the deletion process.