### PR TITLE
Upgrade to Spring Security SAML 1.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ configure(javaProjects) {
             }
             dependency("org.opensaml:opensaml:2.6.4")
             dependency("org.python:jython-standalone:2.7.1")
-            dependency("org.springframework.security.extensions:spring-security-saml2-core:1.0.2.RELEASE")
+            dependency("org.springframework.security.extensions:spring-security-saml2-core:1.0.3.RELEASE")
         }
     }
 


### PR DESCRIPTION
For compatibility with [Spring 5](https://spring.io/blog/2017/12/20/spring-security-saml-1-0-3-release)