### PR TITLE
Add message to @NotBlank validation annotations of Tag and File

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaBaseService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaBaseService.java
@@ -33,6 +33,7 @@ import com.netflix.genie.core.services.TagService;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.constraints.NotBlank;
 
 import java.text.DateFormat;
 import java.util.Set;
@@ -94,7 +95,9 @@ class JpaBaseService {
      * @return The file entity that has been persisted in the database
      * @throws GenieException on error
      */
-    FileEntity createAndGetFileEntity(final String file) throws GenieException {
+    FileEntity createAndGetFileEntity(
+        @NotBlank(message = "File path cannot be blank") final String file
+    ) throws GenieException {
         this.fileService.createFileIfNotExists(file);
         return this.fileRepository.findByFile(file).orElseThrow(
             () -> new GenieNotFoundException("Couldn't find file entity for file " + file)
@@ -123,7 +126,9 @@ class JpaBaseService {
      * @return The tag entity that has been persisted in the database
      * @throws GenieException on error
      */
-    TagEntity createAndGetTagEntity(final String tag) throws GenieException {
+    TagEntity createAndGetTagEntity(
+        @NotBlank(message = "Tag name cannot be blank") final String tag
+    ) throws GenieException {
         this.tagService.createTagIfNotExists(tag);
         return this.tagRepository.findByTag(tag).orElseThrow(
             () -> new GenieNotFoundException("Couldn't find tag entity for tag " + tag)

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaFileServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaFileServiceImpl.java
@@ -52,7 +52,9 @@ public class JpaFileServiceImpl implements FileService {
      */
     @Override
 //    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createFileIfNotExists(@NotBlank final String file) throws GenieException {
+    public void createFileIfNotExists(
+        @NotBlank(message = "File path cannot be blank") final String file
+    ) throws GenieException {
         if (this.fileRepository.existsByFile(file)) {
             return;
         }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaTagServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaTagServiceImpl.java
@@ -52,7 +52,9 @@ public class JpaTagServiceImpl implements TagService {
      */
     @Override
 //    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createTagIfNotExists(@NotBlank final String tag) throws GenieException {
+    public void createTagIfNotExists(
+        @NotBlank(message = "Tag name cannot be blank") final String tag
+    ) throws GenieException {
         if (this.tagRepository.existsByTag(tag)) {
             return;
         }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/FileService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/FileService.java
@@ -36,5 +36,7 @@ public interface FileService {
      * @param file the file to create. Not blank.
      * @throws GenieException on any error except that the file already exists
      */
-    void createFileIfNotExists(@NotBlank final String file) throws GenieException;
+    void createFileIfNotExists(
+        @NotBlank(message = "File path cannot be blank") final String file
+    ) throws GenieException;
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/TagService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/TagService.java
@@ -36,5 +36,7 @@ public interface TagService {
      * @param tag the tag to create. Not blank.
      * @throws GenieException on any error except that the tag already exists
      */
-    void createTagIfNotExists(@NotBlank final String tag) throws GenieException;
+    void createTagIfNotExists(
+        @NotBlank(message = "Tag name cannot be blank") final String tag
+    ) throws GenieException;
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/ClusterRestControllerIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/ClusterRestControllerIntegrationTests.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.jsonpatch.JsonPatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.ClusterStatus;
 import com.netflix.genie.common.dto.Command;
@@ -1240,5 +1241,80 @@ public class ClusterRestControllerIntegrationTests extends RestControllerIntegra
             final String decoded = URLDecoder.decode(params.get("name"), StandardCharsets.UTF_8.name());
             Assert.assertEquals(singleEncodedNameQuery, decoded);
         }
+    }
+
+    /**
+     * Test creating a Cluster with a blank setup file path.
+     *
+     * @throws Exception When issue in creation
+     */
+    @Test
+    public void cantCreateClusterWithBlankSetupFile() throws Exception {
+        Assert.assertThat(this.jpaClusterRepository.count(), Matchers.is(0L));
+
+        final Cluster clusterResource = new Cluster.Builder(NAME, USER, VERSION, ClusterStatus.UP)
+            .withId(ID)
+            .withSetupFile(" ")
+            .build();
+
+        this.mvc
+            .perform(
+                MockMvcRequestBuilders.post(CLUSTERS_API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(this.objectMapper.writeValueAsBytes(clusterResource))
+            )
+            .andExpect(MockMvcResultMatchers.status().isPreconditionFailed());
+
+        Assert.assertThat(this.jpaClusterRepository.count(), Matchers.is(0L));
+    }
+
+    /**
+     * Test creating a Cluster with a blank config file path.
+     *
+     * @throws Exception When issue in creation
+     */
+    @Test
+    public void cantCreateClusterWithBlankConfigFile() throws Exception {
+        Assert.assertThat(this.jpaClusterRepository.count(), Matchers.is(0L));
+
+        final Cluster clusterResource = new Cluster.Builder(NAME, USER, VERSION, ClusterStatus.UP)
+            .withId(ID)
+            .withConfigs(Sets.newHashSet("foo", " "))
+            .build();
+
+        this.mvc
+            .perform(
+                MockMvcRequestBuilders.post(CLUSTERS_API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(this.objectMapper.writeValueAsBytes(clusterResource))
+            )
+            .andExpect(MockMvcResultMatchers.status().isPreconditionFailed());
+
+        Assert.assertThat(this.jpaClusterRepository.count(), Matchers.is(0L));
+    }
+
+    /**
+     * Test creating a Cluster with a blank tag.
+     *
+     * @throws Exception When issue in creation
+     */
+    @Test
+    public void cantCreateClusterWithBlankTag() throws Exception {
+        Assert.assertThat(this.jpaClusterRepository.count(), Matchers.is(0L));
+
+        final Cluster clusterResource = new Cluster.Builder(NAME, USER, VERSION, ClusterStatus.UP)
+            .withId(ID)
+            .withTags(Sets.newHashSet("foo", " "))
+            .build();
+
+        this.mvc
+            .perform(
+                MockMvcRequestBuilders.post(CLUSTERS_API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(this.objectMapper.writeValueAsBytes(clusterResource))
+            )
+            .andExpect(MockMvcResultMatchers.status().isPreconditionFailed());
+
+        Assert.assertThat(this.jpaClusterRepository.count(), Matchers.is(0L));
     }
 }


### PR DESCRIPTION
Without an explicitly message, the error propagated back to the user is a generic "cannot be empty".
This change makes it a little simpler to identify which field contains a blank string that is getting rejected.