### PR TITLE
Split unused file and tag entity deletion into a SELECT ... FOR UPDATE and a DELETE to prevent database locking

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaFileServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaFileServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 /**
  * JPA based implementation of the FileService interface.
@@ -74,7 +75,13 @@ public class JpaFileServiceImpl implements FileService {
      * {@inheritDoc}
      */
     @Override
-    public int deleteUnusedFiles(@NotNull final Instant createdThreshold) {
-        return this.fileRepository.deleteUnusedFiles(Date.from(createdThreshold));
+    public long deleteUnusedFiles(@NotNull final Instant createdThreshold) {
+        return this.fileRepository.deleteByIdIn(
+            this.fileRepository
+                .findUnusedFiles(Date.from(createdThreshold))
+                .stream()
+                .map(Number::longValue)
+                .collect(Collectors.toSet())
+        );
     }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaTagServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/jpa/services/JpaTagServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 /**
  * JPA based implementation of the TagService interface.
@@ -71,7 +72,13 @@ public class JpaTagServiceImpl implements TagService {
      * {@inheritDoc}
      */
     @Override
-    public int deleteUnusedTags(@NotNull final Instant createdThreshold) {
-        return this.tagRepository.deleteUnusedTags(Date.from(createdThreshold));
+    public long deleteUnusedTags(@NotNull final Instant createdThreshold) {
+        return this.tagRepository.deleteByIdIn(
+            this.tagRepository
+                .findUnusedTags(Date.from(createdThreshold))
+                .stream()
+                .map(Number::longValue)
+                .collect(Collectors.toSet())
+        );
     }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/FileService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/FileService.java
@@ -47,5 +47,5 @@ public interface FileService {
      *                         will be deleted. Inclusive
      * @return The number of files deleted
      */
-    int deleteUnusedFiles(@NotNull final Instant createdThreshold);
+    long deleteUnusedFiles(@NotNull final Instant createdThreshold);
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/TagService.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/TagService.java
@@ -47,5 +47,5 @@ public interface TagService {
      *                         will be deleted. Inclusive
      * @return The number of tags deleted
      */
-    int deleteUnusedTags(@NotNull final Instant createdThreshold);
+    long deleteUnusedTags(@NotNull final Instant createdThreshold);
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaFileServiceImplIntegrationTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaFileServiceImplIntegrationTest.java
@@ -122,7 +122,7 @@ public class JpaFileServiceImplIntegrationTest extends DBUnitTestBase {
         Assert.assertTrue(this.fileRepository.existsByFile(file4));
         Assert.assertTrue(this.fileRepository.existsByFile(file5));
 
-        Assert.assertThat(this.fileService.deleteUnusedFiles(Instant.now()), Matchers.is(2));
+        Assert.assertThat(this.fileService.deleteUnusedFiles(Instant.now()), Matchers.is(2L));
 
         Assert.assertFalse(this.fileRepository.existsByFile(file1));
         Assert.assertTrue(this.fileRepository.existsByFile(file2));

--- a/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaTagServiceImplIntegrationTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/jpa/services/JpaTagServiceImplIntegrationTest.java
@@ -112,7 +112,7 @@ public class JpaTagServiceImplIntegrationTest extends DBUnitTestBase {
         Assert.assertTrue(this.tagRepository.existsByTag(tag1));
         Assert.assertTrue(this.tagRepository.existsByTag(tag2));
 
-        Assert.assertThat(this.tagService.deleteUnusedTags(Instant.now()), Matchers.is(1));
+        Assert.assertThat(this.tagService.deleteUnusedTags(Instant.now()), Matchers.is(1L));
 
         Assert.assertFalse(this.tagRepository.existsByTag(tag1));
         Assert.assertTrue(this.tagRepository.existsByTag(tag2));

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
@@ -174,7 +174,7 @@ public class DatabaseCleanupTask extends LeadershipTask {
                 log.debug("Skipping files cleanup");
                 this.numDeletedFiles.set(0);
             } else {
-                final int countDeletedFiles = this.fileService.deleteUnusedFiles(creationThreshold);
+                final long countDeletedFiles = this.fileService.deleteUnusedFiles(creationThreshold);
                 log.info(
                     "Deleted {} files that were unused by any resource and created over an hour ago",
                     countDeletedFiles
@@ -186,7 +186,7 @@ public class DatabaseCleanupTask extends LeadershipTask {
                 log.debug("Skipping tags cleanup");
                 this.numDeletedTags.set(0);
             } else {
-                final int countDeletedTags = this.tagService.deleteUnusedTags(creationThreshold);
+                final long countDeletedTags = this.tagService.deleteUnusedTags(creationThreshold);
                 log.info(
                     "Deleted {} tags that were unused by any resource and created over an hour ago",
                     countDeletedTags

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskUnitTests.java
@@ -125,8 +125,8 @@ public class DatabaseCleanupTaskUnitTests {
             .thenReturn(0L);
 
         Mockito.when(this.clusterService.deleteTerminatedClusters()).thenReturn(1, 2);
-        Mockito.when(this.fileService.deleteUnusedFiles(Mockito.any(Instant.class))).thenReturn(3, 4);
-        Mockito.when(this.tagService.deleteUnusedTags(Mockito.any(Instant.class))).thenReturn(5, 6);
+        Mockito.when(this.fileService.deleteUnusedFiles(Mockito.any(Instant.class))).thenReturn(3L, 4L);
+        Mockito.when(this.tagService.deleteUnusedTags(Mockito.any(Instant.class))).thenReturn(5L, 6L);
 
         // The multiple calendar instances are to protect against running this test when the day flips
         final Calendar before = Calendar.getInstance(JobConstants.UTC);


### PR DESCRIPTION
The previous `DELETE FROM...` query on internal sample data took 9 minutes to complete. The select takes of the same query form only took 100ms. This implementation selects the `id`'s to delete from the `FILES` and `TAGS` tables and locks the rows as `FOR UPDATE`. It then explicitely calls `DELETE` on set of ids preventing all other tables from having to be opened.