### PR TITLE
JobRestController: Forward response status code

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -673,7 +673,7 @@ public class JobRestController {
                         HttpMethod.GET,
                         forwardRequest -> copyRequestHeaders(request, forwardRequest),
                         (ResponseExtractor<Void>) forwardResponse -> {
-                            response.setStatus(HttpStatus.OK.value());
+                            response.setStatus(forwardResponse.getStatusCode().value());
                             copyResponseHeaders(response, forwardResponse);
                             // Documentation I could find pointed to the HttpEntity reading the bytes off
                             // the stream so this should resolve memory problems if the file returned is large


### PR DESCRIPTION
Let's say we have server A and B, and the job is running
on B. One user want to see job output via A, and A forward
the request to B.

If user refresh the page in browser, browser add
If-Modified-Since header to the request. Server A forward the header
to B and B will return 304, as the file is not changed since. But
user will see 200 and empty content because A set the status.

In order to let browser display cached file content, we can let
server A forward 304 to user.