### PR TITLE
Introduce getCommandArgs getter for Job and JobRequest with pre-3.3.x…

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -96,6 +97,18 @@ public class Job extends CommonDTO {
      */
     public Optional<String> getCommandArgs() {
         return Optional.ofNullable(this.commandArgs);
+    }
+
+    /**
+     * Get the arguments to be put on the command line along with the command executable as a string.
+     * @deprecated replaced by {@link #getCommandArgs()}
+     *
+     * @return The command arguments as a (possibly empty) string
+     */
+    @Deprecated
+    @JsonIgnore
+    public String getCommandArgsString() {
+        return this.commandArgs == null ? "" : this.commandArgs;
     }
 
     /**

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
@@ -108,6 +109,18 @@ public class JobRequest extends ExecutionEnvironmentDTO {
      */
     public Optional<String> getCommandArgs() {
         return Optional.ofNullable(this.commandArgs);
+    }
+
+    /**
+     * Get the arguments to be put on the command line along with the command executable as a string.
+     * @deprecated replaced by {@link #getCommandArgs()}
+     *
+     * @return The command arguments as a (possibly empty) string
+     */
+    @Deprecated
+    @JsonIgnore
+    public String getCommandArgsString() {
+        return this.commandArgs == null ? "" : this.commandArgs;
     }
 
     /**

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/JobRequestUnitTests.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/JobRequestUnitTests.java
@@ -81,6 +81,10 @@ public class JobRequestUnitTests {
             request.getCommandArgs().orElseThrow(IllegalArgumentException::new),
             Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
         );
+        Assert.assertThat(
+            request.getCommandArgsString(),
+            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+        );
         Assert.assertThat(request.getClusterCriterias(), Matchers.is(CLUSTER_CRITERIAS));
         Assert.assertThat(request.getCommandCriteria(), Matchers.is(COMMAND_CRITERIA));
         Assert.assertFalse(request.getCpu().isPresent());
@@ -113,6 +117,7 @@ public class JobRequestUnitTests {
         Assert.assertThat(request.getUser(), Matchers.is(USER));
         Assert.assertThat(request.getVersion(), Matchers.is(VERSION));
         Assert.assertFalse(request.getCommandArgs().isPresent());
+        Assert.assertEquals("", request.getCommandArgsString());
         Assert.assertThat(request.getClusterCriterias(), Matchers.is(CLUSTER_CRITERIAS));
         Assert.assertThat(request.getCommandCriteria(), Matchers.is(COMMAND_CRITERIA));
         Assert.assertFalse(request.getCpu().isPresent());
@@ -221,6 +226,10 @@ public class JobRequestUnitTests {
         Assert.assertThat(request.getVersion(), Matchers.is(VERSION));
         Assert.assertThat(
             request.getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+        );
+        Assert.assertThat(
+            request.getCommandArgsString(),
             Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
         );
         Assert.assertThat(request.getClusterCriterias(), Matchers.is(CLUSTER_CRITERIAS));
@@ -337,6 +346,10 @@ public class JobRequestUnitTests {
             request.getCommandArgs().orElseThrow(IllegalArgumentException::new),
             Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
         );
+        Assert.assertThat(
+            request.getCommandArgsString(),
+            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+        );
         Assert.assertThat(request.getClusterCriterias(), Matchers.is(CLUSTER_CRITERIAS));
         Assert.assertThat(request.getCommandCriteria(), Matchers.is(COMMAND_CRITERIA));
         Assert.assertThat(request.getCpu().orElseThrow(IllegalArgumentException::new), Matchers.is(cpu));
@@ -387,6 +400,7 @@ public class JobRequestUnitTests {
         Assert.assertThat(request.getUser(), Matchers.is(USER));
         Assert.assertThat(request.getVersion(), Matchers.is(VERSION));
         Assert.assertFalse(request.getCommandArgs().isPresent());
+        Assert.assertEquals("", request.getCommandArgsString());
         Assert.assertThat(request.getClusterCriterias(), Matchers.empty());
         Assert.assertThat(request.getCommandCriteria(), Matchers.empty());
         Assert.assertFalse(request.getCpu().isPresent());

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/JobUnitTests.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/JobUnitTests.java
@@ -61,6 +61,10 @@ public class JobUnitTests {
             job.getCommandArgs().orElseThrow(IllegalArgumentException::new),
             Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
         );
+        Assert.assertThat(
+            job.getCommandArgsString(),
+            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+        );
         Assert.assertFalse(job.getArchiveLocation().isPresent());
         Assert.assertFalse(job.getClusterName().isPresent());
         Assert.assertFalse(job.getCommandName().isPresent());
@@ -88,6 +92,7 @@ public class JobUnitTests {
         Assert.assertThat(job.getUser(), Matchers.is(USER));
         Assert.assertThat(job.getVersion(), Matchers.is(VERSION));
         Assert.assertThat(job.getCommandArgs(), Matchers.is(Optional.empty()));
+        Assert.assertThat(job.getCommandArgsString(), Matchers.isEmptyString());
         Assert.assertFalse(job.getArchiveLocation().isPresent());
         Assert.assertFalse(job.getClusterName().isPresent());
         Assert.assertFalse(job.getCommandName().isPresent());
@@ -168,6 +173,10 @@ public class JobUnitTests {
         Assert.assertThat(job.getVersion(), Matchers.is(VERSION));
         Assert.assertThat(
             job.getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+        );
+        Assert.assertThat(
+            job.getCommandArgsString(),
             Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
         );
         Assert.assertThat(
@@ -257,6 +266,10 @@ public class JobUnitTests {
             Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
         );
         Assert.assertThat(
+            job.getCommandArgsString(),
+            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+        );
+        Assert.assertThat(
             job.getArchiveLocation().orElseThrow(IllegalArgumentException::new), Matchers.is(archiveLocation)
         );
         Assert.assertThat(job.getClusterName().orElseThrow(IllegalArgumentException::new), Matchers.is(clusterName));
@@ -303,6 +316,7 @@ public class JobUnitTests {
         Assert.assertThat(job.getUser(), Matchers.is(USER));
         Assert.assertThat(job.getVersion(), Matchers.is(VERSION));
         Assert.assertFalse(job.getCommandArgs().isPresent());
+        Assert.assertEquals("", job.getCommandArgsString());
         Assert.assertFalse(job.getArchiveLocation().isPresent());
         Assert.assertFalse(job.getClusterName().isPresent());
         Assert.assertFalse(job.getCommandName().isPresent());


### PR DESCRIPTION
… behavior

Commit https://github.com/Netflix/genie/commit/b5ab6a180a760bdd917734cd0e82e19ce9fe5cd5 changed the return type of getCommandArgs() from String to Optional<String>.
This commit introduces getCommandArgsString which mimics this legacy behavior.