### PR TITLE
Don't save requests against API resources when OAuth2 security enabled

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/security/SecurityUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/SecurityUtils.java
@@ -22,6 +22,7 @@ import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.savedrequest.NullRequestCache;
 
 import javax.validation.constraints.NotNull;
 
@@ -82,6 +83,8 @@ public final class SecurityUtils {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.NEVER)
 //            .and()
 //                .requiresChannel().anyRequest().requiresSecure()
+            .and()
+                .requestCache().requestCache(new NullRequestCache())
             .and()
                 .csrf().disable();
         // @formatter:on

--- a/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/security/saml/SAMLConfig.java
@@ -764,11 +764,11 @@ public class SAMLConfig extends WebSecurityConfigurerAdapter {
         // @formatter:on
     }
 
-    protected void setSamlProperties(final SAMLProperties samlProperties) {
+    void setSamlProperties(final SAMLProperties samlProperties) {
         this.samlProperties = samlProperties;
     }
 
-    protected void setResourceLoader(final ResourceLoader resourceLoader) {
+    void setResourceLoader(final ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
     }
 }


### PR DESCRIPTION
Previously requests against resources (API's) which were supposed to be stateless were creating (and saving) sessions when authentication failed in case the user had to be redirected after authentication. This shouldn't happen for stateless API access. Only SAML authentication should deal with sessions and if UI is accessing the API's the session will be restated by `Spring Session` before reaching OAuth2 resource filter and bypass OAuth authentication.