### PR TITLE
Make S3 strict URL checking optional and disabled by default

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/properties/S3FileTransferProperties.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/properties/S3FileTransferProperties.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.core.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Properties for S3FileTransfer.
+ *
+ * @author mprimi
+ * @since 3.1.0
+ */
+@Getter
+@Setter
+public class S3FileTransferProperties {
+    private boolean strictUrlCheckEnabled;
+}

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -212,6 +212,12 @@ and system metrics and statistics.
 |S3FileTransferImpl
 |status, exceptionClass
 
+|genie.files.s3.failStrictValidation.counter
+|Count the number of times a S3 URL fails strict validation, but is allowed through anyway
+|count
+|S3FileTransferImpl
+|-
+
 |genie.web.controllers.exception
 |Counts exceptions returned to the user
 |count

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -337,6 +337,10 @@ to the number of CPU cores x 2 + 1
 |The namespace to use for Genie leadership election of a given cluster
 |/genie/leader/
 
+|genie.s3filetransfer.strictUrlCheckEnabled
+|Wether to strictly check an S3 URL for illegal characters before attempting to use it
+|false
+
 |===
 
 ==== Spring Properties

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/PropertiesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/PropertiesConfig.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.configs;
 import com.netflix.genie.core.properties.DataServiceRetryProperties;
 import com.netflix.genie.core.properties.HealthProperties;
 import com.netflix.genie.core.properties.JobsProperties;
+import com.netflix.genie.core.properties.S3FileTransferProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -64,5 +65,16 @@ public class PropertiesConfig {
     @ConfigurationProperties("genie.health")
     public HealthProperties healthProperties() {
         return new HealthProperties();
+    }
+
+    /**
+     * All the properties related to configuring S3 file transfer.
+     *
+     * @return The S3FileTransfer properties structure
+     */
+    @Bean
+    @ConfigurationProperties("genie.s3filetransfer")
+    public S3FileTransferProperties s3FileTransferProperties() {
+        return new S3FileTransferProperties();
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsS3Config.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsS3Config.java
@@ -25,6 +25,7 @@ import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.core.properties.S3FileTransferProperties;
 import com.netflix.genie.core.services.impl.S3FileTransferImpl;
 import com.netflix.spectator.api.Registry;
 import lombok.extern.slf4j.Slf4j;
@@ -105,6 +106,7 @@ public class AwsS3Config {
      *
      * @param s3Client S3 client to initialize the service
      * @param registry The metrics registry to use
+     * @param s3FileTransferProperties Configuration properties
      * @return An s3 implementation of the FileTransfer interface
      * @throws GenieException if there is any problem
      */
@@ -113,8 +115,9 @@ public class AwsS3Config {
     @ConditionalOnBean(AmazonS3.class)
     public S3FileTransferImpl s3FileTransferImpl(
         final AmazonS3 s3Client,
-        final Registry registry
+        final Registry registry,
+        final S3FileTransferProperties s3FileTransferProperties
     ) throws GenieException {
-        return new S3FileTransferImpl(s3Client, registry);
+        return new S3FileTransferImpl(s3Client, registry, s3FileTransferProperties);
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/S3FileTransferPropertiesUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/S3FileTransferPropertiesUnitTests.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import com.netflix.genie.core.properties.S3FileTransferProperties;
+import com.netflix.genie.test.categories.UnitTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Unit tests for S3FileTransferProperties.
+ *
+ * @author mprimi
+ * @since 3.1.0
+ */
+@Category(UnitTest.class)
+public class S3FileTransferPropertiesUnitTests {
+
+    private S3FileTransferProperties properties;
+
+    /**
+     * Setup for tests.
+     */
+    @Before
+    public void setup() {
+        this.properties = new S3FileTransferProperties();
+    }
+
+    /**
+     * Make sure constructor sets reasonable defaults.
+     */
+    @Test
+    public void canGetDefaultValues() {
+        Assert.assertFalse(this.properties.isStrictUrlCheckEnabled());
+    }
+
+    /**
+     * Make sure can enable strict URL checking.
+     */
+    @Test
+    public void canEnableStrictUrlChecking() {
+        this.properties.setStrictUrlCheckEnabled(true);
+        Assert.assertTrue(this.properties.isStrictUrlCheckEnabled());
+    }
+}


### PR DESCRIPTION
By default, turn off strict S3 URL checking and let arbitrary buckets/keys through.
Strict checking can be enabled via newly introduced property.