### PR TITLE
Fix area of possible NPE in response mapping interceptor for the java client

### DIFF
--- a/genie-client/build.gradle
+++ b/genie-client/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 
     testCompile(project(":genie-test"))
     testCompile(project(":genie-web"))
+
+    testCompile("com.github.tomakehurst:wiremock")
+    testCompile("org.springframework.boot:spring-boot-starter-jetty")
 }
 
 clean {

--- a/genie-client/src/main/java/com/netflix/genie/client/interceptors/ResponseMappingInterceptor.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/interceptors/ResponseMappingInterceptor.java
@@ -23,17 +23,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.genie.client.exceptions.GenieClientException;
 import okhttp3.Interceptor;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 import java.io.IOException;
+import java.io.Reader;
 
 /**
- * Class that evaluates the retrofit response code and maps it to an gitappropriate Genie Exception.
+ * Class that evaluates the retrofit response code and maps it to an appropriate Genie Exception.
  *
  * @author amsharma
  * @since 3.0.0
  */
 public class ResponseMappingInterceptor implements Interceptor {
 
+    private static final String EMPTY_STRING = "";
+    private static final String ERROR_MESSAGE_KEY = "message";
     private final ObjectMapper mapper;
 
     /**
@@ -53,17 +57,28 @@ public class ResponseMappingInterceptor implements Interceptor {
         if (response.isSuccessful()) {
             return response;
         } else {
-            final String bodyContent = response.body().string();
+            final ResponseBody body = response.body();
+            if (body != null) {
+                final Reader bodyReader = body.charStream();
 
-            try {
-                final JsonNode responseBody = this.mapper.readTree(bodyContent);
-                throw new GenieClientException(
-                    response.code(),
-                    response.message() + " : " + responseBody.get("message")
-                );
-            } catch (final JsonProcessingException jpe) {
-                throw new GenieClientException(response.code(), response.message() + bodyContent);
+                if (bodyReader != null) {
+                    try {
+                        final JsonNode responseBody = this.mapper.readTree(bodyReader);
+                        final String errorMessage =
+                            responseBody == null || !responseBody.has(ERROR_MESSAGE_KEY)
+                                ? EMPTY_STRING
+                                : responseBody.get(ERROR_MESSAGE_KEY).asText();
+                        throw new GenieClientException(
+                            response.code(),
+                            response.message() + " : " + errorMessage
+                        );
+                    } catch (final JsonProcessingException jpe) {
+                        throw new GenieClientException(response.code(), response.message() + " " + jpe.getMessage());
+                    }
+                }
             }
+
+            throw new GenieClientException(response.code(), "Unable to find response body to parse error message from");
         }
     }
 }


### PR DESCRIPTION
Cherry pick of (#627)

* Fix area of possible NPE in response mapping interceptor for the java client

* Add another null check on the response body returned from the JSON mapper