### PR TITLE
Optimize DTO collection immutability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - genie-web/node_modules/
+    - genie-web/.gradle/nodejs
+    - genie-web/.gradle/npm
   timeout: 1000
 env:
   global:

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/BaseDTO.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/BaseDTO.java
@@ -60,7 +60,7 @@ public abstract class BaseDTO implements Serializable {
      *
      * @param builder The builder to use
      */
-    protected BaseDTO(final Builder builder) {
+    BaseDTO(final Builder builder) {
         this.id = builder.bId;
         this.created = builder.bCreated == null ? null : new Date(builder.bCreated.getTime());
         this.updated = builder.bUpdated == null ? null : new Date(builder.bUpdated.getTime());
@@ -122,8 +122,12 @@ public abstract class BaseDTO implements Serializable {
      * @author tgianos
      * @since 3.0.0
      */
+    // NOTE: These abstract class builders are marked public not protected due to a JDK bug from 1999 which caused
+    //       issues with Clojure clients which use reflection to make the Java API calls.
+    //       http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4283544
+    //       Setting them to public seems to have solved the issue at the expense of "proper" code design
     @SuppressWarnings("unchecked")
-    protected abstract static class Builder<T extends Builder> {
+    public abstract static class Builder<T extends Builder> {
 
         private String bId;
         private Date bCreated;

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/ClusterCriteria.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/ClusterCriteria.java
@@ -19,13 +19,13 @@ package com.netflix.genie.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -35,13 +35,14 @@ import java.util.Set;
  * @author tgianos
  * @since 2.0.0
  */
+@Getter
 @EqualsAndHashCode(doNotUseGetters = true)
 public class ClusterCriteria implements Serializable {
 
     private static final long serialVersionUID = 1782794735938665541L;
 
     @NotEmpty(message = "No valid (e.g. non-blank) tags present")
-    private Set<String> tags = new HashSet<>();
+    private Set<String> tags;
 
     /**
      * Create a cluster criteria object with the included tags.
@@ -53,23 +54,16 @@ public class ClusterCriteria implements Serializable {
         @JsonProperty("tags")
         final Set<String> tags
     ) {
+        final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
         if (tags != null) {
             tags.forEach(
                 tag -> {
                     if (StringUtils.isNotBlank(tag)) {
-                        this.tags.add(tag);
+                        builder.add(tag);
                     }
                 }
             );
         }
-    }
-
-    /**
-     * Get the tags for this cluster criteria.
-     *
-     * @return The tags for this criteria as a read-only set. Any attempt to modify will throw exception.
-     */
-    public Set<String> getTags() {
-        return Collections.unmodifiableSet(this.tags);
+        this.tags = builder.build();
     }
 }

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/CommonDTO.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/CommonDTO.java
@@ -17,11 +17,11 @@
  */
 package com.netflix.genie.common.dto;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.Size;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -37,8 +37,6 @@ public abstract class CommonDTO extends BaseDTO {
 
     private static final long serialVersionUID = -2082573569004634251L;
 
-    private final Set<String> tags = new HashSet<>();
-
     @NotEmpty(message = "A version is required and must be at most 255 characters.")
     @Size(max = 255, message = "The version can be no longer than 255 characters")
     private final String version;
@@ -49,6 +47,7 @@ public abstract class CommonDTO extends BaseDTO {
     @Size(max = 255, message = "The name can be no longer than 255 characters")
     private final String name;
     private final String description;
+    private final Set<String> tags;
 
     /**
      * Constructor.
@@ -56,13 +55,13 @@ public abstract class CommonDTO extends BaseDTO {
      * @param builder The builder to use
      */
     @SuppressWarnings("unchecked")
-    protected CommonDTO(final Builder builder) {
+    CommonDTO(final Builder builder) {
         super(builder);
         this.name = builder.bName;
         this.user = builder.bUser;
         this.version = builder.bVersion;
         this.description = builder.bDescription;
-        this.tags.addAll(builder.bTags);
+        this.tags = ImmutableSet.copyOf(builder.bTags);
     }
 
     /**
@@ -75,23 +74,18 @@ public abstract class CommonDTO extends BaseDTO {
     }
 
     /**
-     * Get a readonly copy of the tags.
-     *
-     * @return The tags. Read only. Will throw exception if try to modify.
-     */
-    public Set<String> getTags() {
-        return Collections.unmodifiableSet(this.tags);
-    }
-
-    /**
      * Builder pattern to save constructor arguments.
      *
      * @param <T> Type of builder that extends this
      * @author tgianos
      * @since 3.0.0
      */
+    // NOTE: These abstract class builders are marked public not protected due to a JDK bug from 1999 which caused
+    //       issues with Clojure clients which use reflection to make the Java API calls.
+    //       http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4283544
+    //       Setting them to public seems to have solved the issue at the expense of "proper" code design
     @SuppressWarnings("unchecked")
-    protected abstract static class Builder<T extends Builder> extends BaseDTO.Builder<T> {
+    public abstract static class Builder<T extends Builder> extends BaseDTO.Builder<T> {
 
         private final String bName;
         private final String bUser;
@@ -123,6 +117,7 @@ public abstract class CommonDTO extends BaseDTO {
          * @return The builder
          */
         public T withTags(final Set<String> tags) {
+            this.bTags.clear();
             if (tags != null) {
                 this.bTags.addAll(tags);
             }

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/ExecutionEnvironmentDTO.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/ExecutionEnvironmentDTO.java
@@ -17,10 +17,10 @@
  */
 package com.netflix.genie.common.dto;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 
 import javax.validation.constraints.Size;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -35,8 +35,8 @@ import java.util.Set;
 public abstract class ExecutionEnvironmentDTO extends CommonDTO {
 
     private static final long serialVersionUID = 2116254045303538065L;
-    private final Set<String> configs = new HashSet<>();
-    private final Set<String> dependencies = new HashSet<>();
+    private final Set<String> configs;
+    private final Set<String> dependencies;
     @Size(max = 1024, message = "Max length of the setup file is 1024 characters")
     private final String setupFile;
 
@@ -46,11 +46,11 @@ public abstract class ExecutionEnvironmentDTO extends CommonDTO {
      * @param builder The builder to use
      */
     @SuppressWarnings("unchecked")
-    protected ExecutionEnvironmentDTO(final Builder builder) {
+    ExecutionEnvironmentDTO(final Builder builder) {
         super(builder);
         this.setupFile = builder.bSetupFile;
-        this.configs.addAll(builder.bConfigs);
-        this.dependencies.addAll(builder.bDependencies);
+        this.configs = ImmutableSet.copyOf(builder.bConfigs);
+        this.dependencies = ImmutableSet.copyOf(builder.bDependencies);
     }
 
     /**
@@ -63,32 +63,18 @@ public abstract class ExecutionEnvironmentDTO extends CommonDTO {
     }
 
     /**
-     * Get the set of configs for the entity.
-     *
-     * @return The configs for the entity as a read-only set.
-     */
-    public Set<String> getConfigs() {
-        return Collections.unmodifiableSet(this.configs);
-    }
-
-    /**
-     * Get the set of dependencies for the entity.
-     *
-     * @return The dependencies for the entity as a read-only set.
-     */
-    public Set<String> getDependencies() {
-        return Collections.unmodifiableSet(this.dependencies);
-    }
-
-    /**
      * A builder for helping to create instances.
      *
      * @param <T> The type of builder that extends this builder for final implementation
      * @author tgianos
      * @since 3.0.0
      */
+    // NOTE: These abstract class builders are marked public not protected due to a JDK bug from 1999 which caused
+    //       issues with Clojure clients which use reflection to make the Java API calls.
+    //       http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4283544
+    //       Setting them to public seems to have solved the issue at the expense of "proper" code design
     @SuppressWarnings("unchecked")
-    protected abstract static class Builder<T extends Builder> extends CommonDTO.Builder<T> {
+    public abstract static class Builder<T extends Builder> extends CommonDTO.Builder<T> {
 
         private final Set<String> bConfigs = new HashSet<>();
         private final Set<String> bDependencies = new HashSet<>();
@@ -123,6 +109,7 @@ public abstract class ExecutionEnvironmentDTO extends CommonDTO {
          * @return The builder
          */
         public T withConfigs(final Set<String> configs) {
+            this.bConfigs.clear();
             if (configs != null) {
                 this.bConfigs.addAll(configs);
             }
@@ -136,6 +123,7 @@ public abstract class ExecutionEnvironmentDTO extends CommonDTO {
          * @return The builder
          */
         public T withDependencies(final Set<String> dependencies) {
+            this.bDependencies.clear();
             if (dependencies != null) {
                 this.bDependencies.addAll(dependencies);
             }

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
@@ -19,6 +19,8 @@ package com.netflix.genie.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.Email;
@@ -29,7 +31,6 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -57,9 +58,9 @@ public class JobRequest extends ExecutionEnvironmentDTO {
     private final String commandArgs;
     @Valid
     @NotEmpty(message = "At least one cluster criteria is required")
-    private final List<ClusterCriteria> clusterCriterias = new ArrayList<>();
+    private final List<ClusterCriteria> clusterCriterias;
     @NotEmpty(message = "At least one valid (e.g. non-blank) command criteria is required")
-    private final Set<String> commandCriteria = new HashSet<>();
+    private final Set<String> commandCriteria;
     @Size(max = 255, message = "Max length of the group is 255 characters")
     private final String group;
     private final boolean disableLogArchival;
@@ -72,7 +73,7 @@ public class JobRequest extends ExecutionEnvironmentDTO {
     private final Integer memory;
     @Min(value = 1, message = "The timeout must be at least 1 second, preferably much more.")
     private final Integer timeout;
-    private final List<String> applications = new ArrayList<>();
+    private final List<String> applications;
 
     /**
      * Constructor used by the builder build() method.
@@ -80,18 +81,18 @@ public class JobRequest extends ExecutionEnvironmentDTO {
      * @param builder The builder to use
      */
     @SuppressWarnings("unchecked")
-    protected JobRequest(@Valid final Builder builder) {
+    JobRequest(@Valid final Builder builder) {
         super(builder);
         this.commandArgs = builder.bCommandArgs;
-        this.clusterCriterias.addAll(builder.bClusterCriterias);
-        this.commandCriteria.addAll(builder.bCommandCriteria);
+        this.clusterCriterias = ImmutableList.copyOf(builder.bClusterCriterias);
+        this.commandCriteria = ImmutableSet.copyOf(builder.bCommandCriteria);
         this.group = builder.bGroup;
         this.disableLogArchival = builder.bDisableLogArchival;
         this.email = builder.bEmail;
         this.cpu = builder.bCpu;
         this.memory = builder.bMemory;
         this.timeout = builder.bTimeout;
-        this.applications.addAll(builder.bApplications);
+        this.applications = ImmutableList.copyOf(builder.bApplications);
     }
 
     /**
@@ -137,33 +138,6 @@ public class JobRequest extends ExecutionEnvironmentDTO {
      */
     public Optional<Integer> getTimeout() {
         return Optional.ofNullable(this.timeout);
-    }
-
-    /**
-     * Get the list of cluster criterias.
-     *
-     * @return Read-only version of the cluster criterias. Attempts to modify will throw exception
-     */
-    public List<ClusterCriteria> getClusterCriterias() {
-        return Collections.unmodifiableList(this.clusterCriterias);
-    }
-
-    /**
-     * Get the set of command criteria.
-     *
-     * @return Read-only version of the command criteria. Attempts to modify will throw exception
-     */
-    public Set<String> getCommandCriteria() {
-        return Collections.unmodifiableSet(this.commandCriteria);
-    }
-
-    /**
-     * Get the list of application id's this job is requesting to override the default applications with.
-     *
-     * @return The application ids as an read-only list. Attempts to modify with throw runtime exception.
-     */
-    public List<String> getApplications() {
-        return Collections.unmodifiableList(this.applications);
     }
 
     /**


### PR DESCRIPTION
- Work around 1999 reflection bug in dto builders for Clojure
- Cache NPM related stuff from genie-web to try and speed up travis build
- Fix some collection related builder methods to call `clear` first to ensure not adding on top of previous calls to `with`