### PR TITLE
Split database cleanup of jobs into multiple transactions

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobPersistenceService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobPersistenceService.java
@@ -126,11 +126,15 @@ public interface JobPersistenceService {
     ) throws GenieException;
 
     /**
-     * This method will delete all jobs whose created time is less than date.
+     * This method will delete a chunk of jobs whose creation time is earlier than the given date.
      *
-     * @param date      The date before which all jobs should be deleted
-     * @param batchSize The maximum number of jobs that should be deleted per iteration
+     * @param date       The date before which all jobs should be deleted
+     * @param maxDeleted The maximum number of jobs that should be deleted
+     *                   (soft limit, can be rounded up to multiple of page size)
+     * @param pageSize   Page size used to iterate through jobs
      * @return the number of deleted jobs
      */
-    long deleteAllJobsCreatedBeforeDate(@NotNull final Date date, @Min(1) final int batchSize);
+    long deleteBatchOfJobsCreatedBeforeDate(@NotNull final Date date,
+                                            @Min(1) final int maxDeleted,
+                                            @Min(1) final int pageSize);
 }

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -290,10 +290,16 @@ lost and failed by the Genie leader
 |Whether or not to delete old job records from the database
 |true
 
-|genie.tasks.databaseCleanup.batchSize
-|The number of jobs to delete from the database at a time. Genie will loop until all jobs older than the retention
-time are deleted.
-|10000
+|genie.tasks.databaseCleanup.maxDeletedPerTransaction
+|The number of job records (across multiple tables) to delete from the database
+ in a single transaction. Genie will loop and perform multiple transactions until
+ all jobs older than the retention time are deleted.
+ This is a soft limit, it could be rounded up to the next multiple of page size.
+|1000
+
+|genie.tasks.databaseCleanup.pageSize
+|The page size used within each cleanup transaction to iterate through the job records
+|1000
 
 |genie.tasks.databaseCleanup.expression
 |The cron expression for how often to run the database cleanup task

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/DatabaseCleanupProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/DatabaseCleanupProperties.java
@@ -36,5 +36,6 @@ public class DatabaseCleanupProperties {
     private boolean enabled;
     private String expression = "0 0 0 * * *";
     private int retention = 90;
-    private int batchSize = 10_000;
+    private int maxDeletedPerTransaction = 1_000;
+    private int pageSize = 1_000;
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesUnitTests.java
@@ -53,6 +53,8 @@ public class DatabaseCleanupPropertiesUnitTests {
         Assert.assertFalse(this.properties.isEnabled());
         Assert.assertThat(this.properties.getExpression(), Matchers.is("0 0 0 * * *"));
         Assert.assertThat(this.properties.getRetention(), Matchers.is(90));
+        Assert.assertThat(this.properties.getMaxDeletedPerTransaction(), Matchers.is(1000));
+        Assert.assertThat(this.properties.getPageSize(), Matchers.is(1000));
     }
 
     /**
@@ -82,5 +84,25 @@ public class DatabaseCleanupPropertiesUnitTests {
         final int retention = 2318;
         this.properties.setRetention(retention);
         Assert.assertThat(this.properties.getRetention(), Matchers.is(retention));
+    }
+
+    /**
+     * Make sure can set a max deletion batch size.
+     */
+    @Test
+    public void canSetMaxDeletedPerTransaction() {
+        final int max = 2318;
+        this.properties.setMaxDeletedPerTransaction(max);
+        Assert.assertThat(this.properties.getMaxDeletedPerTransaction(), Matchers.is(max));
+    }
+
+    /**
+     * Make sure can set a new page size.
+     */
+    @Test
+    public void canPageSize() {
+        final int size = 2318;
+        this.properties.setPageSize(size);
+        Assert.assertThat(this.properties.getPageSize(), Matchers.is(size));
     }
 }


### PR DESCRIPTION
The strategy of deleting a very large number of jobs with a single paginated transaction can result in timeouts if the number of jobs to delete is large.
Split the deletion in multiple transactions (with a configurable max per transaction). Each transaction still paginates (with a configurable page size).