### PR TITLE
Tweak build verbosity for test execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,6 +258,16 @@ configure(javaProjects) {
             jacocoTestReport.executionData += files("$buildDir/jacoco/${task.name}.exec")
     }
 
+    test {
+        testLogging {
+            if (System.getenv("CI") != null) {
+                events "passed", "skipped", "failed"
+            } else {
+                events "failed"
+            }
+        }
+    }
+
     license {
         ignoreFailures false
     }


### PR DESCRIPTION
Increase verbosity of test tasks for CI build. Print each test method outcome (pass/skip/fail).