### PR TITLE
Fix area of possible NPE in response mapping interceptor for the java client

### DIFF
--- a/genie-client/build.gradle
+++ b/genie-client/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 
     testCompile(project(":genie-test"))
     testCompile(project(":genie-web"))
+
+    testCompile("com.github.tomakehurst:wiremock")
+    testCompile("org.springframework.boot:spring-boot-starter-jetty")
 }
 
 clean {

--- a/genie-client/src/main/java/com/netflix/genie/client/interceptors/ResponseMappingInterceptor.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/interceptors/ResponseMappingInterceptor.java
@@ -36,6 +36,7 @@ import java.io.Reader;
  */
 public class ResponseMappingInterceptor implements Interceptor {
 
+    private static final String EMPTY_STRING = "";
     private static final String ERROR_MESSAGE_KEY = "message";
     private final ObjectMapper mapper;
 
@@ -63,9 +64,13 @@ public class ResponseMappingInterceptor implements Interceptor {
                 if (bodyReader != null) {
                     try {
                         final JsonNode responseBody = this.mapper.readTree(bodyReader);
+                        final String errorMessage =
+                            responseBody == null || !responseBody.has(ERROR_MESSAGE_KEY)
+                                ? EMPTY_STRING
+                                : responseBody.get(ERROR_MESSAGE_KEY).asText();
                         throw new GenieClientException(
                             response.code(),
-                            response.message() + " : " + responseBody.get(ERROR_MESSAGE_KEY).asText()
+                            response.message() + " : " + errorMessage
                         );
                     } catch (final JsonProcessingException jpe) {
                         throw new GenieClientException(response.code(), response.message() + " " + jpe.getMessage());


### PR DESCRIPTION
It was reported that sometimes if the server or proxy (e.g. ELB) returned an error response without a body that a NPE could be thrown out of the response mapper instead of the expected `GenieClientException`. This PR should fix that issue.