### PR TITLE
Annotate '@Lob' entity fields as TextType to aid Hibernate/PostgreSQL…

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/CommonFieldsEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/CommonFieldsEntity.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import com.netflix.genie.common.exceptions.GenieException;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.Type;
 import org.hibernate.validator.constraints.NotBlank;
 
 import javax.persistence.Basic;
@@ -77,6 +78,7 @@ public class CommonFieldsEntity extends BaseEntity {
 
     @Lob
     @Basic(fetch = FetchType.LAZY)
+    @Type(type = "org.hibernate.type.TextType")
     @Column(name = "description")
     private String description;
 

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobRequestEntity.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/entities/JobRequestEntity.java
@@ -25,6 +25,7 @@ import com.netflix.genie.common.util.JsonUtils;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.annotations.Type;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.Basic;
@@ -72,22 +73,26 @@ public class JobRequestEntity extends SetupFileEntity {
 
     @Lob
     @Basic(optional = false)
+    @Type(type = "org.hibernate.type.TextType")
     @Column(name = "cluster_criterias", nullable = false)
     @Size(min = 1, message = "Cluster criterias cannot be empty")
     private String clusterCriterias = EMPTY_JSON_ARRAY;
 
     @Lob
     @Basic(optional = false)
+    @Type(type = "org.hibernate.type.TextType")
     @Column(name = "command_criteria", nullable = false)
     @Size(min = 1, message = "Command criteria cannot be empty")
     private String commandCriteria = EMPTY_JSON_ARRAY;
 
     @Lob
+    @Type(type = "org.hibernate.type.TextType")
     @Basic(optional = false)
     @Column(name = "dependencies", nullable = false)
     private String dependencies = EMPTY_JSON_ARRAY;
 
     @Lob
+    @Type(type = "org.hibernate.type.TextType")
     @Basic(optional = false)
     @Column(name = "configs", nullable = false)
     private String configs = EMPTY_JSON_ARRAY;

--- a/genie-ddl/src/main/sql/postgresql/schema.postgresql.sql
+++ b/genie-ddl/src/main/sql/postgresql/schema.postgresql.sql
@@ -70,7 +70,7 @@ CREATE TABLE applications (
     setup_file character varying(1024) DEFAULT NULL::character varying,
     status character varying(20) DEFAULT 'INACTIVE'::character varying NOT NULL,
     entity_version integer DEFAULT 0 NOT NULL,
-    description text DEFAULT NULL,
+    description text,
     tags character varying(10000) DEFAULT NULL::character varying,
     type character varying(255) DEFAULT NULL::character varying
 );
@@ -109,7 +109,7 @@ CREATE TABLE clusters (
     version character varying(255) NOT NULL,
     status character varying(20) DEFAULT 'OUT_OF_SERVICE'::character varying NOT NULL,
     entity_version integer DEFAULT 0 NOT NULL,
-    description text DEFAULT NULL,
+    description text,
     tags character varying(10000) DEFAULT NULL::character varying,
     setup_file character varying(1024) DEFAULT NULL::character varying
 );
@@ -161,7 +161,7 @@ CREATE TABLE commands (
     executable character varying(255) NOT NULL,
     status character varying(20) DEFAULT 'INACTIVE'::character varying NOT NULL,
     entity_version integer DEFAULT 0 NOT NULL,
-    description text DEFAULT NULL,
+    description text,
     tags character varying(10000) DEFAULT NULL::character varying,
     check_delay bigint DEFAULT 10000 NOT NULL,
     memory integer
@@ -226,7 +226,7 @@ CREATE TABLE job_requests (
     name character varying(255) NOT NULL,
     genie_user character varying(255) NOT NULL,
     version character varying(255) NOT NULL,
-    description text DEFAULT NULL,
+    description text,
     entity_version integer DEFAULT 0 NOT NULL,
     command_args character varying(10000) NOT NULL,
     group_name character varying(255) DEFAULT NULL::character varying,
@@ -234,14 +234,14 @@ CREATE TABLE job_requests (
     cluster_criterias text DEFAULT ''::character varying NOT NULL,
     command_criteria text DEFAULT ''::character varying NOT NULL,
     dependencies text DEFAULT ''::character varying NOT NULL,
-    configs text DEFAULT ''::character varying NOT NULL,
     disable_log_archival boolean DEFAULT false NOT NULL,
     email character varying(255) DEFAULT NULL::character varying,
     tags character varying(10000) DEFAULT NULL::character varying,
     cpu integer,
     memory integer,
     applications character varying(2048) DEFAULT '[]'::character varying NOT NULL,
-    timeout integer
+    timeout integer,
+    configs text DEFAULT ''::character varying NOT NULL
 );
 
 
@@ -260,7 +260,7 @@ CREATE TABLE jobs (
     command_args character varying(10000) NOT NULL,
     command_id character varying(255) DEFAULT NULL::character varying,
     command_name character varying(255) DEFAULT NULL::character varying,
-    description text DEFAULT NULL,
+    description text,
     cluster_id character varying(255) DEFAULT NULL::character varying,
     cluster_name character varying(255) DEFAULT NULL::character varying,
     finished timestamp(3) without time zone DEFAULT NULL::timestamp without time zone,


### PR DESCRIPTION
… driver

The PostgreSQL hibernate driver is failing to load values for fields marked @Lob.
The annotation was introduced when the fields were migrated from varchar to text.
PostgreSQL expect a value reference in this column (a integer-type pointer to the actual column value stored externally), and it fails when inline text is found instead.

The resulting error is:
```
  org.postgresql.util.PSQLException: Bad value for type long : <application description>
```

See also: https://github.com/Netflix/genie/issues/636