### PR TITLE
Templatize RestTemplate usage for Job API forwarding

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ControllerUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ControllerUtils.java
@@ -30,12 +30,12 @@ import javax.servlet.http.HttpServletRequest;
  * @since 3.0.0
  */
 @Slf4j
-public final class ControllerUtils {
+final class ControllerUtils {
 
     /**
      * Constructor.
      */
-    protected ControllerUtils() {
+    private ControllerUtils() {
     }
 
     /**
@@ -46,7 +46,7 @@ public final class ControllerUtils {
      * @param request The http servlet request.
      * @return The remaining path
      */
-    public static String getRemainingPath(final HttpServletRequest request) {
+    static String getRemainingPath(final HttpServletRequest request) {
         String path = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
         if (path != null) {
             final String bestMatchPattern

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -117,6 +117,9 @@ public class JobRestController {
     private static final String TRANSFER_ENCODING_HEADER = "Transfer-Encoding";
     private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
     private static final String NAME_HEADER_COOKIE = "cookie";
+    private static final String JOB_API_TEMPLATE = "/api/v3/jobs/{id}";
+    private static final String EMPTY_STRING = "";
+    private static final String COMMA = ",";
 
     private final JobCoordinatorService jobCoordinatorService;
     private final JobSearchService jobSearchService;
@@ -208,13 +211,9 @@ public class JobRestController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResponseEntity<Void> submitJob(
-        @Valid
-        @RequestBody
-        final JobRequest jobRequest,
-        @RequestHeader(value = FORWARDED_FOR_HEADER, required = false)
-        final String clientHost,
-        @RequestHeader(value = HttpHeaders.USER_AGENT, required = false)
-        final String userAgent,
+        @Valid @RequestBody final JobRequest jobRequest,
+        @RequestHeader(value = FORWARDED_FOR_HEADER, required = false) final String clientHost,
+        @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) final String userAgent,
         final HttpServletRequest httpServletRequest
     ) throws GenieException {
         log.info("[submitJob] Called json method type to submit job: {}", jobRequest);
@@ -236,15 +235,10 @@ public class JobRestController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResponseEntity<Void> submitJob(
-        @Valid
-        @RequestPart("request")
-        final JobRequest jobRequest,
-        @RequestPart("attachment")
-        final MultipartFile[] attachments,
-        @RequestHeader(value = FORWARDED_FOR_HEADER, required = false)
-        final String clientHost,
-        @RequestHeader(value = HttpHeaders.USER_AGENT, required = false)
-        final String userAgent,
+        @Valid @RequestPart("request") final JobRequest jobRequest,
+        @RequestPart("attachment") final MultipartFile[] attachments,
+        @RequestHeader(value = FORWARDED_FOR_HEADER, required = false) final String clientHost,
+        @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) final String userAgent,
         final HttpServletRequest httpServletRequest
     ) throws GenieException {
         log.info("[submitJob] Called multipart method to submit job: {}", jobRequest);
@@ -266,7 +260,7 @@ public class JobRestController {
         // get client's host from the context
         final String localClientHost;
         if (StringUtils.isNotBlank(clientHost)) {
-            localClientHost = clientHost.split(",")[0];
+            localClientHost = clientHost.split(COMMA)[0];
         } else {
             localClientHost = httpServletRequest.getRemoteAddr();
         }
@@ -354,8 +348,7 @@ public class JobRestController {
      */
     @GetMapping(value = "/{id}", produces = MediaTypes.HAL_JSON_VALUE)
     public JobResource getJob(
-        @PathVariable("id")
-        final String id) throws GenieException {
+        @PathVariable("id") final String id) throws GenieException {
         log.info("[getJob] Called for job with id: {}", id);
         return this.jobResourceAssembler.toResource(this.jobSearchService.getJob(id));
     }
@@ -369,8 +362,7 @@ public class JobRestController {
      */
     @GetMapping(value = "/{id}/status", produces = MediaType.APPLICATION_JSON_VALUE)
     public JsonNode getJobStatus(
-        @PathVariable("id")
-        final String id) throws GenieException {
+        @PathVariable("id") final String id) throws GenieException {
         log.debug("[getJobStatus] Called for job with id: {}", id);
         final JsonNodeFactory factory = JsonNodeFactory.instance;
         return factory
@@ -402,34 +394,20 @@ public class JobRestController {
     @GetMapping(produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public PagedResources<JobSearchResultResource> findJobs(
-        @RequestParam(value = "id", required = false)
-        final String id,
-        @RequestParam(value = "name", required = false)
-        final String name,
-        @RequestParam(value = "user", required = false)
-        final String user,
-        @RequestParam(value = "status", required = false)
-        final Set<String> statuses,
-        @RequestParam(value = "tag", required = false)
-        final Set<String> tags,
-        @RequestParam(value = "clusterName", required = false)
-        final String clusterName,
-        @RequestParam(value = "clusterId", required = false)
-        final String clusterId,
-        @RequestParam(value = "commandName", required = false)
-        final String commandName,
-        @RequestParam(value = "commandId", required = false)
-        final String commandId,
-        @RequestParam(value = "minStarted", required = false)
-        final Long minStarted,
-        @RequestParam(value = "maxStarted", required = false)
-        final Long maxStarted,
-        @RequestParam(value = "minFinished", required = false)
-        final Long minFinished,
-        @RequestParam(value = "maxFinished", required = false)
-        final Long maxFinished,
-        @PageableDefault(sort = {"created"}, direction = Sort.Direction.DESC)
-        final Pageable page,
+        @RequestParam(value = "id", required = false) final String id,
+        @RequestParam(value = "name", required = false) final String name,
+        @RequestParam(value = "user", required = false) final String user,
+        @RequestParam(value = "status", required = false) final Set<String> statuses,
+        @RequestParam(value = "tag", required = false) final Set<String> tags,
+        @RequestParam(value = "clusterName", required = false) final String clusterName,
+        @RequestParam(value = "clusterId", required = false) final String clusterId,
+        @RequestParam(value = "commandName", required = false) final String commandName,
+        @RequestParam(value = "commandId", required = false) final String commandId,
+        @RequestParam(value = "minStarted", required = false) final Long minStarted,
+        @RequestParam(value = "maxStarted", required = false) final Long maxStarted,
+        @RequestParam(value = "minFinished", required = false) final Long minFinished,
+        @RequestParam(value = "maxFinished", required = false) final Long maxFinished,
+        @PageableDefault(sort = {"created"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<JobSearchResult> assembler
     ) throws GenieException {
         log.info(
@@ -525,10 +503,8 @@ public class JobRestController {
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void killJob(
-        @PathVariable("id")
-        final String id,
-        @RequestHeader(name = JobConstants.GENIE_FORWARDED_FROM_HEADER, required = false)
-        final String forwardedFrom,
+        @PathVariable("id") final String id,
+        @RequestHeader(name = JobConstants.GENIE_FORWARDED_FROM_HEADER, required = false) final String forwardedFrom,
         final HttpServletRequest request,
         final HttpServletResponse response
     ) throws GenieException, IOException, ServletException {
@@ -539,22 +515,25 @@ public class JobRestController {
             final String jobHostname = this.jobSearchService.getJobHost(id);
             if (!this.hostName.equals(jobHostname)) {
                 log.info("Job {} is not on this node. Forwarding kill request to {}", id, jobHostname);
-                final String forwardUrl = buildForwardURL(request, jobHostname);
+                final String forwardHost = this.buildForwardHost(jobHostname);
                 try {
                     //Need to forward job
-                    restTemplate.execute(forwardUrl, HttpMethod.DELETE,
+                    this.restTemplate.execute(
+                        forwardHost + JOB_API_TEMPLATE,
+                        HttpMethod.DELETE,
                         forwardRequest -> copyRequestHeaders(request, forwardRequest),
                         (final ClientHttpResponse forwardResponse) -> {
                             response.setStatus(HttpStatus.ACCEPTED.value());
                             copyResponseHeaders(response, forwardResponse);
                             return null;
-                        }
+                        },
+                        id
                     );
                 } catch (HttpStatusCodeException e) {
-                    log.error("Failed killing job on {}. Error: {}", forwardUrl, e.getMessage());
+                    log.error("Failed killing job on {}. Error: {}", forwardHost, e.getMessage());
                     response.sendError(e.getStatusCode().value(), e.getStatusText());
                 } catch (Exception e) {
-                    log.error("Failed killing job on {}. Error: {}", forwardUrl, e.getMessage());
+                    log.error("Failed killing job on {}. Error: {}", forwardHost, e.getMessage());
                     response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
                 }
 
@@ -579,8 +558,7 @@ public class JobRestController {
     @GetMapping(value = "/{id}/request", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public JobRequestResource getJobRequest(
-        @PathVariable("id")
-        final String id) throws GenieException {
+        @PathVariable("id") final String id) throws GenieException {
         log.info("[getJobRequest] Called for job request with id {}", id);
         return this.jobRequestResourceAssembler.toResource(this.jobSearchService.getJobRequest(id));
     }
@@ -595,8 +573,7 @@ public class JobRestController {
     @GetMapping(value = "/{id}/execution", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public JobExecutionResource getJobExecution(
-        @PathVariable("id")
-        final String id
+        @PathVariable("id") final String id
     ) throws GenieException {
         log.info("[getJobExecution] Called for job execution with id {}", id);
         return this.jobExecutionResourceAssembler.toResource(this.jobSearchService.getJobExecution(id));
@@ -612,8 +589,7 @@ public class JobRestController {
     @GetMapping(value = "/{id}/cluster", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public ClusterResource getJobCluster(
-        @PathVariable("id")
-        final String id
+        @PathVariable("id") final String id
     ) throws GenieException {
         log.info("[getJobCluster] Called for job with id {}", id);
         return this.clusterResourceAssembler.toResource(this.jobSearchService.getJobCluster(id));
@@ -629,8 +605,7 @@ public class JobRestController {
     @GetMapping(value = "/{id}/command", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public CommandResource getJobCommand(
-        @PathVariable("id")
-        final String id) throws GenieException {
+        @PathVariable("id") final String id) throws GenieException {
         log.info("[getJobCommand] Called for job with id {}", id);
         return this.commandResourceAssembler.toResource(this.jobSearchService.getJobCommand(id));
     }
@@ -645,8 +620,7 @@ public class JobRestController {
     @GetMapping(value = "/{id}/applications", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public List<ApplicationResource> getJobApplications(
-        @PathVariable("id")
-        final String id) throws GenieException {
+        @PathVariable("id") final String id) throws GenieException {
         log.info("[getJobApplications] Called for job with id {}", id);
 
         return this.jobSearchService
@@ -676,14 +650,13 @@ public class JobRestController {
         produces = MediaType.ALL_VALUE
     )
     public void getJobOutput(
-        @PathVariable("id")
-        final String id,
-        @RequestHeader(name = JobConstants.GENIE_FORWARDED_FROM_HEADER, required = false)
-        final String forwardedFrom,
+        @PathVariable("id") final String id,
+        @RequestHeader(name = JobConstants.GENIE_FORWARDED_FROM_HEADER, required = false) final String forwardedFrom,
         final HttpServletRequest request,
         final HttpServletResponse response
     ) throws IOException, ServletException, GenieException {
         log.info("[getJobOutput] Called for job with id: {}", id);
+        final String path = ControllerUtils.getRemainingPath(request);
 
         // if forwarded from isn't null it's already been forwarded to this node. Assume data is on this node.
         if (this.jobsProperties.getForwarding().isEnabled() && forwardedFrom == null) {
@@ -693,26 +666,28 @@ public class JobRestController {
             final String jobHostname = this.jobSearchService.getJobHost(id);
             if (!this.hostName.equals(jobHostname)) {
                 log.info("Job {} is not or was not run on this node. Forwarding to {}", id, jobHostname);
-                final String forwardUrl = buildForwardURL(request, jobHostname);
+                final String forwardHost = this.buildForwardHost(jobHostname);
                 try {
-                    this.restTemplate.execute(forwardUrl, HttpMethod.GET,
+                    this.restTemplate.execute(
+                        forwardHost + JOB_API_TEMPLATE + "/output/{path}",
+                        HttpMethod.GET,
                         forwardRequest -> copyRequestHeaders(request, forwardRequest),
-                        new ResponseExtractor<Void>() {
-                            @Override
-                            public Void extractData(final ClientHttpResponse forwardResponse) throws IOException {
-                                response.setStatus(HttpStatus.OK.value());
-                                copyResponseHeaders(response, forwardResponse);
-                                // Documentation I could find pointed to the HttpEntity reading the bytes off
-                                // the stream so this should resolve memory problems if the file returned is large
-                                ByteStreams.copy(forwardResponse.getBody(), response.getOutputStream());
-                                return null;
-                            }
-                        });
-                } catch (HttpStatusCodeException e) {
-                    log.error("Failed getting the remote job output from {}. Error: {}", forwardUrl, e.getMessage());
+                        (ResponseExtractor<Void>) forwardResponse -> {
+                            response.setStatus(HttpStatus.OK.value());
+                            copyResponseHeaders(response, forwardResponse);
+                            // Documentation I could find pointed to the HttpEntity reading the bytes off
+                            // the stream so this should resolve memory problems if the file returned is large
+                            ByteStreams.copy(forwardResponse.getBody(), response.getOutputStream());
+                            return null;
+                        },
+                        id,
+                        path == null ? EMPTY_STRING : path
+                    );
+                } catch (final HttpStatusCodeException e) {
+                    log.error("Failed getting the remote job output from {}. Error: {}", forwardHost, e.getMessage());
                     response.sendError(e.getStatusCode().value(), e.getStatusText());
-                } catch (Exception e) {
-                    log.error("Failed getting the remote job output from {}. Error: {}", forwardUrl, e.getMessage());
+                } catch (final Exception e) {
+                    log.error("Failed getting the remote job output from {}. Error: {}", forwardHost, e.getMessage());
                     response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
                 }
 
@@ -722,7 +697,6 @@ public class JobRestController {
         }
 
         log.info("Job {} is running or was run on this node. Fetching requested resource...", id);
-        final String path = ControllerUtils.getRemainingPath(request);
         if (StringUtils.isNotBlank(path)) {
             request.setAttribute(GenieResourceHttpRequestHandler.GENIE_JOB_IS_ROOT_DIRECTORY, false);
         } else {
@@ -734,13 +708,12 @@ public class JobRestController {
         this.resourceHttpRequestHandler.handleRequest(request, response);
     }
 
-    private String buildForwardURL(final HttpServletRequest request, final String jobHostname) {
+    private String buildForwardHost(final String jobHostname) {
         return this.jobsProperties.getForwarding().getScheme()
             + "://"
             + jobHostname
             + ":"
-            + this.jobsProperties.getForwarding().getPort()
-            + request.getRequestURI();
+            + this.jobsProperties.getForwarding().getPort();
     }
 
     private void copyRequestHeaders(final HttpServletRequest request, final ClientHttpRequest forwardRequest) {

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/HttpFileTransferImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/HttpFileTransferImpl.java
@@ -30,13 +30,11 @@ import org.apache.commons.validator.routines.UrlValidator;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.ResponseExtractor;
 import org.springframework.web.client.RestTemplate;
 
 import javax.validation.constraints.NotNull;
 import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -106,16 +104,12 @@ public class HttpFileTransferImpl implements FileTransfer {
             this.restTemplate.execute(
                 srcRemotePath,
                 HttpMethod.GET,
-                requestEntity ->
-                    requestEntity.getHeaders().setAccept(Lists.newArrayList(MediaType.ALL)),
-                new ResponseExtractor<Void>() {
-                    @Override
-                    public Void extractData(final ClientHttpResponse response) throws IOException {
-                        // Documentation I could find pointed to the HttpEntity reading the bytes off
-                        // the stream so this should resolve memory problems if the file returned is large
-                        FileUtils.copyInputStreamToFile(response.getBody(), outputFile);
-                        return null;
-                    }
+                requestEntity -> requestEntity.getHeaders().setAccept(Lists.newArrayList(MediaType.ALL)),
+                (ResponseExtractor<Void>) response -> {
+                    // Documentation I could find pointed to the HttpEntity reading the bytes off
+                    // the stream so this should resolve memory problems if the file returned is large
+                    FileUtils.copyInputStreamToFile(response.getBody(), outputFile);
+                    return null;
                 }
             );
         } catch (GenieException | RuntimeException e) {

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/ControllerUtilsUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/ControllerUtilsUnitTests.java
@@ -37,14 +37,6 @@ import javax.servlet.http.HttpServletRequest;
 public class ControllerUtilsUnitTests {
 
     /**
-     * Dumb test.
-     */
-    @Test
-    public void canConstruct() {
-        Assert.assertNotNull(new ControllerUtils());
-    }
-
-    /**
      * Test the getRemainingPath method.
      */
     @Test
@@ -68,5 +60,21 @@ public class ControllerUtilsUnitTests {
             .when(request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
             .thenReturn("/api/v3/jobs/{id}/output");
         Assert.assertThat(ControllerUtils.getRemainingPath(request), Matchers.is(""));
+
+        Mockito
+            .when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE))
+            .thenReturn("/api/v3/jobs/1234/output/");
+        Mockito
+            .when(request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
+            .thenReturn("/api/v3/jobs/{id}/output/");
+        Assert.assertThat(ControllerUtils.getRemainingPath(request), Matchers.is(""));
+
+        Mockito
+            .when(request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE))
+            .thenReturn("/api/v3/jobs/1234/output/stdout");
+        Mockito
+            .when(request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
+            .thenReturn("/api/v3/jobs/{id}/output/**");
+        Assert.assertThat(ControllerUtils.getRemainingPath(request), Matchers.is("stdout"));
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerUnitTests.java
@@ -179,8 +179,9 @@ public class JobRestControllerUnitTests {
         this.controller.killJob(jobId, forwardedFrom, request, response);
 
         Mockito.verify(this.jobSearchService, Mockito.times(1)).getJobHost(jobId);
-        Mockito.verify(this.restTemplate, Mockito.never())
-                .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito
+            .verify(this.restTemplate, Mockito.never())
+            .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     /**
@@ -205,8 +206,16 @@ public class JobRestControllerUnitTests {
         Mockito.when(statusLine.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND.value());
         final HttpResponse forwardResponse = Mockito.mock(HttpResponse.class);
         Mockito.when(forwardResponse.getStatusLine()).thenReturn(statusLine);
-        Mockito.when(this.restTemplate.execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+        Mockito.when(
+            this.restTemplate.execute(
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.anyString()
+            )
+        )
+            .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 
         this.controller.killJob(jobId, forwardedFrom, request, response);
 
@@ -214,8 +223,15 @@ public class JobRestControllerUnitTests {
             .verify(response, Mockito.times(1))
             .sendError(Mockito.eq(HttpStatus.NOT_FOUND.value()), Mockito.anyString());
         Mockito.verify(this.jobSearchService, Mockito.times(1)).getJobHost(jobId);
-        Mockito.verify(this.restTemplate, Mockito.times(1))
-                .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito
+            .verify(this.restTemplate, Mockito.times(1))
+            .execute(
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.anyString()
+            );
     }
 
     /**
@@ -241,15 +257,24 @@ public class JobRestControllerUnitTests {
         final HttpResponse forwardResponse = Mockito.mock(HttpResponse.class);
         Mockito.when(forwardResponse.getStatusLine()).thenReturn(statusLine);
         Mockito.when(forwardResponse.getAllHeaders()).thenReturn(new Header[0]);
-        Mockito.when(this.restTemplate.execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(null);
+        Mockito
+            .when(
+                this.restTemplate.execute(
+                    Mockito.anyString(),
+                    Mockito.any(),
+                    Mockito.any(),
+                    Mockito.any(),
+                    Mockito.anyString()
+                )
+            )
+            .thenReturn(null);
 
         this.controller.killJob(jobId, forwardedFrom, request, response);
 
         Mockito.verify(response, Mockito.never()).sendError(Mockito.anyInt(), Mockito.anyString());
         Mockito.verify(this.jobSearchService, Mockito.times(1)).getJobHost(jobId);
         Mockito.verify(this.restTemplate, Mockito.times(1))
-                .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
+            .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     /**
@@ -321,8 +346,16 @@ public class JobRestControllerUnitTests {
         this.controller.getJobOutput(jobId, forwardedFrom, request, response);
 
         Mockito.verify(this.jobSearchService, Mockito.times(1)).getJobHost(Mockito.eq(jobId));
-        Mockito.verify(this.restTemplate, Mockito.never())
-                .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito
+            .verify(this.restTemplate, Mockito.never())
+            .execute(
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.anyString(),
+                Mockito.anyString()
+            );
         Mockito.verify(this.genieResourceHttpRequestHandler, Mockito.times(1)).handleRequest(request, response);
     }
 
@@ -359,14 +392,30 @@ public class JobRestControllerUnitTests {
         Mockito.when(request.getRequestURL()).thenReturn(new StringBuffer(requestUrl));
 
         final int errorCode = 404;
-        Mockito.when(this.restTemplate.execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+        Mockito.when(
+            this.restTemplate.execute(
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.anyString(),
+                Mockito.anyString()
+            )
+        )
+            .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 
         this.controller.getJobOutput(jobId, forwardedFrom, request, response);
 
         Mockito.verify(this.jobSearchService, Mockito.times(1)).getJobHost(Mockito.eq(jobId));
         Mockito.verify(this.restTemplate, Mockito.times(1))
-                .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
+            .execute(
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.anyString(),
+                Mockito.anyString()
+            );
         Mockito.verify(response, Mockito.times(1)).sendError(Mockito.eq(errorCode), Mockito.anyString());
         Mockito.verify(this.genieResourceHttpRequestHandler, Mockito.never()).handleRequest(request, response);
     }
@@ -429,9 +478,9 @@ public class JobRestControllerUnitTests {
         final ClientHttpRequestFactory factory = Mockito.mock(ClientHttpRequestFactory.class);
         final ClientHttpRequest clientHttpRequest = Mockito.mock(ClientHttpRequest.class);
         Mockito.when(clientHttpRequest.execute())
-                .thenReturn(new MockClientHttpResponse(text.getBytes(UTF_8), HttpStatus.OK));
+            .thenReturn(new MockClientHttpResponse(text.getBytes(UTF_8), HttpStatus.OK));
         Mockito.when(clientHttpRequest.getHeaders())
-                .thenReturn(new HttpHeaders());
+            .thenReturn(new HttpHeaders());
         Mockito.when(factory.createRequest(Mockito.any(), Mockito.any())).thenReturn(clientHttpRequest);
         final RestTemplate template = new RestTemplate(factory);
         final Registry registry = Mockito.mock(Registry.class);
@@ -439,21 +488,21 @@ public class JobRestControllerUnitTests {
         Mockito.when(registry.counter(Mockito.anyString())).thenReturn(counter);
 
         final JobRestController jobController = new JobRestController(
-                Mockito.mock(JobCoordinatorService.class),
-                this.jobSearchService,
-                Mockito.mock(AttachmentService.class),
-                Mockito.mock(ApplicationResourceAssembler.class),
-                Mockito.mock(ClusterResourceAssembler.class),
-                Mockito.mock(CommandResourceAssembler.class),
-                Mockito.mock(JobResourceAssembler.class),
-                Mockito.mock(JobRequestResourceAssembler.class),
-                Mockito.mock(JobExecutionResourceAssembler.class),
-                Mockito.mock(JobSearchResultResourceAssembler.class),
-                this.hostname,
-                template,
-                this.genieResourceHttpRequestHandler,
-                this.jobsProperties,
-                registry
+            Mockito.mock(JobCoordinatorService.class),
+            this.jobSearchService,
+            Mockito.mock(AttachmentService.class),
+            Mockito.mock(ApplicationResourceAssembler.class),
+            Mockito.mock(ClusterResourceAssembler.class),
+            Mockito.mock(CommandResourceAssembler.class),
+            Mockito.mock(JobResourceAssembler.class),
+            Mockito.mock(JobRequestResourceAssembler.class),
+            Mockito.mock(JobExecutionResourceAssembler.class),
+            Mockito.mock(JobSearchResultResourceAssembler.class),
+            this.hostname,
+            template,
+            this.genieResourceHttpRequestHandler,
+            this.jobsProperties,
+            registry
         );
         jobController.getJobOutput(jobId, forwardedFrom, request, response);
 


### PR DESCRIPTION
Rest template usage was generating a URI tag for each unique request ballooning heap usage before GC.

See `Default Metrics Collection` section of [this document](http://cloud.spring.io/spring-cloud-static/spring-cloud-netflix/1.3.4.RELEASE/)