### PR TITLE
Abstract eventing behind interface. Fix issue where synchronous events sent asynchronously

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/events/GenieEventBus.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/events/GenieEventBus.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.events;
+
+import lombok.NonNull;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Genie Event Bus interface.
+ *
+ * @author tgianos
+ * @since 3.1.2
+ */
+public interface GenieEventBus {
+
+    /**
+     * Publish an event in the same thread as the calling thread.
+     *
+     * @param event The event to publish
+     */
+    void publishSynchronousEvent(@NonNull final ApplicationEvent event);
+
+    /**
+     * Publish an event in a different thread than the calling thread.
+     *
+     * @param event The event to publish
+     */
+    void publishAsynchronousEvent(@NonNull final ApplicationEvent event);
+}

--- a/genie-core/src/main/java/com/netflix/genie/core/events/GenieEventBusImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/events/GenieEventBusImpl.java
@@ -1,0 +1,162 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.events;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
+import org.springframework.core.ResolvableType;
+
+/**
+ * An event bus implementation for the Genie application to use.
+ *
+ * @author tgianos
+ * @since 3.1.2
+ */
+@Slf4j
+public class GenieEventBusImpl implements
+    GenieEventBus, ApplicationEventMulticaster, BeanClassLoaderAware, BeanFactoryAware {
+
+    private final SimpleApplicationEventMulticaster syncMulticaster;
+    private final SimpleApplicationEventMulticaster asyncMulticaster;
+
+    /**
+     * Constructor.
+     *
+     * @param syncEventMulticaster  The synchronous task multicaster to use
+     * @param asyncEventMulticaster The asynchronous task multicaster to use
+     */
+    public GenieEventBusImpl(
+        @NonNull final SimpleApplicationEventMulticaster syncEventMulticaster,
+        @NonNull final SimpleApplicationEventMulticaster asyncEventMulticaster
+    ) {
+        this.syncMulticaster = syncEventMulticaster;
+        this.asyncMulticaster = asyncEventMulticaster;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void publishSynchronousEvent(@NonNull final ApplicationEvent event) {
+        // TODO: Metric here?
+        log.debug("Publishing synchronous event {}", event);
+        this.syncMulticaster.multicastEvent(event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void publishAsynchronousEvent(@NonNull final ApplicationEvent event) {
+        // TODO: Metric here?
+        log.debug("Publishing asynchronous event {}", event);
+        this.asyncMulticaster.multicastEvent(event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addApplicationListener(final ApplicationListener<?> listener) {
+        log.debug("Adding application listener {}", listener);
+        this.syncMulticaster.addApplicationListener(listener);
+        this.asyncMulticaster.addApplicationListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addApplicationListenerBean(final String listenerBeanName) {
+        log.debug("Adding application listener bean with name {}", listenerBeanName);
+        this.syncMulticaster.addApplicationListenerBean(listenerBeanName);
+        this.asyncMulticaster.addApplicationListenerBean(listenerBeanName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeApplicationListener(final ApplicationListener<?> listener) {
+        log.debug("Removing application listener {}", listener);
+        this.syncMulticaster.removeApplicationListener(listener);
+        this.asyncMulticaster.removeApplicationListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeApplicationListenerBean(final String listenerBeanName) {
+        log.debug("Removing application listener bean with name {}", listenerBeanName);
+        this.syncMulticaster.removeApplicationListenerBean(listenerBeanName);
+        this.asyncMulticaster.removeApplicationListenerBean(listenerBeanName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeAllListeners() {
+        log.debug("Removing all application listeners");
+        this.syncMulticaster.removeAllListeners();
+        this.asyncMulticaster.removeAllListeners();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void multicastEvent(final ApplicationEvent event) {
+        // TODO: Metric here?
+        log.debug("Multi-casting event {}", event);
+        this.asyncMulticaster.multicastEvent(event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void multicastEvent(final ApplicationEvent event, final ResolvableType eventType) {
+        // TODO: Metric here?
+        log.debug("Multi-casting event {} of type {}", event, eventType);
+        this.asyncMulticaster.multicastEvent(event, eventType);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setBeanClassLoader(final ClassLoader classLoader) {
+        this.syncMulticaster.setBeanClassLoader(classLoader);
+        this.asyncMulticaster.setBeanClassLoader(classLoader);
+    }
+
+    @Override
+    public void setBeanFactory(final BeanFactory beanFactory) {
+        this.syncMulticaster.setBeanFactory(beanFactory);
+        this.asyncMulticaster.setBeanFactory(beanFactory);
+    }
+}

--- a/genie-core/src/main/java/com/netflix/genie/core/events/package-info.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/events/package-info.java
@@ -23,4 +23,7 @@
  * @author tgianos
  * @since 3.0.0
  */
+@ParametersAreNonnullByDefault
 package com.netflix.genie.core.events;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-core/src/main/java/com/netflix/genie/core/services/JobSubmitterService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/JobSubmitterService.java
@@ -51,18 +51,13 @@ public interface JobSubmitterService {
      * @throws GenieException if there is an error
      */
     void submitJob(
-        @Valid
         @NotNull(message = "No job provided. Unable to submit job for execution.")
-        final JobRequest jobRequest,
-        @Valid
+        @Valid final JobRequest jobRequest,
         @NotNull(message = "No cluster provided. Unable to submit job for execution")
-        final Cluster cluster,
-        @Valid
+        @Valid final Cluster cluster,
         @NotNull(message = "No command provided. Unable to submit job for execution")
-        final Command command,
-        @NotNull(message = "No applications provided. Unable to submit job for execution")
-        final List<Application> applications,
-        @Min(value = 1, message = "Memory can't be less than 1 MB")
-        final int memory
+        @Valid final Command command,
+        @NotNull(message = "No applications provided. Unable to execute") final List<Application> applications,
+        @Min(value = 1, message = "Memory can't be less than 1 MB") final int memory
     ) throws GenieException;
 }

--- a/genie-core/src/test/groovy/com/netflix/genie/core/events/GenieEventBusImplSpec.groovy
+++ b/genie-core/src/test/groovy/com/netflix/genie/core/events/GenieEventBusImplSpec.groovy
@@ -1,0 +1,160 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.core.events
+
+import com.netflix.genie.test.categories.UnitTest
+import org.junit.experimental.categories.Category
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.SimpleApplicationEventMulticaster
+import org.springframework.core.ResolvableType
+import spock.lang.Specification
+/**
+ * Specification for the GenieEventBusImpl.
+ *
+ * @author tgianos
+ * @since 3.1.2
+ */
+@Category(UnitTest.class)
+class GenieEventBusImplSpec extends Specification {
+
+    def syncMulticaster = Mock(SimpleApplicationEventMulticaster)
+    def asyncMulticaster = Mock(SimpleApplicationEventMulticaster)
+    def eventBus = new GenieEventBusImpl(this.syncMulticaster, this.asyncMulticaster)
+
+    def "Can publish synchronous event"() {
+        def event = Mock(ApplicationEvent)
+
+        when:
+        this.eventBus.publishSynchronousEvent(event)
+
+        then:
+        1 * this.syncMulticaster.multicastEvent(event)
+        0 * this.asyncMulticaster.multicastEvent(event)
+    }
+
+    def "Can publish asynchronous event"() {
+        def event = Mock(ApplicationEvent)
+
+        when:
+        this.eventBus.publishAsynchronousEvent(event)
+
+        then:
+        0 * this.syncMulticaster.multicastEvent(event)
+        1 * this.asyncMulticaster.multicastEvent(event)
+    }
+
+    def "Can add application listener"() {
+        def listener = Mock(ApplicationListener)
+
+        when:
+        this.eventBus.addApplicationListener(listener)
+
+        then:
+        1 * this.syncMulticaster.addApplicationListener(listener)
+        1 * this.asyncMulticaster.addApplicationListener(listener)
+    }
+
+    def "Can add application listener bean"() {
+        def beanName = UUID.randomUUID().toString()
+
+        when:
+        this.eventBus.addApplicationListenerBean(beanName)
+
+        then:
+        1 * this.syncMulticaster.addApplicationListenerBean(beanName)
+        1 * this.asyncMulticaster.addApplicationListenerBean(beanName)
+    }
+
+    def "Can remove application listener"() {
+        def listener = Mock(ApplicationListener)
+
+        when:
+        this.eventBus.removeApplicationListener(listener)
+
+        then:
+        1 * this.syncMulticaster.removeApplicationListener(listener)
+        1 * this.asyncMulticaster.removeApplicationListener(listener)
+    }
+
+    def "Can remove application listener bean"() {
+        def beanName = UUID.randomUUID().toString()
+
+        when:
+        this.eventBus.removeApplicationListenerBean(beanName)
+
+        then:
+        1 * this.syncMulticaster.removeApplicationListenerBean(beanName)
+        1 * this.asyncMulticaster.removeApplicationListenerBean(beanName)
+    }
+
+    def "Can remove all listeners"() {
+        when:
+        this.eventBus.removeAllListeners()
+
+        then:
+        1 * this.syncMulticaster.removeAllListeners()
+        1 * this.asyncMulticaster.removeAllListeners()
+    }
+
+    def "Can multicast event"() {
+        def event = Mock(ApplicationEvent)
+
+        when:
+        this.eventBus.multicastEvent(event)
+
+        then:
+        0 * this.syncMulticaster.multicastEvent(event)
+        1 * this.asyncMulticaster.multicastEvent(event)
+    }
+
+    def "Can multicast event with resolvable type"() {
+        def event = Mock(ApplicationEvent)
+        def type = Mock(ResolvableType)
+
+        when:
+        this.eventBus.multicastEvent(event, type)
+
+        then:
+        0 * this.syncMulticaster.multicastEvent(event, type)
+        1 * this.asyncMulticaster.multicastEvent(event, type)
+    }
+
+    def "Can set bean factory"() {
+        def beanFactory = Mock(BeanFactory)
+
+        when:
+        this.eventBus.setBeanFactory(beanFactory)
+
+        then:
+        1 * this.syncMulticaster.setBeanFactory(beanFactory)
+        1 * this.asyncMulticaster.setBeanFactory(beanFactory)
+    }
+
+    def "Can set bean class loader"() {
+        def classLoader = Mock(ClassLoader)
+
+        when:
+        this.eventBus.setBeanClassLoader(classLoader)
+
+        then:
+        1 * this.syncMulticaster.setBeanClassLoader(classLoader)
+        1 * this.asyncMulticaster.setBeanClassLoader(classLoader)
+    }
+}

--- a/genie-core/src/test/groovy/com/netflix/genie/core/services/impl/JobStateServiceImplSpec.groovy
+++ b/genie-core/src/test/groovy/com/netflix/genie/core/services/impl/JobStateServiceImplSpec.groovy
@@ -5,10 +5,10 @@ import com.netflix.genie.common.dto.Application
 import com.netflix.genie.common.dto.Cluster
 import com.netflix.genie.common.dto.Command
 import com.netflix.genie.common.dto.JobRequest
+import com.netflix.genie.core.events.GenieEventBus
 import com.netflix.genie.core.services.JobStateService
 import com.netflix.genie.core.services.JobSubmitterService
 import com.netflix.spectator.api.Registry
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.TaskScheduler
 import spock.lang.Specification
 
@@ -18,20 +18,21 @@ import spock.lang.Specification
  * @author amajumdar
  * @since 3.0.0
  */
-class JobStateServiceImplSpec extends Specification{
+class JobStateServiceImplSpec extends Specification {
     JobSubmitterService jobSubmitterService = Mock(JobSubmitterService)
     TaskScheduler scheduler = Mock(TaskScheduler)
-    ApplicationEventPublisher publisher = Mock(ApplicationEventPublisher)
+    GenieEventBus genieEventBus = Mock(GenieEventBus)
     Registry registry = Mock(Registry)
     JobRequest jobRequest = Mock(JobRequest)
     Cluster cluster = Mock(Cluster)
     Command command = Mock(Command)
     List<Application> applications = Lists.newArrayList(Mock(Application))
-    JobStateService jobStateService = new JobStateServiceImpl(jobSubmitterService, scheduler, publisher, registry)
+    JobStateService jobStateService = new JobStateServiceImpl(jobSubmitterService, scheduler, genieEventBus, registry)
     String job1Id = "1"
     String job2Id = "2"
-    int memory = 1024;
-    def testInit(){
+    int memory = 1024
+
+    def testInit() {
         when:
         jobStateService.init(job1Id)
         then:
@@ -44,7 +45,8 @@ class JobStateServiceImplSpec extends Specification{
         jobStateService.jobExists(job1Id)
         jobStateService.getNumActiveJobs() == 0
     }
-    def testSchedule(){
+
+    def testSchedule() {
         when:
         jobStateService.init(job1Id)
         jobStateService.schedule(job1Id, jobRequest, cluster, command, applications, memory)
@@ -69,7 +71,8 @@ class JobStateServiceImplSpec extends Specification{
         jobStateService.getNumActiveJobs() == 1
         jobStateService.getUsedMemory() == 1024
     }
-    def testDone(){
+
+    def testDone() {
         when:
         jobStateService.init(job1Id)
         jobStateService.done(job1Id)

--- a/genie-core/src/test/java/com/netflix/genie/core/services/impl/LocalJobRunnerUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/services/impl/LocalJobRunnerUnitTests.java
@@ -27,6 +27,7 @@ import com.netflix.genie.common.dto.CommandStatus;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.core.events.GenieEventBus;
 import com.netflix.genie.core.jobs.JobConstants;
 import com.netflix.genie.core.jobs.workflow.WorkflowTask;
 import com.netflix.genie.core.services.JobPersistenceService;
@@ -41,8 +42,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.core.io.Resource;
 
 import java.io.File;
@@ -90,8 +89,7 @@ public class LocalJobRunnerUnitTests {
      */
     @Before
     public void setup() throws IOException {
-        final ApplicationEventPublisher eventPublisher = Mockito.mock(ApplicationEventPublisher.class);
-        final ApplicationEventMulticaster eventMulticaster = Mockito.mock(ApplicationEventMulticaster.class);
+        final GenieEventBus genieEventBus = Mockito.mock(GenieEventBus.class);
         final WorkflowTask task1 = Mockito.mock(WorkflowTask.class);
         this.task2 = Mockito.mock(WorkflowTask.class);
 
@@ -108,8 +106,7 @@ public class LocalJobRunnerUnitTests {
 
         this.jobSubmitterService = new LocalJobRunner(
             Mockito.mock(JobPersistenceService.class),
-            eventPublisher,
-            eventMulticaster,
+            genieEventBus,
             jobWorkflowTasks,
             baseWorkingDirResource,
             registry

--- a/genie-demo/src/main/docker/apache/Dockerfile
+++ b/genie-demo/src/main/docker/apache/Dockerfile
@@ -1,7 +1,7 @@
 from httpd:2.4-alpine
 MAINTAINER NetflixOSS <netflixoss@netflix.com>
 COPY ./files/ /usr/local/apache2/htdocs/
-ADD http://apache.cs.utah.edu/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz /usr/local/apache2/htdocs/applications/hadoop/2.7.1/
+ADD https://archive.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz /usr/local/apache2/htdocs/applications/hadoop/2.7.1/
 ADD http://d3kbcqa49mib13.cloudfront.net/spark-1.6.3-bin-hadoop2.6.tgz /usr/local/apache2/htdocs/applications/spark/1.6.3/
 ADD http://d3kbcqa49mib13.cloudfront.net/spark-2.0.1-bin-hadoop2.7.tgz /usr/local/apache2/htdocs/applications/spark/2.0.1/
 #ADD http://apache.cs.utah.edu/pig/pig-0.16.0/pig-0.16.0.tar.gz /usr/local/apache2/htdocs/applications/pig/0.16.0/

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/EventConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/EventConfig.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.configs;
+
+import com.netflix.genie.core.events.GenieEventBusImpl;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.SyncTaskExecutor;
+
+/**
+ * Configuration related to Eventing within the Genie application.
+ *
+ * @author tgianos
+ * @since 3.1.2
+ */
+@Configuration
+public class EventConfig {
+
+    /**
+     * A multicast event publisher to replace the default one used by Spring via the ApplicationContext.
+     *
+     * @param syncTaskExecutor  The synchronous task executor to use
+     * @param asyncTaskExecutor The asynchronous task executor to use
+     * @return The application event multicaster to use
+     */
+    @Bean
+    public GenieEventBusImpl applicationEventMulticaster(
+        @Qualifier("genieSyncTaskExecutor") final SyncTaskExecutor syncTaskExecutor,
+        @Qualifier("genieAsyncTaskExecutor") final AsyncTaskExecutor asyncTaskExecutor
+    ) {
+        final SimpleApplicationEventMulticaster syncMulticaster = new SimpleApplicationEventMulticaster();
+        syncMulticaster.setTaskExecutor(syncTaskExecutor);
+
+        final SimpleApplicationEventMulticaster asyncMulticaster = new SimpleApplicationEventMulticaster();
+        asyncMulticaster.setTaskExecutor(asyncTaskExecutor);
+        return new GenieEventBusImpl(syncMulticaster, asyncMulticaster);
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/LeadershipConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/LeadershipConfig.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.configs;
 
+import com.netflix.genie.core.events.GenieEventBus;
 import com.netflix.genie.web.properties.ZookeeperProperties;
 import com.netflix.genie.web.tasks.leader.LeadershipTask;
 import com.netflix.genie.web.tasks.leader.LeadershipTasksCoordinator;
@@ -25,7 +26,6 @@ import org.apache.curator.framework.CuratorFramework;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.zookeeper.config.LeaderInitiatorFactoryBean;
@@ -84,16 +84,16 @@ public class LeadershipConfig {
      * If Spring Cloud Leadership is disabled and this node is forced to be the leader create the local leader
      * bean which will fire appropriate events.
      *
-     * @param publisher The application event publisher to use
-     * @param isLeader  Whether this node is the leader of the cluster or not
+     * @param genieEventBus The genie event bus implementation to use
+     * @param isLeader      Whether this node is the leader of the cluster or not
      * @return The local leader bean
      */
     @Bean
     @ConditionalOnProperty(value = "genie.zookeeper.enabled", havingValue = "false", matchIfMissing = true)
     public LocalLeader localLeader(
-        final ApplicationEventPublisher publisher,
+        final GenieEventBus genieEventBus,
         @Value("${genie.leader.enabled}") final boolean isLeader
     ) {
-        return new LocalLeader(publisher, isLeader);
+        return new LocalLeader(genieEventBus, isLeader);
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/TaskConfig.java
@@ -23,11 +23,8 @@ import org.apache.commons.exec.PumpStreamHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.event.ApplicationEventMulticaster;
-import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.core.task.AsyncTaskExecutor;
-import org.springframework.core.task.TaskExecutor;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -55,26 +52,15 @@ public class TaskConfig {
     }
 
     /**
-     * A multicast (async) event publisher to replace the synchronous one used by Spring via the ApplicationContext.
-     *
-     * @param taskExecutor The task executor to use
-     * @return The application event multicaster to use
-     */
-    @Bean
-    public ApplicationEventMulticaster applicationEventMulticaster(final TaskExecutor taskExecutor) {
-        final SimpleApplicationEventMulticaster applicationEventMulticaster = new SimpleApplicationEventMulticaster();
-        applicationEventMulticaster.setTaskExecutor(taskExecutor);
-        return applicationEventMulticaster;
-    }
-
-    /**
      * Get a task scheduler.
      *
      * @param poolSize The initial size of the thread pool that should be allocated
      * @return The task scheduler
      */
     @Bean
-    public TaskScheduler taskScheduler(@Value("${genie.tasks.scheduler.pool.size:1}") final int poolSize) {
+    public ThreadPoolTaskScheduler genieTaskScheduler(
+        @Value("${genie.tasks.scheduler.pool.size:1}") final int poolSize
+    ) {
         final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setPoolSize(poolSize);
         return scheduler;
@@ -87,9 +73,19 @@ public class TaskConfig {
      * @return The task executor the system to use
      */
     @Bean
-    public AsyncTaskExecutor taskExecutor(@Value("${genie.tasks.executor.pool.size:1}") final int poolSize) {
+    public AsyncTaskExecutor genieAsyncTaskExecutor(@Value("${genie.tasks.executor.pool.size:1}") final int poolSize) {
         final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(poolSize);
         return executor;
+    }
+
+    /**
+     * Synchronous task executor.
+     *
+     * @return The synchronous task executor to use
+     */
+    @Bean
+    public SyncTaskExecutor genieSyncTaskExecutor() {
+        return new SyncTaskExecutor();
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/package-info.java
@@ -22,4 +22,7 @@
  * @author tgianos
  * @since 3.0.0
  */
+@ParametersAreNonnullByDefault
 package com.netflix.genie.web.configs;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/TasksCleanup.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/TasksCleanup.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.tasks;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -44,7 +45,7 @@ public class TasksCleanup {
      * @param scheduler The task scheduler for the system.
      */
     @Autowired
-    public TasksCleanup(@NotNull final ThreadPoolTaskScheduler scheduler) {
+    public TasksCleanup(@Qualifier("genieTaskScheduler") @NotNull final ThreadPoolTaskScheduler scheduler) {
         this.scheduler = scheduler;
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/node/DiskCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/node/DiskCleanupTask.java
@@ -32,6 +32,7 @@ import org.apache.commons.exec.Executor;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.io.Resource;
 import org.springframework.scheduling.TaskScheduler;
@@ -81,7 +82,7 @@ public class DiskCleanupTask implements Runnable {
     @Autowired
     public DiskCleanupTask(
         @NotNull final DiskCleanupProperties properties,
-        @NotNull final TaskScheduler scheduler,
+        @Qualifier("genieTaskScheduler") @NotNull final TaskScheduler scheduler,
         @NotNull final Resource jobsDir,
         @NotNull final JobSearchService jobSearchService,
         @NotNull final JobsProperties jobsProperties,

--- a/genie-web/src/test/groovy/com/netflix/genie/web/configs/EventConfigSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/configs/EventConfigSpec.groovy
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.configs
+
+import com.netflix.genie.test.categories.UnitTest
+import org.junit.experimental.categories.Category
+import org.springframework.core.task.AsyncTaskExecutor
+import org.springframework.core.task.SyncTaskExecutor
+import spock.lang.Specification
+
+/**
+ * Specification for the EventConfig class.
+ *
+ * @author tgianos
+ * @since 3.1.2
+ */
+@Category(UnitTest.class)
+class EventConfigSpec extends Specification {
+
+    def "Can create Genie Event Bus"() {
+        def config = new EventConfig()
+        def syncExecutor = Mock(SyncTaskExecutor)
+        def asyncExecutor = Mock(AsyncTaskExecutor)
+
+        when:
+        def eventBus = config.applicationEventMulticaster(syncExecutor, asyncExecutor)
+
+        then:
+        eventBus != null
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/LeadershipConfigTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/LeadershipConfigTest.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.configs;
 
 import com.google.common.collect.Sets;
+import com.netflix.genie.core.events.GenieEventBus;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.web.properties.ZookeeperProperties;
 import com.netflix.genie.web.tasks.leader.LeadershipTask;
@@ -26,7 +27,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.TaskScheduler;
 
 import java.util.Collection;
@@ -65,7 +65,7 @@ public class LeadershipConfigTest {
      */
     @Test
     public void canGetLocalLeader() {
-        final ApplicationEventPublisher publisher = Mockito.mock(ApplicationEventPublisher.class);
-        Assert.assertNotNull(new LeadershipConfig().localLeader(publisher, true));
+        final GenieEventBus genieEventBus = Mockito.mock(GenieEventBus.class);
+        Assert.assertNotNull(new LeadershipConfig().localLeader(genieEventBus, true));
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.configs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.core.events.GenieEventBus;
 import com.netflix.genie.core.jobs.workflow.WorkflowTask;
 import com.netflix.genie.core.jpa.repositories.JpaApplicationRepository;
 import com.netflix.genie.core.jpa.repositories.JpaClusterRepository;
@@ -45,8 +46,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -206,16 +205,14 @@ public class ServicesConfigUnitTests {
     @Test
     public void canGetJobSubmitterServiceBean() {
         final JobPersistenceService jobPersistenceService = Mockito.mock(JobPersistenceService.class);
-        final ApplicationEventPublisher eventPublisher = Mockito.mock(ApplicationEventPublisher.class);
-        final ApplicationEventMulticaster eventMulticaster = Mockito.mock(ApplicationEventMulticaster.class);
+        final GenieEventBus genieEventBus = Mockito.mock(GenieEventBus.class);
         final Resource resource = Mockito.mock(Resource.class);
         final List<WorkflowTask> workflowTasks = new ArrayList<>();
 
         Assert.assertNotNull(
             this.servicesConfig.jobSubmitterService(
                 jobPersistenceService,
-                eventPublisher,
-                eventMulticaster,
+                genieEventBus,
                 workflowTasks,
                 resource,
                 Mockito.mock(Registry.class)
@@ -278,7 +275,7 @@ public class ServicesConfigUnitTests {
                 this.jobSearchService,
                 Mockito.mock(Executor.class),
                 new JobsProperties(),
-                Mockito.mock(ApplicationEventPublisher.class),
+                Mockito.mock(GenieEventBus.class),
                 Mockito.mock(FileSystemResource.class),
                 new ObjectMapper()
             )

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/TaskConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/TaskConfigUnitTests.java
@@ -44,6 +44,6 @@ public class TaskConfigUnitTests {
      */
     @Test
     public void canGetTaskScheduler() {
-        Assert.assertNotNull(new TaskConfig().taskScheduler(7));
+        Assert.assertNotNull(new TaskConfig().genieTaskScheduler(7));
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/LocalLeaderUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/LocalLeaderUnitTests.java
@@ -17,13 +17,13 @@
  */
 package com.netflix.genie.web.tasks.leader;
 
+import com.netflix.genie.core.events.GenieEventBus;
 import com.netflix.genie.test.categories.UnitTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.integration.leader.event.OnGrantedEvent;
@@ -39,7 +39,7 @@ import org.springframework.integration.leader.event.OnRevokedEvent;
 public class LocalLeaderUnitTests {
 
     private LocalLeader localLeader;
-    private ApplicationEventPublisher publisher;
+    private GenieEventBus genieEventBus;
     private ContextRefreshedEvent contextRefreshedEvent;
     private ContextClosedEvent contextClosedEvent;
 
@@ -48,7 +48,7 @@ public class LocalLeaderUnitTests {
      */
     @Before
     public void setup() {
-        this.publisher = Mockito.mock(ApplicationEventPublisher.class);
+        this.genieEventBus = Mockito.mock(GenieEventBus.class);
         this.contextRefreshedEvent = Mockito.mock(ContextRefreshedEvent.class);
         this.contextClosedEvent = Mockito.mock(ContextClosedEvent.class);
     }
@@ -66,9 +66,9 @@ public class LocalLeaderUnitTests {
      */
     @Test
     public void canStartLeadershipIfLeader() {
-        this.localLeader = new LocalLeader(this.publisher, true);
+        this.localLeader = new LocalLeader(this.genieEventBus, true);
         this.localLeader.startLeadership(this.contextRefreshedEvent);
-        Mockito.verify(this.publisher, Mockito.times(1)).publishEvent(Mockito.any(OnGrantedEvent.class));
+        Mockito.verify(this.genieEventBus, Mockito.times(1)).publishSynchronousEvent(Mockito.any(OnGrantedEvent.class));
     }
 
     /**
@@ -76,9 +76,9 @@ public class LocalLeaderUnitTests {
      */
     @Test
     public void wontStartLeadershipIfNotLeader() {
-        this.localLeader = new LocalLeader(this.publisher, false);
+        this.localLeader = new LocalLeader(this.genieEventBus, false);
         this.localLeader.startLeadership(this.contextRefreshedEvent);
-        Mockito.verify(this.publisher, Mockito.never()).publishEvent(Mockito.any(OnGrantedEvent.class));
+        Mockito.verify(this.genieEventBus, Mockito.never()).publishSynchronousEvent(Mockito.any(OnGrantedEvent.class));
     }
 
     /**
@@ -86,9 +86,9 @@ public class LocalLeaderUnitTests {
      */
     @Test
     public void canStopLeadershipIfLeader() {
-        this.localLeader = new LocalLeader(this.publisher, true);
+        this.localLeader = new LocalLeader(this.genieEventBus, true);
         this.localLeader.stopLeadership(this.contextClosedEvent);
-        Mockito.verify(this.publisher, Mockito.times(1)).publishEvent(Mockito.any(OnRevokedEvent.class));
+        Mockito.verify(this.genieEventBus, Mockito.times(1)).publishSynchronousEvent(Mockito.any(OnRevokedEvent.class));
     }
 
     /**
@@ -96,8 +96,8 @@ public class LocalLeaderUnitTests {
      */
     @Test
     public void wontStopLeadershipIfNotLeader() {
-        this.localLeader = new LocalLeader(this.publisher, false);
+        this.localLeader = new LocalLeader(this.genieEventBus, false);
         this.localLeader.stopLeadership(this.contextClosedEvent);
-        Mockito.verify(this.publisher, Mockito.never()).publishEvent(Mockito.any(OnRevokedEvent.class));
+        Mockito.verify(this.genieEventBus, Mockito.never()).publishSynchronousEvent(Mockito.any(OnRevokedEvent.class));
     }
 }


### PR DESCRIPTION
Cherry Pick (#601)

- Fix potentially serious issue where events that were supposed to be sent synchronously were instead sent asynchronously
- Abstract all eventing behind a simple GenieEventBus interface to abstract details and complexity of which backend mechanism to use
- Clean up bean configurations to make wiring more explicit