### PR TITLE
Fix a few places where exception traces were not being propagated

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTask.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jobs/workflow/impl/JobKickoffTask.java
@@ -117,7 +117,7 @@ public class JobKickoffTask extends GenieBaseTask {
                 writer.flush();
                 writer.close();
             } catch (IOException e) {
-                throw new GenieServerException("Failed to execute job with exception." + e);
+                throw new GenieServerException("Failed to execute job", e);
             }
             // Create user, if enabled
             if (isUserCreationEnabled) {
@@ -209,7 +209,7 @@ public class JobKickoffTask extends GenieBaseTask {
         try {
             this.executor.execute(commandLIne);
         } catch (IOException ioe) {
-            throw new GenieServerException("Could not make the job working logs directory group writable.");
+            throw new GenieServerException("Could not make the job working logs directory group writable.", ioe);
         }
     }
 
@@ -260,7 +260,7 @@ public class JobKickoffTask extends GenieBaseTask {
                 log.debug("Running command to create user: [{}]", userCreateCommandLine);
                 this.executor.execute(userCreateCommandLine);
             } catch (IOException ioexception) {
-                throw new GenieServerException("Could not create user " + user + " with exception " + ioexception);
+                throw new GenieServerException("Could not create user " + user, ioexception);
             }
         }
     }
@@ -282,7 +282,7 @@ public class JobKickoffTask extends GenieBaseTask {
         try {
             this.executor.execute(commandLine);
         } catch (IOException ioexception) {
-            throw new GenieServerException("Could not change ownership with exception " + ioexception);
+            throw new GenieServerException("Could not change ownership", ioexception);
         }
     }
 

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/FileSystemAttachmentService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/FileSystemAttachmentService.java
@@ -115,7 +115,8 @@ public class FileSystemAttachmentService implements AttachmentService {
             this.attachmentDirectory = dir;
         } catch (IOException | URISyntaxException e) {
             throw new IllegalArgumentException(
-                    "Failed to create attachments directory " + attachmentsDirectoryPath
+                "Failed to create attachments directory " + attachmentsDirectoryPath,
+                e
             );
         }
     }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/GenieFileTransferService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/GenieFileTransferService.java
@@ -88,7 +88,7 @@ public class GenieFileTransferService {
             final URI uri = new URI(path);
             result = fileTransferFactory.get(BEAN_NAME_FILE_SYSTEM_PREFIX + uri.getScheme());
         } catch (URISyntaxException ignored) {
-            throw new GenieNotFoundException("Invalid file path: " + path);
+            throw new GenieNotFoundException("Invalid file path: " + path, ignored);
         }
         if (result == null) {
             throw new GenieNotFoundException("Failed getting the appropriate FileTransfer implementation to get file: "

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/MailServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/MailServiceImpl.java
@@ -71,7 +71,7 @@ public class MailServiceImpl implements MailService {
         try {
             this.javaMailSender.send(simpleMailMessage);
         } catch (final MailException me) {
-            throw new GenieServerException("Failure to send email: " + me);
+            throw new GenieServerException("Failure to send email", me);
         }
     }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/S3FileTransferImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/S3FileTransferImpl.java
@@ -119,7 +119,7 @@ public class S3FileTransferImpl implements FileTransfer {
                 );
             } catch (AmazonS3Exception ase) {
                 log.error("Error fetching file {} from s3 due to exception {}", srcRemotePath, ase.toString());
-                throw new GenieServerException("Error downloading file from s3. Filename: " + srcRemotePath);
+                throw new GenieServerException("Error downloading file from s3. Filename: " + srcRemotePath, ase);
             }
         } catch (Throwable t) {
             MetricsUtils.addFailureTagsWithException(tags, t);
@@ -151,7 +151,7 @@ public class S3FileTransferImpl implements FileTransfer {
                 this.s3Client.putObject(s3Uri.getBucket(), s3Uri.getKey(), new File(srcLocalPath));
             } catch (AmazonS3Exception ase) {
                 log.error("Error posting file {} to s3 due to exception {}", dstRemotePath, ase.toString());
-                throw new GenieServerException("Error uploading file to s3. Filename: " + dstRemotePath);
+                throw new GenieServerException("Error uploading file to s3. Filename: " + dstRemotePath, ase);
             }
         } catch (Throwable t) {
             MetricsUtils.addFailureTagsWithException(tags, t);

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
@@ -131,7 +131,7 @@ public class JobCompletionService {
         try {
             this.baseWorkingDir = genieWorkingDir.getFile();
         } catch (IOException gse) {
-            throw new GenieServerException("Could not load the base path from resource");
+            throw new GenieServerException("Could not load the base path from resource", gse);
         }
 
         // Set up the metrics


### PR DESCRIPTION
To aid human debugging and machine monitoring of logs, find and fix all the places where exception are being swallowed, rather than being wrapped into new exceptions thrown by Genie.