### PR TITLE
Upgrade to Spring Boot 1.5.10 and associated release trains. 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,9 +19,9 @@
 ## Spring Dependency Versions
 
 # Used in documentation and for including the Gradle plugin
-spring_boot_version=1.5.9.RELEASE
-spring_cloud_version=Edgware.RELEASE
-spring_platform_version=Brussels-SR6
+spring_boot_version=1.5.10.RELEASE
+spring_cloud_version=Edgware.SR1
+spring_platform_version=Brussels-SR7
 
 ## Override Spring Platform IO Versions
 


### PR DESCRIPTION
Primarily to pick up security vulnerability fix

Cherry pick of #689 from 3.3.x train