### PR TITLE
Add additional database cleanup actions to the scheduled task

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ This is the image that has Genie deployed as a WAR file within Tomcat. You can u
 `docker pull netflixoss/genie-war:{version}` to test the one you want.
 
 You can run via `docker run -t --rm -p 8080:8080 netflixoss/genie-war:{version}`
+
+## Python Client
+
+The [Genie Python](https://github.com/Netflix/pygenie) client has been moved into its own repo.

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -380,8 +380,26 @@ and system metrics and statistics.
 |ClusterCheckerTask
 |-
 
+|genie.tasks.databaseCleanup.numDeletedClusters.gauge
+|Number of terminated cluster records purged during the last database cleanup pass
+|amount
+|DatabaseCleanupTask
+|-
+
+|genie.tasks.databaseCleanup.numDeletedFiles.gauge
+|Number of unused file references purged during the last database cleanup pass
+|amount
+|DatabaseCleanupTask
+|-
+
 |genie.tasks.databaseCleanup.numDeletedJobs.gauge
-|Number of database records purged during the last database cleanup pass
+|Number of job records purged during the last database cleanup pass
+|amount
+|DatabaseCleanupTask
+|-
+
+|genie.tasks.databaseCleanup.numDeletedTags.gauge
+|Number of unused tag records purged during the last database cleanup pass
 |amount
 |DatabaseCleanupTask
 |-

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -287,7 +287,8 @@ lost and failed by the Genie leader
 |http
 
 |genie.tasks.databaseCleanup.enabled
-|Whether or not to delete old job records from the database
+|Whether or not to delete old and unused records from the database at a scheduled interval.
+See: `genie.tasks.databaseCleanup.expression`
 |true
 
 |genie.tasks.databaseCleanup.maxDeletedPerTransaction

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaFileRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaFileRepository.java
@@ -18,7 +18,11 @@
 package com.netflix.genie.web.jpa.repositories;
 
 import com.netflix.genie.web.jpa.entities.FileEntity;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -28,6 +32,26 @@ import java.util.Optional;
  * @since 3.3.0
  */
 public interface JpaFileRepository extends JpaIdRepository<FileEntity> {
+
+    /**
+     * The query used to delete any dangling file references.
+     */
+    String DELETE_UNUSED_FILES_SQL =
+        "DELETE "
+            + "FROM files "
+            + "WHERE id NOT IN (SELECT DISTINCT(setup_file) FROM applications WHERE setup_file IS NOT NULL) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM applications_configs) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM applications_dependencies) "
+            + "AND id NOT IN (SELECT DISTINCT(setup_file) FROM clusters WHERE setup_file IS NOT NULL) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM clusters_configs) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM clusters_dependencies) "
+            + "AND id NOT IN (SELECT DISTINCT(setup_file) FROM commands WHERE setup_file IS NOT NULL) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM commands_configs) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM commands_dependencies) "
+            + "AND id NOT IN (SELECT DISTINCT(setup_file) FROM jobs WHERE setup_file IS NOT NULL) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM jobs_configs) "
+            + "AND id NOT IN (SELECT DISTINCT(file_id) FROM jobs_dependencies) "
+            + "AND created <= :createdThreshold ;";
 
     /**
      * Find a file by its unique file value.
@@ -44,4 +68,16 @@ public interface JpaFileRepository extends JpaIdRepository<FileEntity> {
      * @return True if the file exists
      */
     boolean existsByFile(final String file);
+
+    /**
+     * Delete all files from the database that aren't referenced which were created before the supplied created
+     * threshold.
+     *
+     * @param createdThreshold The instant in time where files created before this time that aren't referenced
+     *                         will be deleted. Inclusive.
+     * @return The number of files deleted
+     */
+    @Modifying
+    @Query(value = DELETE_UNUSED_FILES_SQL, nativeQuery = true)
+    int deleteUnusedFiles(@Param("createdThreshold") final Instant createdThreshold);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaTagRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaTagRepository.java
@@ -18,7 +18,11 @@
 package com.netflix.genie.web.jpa.repositories;
 
 import com.netflix.genie.web.jpa.entities.TagEntity;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
 
@@ -29,6 +33,19 @@ import java.util.Set;
  * @since 3.3.0
  */
 public interface JpaTagRepository extends JpaIdRepository<TagEntity> {
+
+    /**
+     * This is the query used to find and delete tags that aren't referenced by any of the other tables.
+     */
+    String DELETE_UNUSED_TAGS_SQL =
+        "DELETE "
+            + "FROM tags "
+            + "WHERE id NOT IN (SELECT DISTINCT(tag_id) FROM applications_tags) "
+            + "AND id NOT IN (SELECT DISTINCT(tag_id) FROM clusters_tags) "
+            + "AND id NOT IN (SELECT DISTINCT(tag_id) FROM commands_tags) "
+            + "AND id NOT IN (SELECT DISTINCT(tag_id) FROM criteria_tags) "
+            + "AND id NOT IN (SELECT DISTINCT(tag_id) FROM jobs_tags) "
+            + "AND created <= :createdThreshold ;";
 
     /**
      * Find a tag by its unique tag value.
@@ -50,7 +67,19 @@ public interface JpaTagRepository extends JpaIdRepository<TagEntity> {
      * Find tag entities where the tag value is in the given set of tags.
      *
      * @param tags The tags to find entities for
-     * @return The tag entites
+     * @return The tag entities
      */
     Set<TagEntity> findByTagIn(final Set<String> tags);
+
+    /**
+     * Delete all tags from the database that aren't referenced which were created before the supplied created
+     * threshold.
+     *
+     * @param createdThreshold The instant in time where tags created before this time that aren't referenced
+     *                         will be deleted. Inclusive
+     * @return The number of tags deleted
+     */
+    @Modifying
+    @Query(value = DELETE_UNUSED_TAGS_SQL, nativeQuery = true)
+    int deleteUnusedTags(@Param("createdThreshold") final Instant createdThreshold);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaClusterServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaClusterServiceImpl.java
@@ -580,6 +580,14 @@ public class JpaClusterServiceImpl extends JpaBaseService implements ClusterServ
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deleteTerminatedClusters() {
+        return this.clusterRepository.deleteTerminatedClusters();
+    }
+
+    /**
      * Helper method to find a cluster entity to save code.
      *
      * @param id The id of the cluster to find

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaFileServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaFileServiceImpl.java
@@ -17,7 +17,6 @@
  */
 package com.netflix.genie.web.jpa.services;
 
-import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.web.jpa.entities.FileEntity;
 import com.netflix.genie.web.jpa.repositories.JpaFileRepository;
 import com.netflix.genie.web.services.FileService;
@@ -25,6 +24,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
 
 /**
  * JPA based implementation of the FileService interface.
@@ -51,10 +53,7 @@ public class JpaFileServiceImpl implements FileService {
      * {@inheritDoc}
      */
     @Override
-//    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createFileIfNotExists(
-        @NotBlank(message = "File path cannot be blank") final String file
-    ) throws GenieException {
+    public void createFileIfNotExists(@NotBlank(message = "File path cannot be blank") final String file) {
         if (this.fileRepository.existsByFile(file)) {
             return;
         }
@@ -68,5 +67,13 @@ public class JpaFileServiceImpl implements FileService {
             // Must've been created during the time between exists query and now
             log.error("File expected not to be there but seems to be {}", e.getMessage(), e);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deleteUnusedFiles(@NotNull final Instant createdThreshold) {
+        return this.fileRepository.deleteUnusedFiles(createdThreshold);
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaTagServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaTagServiceImpl.java
@@ -17,7 +17,6 @@
  */
 package com.netflix.genie.web.jpa.services;
 
-import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.web.jpa.entities.TagEntity;
 import com.netflix.genie.web.jpa.repositories.JpaTagRepository;
 import com.netflix.genie.web.services.TagService;
@@ -25,6 +24,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
 
 /**
  * JPA based implementation of the TagService interface.
@@ -51,10 +53,7 @@ public class JpaTagServiceImpl implements TagService {
      * {@inheritDoc}
      */
     @Override
-//    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createTagIfNotExists(
-        @NotBlank(message = "Tag cannot be blank") final String tag
-    ) throws GenieException {
+    public void createTagIfNotExists(@NotBlank(message = "Tag cannot be blank") final String tag) {
         if (this.tagRepository.existsByTag(tag)) {
             return;
         }
@@ -65,5 +64,13 @@ public class JpaTagServiceImpl implements TagService {
             // Must've been created during the time between exists query and now
             log.error("Tag expected not to be there but seems to be {}", e.getMessage(), e);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deleteUnusedTags(@NotNull final Instant createdThreshold) {
+        return this.tagRepository.deleteUnusedTags(createdThreshold);
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/ClusterService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/ClusterService.java
@@ -387,4 +387,11 @@ public interface ClusterService {
         @NotBlank(message = "No cluster id entered. Unable to remove command.") final String id,
         @NotBlank(message = "No command id entered. Unable to remove command.") final String cmdId
     ) throws GenieException;
+
+    /**
+     * Delete all clusters that are in a terminated state and aren't attached to any jobs.
+     *
+     * @return The number of clusters deleted
+     */
+    int deleteTerminatedClusters();
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/FileService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/FileService.java
@@ -17,9 +17,11 @@
  */
 package com.netflix.genie.web.services;
 
-import com.netflix.genie.common.exceptions.GenieException;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
 
 /**
  * API definition for manipulating file references within Genie.
@@ -34,9 +36,16 @@ public interface FileService {
      * Attempt to create a file reference in the system if it doesn't already exist.
      *
      * @param file the file to create. Not blank.
-     * @throws GenieException on any error except that the file already exists
      */
-    void createFileIfNotExists(
-        @NotBlank(message = "File path cannot be blank") final String file
-    ) throws GenieException;
+    void createFileIfNotExists(@NotBlank(message = "File path cannot be blank") final String file);
+
+    /**
+     * Delete all files from the database that aren't referenced which were created before the supplied created
+     * threshold.
+     *
+     * @param createdThreshold The instant in time where files created before this time that aren't referenced
+     *                         will be deleted. Inclusive
+     * @return The number of files deleted
+     */
+    int deleteUnusedFiles(@NotNull final Instant createdThreshold);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/TagService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/TagService.java
@@ -17,9 +17,11 @@
  */
 package com.netflix.genie.web.services;
 
-import com.netflix.genie.common.exceptions.GenieException;
 import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
 
 /**
  * API definition for manipulating tag references within Genie.
@@ -34,9 +36,16 @@ public interface TagService {
      * Attempt to create a tag in the system if it doesn't already exist.
      *
      * @param tag the tag to create. Not blank.
-     * @throws GenieException on any error except that the tag already exists
      */
-    void createTagIfNotExists(
-        @NotBlank(message = "Tag cannot be blank") final String tag
-    ) throws GenieException;
+    void createTagIfNotExists(@NotBlank(message = "Tag cannot be blank") final String tag);
+
+    /**
+     * Delete all tags from the database that aren't referenced which were created before the supplied created
+     * threshold.
+     *
+     * @param createdThreshold The instant in time where tags created before this time that aren't referenced
+     *                         will be deleted. Inclusive
+     * @return The number of tags deleted
+     */
+    int deleteUnusedTags(@NotNull final Instant createdThreshold);
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaClusterServiceImplIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaClusterServiceImplIntegrationTests.java
@@ -31,6 +31,7 @@ import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.util.GenieObjectMapper;
 import com.netflix.genie.test.categories.IntegrationTest;
+import com.netflix.genie.web.jpa.repositories.JpaClusterRepository;
 import com.netflix.genie.web.services.ClusterService;
 import com.netflix.genie.web.services.CommandService;
 import org.hamcrest.Matchers;
@@ -90,6 +91,9 @@ public class JpaClusterServiceImplIntegrationTests extends DBUnitTestBase {
 
     @Autowired
     private CommandService commandService;
+
+    @Autowired
+    private JpaClusterRepository clusterRepository;
 
     /**
      * Test the get cluster method.
@@ -882,5 +886,56 @@ public class JpaClusterServiceImplIntegrationTests extends DBUnitTestBase {
         Assert.assertTrue(this.service.getTagsForCluster(CLUSTER_1_ID).contains("prod"));
         this.service.removeTagForCluster(CLUSTER_1_ID, "prod");
         Assert.assertFalse(this.service.getTagsForCluster(CLUSTER_1_ID).contains("prod"));
+    }
+
+    /**
+     * Test the API for deleting all terminated clusters that aren't attached to jobs.
+     *
+     * @throws GenieException On Error
+     * @throws IOException    On JSON patch error
+     */
+    @Test
+    public void testDeleteTerminatedClusters() throws GenieException, IOException {
+        Assert.assertThat(this.clusterRepository.count(), Matchers.is(2L));
+        final String testClusterId = UUID.randomUUID().toString();
+        final Cluster testCluster = new Cluster.Builder(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            ClusterStatus.OUT_OF_SERVICE
+        )
+            .withId(testClusterId)
+            .withConfigs(Sets.newHashSet(UUID.randomUUID().toString()))
+            .withDependencies(Sets.newHashSet(UUID.randomUUID().toString()))
+            .withSetupFile(UUID.randomUUID().toString())
+            .withTags(Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString()))
+            .build();
+        this.service.createCluster(testCluster);
+
+        // Shouldn't delete any clusters as all are UP or OOS
+        Assert.assertThat(this.service.deleteTerminatedClusters(), Matchers.is(0));
+
+        // Change status to UP
+        String patchString = "[{ \"op\": \"replace\", \"path\": \"/status\", \"value\": \"UP\" }]";
+        JsonPatch patch = JsonPatch.fromJson(GenieObjectMapper.getMapper().readTree(patchString));
+        this.service.patchCluster(testClusterId, patch);
+        Assert.assertThat(this.service.getCluster(testClusterId).getStatus(), Matchers.is(ClusterStatus.UP));
+
+        // All clusters are UP/OOS or attached to jobs
+        Assert.assertThat(this.service.deleteTerminatedClusters(), Matchers.is(0));
+
+        // Change status to terminated
+        patchString = "[{ \"op\": \"replace\", \"path\": \"/status\", \"value\": \"TERMINATED\" }]";
+        patch = JsonPatch.fromJson(GenieObjectMapper.getMapper().readTree(patchString));
+        this.service.patchCluster(testClusterId, patch);
+        Assert.assertThat(this.service.getCluster(testClusterId).getStatus(), Matchers.is(ClusterStatus.TERMINATED));
+
+        // All clusters are UP/OOS or attached to jobs
+        Assert.assertThat(this.service.deleteTerminatedClusters(), Matchers.is(1));
+
+        // Make sure it didn't delete any of the clusters we wanted
+        Assert.assertTrue(this.clusterRepository.existsByUniqueId(CLUSTER_1_ID));
+        Assert.assertTrue(this.clusterRepository.existsByUniqueId(CLUSTER_2_ID));
+        Assert.assertFalse(this.clusterRepository.existsByUniqueId(testClusterId));
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaFileServiceImplIntegrationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaFileServiceImplIntegrationTest.java
@@ -18,10 +18,14 @@
 package com.netflix.genie.web.jpa.services;
 
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import com.google.common.collect.Sets;
+import com.netflix.genie.common.dto.Application;
+import com.netflix.genie.common.dto.ApplicationStatus;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.test.categories.IntegrationTest;
 import com.netflix.genie.web.jpa.entities.FileEntity;
 import com.netflix.genie.web.jpa.repositories.JpaFileRepository;
+import com.netflix.genie.web.services.ApplicationService;
 import com.netflix.genie.web.services.FileService;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -29,6 +33,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -49,14 +54,15 @@ public class JpaFileServiceImplIntegrationTest extends DBUnitTestBase {
     @Autowired
     private JpaFileRepository fileRepository;
 
+    @Autowired
+    private ApplicationService applicationService;
+
     /**
      * Make sure that no matter how many times we try to create a file it doesn't throw an error on duplicate key it
      * just does nothing.
-     *
-     * @throws GenieException on error
      */
     @Test
-    public void canCreateFileIfNotExists() throws GenieException {
+    public void canCreateFileIfNotExists() {
         Assert.assertThat(this.fileRepository.count(), Matchers.is(0L));
         final String file = UUID.randomUUID().toString();
         this.fileService.createFileIfNotExists(file);
@@ -78,5 +84,52 @@ public class JpaFileServiceImplIntegrationTest extends DBUnitTestBase {
 
         // Make sure the ids are still equal
         Assert.assertThat(fileEntity2.getId(), Matchers.is(fileEntity.getId()));
+    }
+
+    /**
+     * Make sure we can delete files that aren't attached to other resources.
+     *
+     * @throws GenieException on error
+     */
+    @Test
+    public void canDeleteUnusedFiles() throws GenieException {
+        Assert.assertThat(this.fileRepository.count(), Matchers.is(0L));
+        final String file1 = UUID.randomUUID().toString();
+        final String file2 = UUID.randomUUID().toString();
+        final String file3 = UUID.randomUUID().toString();
+        final String file4 = UUID.randomUUID().toString();
+        final String file5 = UUID.randomUUID().toString();
+
+        this.fileService.createFileIfNotExists(file1);
+        this.fileService.createFileIfNotExists(file4);
+
+        final Application app = new Application.Builder(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            ApplicationStatus.ACTIVE
+        )
+            .withDependencies(Sets.newHashSet(file2))
+            .withConfigs(Sets.newHashSet(file3))
+            .withSetupFile(file5)
+            .build();
+
+        final String appId = this.applicationService.createApplication(app);
+
+        Assert.assertTrue(this.fileRepository.existsByFile(file1));
+        Assert.assertTrue(this.fileRepository.existsByFile(file2));
+        Assert.assertTrue(this.fileRepository.existsByFile(file3));
+        Assert.assertTrue(this.fileRepository.existsByFile(file4));
+        Assert.assertTrue(this.fileRepository.existsByFile(file5));
+
+        Assert.assertThat(this.fileService.deleteUnusedFiles(Instant.now()), Matchers.is(2));
+
+        Assert.assertFalse(this.fileRepository.existsByFile(file1));
+        Assert.assertTrue(this.fileRepository.existsByFile(file2));
+        Assert.assertTrue(this.fileRepository.existsByFile(file3));
+        Assert.assertFalse(this.fileRepository.existsByFile(file4));
+        Assert.assertTrue(this.fileRepository.existsByFile(file5));
+
+        this.applicationService.deleteApplication(appId);
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaTagServiceImplIntegrationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaTagServiceImplIntegrationTest.java
@@ -18,10 +18,14 @@
 package com.netflix.genie.web.jpa.services;
 
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import com.google.common.collect.Sets;
+import com.netflix.genie.common.dto.Application;
+import com.netflix.genie.common.dto.ApplicationStatus;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.test.categories.IntegrationTest;
 import com.netflix.genie.web.jpa.entities.TagEntity;
 import com.netflix.genie.web.jpa.repositories.JpaTagRepository;
+import com.netflix.genie.web.services.ApplicationService;
 import com.netflix.genie.web.services.TagService;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -29,6 +33,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -49,14 +54,15 @@ public class JpaTagServiceImplIntegrationTest extends DBUnitTestBase {
     @Autowired
     private JpaTagRepository tagRepository;
 
+    @Autowired
+    private ApplicationService applicationService;
+
     /**
      * Make sure that no matter how many times we try to create a tag it doesn't throw an error on duplicate key it
      * just does nothing.
-     *
-     * @throws GenieException on error
      */
     @Test
-    public void canCreateTagIfNotExists() throws GenieException {
+    public void canCreateTagIfNotExists() {
         Assert.assertThat(this.tagRepository.count(), Matchers.is(0L));
         final String tag = UUID.randomUUID().toString();
         this.tagService.createTagIfNotExists(tag);
@@ -78,5 +84,37 @@ public class JpaTagServiceImplIntegrationTest extends DBUnitTestBase {
 
         // Make sure the ids are still equal
         Assert.assertThat(tagEntity2.getId(), Matchers.is(tagEntity.getId()));
+    }
+
+    /**
+     * Make sure we can delete tags that aren't attached to other resources.
+     *
+     * @throws GenieException on error
+     */
+    @Test
+    public void canDeleteUnusedTags() throws GenieException {
+        Assert.assertThat(this.tagRepository.count(), Matchers.is(0L));
+        final String tag1 = UUID.randomUUID().toString();
+        final String tag2 = UUID.randomUUID().toString();
+        this.tagService.createTagIfNotExists(tag1);
+
+        final Application app = new Application.Builder(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            ApplicationStatus.ACTIVE
+        )
+            .withTags(Sets.newHashSet(tag2))
+            .build();
+
+        this.applicationService.createApplication(app);
+
+        Assert.assertTrue(this.tagRepository.existsByTag(tag1));
+        Assert.assertTrue(this.tagRepository.existsByTag(tag2));
+
+        Assert.assertThat(this.tagService.deleteUnusedTags(Instant.now()), Matchers.is(1));
+
+        Assert.assertFalse(this.tagRepository.existsByTag(tag1));
+        Assert.assertTrue(this.tagRepository.existsByTag(tag2));
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskUnitTests.java
@@ -20,7 +20,10 @@ package com.netflix.genie.web.tasks.leader;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.web.jobs.JobConstants;
 import com.netflix.genie.web.properties.DatabaseCleanupProperties;
+import com.netflix.genie.web.services.ClusterService;
+import com.netflix.genie.web.services.FileService;
 import com.netflix.genie.web.services.JobPersistenceService;
+import com.netflix.genie.web.services.TagService;
 import com.netflix.genie.web.tasks.GenieTaskScheduleType;
 import com.netflix.spectator.api.DefaultRegistry;
 import org.hamcrest.Matchers;
@@ -46,6 +49,9 @@ public class DatabaseCleanupTaskUnitTests {
 
     private DatabaseCleanupProperties cleanupProperties;
     private JobPersistenceService jobPersistenceService;
+    private ClusterService clusterService;
+    private FileService fileService;
+    private TagService tagService;
     private DatabaseCleanupTask task;
 
     /**
@@ -55,7 +61,17 @@ public class DatabaseCleanupTaskUnitTests {
     public void setup() {
         this.cleanupProperties = Mockito.mock(DatabaseCleanupProperties.class);
         this.jobPersistenceService = Mockito.mock(JobPersistenceService.class);
-        this.task = new DatabaseCleanupTask(this.cleanupProperties, this.jobPersistenceService, new DefaultRegistry());
+        this.clusterService = Mockito.mock(ClusterService.class);
+        this.fileService = Mockito.mock(FileService.class);
+        this.tagService = Mockito.mock(TagService.class);
+        this.task = new DatabaseCleanupTask(
+            this.cleanupProperties,
+            this.jobPersistenceService,
+            this.clusterService,
+            this.fileService,
+            this.tagService,
+            new DefaultRegistry()
+        );
     }
 
     /**
@@ -107,6 +123,10 @@ public class DatabaseCleanupTaskUnitTests {
             .thenReturn(deletedCount3)
             .thenReturn(0L);
 
+        Mockito.when(this.clusterService.deleteTerminatedClusters()).thenReturn(1, 2);
+        Mockito.when(this.fileService.deleteUnusedFiles(Mockito.any(Instant.class))).thenReturn(3, 4);
+        Mockito.when(this.tagService.deleteUnusedTags(Mockito.any(Instant.class))).thenReturn(5, 6);
+
         // The multiple calendar instances are to protect against running this test when the day flips
         final Calendar before = Calendar.getInstance(JobConstants.UTC);
         this.task.run();
@@ -125,6 +145,13 @@ public class DatabaseCleanupTaskUnitTests {
             date.add(Calendar.DAY_OF_YEAR, negativeDays);
             Assert.assertThat(argument.getAllValues().get(0).toEpochMilli(), Matchers.is(date.getTime().getTime()));
             Assert.assertThat(argument.getAllValues().get(1).toEpochMilli(), Matchers.is(date.getTime().getTime()));
+            Mockito.verify(this.clusterService, Mockito.times(2)).deleteTerminatedClusters();
+            Mockito
+                .verify(this.fileService, Mockito.times(2))
+                .deleteUnusedFiles(Mockito.any(Instant.class));
+            Mockito
+                .verify(this.tagService, Mockito.times(2))
+                .deleteUnusedTags(Mockito.any(Instant.class));
         }
     }
 


### PR DESCRIPTION
This PR adds actions to the `DatabaseCleanupTask` (if it is enabled) to:

1. Delete any `cluster` records from the database that are in `TERMINATED` state and aren't referenced by existing `job` records
2. Delete any `file` records from the database that aren't referenced by any other table and were created over an hour earlier than the task is run
3. Delete any `tag` records from the database that aren't referenced by any other table and were created over an hour earlier than the task is run

Documentation was also updated to reflect new metrics captured as part of these actions.

The actions will only run on the node elected the leader.

This is a cherry-pick and modifications to fix breaks due to divergance of the commits made as part of #675 in `3.3.x` release line.