### PR TITLE
Disable Redis and Mail health checks

### DIFF
--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -121,6 +121,11 @@ management:
   context-path: /actuator
   security:
     roles: ADMIN
+  health:
+    redis:
+      enabled: false
+    mail:
+      enabled: false
 
 security:
   basic:


### PR DESCRIPTION
Disable non-essential health checks that can make Genie unavailable (due to removal from load balancer).
Redis is only used in the path of the web UI. Genie instances should not stop accepting jobs if the latter is temporarily unreachable.
Similarly, the mail notification server does not warrant genie reporting unhealthy status.