### PR TITLE
Add additional database cleanup actions to the scheduled task

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ This is the image that has Genie deployed as a WAR file within Tomcat. You can u
 `docker pull netflixoss/genie-war:{version}` to test the one you want.
 
 You can run via `docker run -t --rm -p 8080:8080 netflixoss/genie-war:{version}`
+
+## Python Client
+
+The [Genie Python](https://github.com/Netflix/pygenie) client has been moved into its own repo.

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaFileRepository.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/repositories/JpaFileRepository.java
@@ -18,7 +18,11 @@
 package com.netflix.genie.core.jpa.repositories;
 
 import com.netflix.genie.core.jpa.entities.FileEntity;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Date;
 import java.util.Optional;
 
 /**
@@ -28,6 +32,26 @@ import java.util.Optional;
  * @since 3.3.0
  */
 public interface JpaFileRepository extends JpaIdRepository<FileEntity> {
+
+    /**
+     * The query used to delete any dangling file references.
+     */
+    String DELETE_UNUSED_FILES_SQL =
+        "DELETE "
+            + "FROM files "
+            + "WHERE id NOT IN (SELECT DISTINCT(setup_file) FROM applications WHERE setup_file IS NOT NULL) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM applications_configs) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM applications_dependencies) "
+            + "AND id NOT IN (SELECT DISTINCT(setup_file) FROM clusters WHERE setup_file IS NOT NULL) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM clusters_configs) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM clusters_dependencies) "
+            + "AND id NOT IN (SELECT DISTINCT(setup_file) FROM commands WHERE setup_file IS NOT NULL) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM commands_configs) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM commands_dependencies) "
+            + "AND id NOT IN (SELECT DISTINCT(setup_file) FROM jobs WHERE setup_file IS NOT NULL) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM jobs_configs) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM jobs_dependencies) "
+            + "AND created <= :createdThreshold ;";
 
     /**
      * Find a file by its unique file value.
@@ -44,4 +68,16 @@ public interface JpaFileRepository extends JpaIdRepository<FileEntity> {
      * @return True if the file exists
      */
     boolean existsByFile(final String file);
+
+    /**
+     * Delete all files from the database that aren't referenced which were created before the supplied created
+     * threshold.
+     *
+     * @param createdThreshold The instant in time where files created before this time that aren't referenced
+     *                         will be deleted. Inclusive.
+     * @return The number of files deleted
+     */
+    @Modifying
+    @Query(value = DELETE_UNUSED_FILES_SQL, nativeQuery = true)
+    int deleteUnusedFiles(@Param("createdThreshold") final Date createdThreshold);
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaClusterServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaClusterServiceImpl.java
@@ -579,6 +579,30 @@ public class JpaClusterServiceImpl extends JpaBaseService implements ClusterServ
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deleteTerminatedClusters() {
+        log.info(
+            "Deleted {} cluster command references in preparation for terminated cluster deletion",
+            this.clusterRepository.deleteTerminatedClustersCommandsReferences()
+        );
+        log.info(
+            "Deleted {} cluster config file references in preparation for terminated cluster deletion",
+            this.clusterRepository.deleteTerminatedClustersConfigsFileReferences()
+        );
+        log.info(
+            "Deleted {} cluster dependency file references in preparation for terminated cluster deletion",
+            this.clusterRepository.deleteTerminatedClustersDependenciesFileReferences()
+        );
+        log.info(
+            "Deleted {} cluster tag references in preparation for terminated cluster deletion",
+            this.clusterRepository.deleteTerminatedClustersTagsReferences()
+        );
+        return this.clusterRepository.deleteTerminatedClusters();
+    }
+
+    /**
      * Helper method to find a cluster entity to save code.
      *
      * @param id The id of the cluster to find

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaFileServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaFileServiceImpl.java
@@ -17,7 +17,6 @@
  */
 package com.netflix.genie.core.jpa.services;
 
-import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.core.jpa.entities.FileEntity;
 import com.netflix.genie.core.jpa.repositories.JpaFileRepository;
 import com.netflix.genie.core.services.FileService;
@@ -25,6 +24,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.Date;
 
 /**
  * JPA based implementation of the FileService interface.
@@ -51,10 +54,7 @@ public class JpaFileServiceImpl implements FileService {
      * {@inheritDoc}
      */
     @Override
-//    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createFileIfNotExists(
-        @NotBlank(message = "File path cannot be blank") final String file
-    ) throws GenieException {
+    public void createFileIfNotExists(@NotBlank(message = "File path cannot be blank") final String file) {
         if (this.fileRepository.existsByFile(file)) {
             return;
         }
@@ -68,5 +68,13 @@ public class JpaFileServiceImpl implements FileService {
             // Must've been created during the time between exists query and now
             log.error("File expected not to be there but seems to be {}", e.getMessage(), e);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deleteUnusedFiles(@NotNull final Instant createdThreshold) {
+        return this.fileRepository.deleteUnusedFiles(Date.from(createdThreshold));
     }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaTagServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaTagServiceImpl.java
@@ -17,7 +17,6 @@
  */
 package com.netflix.genie.core.jpa.services;
 
-import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.core.jpa.entities.TagEntity;
 import com.netflix.genie.core.jpa.repositories.JpaTagRepository;
 import com.netflix.genie.core.services.TagService;
@@ -25,6 +24,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.Date;
 
 /**
  * JPA based implementation of the TagService interface.
@@ -51,10 +54,7 @@ public class JpaTagServiceImpl implements TagService {
      * {@inheritDoc}
      */
     @Override
-//    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createTagIfNotExists(
-        @NotBlank(message = "Tag cannot be blank") final String tag
-    ) throws GenieException {
+    public void createTagIfNotExists(@NotBlank(message = "Tag cannot be blank") final String tag) {
         if (this.tagRepository.existsByTag(tag)) {
             return;
         }
@@ -65,5 +65,13 @@ public class JpaTagServiceImpl implements TagService {
             // Must've been created during the time between exists query and now
             log.error("Tag expected not to be there but seems to be {}", e.getMessage(), e);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deleteUnusedTags(@NotNull final Instant createdThreshold) {
+        return this.tagRepository.deleteUnusedTags(Date.from(createdThreshold));
     }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/ClusterService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/ClusterService.java
@@ -423,4 +423,11 @@ public interface ClusterService {
         @NotBlank(message = "No command id entered. Unable to remove command.")
         final String cmdId
     ) throws GenieException;
+
+    /**
+     * Delete all clusters that are in a terminated state and aren't attached to any jobs.
+     *
+     * @return The number of clusters deleted
+     */
+    int deleteTerminatedClusters();
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/FileService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/FileService.java
@@ -17,9 +17,11 @@
  */
 package com.netflix.genie.core.services;
 
-import com.netflix.genie.common.exceptions.GenieException;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
 
 /**
  * API definition for manipulating file references within Genie.
@@ -34,9 +36,16 @@ public interface FileService {
      * Attempt to create a file reference in the system if it doesn't already exist.
      *
      * @param file the file to create. Not blank.
-     * @throws GenieException on any error except that the file already exists
      */
-    void createFileIfNotExists(
-        @NotBlank(message = "File path cannot be blank") final String file
-    ) throws GenieException;
+    void createFileIfNotExists(@NotBlank(message = "File path cannot be blank") final String file);
+
+    /**
+     * Delete all files from the database that aren't referenced which were created before the supplied created
+     * threshold.
+     *
+     * @param createdThreshold The instant in time where files created before this time that aren't referenced
+     *                         will be deleted. Inclusive
+     * @return The number of files deleted
+     */
+    int deleteUnusedFiles(@NotNull final Instant createdThreshold);
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/TagService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/TagService.java
@@ -17,9 +17,11 @@
  */
 package com.netflix.genie.core.services;
 
-import com.netflix.genie.common.exceptions.GenieException;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
 
 /**
  * API definition for manipulating tag references within Genie.
@@ -34,9 +36,16 @@ public interface TagService {
      * Attempt to create a tag in the system if it doesn't already exist.
      *
      * @param tag the tag to create. Not blank.
-     * @throws GenieException on any error except that the tag already exists
      */
-    void createTagIfNotExists(
-        @NotBlank(message = "Tag cannot be blank") final String tag
-    ) throws GenieException;
+    void createTagIfNotExists(@NotBlank(message = "Tag cannot be blank") final String tag);
+
+    /**
+     * Delete all tags from the database that aren't referenced which were created before the supplied created
+     * threshold.
+     *
+     * @param createdThreshold The instant in time where tags created before this time that aren't referenced
+     *                         will be deleted. Inclusive
+     * @return The number of tags deleted
+     */
+    int deleteUnusedTags(@NotNull final Instant createdThreshold);
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaFileServiceImplIntegrationTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaFileServiceImplIntegrationTest.java
@@ -18,9 +18,13 @@
 package com.netflix.genie.core.jpa.services;
 
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import com.google.common.collect.Sets;
+import com.netflix.genie.common.dto.Application;
+import com.netflix.genie.common.dto.ApplicationStatus;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.core.jpa.entities.FileEntity;
 import com.netflix.genie.core.jpa.repositories.JpaFileRepository;
+import com.netflix.genie.core.services.ApplicationService;
 import com.netflix.genie.core.services.FileService;
 import com.netflix.genie.test.categories.IntegrationTest;
 import org.hamcrest.Matchers;
@@ -29,6 +33,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -49,14 +54,15 @@ public class JpaFileServiceImplIntegrationTest extends DBUnitTestBase {
     @Autowired
     private JpaFileRepository fileRepository;
 
+    @Autowired
+    private ApplicationService applicationService;
+
     /**
      * Make sure that no matter how many times we try to create a file it doesn't throw an error on duplicate key it
      * just does nothing.
-     *
-     * @throws GenieException on error
      */
     @Test
-    public void canCreateFileIfNotExists() throws GenieException {
+    public void canCreateFileIfNotExists() {
         Assert.assertThat(this.fileRepository.count(), Matchers.is(0L));
         final String file = UUID.randomUUID().toString();
         this.fileService.createFileIfNotExists(file);
@@ -78,5 +84,52 @@ public class JpaFileServiceImplIntegrationTest extends DBUnitTestBase {
 
         // Make sure the ids are still equal
         Assert.assertThat(fileEntity2.getId(), Matchers.is(fileEntity.getId()));
+    }
+
+    /**
+     * Make sure we can delete files that aren't attached to other resources.
+     *
+     * @throws GenieException on error
+     */
+    @Test
+    public void canDeleteUnusedFiles() throws GenieException {
+        Assert.assertThat(this.fileRepository.count(), Matchers.is(0L));
+        final String file1 = UUID.randomUUID().toString();
+        final String file2 = UUID.randomUUID().toString();
+        final String file3 = UUID.randomUUID().toString();
+        final String file4 = UUID.randomUUID().toString();
+        final String file5 = UUID.randomUUID().toString();
+
+        this.fileService.createFileIfNotExists(file1);
+        this.fileService.createFileIfNotExists(file4);
+
+        final Application app = new Application.Builder(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            ApplicationStatus.ACTIVE
+        )
+            .withDependencies(Sets.newHashSet(file2))
+            .withConfigs(Sets.newHashSet(file3))
+            .withSetupFile(file5)
+            .build();
+
+        final String appId = this.applicationService.createApplication(app);
+
+        Assert.assertTrue(this.fileRepository.existsByFile(file1));
+        Assert.assertTrue(this.fileRepository.existsByFile(file2));
+        Assert.assertTrue(this.fileRepository.existsByFile(file3));
+        Assert.assertTrue(this.fileRepository.existsByFile(file4));
+        Assert.assertTrue(this.fileRepository.existsByFile(file5));
+
+        Assert.assertThat(this.fileService.deleteUnusedFiles(Instant.now()), Matchers.is(2));
+
+        Assert.assertFalse(this.fileRepository.existsByFile(file1));
+        Assert.assertTrue(this.fileRepository.existsByFile(file2));
+        Assert.assertTrue(this.fileRepository.existsByFile(file3));
+        Assert.assertFalse(this.fileRepository.existsByFile(file4));
+        Assert.assertTrue(this.fileRepository.existsByFile(file5));
+
+        this.applicationService.deleteApplication(appId);
     }
 }

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -380,8 +380,26 @@ and system metrics and statistics.
 |ClusterCheckerTask
 |-
 
+|genie.tasks.databaseCleanup.numDeletedClusters.gauge
+|Number of terminated cluster records purged during the last database cleanup pass
+|amount
+|DatabaseCleanupTask
+|-
+
+|genie.tasks.databaseCleanup.numDeletedFiles.gauge
+|Number of unused file references purged during the last database cleanup pass
+|amount
+|DatabaseCleanupTask
+|-
+
 |genie.tasks.databaseCleanup.numDeletedJobs.gauge
-|Number of database records purged during the last database cleanup pass
+|Number of job records purged during the last database cleanup pass
+|amount
+|DatabaseCleanupTask
+|-
+
+|genie.tasks.databaseCleanup.numDeletedTags.gauge
+|Number of unused tag records purged during the last database cleanup pass
 |amount
 |DatabaseCleanupTask
 |-

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -287,7 +287,8 @@ lost and failed by the Genie leader
 |http
 
 |genie.tasks.databaseCleanup.enabled
-|Whether or not to delete old job records from the database
+|Whether or not to delete old and unused records from the database at a scheduled interval.
+See: `genie.tasks.databaseCleanup.expression`
 |true
 
 |genie.tasks.databaseCleanup.maxDeletedPerTransaction

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
@@ -18,7 +18,10 @@
 package com.netflix.genie.web.tasks.leader;
 
 import com.netflix.genie.core.jobs.JobConstants;
+import com.netflix.genie.core.services.ClusterService;
+import com.netflix.genie.core.services.FileService;
 import com.netflix.genie.core.services.JobPersistenceService;
+import com.netflix.genie.core.services.TagService;
 import com.netflix.genie.core.util.MetricsUtils;
 import com.netflix.genie.web.properties.DatabaseCleanupProperties;
 import com.netflix.genie.web.tasks.GenieTaskScheduleType;
@@ -36,6 +39,8 @@ import org.springframework.stereotype.Component;
 import javax.validation.constraints.NotNull;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
@@ -56,9 +61,15 @@ public class DatabaseCleanupTask extends LeadershipTask {
     private final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     private final DatabaseCleanupProperties cleanupProperties;
     private final JobPersistenceService jobPersistenceService;
+    private final ClusterService clusterService;
+    private final FileService fileService;
+    private final TagService tagService;
 
     private final Registry registry;
     private final AtomicLong numDeletedJobs;
+    private final AtomicLong numDeletedClusters;
+    private final AtomicLong numDeletedTags;
+    private final AtomicLong numDeletedFiles;
     private final Id deletionTimerId;
 
     /**
@@ -66,21 +77,42 @@ public class DatabaseCleanupTask extends LeadershipTask {
      *
      * @param cleanupProperties     The properties to use to configure this task
      * @param jobPersistenceService The persistence service to use to cleanup the data store
+     * @param clusterService        The cluster service to use to delete terminated clusters
+     * @param fileService           The file service to use to delete unused file references
+     * @param tagService            The tag service to use to delete unused tag references
      * @param registry              The metrics registry
      */
     @Autowired
     public DatabaseCleanupTask(
         @NotNull final DatabaseCleanupProperties cleanupProperties,
         @NotNull final JobPersistenceService jobPersistenceService,
+        @NotNull final ClusterService clusterService,
+        @NotNull final FileService fileService,
+        @NotNull final TagService tagService,
         @NotNull final Registry registry
     ) {
         this.registry = registry;
         this.cleanupProperties = cleanupProperties;
         this.jobPersistenceService = jobPersistenceService;
+        this.clusterService = clusterService;
+        this.fileService = fileService;
+        this.tagService = tagService;
 
         this.numDeletedJobs = PolledMeter
             .using(registry)
             .withName("genie.tasks.databaseCleanup.numDeletedJobs.gauge")
+            .monitorValue(new AtomicLong());
+        this.numDeletedClusters = PolledMeter
+            .using(registry)
+            .withName("genie.tasks.databaseCleanup.numDeletedClusters.gauge")
+            .monitorValue(new AtomicLong());
+        this.numDeletedTags = PolledMeter
+            .using(registry)
+            .withName("genie.tasks.databaseCleanup.numDeletedTags.gauge")
+            .monitorValue(new AtomicLong());
+        this.numDeletedFiles = PolledMeter
+            .using(registry)
+            .withName("genie.tasks.databaseCleanup.numDeletedFiles.gauge")
             .monitorValue(new AtomicLong());
         this.deletionTimerId = registry.createId("genie.tasks.databaseCleanup.duration.timer");
     }
@@ -109,41 +141,40 @@ public class DatabaseCleanupTask extends LeadershipTask {
         final long start = System.nanoTime();
         final Map<String, String> tags = MetricsUtils.newSuccessTagsMap();
         try {
-            final Calendar cal = TaskUtils.getMidnightUTC();
-            // Move the date back the number of days retention is set for
-            TaskUtils.subtractDaysFromDate(cal, this.cleanupProperties.getRetention());
-            final Date retentionLimit = cal.getTime();
-            final String retentionLimitString = this.dateFormat.format(retentionLimit);
-            final int batchSize = this.cleanupProperties.getMaxDeletedPerTransaction();
-            final int pageSize = this.cleanupProperties.getPageSize();
+            // Delete jobs that are older than the retention threshold and are complete
+            this.deleteJobs();
 
+            // Delete all clusters that are marked terminated and aren't attached to any jobs after jobs were deleted
+            final int countDeletedClusters = this.clusterService.deleteTerminatedClusters();
             log.info(
-                "Attempting to delete jobs from before {} in batches of {} jobs per iteration",
-                retentionLimitString,
-                batchSize
+                "Deleted {} clusters that were in TERMINATED state and weren't attached to any jobs",
+                countDeletedClusters
             );
-            long totalDeletedJobs = 0;
-            while (true) {
-                final long numberDeletedJobs = this.jobPersistenceService.deleteBatchOfJobsCreatedBeforeDate(
-                    retentionLimit,
-                    batchSize,
-                    pageSize
-                );
-                totalDeletedJobs += numberDeletedJobs;
-                if (numberDeletedJobs == 0) {
-                    break;
-                }
-            }
-            log.info("Deleted {} jobs from before {}", totalDeletedJobs, retentionLimitString);
-            this.numDeletedJobs.set(totalDeletedJobs);
-        } catch (Throwable t) {
+            this.numDeletedClusters.set(countDeletedClusters);
+
+            // Get now - 1 hour to avoid deleting references that were created as part of new resources recently
+            final Instant creationThreshold = Instant.now().minus(1L, ChronoUnit.HOURS);
+            final int countDeletedFiles = this.fileService.deleteUnusedFiles(creationThreshold);
+            log.info(
+                "Deleted {} files that were unused by any resource and created over an hour ago",
+                countDeletedFiles
+            );
+            this.numDeletedFiles.set(countDeletedFiles);
+
+            final int countDeletedTags = this.tagService.deleteUnusedTags(creationThreshold);
+            log.info(
+                "Deleted {} tags that were unused by any resource and created over an hour ago",
+                countDeletedTags
+            );
+            this.numDeletedTags.set(countDeletedTags);
+        } catch (final Throwable t) {
             MetricsUtils.addFailureTagsWithException(tags, t);
             throw t;
         } finally {
             final long finish = System.nanoTime();
-            this.registry.timer(
-                deletionTimerId.withTags(tags)
-            ).record(finish - start, TimeUnit.NANOSECONDS);
+            this.registry
+                .timer(this.deletionTimerId.withTags(tags))
+                .record(finish - start, TimeUnit.NANOSECONDS);
         }
     }
 
@@ -153,5 +184,38 @@ public class DatabaseCleanupTask extends LeadershipTask {
     @Override
     public void cleanup() {
         this.numDeletedJobs.set(0L);
+        this.numDeletedClusters.set(0L);
+        this.numDeletedTags.set(0L);
+        this.numDeletedFiles.set(0L);
+    }
+
+    private void deleteJobs() {
+        final Calendar cal = TaskUtils.getMidnightUTC();
+        // Move the date back the number of days retention is set for
+        TaskUtils.subtractDaysFromDate(cal, this.cleanupProperties.getRetention());
+        final Date retentionLimit = cal.getTime();
+        final String retentionLimitString = this.dateFormat.format(retentionLimit);
+        final int batchSize = this.cleanupProperties.getMaxDeletedPerTransaction();
+        final int pageSize = this.cleanupProperties.getPageSize();
+
+        log.info(
+            "Attempting to delete jobs from before {} in batches of {} jobs per iteration",
+            retentionLimitString,
+            batchSize
+        );
+        long totalDeletedJobs = 0;
+        while (true) {
+            final long numberDeletedJobs = this.jobPersistenceService.deleteBatchOfJobsCreatedBeforeDate(
+                retentionLimit,
+                batchSize,
+                pageSize
+            );
+            totalDeletedJobs += numberDeletedJobs;
+            if (numberDeletedJobs == 0) {
+                break;
+            }
+        }
+        log.info("Deleted {} jobs from before {}", totalDeletedJobs, retentionLimitString);
+        this.numDeletedJobs.set(totalDeletedJobs);
     }
 }


### PR DESCRIPTION
This PR adds actions to the `DatabaseCleanupTask` (if it is enabled) to:

1. Delete any `cluster` records from the database that are in `TERMINATED` state and aren't referenced by existing `job` records
2. Delete any `file` records from the database that aren't referenced by any other table and were created over an hour earlier than the task is run
3. Delete any `tag` records from the database that aren't referenced by any other table and were created over an hour earlier than the task is run

Documentation was also updated to reflect new metrics captured as part of these actions.

The actions will only run on the node elected the leader.