### PR TITLE
Fix migration scripts for commands table

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/configs/SwaggerConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/SwaggerConfig.java
@@ -40,7 +40,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
  * @since 3.0.0
  */
 @Configuration
-@ConditionalOnProperty("genie.swagger.enabled")
+@ConditionalOnProperty(value = "genie.swagger.enabled", havingValue = "true")
 @EnableSwagger2
 @Import(BeanValidatorPluginsConfiguration.class)
 public class SwaggerConfig {

--- a/genie-web/src/main/resources/db/migration/mysql/V3_3_0__Merge_Jobs_Tables.sql
+++ b/genie-web/src/main/resources/db/migration/mysql/V3_3_0__Merge_Jobs_Tables.sql
@@ -1348,7 +1348,7 @@ CREATE PROCEDURE GENIE_SPLIT_COMMANDS_320()
         FROM `files` `f`
         WHERE `f`.`file` = `old_setup_file`;
 
-        UPDATE `clusters`
+        UPDATE `commands`
         SET `setup_file` = @file_id
         WHERE `id` = `new_command_id`;
       END IF;

--- a/genie-web/src/main/resources/db/migration/postgresql/V3_3_0__Merge_Jobs_Tables.sql
+++ b/genie-web/src/main/resources/db/migration/postgresql/V3_3_0__Merge_Jobs_Tables.sql
@@ -1252,7 +1252,7 @@ BEGIN
       FROM files f
       WHERE f.file = command_record.setup_file;
 
-      UPDATE clusters c
+      UPDATE commands c
       SET c.setup_file = file_id
       WHERE c.id = new_command_id;
     END IF;


### PR DESCRIPTION
Fix bug in script that caused setup files for commands to be written into clusters table instead

Discovered during testing of 3.3.0 migration on internal data