### PR TITLE
Begin porting internal service tier to V4 structures

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/dto/v4/Command.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/v4/Command.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * An immutable V4 Cluster resource.
+ * An immutable V4 Command resource.
  *
  * @author tgianos
  * @since 4.0.0
@@ -53,6 +53,12 @@ public class Command extends CommonResource {
         message = "The minimum amount of memory if desired is 1 MB. Probably should be much more than that"
     )
     private final Integer memory;
+    @Min(
+        value = 1,
+        message = "The delay between checks must be at least 1 millisecond. Probably should be much more than that"
+    )
+    // TODO: This is here for Genie 3 backwards compatibility while Genie 4 agent is still in development
+    private final long checkDelay;
 
     /**
      * Constructor.
@@ -66,6 +72,8 @@ public class Command extends CommonResource {
      *                   this will start with the binary and be followed optionally by default arguments. Must have
      *                   at least one
      * @param memory     The default memory that should be used to run a job with this command
+     * @param checkDelay The amount of time (in milliseconds) to delay between checks of job status for jobs run using
+     *                   this command. Min 1 but preferably much more
      */
     @JsonCreator
     public Command(
@@ -75,12 +83,14 @@ public class Command extends CommonResource {
         @JsonProperty(value = "resources") @Nullable final ExecutionEnvironment resources,
         @JsonProperty(value = "metadata", required = true) final CommandMetadata metadata,
         @JsonProperty(value = "executable", required = true) final List<String> executable,
-        @JsonProperty(value = "memory") @Nullable final Integer memory
+        @JsonProperty(value = "memory") @Nullable final Integer memory,
+        @JsonProperty(value = "checkDelay", required = true) final long checkDelay
     ) {
         super(id, created, updated, resources);
         this.metadata = metadata;
         this.executable = ImmutableList.copyOf(executable);
         this.memory = memory;
+        this.checkDelay = checkDelay;
     }
 
     /**

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/v4/CommandRequest.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/v4/CommandRequest.java
@@ -56,12 +56,20 @@ public class CommandRequest extends CommonRequestImpl {
         message = "The minimum amount of memory if desired is 1 MB. Probably should be much more than that"
     )
     private final Integer memory;
+    @Min(
+        value = 1,
+        message = "The delay between checks must be at least 1 millisecond. Probably should be much more than that"
+    )
+    // TODO: This is here for backwards compatibility with Genie 3 while the agent is in development
+    //       It will no longer be relevant once the agent is 1 to 1 with a job and not polling
+    private final Long checkDelay;
 
     private CommandRequest(final Builder builder) {
         super(builder);
         this.metadata = builder.bMetadata;
         this.executable = builder.bExecutable;
         this.memory = builder.bMemory;
+        this.checkDelay = builder.bCheckDelay;
     }
 
     /**
@@ -71,6 +79,15 @@ public class CommandRequest extends CommonRequestImpl {
      */
     public Optional<Integer> getMemory() {
         return Optional.ofNullable(this.memory);
+    }
+
+    /**
+     * Get the requested amount of time (in milliseconds) between checks of job status for jobs run using this command.
+     *
+     * @return The amount of time if one was requested wrapped in an {@link Optional}
+     */
+    public Optional<Long> getCheckDelay() {
+        return Optional.ofNullable(this.checkDelay);
     }
 
     /**
@@ -94,6 +111,7 @@ public class CommandRequest extends CommonRequestImpl {
         private final CommandMetadata bMetadata;
         private final ImmutableList<String> bExecutable;
         private Integer bMemory;
+        private Long bCheckDelay;
 
         /**
          * Constructor which has required fields.
@@ -120,6 +138,18 @@ public class CommandRequest extends CommonRequestImpl {
          */
         public Builder withMemory(@Nullable final Integer memory) {
             this.bMemory = memory;
+            return this;
+        }
+
+        /**
+         * Set the amount of time (in milliseconds) desired to delay between checks of the job status for jobs run
+         * using this command.
+         *
+         * @param checkDelay The amount of time (in milliseconds) between checks. Minimum 1 preferably much more
+         * @return The builder
+         */
+        public Builder withCheckDelay(@Nullable final Long checkDelay) {
+            this.bCheckDelay = checkDelay;
             return this;
         }
 

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/v4/CommonMetadata.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/v4/CommonMetadata.java
@@ -42,7 +42,7 @@ import java.util.Set;
 @Getter
 @EqualsAndHashCode(doNotUseGetters = true)
 @ToString(doNotUseGetters = true)
-abstract class CommonMetadata {
+public abstract class CommonMetadata {
     @NotEmpty(message = "A name is required and must be at most 255 characters")
     @Size(max = 255, message = "The name can be no longer than 255 characters")
     private final String name;

--- a/genie-common/src/test/groovy/com/netflix/genie/common/dto/v4/CommandRequestSpec.groovy
+++ b/genie-common/src/test/groovy/com/netflix/genie/common/dto/v4/CommandRequestSpec.groovy
@@ -39,6 +39,7 @@ class CommandRequestSpec extends Specification {
         def resources = new ExecutionEnvironment(null, null, UUID.randomUUID().toString())
         def executable = Lists.newArrayList(UUID.randomUUID().toString(), UUID.randomUUID().toString())
         def memory = 3_820
+        def checkDelay = 380_324L
         CommandRequest request
 
         when:
@@ -46,6 +47,7 @@ class CommandRequestSpec extends Specification {
                 .withRequestedId(requestedId)
                 .withResources(resources)
                 .withMemory(memory)
+                .withCheckDelay(checkDelay)
                 .build()
 
         then:
@@ -54,6 +56,7 @@ class CommandRequestSpec extends Specification {
         request.getResources() == resources
         request.getExecutable() == executable
         request.getMemory().orElse(-1) == memory
+        request.getCheckDelay().orElse(null) == checkDelay
 
         when:
         request = new CommandRequest.Builder(metadata, executable).build()
@@ -64,5 +67,6 @@ class CommandRequestSpec extends Specification {
         request.getResources() != null
         request.getExecutable() == executable
         !request.getMemory().isPresent()
+        !request.getCheckDelay().isPresent()
     }
 }

--- a/genie-common/src/test/groovy/com/netflix/genie/common/dto/v4/CommandSpec.groovy
+++ b/genie-common/src/test/groovy/com/netflix/genie/common/dto/v4/CommandSpec.groovy
@@ -43,6 +43,7 @@ class CommandSpec extends Specification {
         def updated = Instant.now()
         def executable = Lists.newArrayList(UUID.randomUUID().toString(), UUID.randomUUID().toString())
         def memory = 280
+        def checkDelay = 389_132L
         Command command
 
         when:
@@ -53,7 +54,8 @@ class CommandSpec extends Specification {
                 resources,
                 metadata,
                 executable,
-                memory
+                memory,
+                checkDelay
         )
 
         then:
@@ -64,6 +66,7 @@ class CommandSpec extends Specification {
         command.getMetadata() == metadata
         command.getExecutable() == executable
         command.getMemory().orElse(-1) == memory
+        command.getCheckDelay() == checkDelay
 
         when:
         command = new Command(
@@ -73,7 +76,8 @@ class CommandSpec extends Specification {
                 null,
                 metadata,
                 executable,
-                null
+                null,
+                checkDelay
         )
 
         then:
@@ -84,5 +88,6 @@ class CommandSpec extends Specification {
         command.getMetadata() == metadata
         command.getExecutable() == executable
         !command.getMemory().isPresent()
+        command.getCheckDelay() == checkDelay
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
@@ -17,11 +17,16 @@
  */
 package com.netflix.genie.web.controllers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.JsonPatchException;
+import com.google.common.collect.Lists;
 import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.ClusterStatus;
 import com.netflix.genie.common.dto.CommandStatus;
 import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.common.util.GenieObjectMapper;
 import com.netflix.genie.web.hateoas.assemblers.ClusterResourceAssembler;
 import com.netflix.genie.web.hateoas.assemblers.CommandResourceAssembler;
 import com.netflix.genie.web.hateoas.resources.ClusterResource;
@@ -29,6 +34,8 @@ import com.netflix.genie.web.hateoas.resources.CommandResource;
 import com.netflix.genie.web.services.ClusterService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -54,9 +61,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.validation.Valid;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -103,9 +113,9 @@ ClusterRestController {
      */
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<Void> createCluster(@RequestBody final Cluster cluster) throws GenieException {
+    public ResponseEntity<Void> createCluster(@RequestBody @Valid final Cluster cluster) throws GenieException {
         log.debug("Called to create new cluster {}", cluster);
-        final String id = this.clusterService.createCluster(cluster);
+        final String id = this.clusterService.createCluster(DtoAdapters.toV4ClusterRequest(cluster));
         final HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setLocation(
             ServletUriComponentsBuilder
@@ -128,7 +138,7 @@ ClusterRestController {
     @ResponseStatus(HttpStatus.OK)
     public ClusterResource getCluster(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id: {}", id);
-        return this.clusterResourceAssembler.toResource(this.clusterService.getCluster(id));
+        return this.clusterResourceAssembler.toResource(DtoAdapters.toV3Cluster(this.clusterService.getCluster(id)));
     }
 
     /**
@@ -167,6 +177,73 @@ ClusterRestController {
             }
         }
 
+        final Page<Cluster> clusters;
+        if (tags != null && tags.stream().filter(tag -> tag.startsWith(DtoAdapters.GENIE_ID_PREFIX)).count() >= 1L) {
+            // TODO: This doesn't take into account others as compounded find...not sure if good or bad
+            final List<Cluster> clusterList = Lists.newArrayList();
+            final int prefixLength = DtoAdapters.GENIE_ID_PREFIX.length();
+            tags
+                .stream()
+                .filter(tag -> tag.startsWith(DtoAdapters.GENIE_ID_PREFIX))
+                .forEach(
+                    tag -> {
+                        final String id = tag.substring(prefixLength);
+                        try {
+                            clusterList.add(DtoAdapters.toV3Cluster(this.clusterService.getCluster(id)));
+                        } catch (final GenieException ge) {
+                            log.debug("No cluster with id {} found", id, ge);
+                        }
+                    }
+                );
+            clusters = new PageImpl<>(clusterList);
+        } else if (tags != null
+            && tags.stream().filter(tag -> tag.startsWith(DtoAdapters.GENIE_NAME_PREFIX)).count() >= 1L) {
+            final Set<String> finalTags = tags
+                .stream()
+                .filter(tag -> !tag.startsWith(DtoAdapters.GENIE_NAME_PREFIX))
+                .collect(Collectors.toSet());
+            if (name == null) {
+                final Optional<String> finalName = tags
+                    .stream()
+                    .filter(tag -> tag.startsWith(DtoAdapters.GENIE_NAME_PREFIX))
+                    .map(tag -> tag.substring(DtoAdapters.GENIE_NAME_PREFIX.length()))
+                    .findFirst();
+
+                clusters = this.clusterService
+                    .getClusters(
+                        finalName.orElse(null),
+                        enumStatuses,
+                        finalTags,
+                        minUpdateTime == null ? null : Instant.ofEpochMilli(minUpdateTime),
+                        maxUpdateTime == null ? null : Instant.ofEpochMilli(maxUpdateTime),
+                        page
+                    )
+                    .map(DtoAdapters::toV3Cluster);
+            } else {
+                clusters = this.clusterService
+                    .getClusters(
+                        name,
+                        enumStatuses,
+                        finalTags,
+                        minUpdateTime == null ? null : Instant.ofEpochMilli(minUpdateTime),
+                        maxUpdateTime == null ? null : Instant.ofEpochMilli(maxUpdateTime),
+                        page
+                    )
+                    .map(DtoAdapters::toV3Cluster);
+            }
+        } else {
+            clusters = this.clusterService
+                .getClusters(
+                    name,
+                    enumStatuses,
+                    tags,
+                    minUpdateTime == null ? null : Instant.ofEpochMilli(minUpdateTime),
+                    maxUpdateTime == null ? null : Instant.ofEpochMilli(maxUpdateTime),
+                    page
+                )
+                .map(DtoAdapters::toV3Cluster);
+        }
+
         // Build the self link which will be used for the next, previous, etc links
         final Link self = ControllerLinkBuilder
             .linkTo(
@@ -184,14 +261,7 @@ ClusterRestController {
             ).withSelfRel();
 
         return assembler.toResource(
-            this.clusterService.getClusters(
-                name,
-                enumStatuses,
-                tags,
-                minUpdateTime == null ? null : Instant.ofEpochMilli(minUpdateTime),
-                maxUpdateTime == null ? null : Instant.ofEpochMilli(maxUpdateTime),
-                page
-            ),
+            clusters,
             this.clusterResourceAssembler,
             self
         );
@@ -211,7 +281,7 @@ ClusterRestController {
         @RequestBody final Cluster updateCluster
     ) throws GenieException {
         log.debug("Called to update cluster with id {} update fields {}", id, updateCluster);
-        this.clusterService.updateCluster(id, updateCluster);
+        this.clusterService.updateCluster(id, DtoAdapters.toV4Cluster(updateCluster));
     }
 
     /**
@@ -228,7 +298,20 @@ ClusterRestController {
         @RequestBody final JsonPatch patch
     ) throws GenieException {
         log.debug("Called to patch cluster {} with patch {}", id, patch);
-        this.clusterService.patchCluster(id, patch);
+
+        final Cluster currentCluster = DtoAdapters.toV3Cluster(this.clusterService.getCluster(id));
+
+        try {
+            log.debug("Will patch cluster {}. Original state: {}", id, currentCluster);
+            final JsonNode clusterNode = GenieObjectMapper.getMapper().valueToTree(currentCluster);
+            final JsonNode postPatchNode = patch.apply(clusterNode);
+            final Cluster patchedCluster = GenieObjectMapper.getMapper().treeToValue(postPatchNode, Cluster.class);
+            log.debug("Finished patching cluster {}. New state: {}", id, patchedCluster);
+            this.clusterService.updateCluster(id, DtoAdapters.toV4Cluster(patchedCluster));
+        } catch (final JsonPatchException | IOException e) {
+            log.error("Unable to patch cluster {} with patch {} due to exception.", id, patch, e);
+            throw new GenieServerException(e.getLocalizedMessage(), e);
+        }
     }
 
     /**
@@ -416,11 +499,9 @@ ClusterRestController {
      */
     @GetMapping(value = "/{id}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public Set<String> getTagsForCluster(
-        @PathVariable("id") final String id
-    ) throws GenieException {
+    public Set<String> getTagsForCluster(@PathVariable("id") final String id) throws GenieException {
         log.debug("Called with id {}", id);
-        return this.clusterService.getTagsForCluster(id);
+        return DtoAdapters.toV3Cluster(this.clusterService.getCluster(id)).getTags();
     }
 
     /**
@@ -519,6 +600,7 @@ ClusterRestController {
 
         return this.clusterService.getCommandsForCluster(id, enumStatuses)
             .stream()
+            .map(DtoAdapters::toV3Command)
             .map(this.commandResourceAssembler::toResource)
             .collect(Collectors.toList());
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
@@ -52,9 +52,15 @@ import java.util.stream.Collectors;
  */
 public final class DtoConverters {
 
+    /**
+     * The Genie 3 prefix for resource ID added to the set of tags by the system.
+     */
+    public static final String GENIE_ID_PREFIX = "genie.id:";
+    /**
+     * The Genie 3 prefix for resource names added to the set of tags by the system.
+     */
+    public static final String GENIE_NAME_PREFIX = "genie.name:";
     static final String NO_VERSION_SPECIFIED = "No Version Specified";
-    static final String GENIE_ID_PREFIX = "genie.id:";
-    static final String GENIE_NAME_PREFIX = "genie.name:";
 
     private DtoConverters() {
     }
@@ -437,7 +443,15 @@ public final class DtoConverters {
         return v3Builder.build();
     }
 
-    private static ImmutableSet<String> toV3Tags(final String id, final String name, final Set<String> tags) {
+    /**
+     * Convert the V4 values supplied to how the tags would have looked in Genie V3.
+     *
+     * @param id   The id of the resource
+     * @param name The name of the resource
+     * @param tags The tags on the resource
+     * @return The set of tags as they would have been in Genie 3
+     */
+    public static ImmutableSet<String> toV3Tags(final String id, final String name, final Set<String> tags) {
         final ImmutableSet.Builder<String> v3Tags = ImmutableSet.builder();
         v3Tags.addAll(tags);
         v3Tags.add(GENIE_ID_PREFIX + id);
@@ -464,11 +478,25 @@ public final class DtoConverters {
         return new ClusterCriteria(toV3CriterionTags(criterion));
     }
 
-    private static Criterion toV4Criterion(final ClusterCriteria criteria) throws GeniePreconditionException {
+    /**
+     * Convert a V3 Cluster Criteria to a V4 Criterion.
+     *
+     * @param criteria The criteria to convert
+     * @return The criterion
+     * @throws GeniePreconditionException If the criteria converts to an invalid criterion
+     */
+    public static Criterion toV4Criterion(final ClusterCriteria criteria) throws GeniePreconditionException {
         return toV4Criterion(criteria.getTags());
     }
 
-    private static Criterion toV4Criterion(final Set<String> tags) throws GeniePreconditionException {
+    /**
+     * Convert a set of V3 criterion tags to a V4 criterion object.
+     *
+     * @param tags The tags to convert
+     * @return The V4 criterion
+     * @throws GeniePreconditionException If the tags convert to an invalid criterion
+     */
+    public static Criterion toV4Criterion(final Set<String> tags) throws GeniePreconditionException {
         final Criterion.Builder builder = new Criterion.Builder();
         final Set<String> v4Tags = Sets.newHashSet();
         for (final String tag : tags) {

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
@@ -50,13 +50,13 @@ import java.util.stream.Collectors;
  * @author tgianos
  * @since 4.0.0
  */
-public final class DtoAdapters {
+public final class DtoConverters {
 
     static final String NO_VERSION_SPECIFIED = "No Version Specified";
     static final String GENIE_ID_PREFIX = "genie.id:";
     static final String GENIE_NAME_PREFIX = "genie.name:";
 
-    private DtoAdapters() {
+    private DtoConverters() {
     }
 
     static ApplicationRequest toV4ApplicationRequest(
@@ -408,7 +408,7 @@ public final class DtoAdapters {
                 .getCriteria()
                 .getClusterCriteria()
                 .stream()
-                .map(DtoAdapters::toClusterCriteria)
+                .map(DtoConverters::toClusterCriteria)
                 .collect(Collectors.toList()),
             toV3CriterionTags(v4JobRequest.getCriteria().getCommandCriterion())
         )

--- a/genie-web/src/main/java/com/netflix/genie/web/jobs/JobExecutionEnvironment.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jobs/JobExecutionEnvironment.java
@@ -17,10 +17,10 @@
  */
 package com.netflix.genie.web.jobs;
 
-import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -95,7 +95,6 @@ public final class JobExecutionEnvironment {
          * @param commandObj The command object.
          * @param memory     The amount of memory (in MB) to use to run the job
          * @param dir        The directory location for this job.
-         * @throws GenieException If there is an error.
          */
         public Builder(
             @NotNull(message = "Job Request cannot be null")
@@ -108,7 +107,7 @@ public final class JobExecutionEnvironment {
             final int memory,
             @NotBlank(message = "Job working directory cannot be empty")
             final File dir
-        ) throws GenieException {
+        ) {
             this.bJobRequest = request;
             this.bCluster = clusterObj;
             this.bCommand = commandObj;

--- a/genie-web/src/main/java/com/netflix/genie/web/jobs/JobLauncher.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jobs/JobLauncher.java
@@ -18,10 +18,10 @@
 package com.netflix.genie.web.jobs;
 
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.web.services.JobSubmitterService;
 import com.netflix.genie.web.util.MetricsUtils;

--- a/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/InitialSetupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/InitialSetupTask.java
@@ -19,10 +19,10 @@ package com.netflix.genie.web.jobs.workflow.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.ClusterCriteria;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
@@ -211,9 +211,8 @@ public class InitialSetupTask extends GenieBaseTask {
     }
 
     @VisibleForTesting
-    void createCommandEnvironmentVariables(final Writer writer, final Command command)
-        throws GenieException, IOException {
-        final String commandId = command.getId().orElseThrow(() -> new GenieServerException("No command id"));
+    void createCommandEnvironmentVariables(final Writer writer, final Command command) throws IOException {
+        final String commandId = command.getId();
         writer.write(JobConstants.EXPORT
             + JobConstants.GENIE_COMMAND_DIR_ENV_VAR
             + JobConstants.EQUALS_SYMBOL
@@ -251,7 +250,7 @@ public class InitialSetupTask extends GenieBaseTask {
                 + JobConstants.GENIE_COMMAND_NAME_ENV_VAR
                 + JobConstants.EQUALS_SYMBOL
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
-                + command.getName()
+                + command.getMetadata().getName()
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
                 + LINE_SEPARATOR
         );
@@ -264,7 +263,7 @@ public class InitialSetupTask extends GenieBaseTask {
                 + JobConstants.GENIE_COMMAND_TAGS_ENV_VAR
                 + JobConstants.EQUALS_SYMBOL
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
-                + tagsToString(command.getTags())
+                + this.tagsToString(command.getMetadata().getTags())
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
                 + LINE_SEPARATOR
         );
@@ -274,9 +273,8 @@ public class InitialSetupTask extends GenieBaseTask {
     }
 
     @VisibleForTesting
-    void createClusterEnvironmentVariables(final Writer writer, final Cluster cluster)
-        throws GenieException, IOException {
-        final String clusterId = cluster.getId().orElseThrow(() -> new GenieServerException("No cluster id"));
+    void createClusterEnvironmentVariables(final Writer writer, final Cluster cluster) throws IOException {
+        final String clusterId = cluster.getId();
 
         writer.write(JobConstants.EXPORT
             + JobConstants.GENIE_CLUSTER_DIR_ENV_VAR
@@ -315,7 +313,7 @@ public class InitialSetupTask extends GenieBaseTask {
                 + JobConstants.GENIE_CLUSTER_NAME_ENV_VAR
                 + JobConstants.EQUALS_SYMBOL
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
-                + cluster.getName()
+                + cluster.getMetadata().getName()
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
                 + LINE_SEPARATOR
         );
@@ -328,7 +326,7 @@ public class InitialSetupTask extends GenieBaseTask {
                 + JobConstants.GENIE_CLUSTER_TAGS_ENV_VAR
                 + JobConstants.EQUALS_SYMBOL
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
-                + this.tagsToString(cluster.getTags())
+                + this.tagsToString(cluster.getMetadata().getTags())
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
                 + LINE_SEPARATOR
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/InitialSetupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/InitialSetupTask.java
@@ -27,6 +27,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.jobs.JobConstants;
+import com.netflix.genie.web.controllers.DtoConverters;
 import com.netflix.genie.web.jobs.JobExecutionEnvironment;
 import com.netflix.genie.web.util.MetricsUtils;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -263,7 +264,13 @@ public class InitialSetupTask extends GenieBaseTask {
                 + JobConstants.GENIE_COMMAND_TAGS_ENV_VAR
                 + JobConstants.EQUALS_SYMBOL
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
-                + this.tagsToString(command.getMetadata().getTags())
+                + this.tagsToString(
+                DtoConverters.toV3Tags(
+                    command.getId(),
+                    command.getMetadata().getName(),
+                    command.getMetadata().getTags()
+                )
+            )
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
                 + LINE_SEPARATOR
         );
@@ -326,7 +333,13 @@ public class InitialSetupTask extends GenieBaseTask {
                 + JobConstants.GENIE_CLUSTER_TAGS_ENV_VAR
                 + JobConstants.EQUALS_SYMBOL
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
-                + this.tagsToString(cluster.getMetadata().getTags())
+                + this.tagsToString(
+                DtoConverters.toV3Tags(
+                    cluster.getId(),
+                    cluster.getMetadata().getName(),
+                    cluster.getMetadata().getTags()
+                )
+            )
                 + JobConstants.DOUBLE_QUOTE_SYMBOL
                 + LINE_SEPARATOR
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/JobTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/JobTask.java
@@ -145,7 +145,7 @@ public class JobTask extends GenieBaseTask {
                 + System.lineSeparator());
 
             writer.write(
-                jobExecEnv.getCommand().getExecutable()
+                StringUtils.join(jobExecEnv.getCommand().getExecutable(), ' ')
                     + JobConstants.WHITE_SPACE
                     + jobExecEnv.getJobRequest().getCommandArgs().orElse(EMPTY_STRING)
                     + JobConstants.STDOUT_REDIRECT

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/BaseEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/BaseEntity.java
@@ -47,7 +47,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @EqualsAndHashCode(of = "uniqueId", callSuper = false)
-@ToString(callSuper = true, exclude = {"description", "setupFile"})
+@ToString(callSuper = true, exclude = {"description", "setupFile", "metadata"})
 @MappedSuperclass
 public class BaseEntity extends AuditEntity implements BaseProjection, SetupFileProjection {
 
@@ -59,9 +59,8 @@ public class BaseEntity extends AuditEntity implements BaseProjection, SetupFile
     @Size(max = 255, message = "Max length in database is 255 characters")
     private String uniqueId = UUID.randomUUID().toString();
 
-    @Basic(optional = false)
-    @Column(name = "version", nullable = false)
-    @NotBlank(message = "Version is missing and is required.")
+    @Basic
+    @Column(name = "version")
     @Size(max = 255, message = "Max length in database is 255 characters")
     private String version;
 
@@ -99,10 +98,26 @@ public class BaseEntity extends AuditEntity implements BaseProjection, SetupFile
     }
 
     /**
-     * Gets the description of this entity.
-     *
-     * @return description
+     * {@inheritDoc}
      */
+    @Override
+    public Optional<String> getVersion() {
+        return Optional.ofNullable(this.version);
+    }
+
+    /**
+     * Set the version of the resource this entity represents.
+     *
+     * @param version The new version or null if there isn't one
+     */
+    public void setVersion(@Nullable final String version) {
+        this.version = version;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Optional<String> getDescription() {
         return Optional.ofNullable(this.description);
     }
@@ -117,10 +132,9 @@ public class BaseEntity extends AuditEntity implements BaseProjection, SetupFile
     }
 
     /**
-     * Get the metadata of this entity which is unstructured JSON.
-     *
-     * @return Optional of the metadata json node represented as a string
+     * {@inheritDoc}
      */
+    @Override
     public Optional<String> getMetadata() {
         return Optional.ofNullable(this.metadata);
     }
@@ -135,10 +149,9 @@ public class BaseEntity extends AuditEntity implements BaseProjection, SetupFile
     }
 
     /**
-     * Get the setup file for this entity.
-     *
-     * @return The setup file as an Optional in case it's null
+     * {@inheritDoc}
      */
+    @Override
     public Optional<FileEntity> getSetupFile() {
         return Optional.ofNullable(this.setupFile);
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
@@ -94,8 +94,6 @@ public class JobEntity extends BaseEntity implements
     JobCommandProjection,
     JobSearchProjection {
 
-    static final String DEFAULT_VERSION = "NA";
-
     private static final long serialVersionUID = 2849367731657512224L;
 
     @Basic
@@ -335,7 +333,6 @@ public class JobEntity extends BaseEntity implements
      */
     public JobEntity() {
         super();
-        this.setVersion(DEFAULT_VERSION);
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/projections/BaseProjection.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/projections/BaseProjection.java
@@ -36,9 +36,9 @@ public interface BaseProjection extends AuditProjection {
     /**
      * Get the version.
      *
-     * @return The version of the resource (job, app, etc)
+     * @return The version of the resource (job, app, etc) wrapped in {@link Optional}
      */
-    String getVersion();
+    Optional<String> getVersion();
 
     /**
      * Get the user who created the resource.

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/EntityDtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/EntityDtoConverters.java
@@ -146,7 +146,8 @@ public final class EntityDtoConverters {
             ),
             metadataBuilder.build(),
             Lists.newArrayList(StringUtils.split(commandEntity.getExecutable(), ' ')),
-            commandEntity.getMemory().orElse(null)
+            commandEntity.getMemory().orElse(null),
+            commandEntity.getCheckDelay()
         );
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/EntityDtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/EntityDtoConverters.java
@@ -1,0 +1,164 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.jpa.entities.v4;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.ApplicationMetadata;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.ClusterMetadata;
+import com.netflix.genie.common.dto.v4.Command;
+import com.netflix.genie.common.dto.v4.CommandMetadata;
+import com.netflix.genie.common.dto.v4.CommonMetadata;
+import com.netflix.genie.common.dto.v4.ExecutionEnvironment;
+import com.netflix.genie.common.exceptions.GeniePreconditionException;
+import com.netflix.genie.web.jpa.entities.ApplicationEntity;
+import com.netflix.genie.web.jpa.entities.ClusterEntity;
+import com.netflix.genie.web.jpa.entities.CommandEntity;
+import com.netflix.genie.web.jpa.entities.FileEntity;
+import com.netflix.genie.web.jpa.entities.TagEntity;
+import com.netflix.genie.web.jpa.entities.projections.BaseProjection;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.stream.Collectors;
+
+/**
+ * Utility methods for converting from V4 DTO to entities and vice versa.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Slf4j
+public final class EntityDtoConverters {
+
+    private EntityDtoConverters() {
+    }
+
+    /**
+     * Convert an application entity to a DTO for external exposure.
+     *
+     * @param applicationEntity The entity to convert
+     * @return The immutable DTO representation of the entity data
+     */
+    static Application toV4ApplicationDto(final ApplicationEntity applicationEntity) {
+        final ApplicationMetadata.Builder metadataBuilder = new ApplicationMetadata.Builder(
+            applicationEntity.getName(),
+            applicationEntity.getUser(),
+            applicationEntity.getStatus()
+        )
+            .withVersion(applicationEntity.getVersion())
+            .withTags(applicationEntity.getTags().stream().map(TagEntity::getTag).collect(Collectors.toSet()));
+
+        applicationEntity.getType().ifPresent(metadataBuilder::withType);
+        applicationEntity.getDescription().ifPresent(metadataBuilder::withDescription);
+        setDtoMetadata(metadataBuilder, applicationEntity);
+
+        return new Application(
+            applicationEntity.getUniqueId(),
+            applicationEntity.getCreated(),
+            applicationEntity.getUpdated(),
+            new ExecutionEnvironment(
+                applicationEntity.getConfigs().stream().map(FileEntity::getFile).collect(Collectors.toSet()),
+                applicationEntity.getDependencies().stream().map(FileEntity::getFile).collect(Collectors.toSet()),
+                applicationEntity.getSetupFile().isPresent() ? applicationEntity.getSetupFile().get().getFile() : null
+            ),
+            metadataBuilder.build()
+        );
+    }
+
+    /**
+     * Convert a cluster entity to a DTO for external exposure.
+     *
+     * @param clusterEntity The entity to convert
+     * @return The immutable DTO representation of the entity data
+     */
+    static Cluster toV4ClusterDto(final ClusterEntity clusterEntity) {
+        final ClusterMetadata.Builder metadataBuilder = new ClusterMetadata.Builder(
+            clusterEntity.getName(),
+            clusterEntity.getUser(),
+            clusterEntity.getStatus()
+        )
+            .withVersion(clusterEntity.getVersion())
+            .withTags(clusterEntity.getTags().stream().map(TagEntity::getTag).collect(Collectors.toSet()));
+
+        clusterEntity.getDescription().ifPresent(metadataBuilder::withDescription);
+        setDtoMetadata(metadataBuilder, clusterEntity);
+
+        return new Cluster(
+            clusterEntity.getUniqueId(),
+            clusterEntity.getCreated(),
+            clusterEntity.getUpdated(),
+            new ExecutionEnvironment(
+                clusterEntity.getConfigs().stream().map(FileEntity::getFile).collect(Collectors.toSet()),
+                clusterEntity.getDependencies().stream().map(FileEntity::getFile).collect(Collectors.toSet()),
+                clusterEntity.getSetupFile().isPresent() ? clusterEntity.getSetupFile().get().getFile() : null
+            ),
+            metadataBuilder.build()
+        );
+    }
+
+    /**
+     * Convert a command entity to a DTO for external exposure.
+     *
+     * @param commandEntity The entity to convert
+     * @return The immutable DTO representation of the entity data
+     */
+    static Command toV4CommandDto(final CommandEntity commandEntity) {
+        final CommandMetadata.Builder metadataBuilder = new CommandMetadata.Builder(
+            commandEntity.getName(),
+            commandEntity.getUser(),
+            commandEntity.getStatus()
+        )
+            .withVersion(commandEntity.getVersion())
+            .withTags(commandEntity.getTags().stream().map(TagEntity::getTag).collect(Collectors.toSet()));
+
+        commandEntity.getDescription().ifPresent(metadataBuilder::withDescription);
+        setDtoMetadata(metadataBuilder, commandEntity);
+
+        return new Command(
+            commandEntity.getUniqueId(),
+            commandEntity.getCreated(),
+            commandEntity.getUpdated(),
+            new ExecutionEnvironment(
+                commandEntity.getConfigs().stream().map(FileEntity::getFile).collect(Collectors.toSet()),
+                commandEntity.getDependencies().stream().map(FileEntity::getFile).collect(Collectors.toSet()),
+                commandEntity.getSetupFile().isPresent() ? commandEntity.getSetupFile().get().getFile() : null
+            ),
+            metadataBuilder.build(),
+            Lists.newArrayList(StringUtils.split(commandEntity.getExecutable(), ' ')),
+            commandEntity.getMemory().orElse(null)
+        );
+    }
+
+    private static <B extends CommonMetadata.Builder, E extends BaseProjection> void setDtoMetadata(
+        final B builder,
+        final E entity
+    ) {
+        if (entity.getMetadata().isPresent()) {
+            try {
+                builder.withMetadata(entity.getMetadata().get());
+            } catch (final GeniePreconditionException gpe) {
+                // Since the DTO can't be constructed on input with invalid JSON this should never even happen
+                log.error("Invalid JSON metadata. Should never happen.", gpe);
+                builder.withMetadata((JsonNode) null);
+            }
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Classes related to working with entities for Genie v4.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.web.jpa.entities.v4;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/CriteriaResolutionRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/CriteriaResolutionRepository.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.jpa.repositories;
+
+import com.netflix.genie.common.dto.v4.Criterion;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Custom extension interfaces for the {@link JpaClusterRepository} which require more hands on control rather than
+ * generated code from Spring.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public interface CriteriaResolutionRepository {
+
+    /**
+     * Given a cluster and command criterion attempt to resolve the cluster and highest priority command that match
+     * said criteria.
+     *
+     * @param clusterCriterion The criterion for selecting a cluster
+     * @param commandCriterion The criterion for selecting a command attached to the selected cluster
+     * @return A tuple of the id of the cluster and the id of the command to use if that cluster is selected by the LB
+     */
+    //TODO: add algorithm explanation
+    @Nonnull
+    List<Object[]> resolveClustersAndCommands(final Criterion clusterCriterion, final Criterion commandCriterion);
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/CriteriaResolutionRepositoryImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/CriteriaResolutionRepositoryImpl.java
@@ -1,0 +1,170 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.jpa.repositories;
+
+import com.netflix.genie.common.dto.ClusterStatus;
+import com.netflix.genie.common.dto.CommandStatus;
+import com.netflix.genie.common.dto.v4.Criterion;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Implementations of the {@link CriteriaResolutionRepository} interface.
+ * <p>
+ * Works as a fragment.
+ * See <a href="https://tinyurl.com/yctelbfh">Spring Data JPA Documentation</a> for more.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public class CriteriaResolutionRepositoryImpl implements CriteriaResolutionRepository {
+
+    private static final String CLUSTER_QUERY_STRING = "{CLUSTER_QUERY_HERE}";
+    private static final String COMMAND_QUERY_STRING = "{COMMAND_QUERY_HERE}";
+
+    private static final String RESOLVE_CLUSTERS_AND_COMMANDS_QUERY =
+        "SELECT "
+            + "  cc.cluster_id,"
+            + "  c.unique_id "
+            + "FROM"
+            + "  ("
+            + "    SELECT"
+            + "      cc.cluster_id as cluster_id,"
+            + "      MIN(cc.command_order) as command_order"
+            + "    FROM"
+            + "      (" + CLUSTER_QUERY_STRING + ") AS selected_clusters join"
+            + "      clusters_commands cc ON selected_clusters.id = cc.cluster_id join"
+            + "      (" + COMMAND_QUERY_STRING + ") AS selected_commands ON selected_commands.id = cc.command_id"
+            + "    GROUP BY cc.cluster_id"
+            + "  ) as cluster_id_order join"
+            + "  clusters_commands cc on"
+            + "    cluster_id_order.cluster_id = cc.cluster_id AND"
+            + "    cc.command_order = cluster_id_order.command_order join"
+            + "  commands c on cc.command_id = c.id;";
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    public List<Object[]> resolveClustersAndCommands(
+        final Criterion clusterCriterion,
+        final Criterion commandCriterion
+    ) {
+        return this.entityManager
+            .createNativeQuery(
+                RESOLVE_CLUSTERS_AND_COMMANDS_QUERY
+                    .replace(CLUSTER_QUERY_STRING, this.buildEntityQueryForType(clusterCriterion, CriteriaType.CLUSTER))
+                    .replace(COMMAND_QUERY_STRING, this.buildEntityQueryForType(commandCriterion, CriteriaType.COMMAND))
+            )
+            .getResultList();
+    }
+
+    private String buildEntityQueryForType(final Criterion criterion, final CriteriaType criteriaType) {
+        final Set<String> tags = criterion.getTags();
+        final boolean hasTags = !tags.isEmpty();
+        final StringBuilder query = new StringBuilder();
+        query
+            .append("SELECT c.id as id FROM ")
+            .append(criteriaType.getPrimaryTable())
+            .append(" c");
+
+        if (hasTags) {
+            query
+                .append(" join ")
+                .append(criteriaType.getTagTable())
+                .append(" ct on c.id = ct.")
+                .append(criteriaType.getTagJoinColumn())
+                .append(" join tags t on ct.tag_id = t.id");
+        }
+
+        query.append(" WHERE");
+
+        criterion.getId().ifPresent(id -> query.append(" c.unique_id = '").append(id).append("' AND"));
+        criterion.getName().ifPresent(name -> query.append(" c.name = '").append(name).append("' AND"));
+
+        if (hasTags) {
+            query
+                .append(" t.tag IN (")
+                .append(
+                    criterion
+                        .getTags()
+                        .stream()
+                        .map(tag -> "'" + tag + "'")
+                        .reduce((first, second) -> first + ", " + second)
+                        .orElse("")
+                )
+                .append(") AND");
+        }
+
+        query
+            .append(" c.status = '")
+            .append(criterion.getStatus().orElse(criteriaType.getDefaultStatus()))
+            .append("'");
+
+        if (hasTags) {
+            query
+                .append(" GROUP BY c.id HAVING COUNT(c.id) = ")
+                .append(criterion.getTags().size());
+        }
+
+        return query.toString();
+    }
+
+
+    /**
+     * Enumeration of the types of criteria and default values that can be supplied to the cluster and command
+     * resolution methods.
+     *
+     * @author tgianos
+     * @since 4.0.0
+     */
+    @Getter
+    private enum CriteriaType {
+
+        CLUSTER("clusters", "clusters_tags", "cluster_id", ClusterStatus.UP.toString()),
+
+        COMMAND("commands", "commands_tags", "command_id", CommandStatus.ACTIVE.toString());
+
+        private final String primaryTable;
+        private final String tagTable;
+        private final String tagJoinColumn;
+        private final String defaultStatus;
+
+        CriteriaType(
+            final String primaryTable,
+            final String tagTable,
+            final String tagJoinColumn,
+            final String defaultStatus
+        ) {
+            this.primaryTable = primaryTable;
+            this.tagTable = tagTable;
+            this.tagJoinColumn = tagJoinColumn;
+            this.defaultStatus = defaultStatus;
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaClusterRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaClusterRepository.java
@@ -18,9 +18,7 @@ package com.netflix.genie.web.jpa.repositories;
 import com.netflix.genie.web.jpa.entities.ClusterEntity;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -28,57 +26,7 @@ import java.util.Set;
  *
  * @author tgianos
  */
-public interface JpaClusterRepository extends JpaBaseRepository<ClusterEntity> {
-    /**
-     * This is the query used to find clusters and commands for given criteria from a user.
-     */
-    String CLUSTER_COMMAND_QUERY =
-        "SELECT "
-            + "  cc.cluster_id,"
-            + "  c.unique_id "
-            + "FROM"
-            + "  ("
-            + "    SELECT"
-            + "      cc.cluster_id as cluster_id,"
-            + "      MIN(cc.command_order) as command_order"
-            + "    FROM"
-            + "      ("
-            + "        SELECT"
-            + "          c.id as id"
-            + "        FROM"
-            + "          clusters c join"
-            + "          clusters_tags ct on c.id = ct.cluster_id join"
-            + "          tags t on ct.tag_id = t.id"
-            + "        WHERE"
-            + "          t.tag IN (:clusterTags) AND"
-            + "          c.status = 'UP'"
-            + "        GROUP BY"
-            + "          c.id"
-            + "        HAVING"
-            + "          COUNT(c.id) = :clusterTagsCount"
-            + "      ) AS selected_clusters join"
-            + "      clusters_commands cc ON selected_clusters.id = cc.cluster_id join"
-            + "      ("
-            + "        SELECT"
-            + "          c.id as id"
-            + "        FROM"
-            + "          commands c join"
-            + "          commands_tags ct on c.id = ct.command_id join"
-            + "          tags t on ct.tag_id = t.id"
-            + "        WHERE"
-            + "          t.tag IN (:commandTags) AND"
-            + "          c.status = 'ACTIVE'"
-            + "        GROUP BY"
-            + "          c.id"
-            + "        HAVING"
-            + "          COUNT(c.id) = :commandTagsCount"
-            + "      ) AS selected_commands ON selected_commands.id = cc.command_id"
-            + "    GROUP BY cc.cluster_id"
-            + "  ) as cluster_id_order join"
-            + "  clusters_commands cc on"
-            + "    cluster_id_order.cluster_id = cc.cluster_id AND"
-            + "    cc.command_order = cluster_id_order.command_order join"
-            + "  commands c on cc.command_id = c.id;";
+public interface JpaClusterRepository extends JpaBaseRepository<ClusterEntity>, CriteriaResolutionRepository {
 
     /**
      * The SQL to find all clusters in a TERMINATED state that aren't attached to any jobs still in the database.
@@ -89,27 +37,6 @@ public interface JpaClusterRepository extends JpaBaseRepository<ClusterEntity> {
             + "WHERE id NOT IN (SELECT DISTINCT(cluster_id) FROM jobs WHERE cluster_id IS NOT NULL) "
             + "AND status = 'TERMINATED' "
             + "FOR UPDATE;";
-
-    /**
-     * Find the cluster and command ids for the given criterion tags. The data is returned as a list of
-     * Long, Long results where the first Long is the cluster id and the second is the command id that should be used
-     * if that cluster is selected. The command id should be the highest priority command that matches the command
-     * criterion which has been associated with the given cluster by administrators.
-     *
-     * @param clusterTags      The tags the cluster must match to be selected (conjunction). e.g. 'tag1','tag2','tag3'
-     * @param clusterTagsCount The number of cluster tags (size of clusterTags)
-     * @param commandTags      The tags the command associated with the cluster must match to be selected. (conjunction)
-     *                         e.g. 'tag1','tag2'
-     * @param commandTagsSize  The number of command tags (size of commandTags)
-     * @return The id pairs found or empty list if no matches
-     */
-    @Query(value = CLUSTER_COMMAND_QUERY, nativeQuery = true)
-    List<Object[]> findClustersAndCommandsForCriterion(
-        @Param("clusterTags") final Set<String> clusterTags,
-        @Param("clusterTagsCount") final int clusterTagsCount,
-        @Param("commandTags") final Set<String> commandTags,
-        @Param("commandTagsCount") final int commandTagsSize
-    );
 
     /**
      * Find the ids of all clusters that are in a terminated state and aren't attached to any jobs.

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaApplicationServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaApplicationServiceImpl.java
@@ -386,9 +386,7 @@ public class JpaApplicationServiceImpl extends JpaBaseService implements Applica
         @NotBlank(message = "No application id entered. Unable to update tags.") final String id,
         @NotNull(message = "No tags entered unable to update tags.") final Set<String> tags
     ) throws GenieException {
-        final ApplicationEntity applicationEntity = this.findApplication(id);
-        final Set<TagEntity> newTags = this.createAndGetTagEntities(tags);
-        applicationEntity.setTags(newTags);
+        this.findApplication(id).setTags(this.createAndGetTagEntities(tags));
     }
 
     /**
@@ -398,16 +396,7 @@ public class JpaApplicationServiceImpl extends JpaBaseService implements Applica
     public void removeAllTagsForApplication(
         @NotBlank(message = "No application id entered. Unable to remove tags.") final String id
     ) throws GenieException {
-        final Set<TagEntity> tags = this.findApplication(id).getTags();
-        // Remove all the tags except the ones that start with "genie."
-        tags.removeAll(
-            tags
-                .stream()
-                .filter(
-                    tagEntity -> !tagEntity.getTag().startsWith(JpaBaseService.GENIE_TAG_NAMESPACE)
-                )
-                .collect(Collectors.toSet())
-        );
+        this.findApplication(id).getTags().clear();
     }
 
     /**
@@ -418,9 +407,7 @@ public class JpaApplicationServiceImpl extends JpaBaseService implements Applica
         @NotBlank(message = "No application id entered. Unable to remove tag.") final String id,
         @NotBlank(message = "No tag entered. Unable to remove.") final String tag
     ) throws GenieException {
-        if (!tag.startsWith(JpaBaseService.GENIE_TAG_NAMESPACE)) {
-            this.getTagRepository().findByTag(tag).ifPresent(this.findApplication(id).getTags()::remove);
-        }
+        this.getTagRepository().findByTag(tag).ifPresent(this.findApplication(id).getTags()::remove);
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaServiceUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaServiceUtils.java
@@ -55,6 +55,8 @@ import java.util.stream.Collectors;
 @Slf4j
 public final class JpaServiceUtils {
 
+    private static final String NO_VERSION_SUPPLIED = "No version supplied";
+
     private JpaServiceUtils() {
     }
 
@@ -68,7 +70,7 @@ public final class JpaServiceUtils {
         final Application.Builder builder = new Application.Builder(
             applicationEntity.getName(),
             applicationEntity.getUser(),
-            applicationEntity.getVersion(),
+            applicationEntity.getVersion().orElse(NO_VERSION_SUPPLIED),
             applicationEntity.getStatus()
         )
             .withId(applicationEntity.getUniqueId())
@@ -98,7 +100,7 @@ public final class JpaServiceUtils {
         final Cluster.Builder builder = new Cluster.Builder(
             clusterEntity.getName(),
             clusterEntity.getUser(),
-            clusterEntity.getVersion(),
+            clusterEntity.getVersion().orElse(NO_VERSION_SUPPLIED),
             clusterEntity.getStatus()
         )
             .withId(clusterEntity.getUniqueId())
@@ -127,7 +129,7 @@ public final class JpaServiceUtils {
         final Command.Builder builder = new Command.Builder(
             commandEntity.getName(),
             commandEntity.getUser(),
-            commandEntity.getVersion(),
+            commandEntity.getVersion().orElse(NO_VERSION_SUPPLIED),
             commandEntity.getStatus(),
             commandEntity.getExecutable(),
             commandEntity.getCheckDelay()
@@ -158,7 +160,7 @@ public final class JpaServiceUtils {
         final Job.Builder builder = new Job.Builder(
             jobProjection.getName(),
             jobProjection.getUser(),
-            jobProjection.getVersion()
+            jobProjection.getVersion().orElse(NO_VERSION_SUPPLIED)
         )
             .withId(jobProjection.getUniqueId())
             .withCreated(jobProjection.getCreated())
@@ -185,7 +187,7 @@ public final class JpaServiceUtils {
         final JobRequest.Builder builder = new JobRequest.Builder(
             jobRequestProjection.getName(),
             jobRequestProjection.getUser(),
-            jobRequestProjection.getVersion(),
+            jobRequestProjection.getVersion().orElse(NO_VERSION_SUPPLIED),
             jobRequestProjection
                 .getClusterCriteria()
                 .stream()

--- a/genie-web/src/main/java/com/netflix/genie/web/services/ApplicationService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/ApplicationService.java
@@ -18,10 +18,11 @@
 package com.netflix.genie.web.services;
 
 import com.github.fge.jsonpatch.JsonPatch;
-import com.netflix.genie.common.dto.Application;
 import com.netflix.genie.common.dto.ApplicationStatus;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.CommandStatus;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.ApplicationRequest;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -46,13 +47,13 @@ public interface ApplicationService {
     /**
      * Create new application.
      *
-     * @param app The application configuration to create
+     * @param applicationRequest The application request containing the metadata of the application to create
      * @return The id of the application that was created
      * @throws GenieException if there is an error
      */
     String createApplication(
         @NotNull(message = "No application entered to create.")
-        @Valid final Application app
+        @Valid final ApplicationRequest applicationRequest
     ) throws GenieException;
 
     /**
@@ -125,6 +126,8 @@ public interface ApplicationService {
     void deleteApplication(
         @NotBlank(message = "No application id entered. Unable to delete.") final String id
     ) throws GenieException;
+
+    // TODO: Look into removing all these extraneous APIs
 
     /**
      * Add a configuration file to the application.

--- a/genie-web/src/main/java/com/netflix/genie/web/services/ClusterLoadBalancer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/ClusterLoadBalancer.java
@@ -17,8 +17,8 @@
  */
 package com.netflix.genie.web.services;
 
-import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Cluster;
 import com.netflix.genie.common.exceptions.GenieException;
 import lombok.NonNull;
 import org.springframework.core.Ordered;

--- a/genie-web/src/main/java/com/netflix/genie/web/services/ClusterService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/ClusterService.java
@@ -18,11 +18,12 @@
 package com.netflix.genie.web.services;
 
 import com.github.fge.jsonpatch.JsonPatch;
-import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.ClusterStatus;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.CommandStatus;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.ClusterRequest;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.dto.v4.Criterion;
 import com.netflix.genie.common.exceptions.GenieException;
 import org.springframework.data.domain.Page;
@@ -52,13 +53,13 @@ public interface ClusterService {
     /**
      * Create new cluster configuration.
      *
-     * @param cluster The cluster to create
+     * @param request The cluster information to create
      * @return The created clusters id
      * @throws GenieException if there is an error
      */
     String createCluster(
-        @NotNull(message = "No cluster entered. Unable to create.")
-        @Valid final Cluster cluster
+        @NotNull(message = "No cluster request entered. Unable to create.")
+        @Valid final ClusterRequest request
     ) throws GenieException;
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/services/CommandService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/CommandService.java
@@ -18,11 +18,12 @@
 package com.netflix.genie.web.services;
 
 import com.github.fge.jsonpatch.JsonPatch;
-import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.ClusterStatus;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.CommandStatus;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
+import com.netflix.genie.common.dto.v4.CommandRequest;
 import com.netflix.genie.common.exceptions.GenieException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -49,14 +50,14 @@ public interface CommandService {
     /**
      * Create new command configuration.
      *
-     * @param command encapsulates the command configuration information to
+     * @param request encapsulates the command configuration information to
      *                create. Not null. Valid.
      * @return The id of the command created
      * @throws GenieException if there is an error
      */
     String createCommand(
         @NotNull(message = "No command entered. Unable to create.")
-        @Valid final Command command
+        @Valid final CommandRequest request
     ) throws GenieException;
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobStateService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobStateService.java
@@ -17,10 +17,10 @@
  */
 package com.netflix.genie.web.services;
 
-import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 
 import java.util.List;
@@ -49,8 +49,14 @@ public interface JobStateService extends JobMetricsService {
      * @param applications applications to use based on the command that was selected
      * @param memory       job memory
      */
-    void schedule(final String jobId, final JobRequest jobRequest, final Cluster cluster, final Command command,
-                  final List<Application> applications, final int memory);
+    void schedule(
+        final String jobId,
+        final JobRequest jobRequest,
+        final Cluster cluster,
+        final Command command,
+        final List<Application> applications,
+        final int memory
+    );
 
     /**
      * Called when the job is done.

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobSubmitterService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobSubmitterService.java
@@ -18,10 +18,10 @@
 
 package com.netflix.genie.web.services;
 
-import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 import org.springframework.validation.annotation.Validated;
 

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -34,6 +34,7 @@ import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
 import com.netflix.genie.common.exceptions.GenieUserLimitExceededException;
 import com.netflix.genie.common.jobs.JobConstants;
+import com.netflix.genie.web.controllers.DtoAdapters;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.properties.JobsUsersActiveLimitProperties;
 import com.netflix.genie.web.services.ApplicationService;
@@ -507,7 +508,9 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
                 applications.addAll(this.commandService.getApplicationsForCommand(commandId));
             } else {
                 for (final String applicationId : jobRequest.getApplications()) {
-                    applications.add(this.applicationService.getApplication(applicationId));
+                    applications.add(
+                        DtoAdapters.toV3Application(this.applicationService.getApplication(applicationId))
+                    );
                 }
             }
             log.info(

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobStateServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobStateServiceImpl.java
@@ -17,10 +17,10 @@
  */
 package com.netflix.genie.web.services.impl;
 
-import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.events.JobScheduledEvent;

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/LocalJobRunner.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/LocalJobRunner.java
@@ -17,20 +17,20 @@
  */
 package com.netflix.genie.web.services.impl;
 
-import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatusMessages;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.common.jobs.JobConstants;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.events.JobFinishedEvent;
 import com.netflix.genie.web.events.JobFinishedReason;
 import com.netflix.genie.web.events.JobStartedEvent;
-import com.netflix.genie.common.jobs.JobConstants;
 import com.netflix.genie.web.jobs.JobExecutionEnvironment;
 import com.netflix.genie.web.jobs.workflow.WorkflowTask;
 import com.netflix.genie.web.services.JobPersistenceService;
@@ -161,7 +161,9 @@ public class LocalJobRunner implements JobSubmitterService {
                                 .orElseThrow(() ->
                                     new GenieServerException("No process id returned. Unable to persist")
                                 ),
-                            jobExecution.getCheckDelay().orElse(Command.DEFAULT_CHECK_DELAY),
+                            jobExecution
+                                .getCheckDelay()
+                                .orElse(com.netflix.genie.common.dto.Command.DEFAULT_CHECK_DELAY),
                             jobExecution
                                 .getTimeout()
                                 .orElseThrow(() ->

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/RandomizedClusterLoadBalancerImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/RandomizedClusterLoadBalancerImpl.java
@@ -17,8 +17,8 @@
  */
 package com.netflix.genie.web.services.impl;
 
-import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Cluster;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.web.services.ClusterLoadBalancer;
 import lombok.NonNull;

--- a/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.v4.Cluster;
 import com.netflix.genie.common.exceptions.GenieException;
-import com.netflix.genie.web.controllers.DtoAdapters;
+import com.netflix.genie.web.controllers.DtoConverters;
 import com.netflix.genie.web.services.ClusterLoadBalancer;
 import com.netflix.genie.web.services.impl.GenieFileTransferService;
 import com.netflix.genie.web.util.MetricsConstants;
@@ -182,7 +182,7 @@ public class ScriptLoadBalancer implements ClusterLoadBalancer {
                     this.mapper.writeValueAsString(
                         clusters
                             .stream()
-                            .map(DtoAdapters::toV3Cluster)
+                            .map(DtoConverters::toV3Cluster)
                             .collect(Collectors.toSet())
                     )
                 );

--- a/genie-web/src/main/resources/application-prod.yml
+++ b/genie-web/src/main/resources/application-prod.yml
@@ -18,7 +18,7 @@
 
 spring:
   datasource:
-    url: jdbc:mysql://127.0.0.1/genie?useUnicode=yes&characterEncoding=UTF-8&useLegacyDatetimeCode=false
+    url: jdbc:mysql://127.0.0.1/genie?useUnicode=yes&characterEncoding=UTF-8&useLegacyDatetimeCode=false&serverTimezone=UTC
     username: root
     password:
     hikari:

--- a/genie-web/src/main/resources/db/migration/h2/V4_0_0__Genie_4.sql
+++ b/genie-web/src/main/resources/db/migration/h2/V4_0_0__Genie_4.sql
@@ -1,0 +1,37 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+ALTER TABLE `applications`
+  ALTER COLUMN `version` SET NULL;
+ALTER TABLE `applications`
+  ALTER COLUMN `version` SET DEFAULT NULL;
+
+ALTER TABLE `clusters`
+  ALTER COLUMN `version` SET NULL;
+ALTER TABLE `clusters`
+  ALTER COLUMN `version` SET DEFAULT NULL;
+
+ALTER TABLE `commands`
+  ALTER COLUMN `version` SET NULL;
+ALTER TABLE `commands`
+  ALTER COLUMN `version` SET DEFAULT NULL;
+
+ALTER TABLE `jobs`
+  ALTER COLUMN `version` SET NULL;
+ALTER TABLE `jobs`
+  ALTER COLUMN `version` SET DEFAULT NULL;

--- a/genie-web/src/main/resources/db/migration/mysql/V4_0_0__Genie_4.sql
+++ b/genie-web/src/main/resources/db/migration/mysql/V4_0_0__Genie_4.sql
@@ -1,0 +1,29 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+ALTER TABLE `applications`
+  CHANGE `version` `version` VARCHAR(255) DEFAULT NULL;
+
+ALTER TABLE `clusters`
+  CHANGE `version` `version` VARCHAR(255) DEFAULT NULL;
+
+ALTER TABLE `commands`
+  CHANGE `version` `version` VARCHAR(255) DEFAULT NULL;
+
+ALTER TABLE `jobs`
+  CHANGE `version` `version` VARCHAR(255) DEFAULT NULL;

--- a/genie-web/src/main/resources/db/migration/mysql/V4_0_0__Genie_4.sql
+++ b/genie-web/src/main/resources/db/migration/mysql/V4_0_0__Genie_4.sql
@@ -16,6 +16,24 @@
  *
  */
 
+DROP TABLE IF EXISTS
+`job_metadata_320`,
+`job_executions_320`,
+`jobs_applications_320`,
+`jobs_320`,
+`job_requests_320`,
+`application_configs_320`,
+`application_dependencies_320`,
+`cluster_configs_320`,
+`cluster_dependencies_320`,
+`command_configs_320`,
+`command_dependencies_320`,
+`commands_applications_320`,
+`clusters_commands_320`,
+`applications_320`,
+`clusters_320`,
+`commands_320`;
+
 ALTER TABLE `applications`
   CHANGE `version` `version` VARCHAR(255) DEFAULT NULL;
 

--- a/genie-web/src/main/resources/db/migration/postgresql/V4_0_0__Genie_4.sql
+++ b/genie-web/src/main/resources/db/migration/postgresql/V4_0_0__Genie_4.sql
@@ -1,0 +1,33 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+ALTER TABLE applications
+  ALTER COLUMN version DROP NOT NULL,
+  ALTER COLUMN version SET DEFAULT NULL;
+
+ALTER TABLE clusters
+  ALTER COLUMN version DROP NOT NULL,
+  ALTER COLUMN version SET DEFAULT NULL;
+
+ALTER TABLE commands
+  ALTER COLUMN version DROP NOT NULL,
+  ALTER COLUMN version SET DEFAULT NULL;
+
+ALTER TABLE jobs
+  ALTER COLUMN version DROP NOT NULL,
+  ALTER COLUMN version SET DEFAULT NULL;

--- a/genie-web/src/main/resources/db/migration/postgresql/V4_0_0__Genie_4.sql
+++ b/genie-web/src/main/resources/db/migration/postgresql/V4_0_0__Genie_4.sql
@@ -16,6 +16,24 @@
  *
  */
 
+DROP TABLE IF EXISTS
+job_metadata_320,
+job_executions_320,
+jobs_applications_320,
+jobs_320,
+job_requests_320,
+application_configs_320,
+application_dependencies_320,
+cluster_configs_320,
+cluster_dependencies_320,
+command_configs_320,
+command_dependencies_320,
+commands_applications_320,
+clusters_commands_320,
+applications_320,
+clusters_320,
+commands_320;
+
 ALTER TABLE applications
   ALTER COLUMN version DROP NOT NULL,
   ALTER COLUMN version SET DEFAULT NULL;

--- a/genie-web/src/test/groovy/com/netflix/genie/web/controllers/DtoAdaptersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/controllers/DtoAdaptersSpec.groovy
@@ -122,6 +122,73 @@ class DtoAdaptersSpec extends Specification {
         applicationRequest.getResources().getDependencies().isEmpty()
     }
 
+    def "Can convert V3 Application to V4 Application"() {
+        def id = UUID.randomUUID().toString()
+        def created = Instant.now()
+        def updated = Instant.now()
+        def name = UUID.randomUUID().toString()
+        def user = UUID.randomUUID().toString()
+        def version = UUID.randomUUID().toString()
+        def status = ApplicationStatus.DEPRECATED
+        def tags = Sets.newHashSet(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                DtoAdapters.GENIE_ID_PREFIX + id,
+                DtoAdapters.GENIE_NAME_PREFIX + name
+        )
+        def metadata = "{\"" + UUID.randomUUID().toString() + "\":\"" + UUID.randomUUID().toString() + "\"}"
+        def type = UUID.randomUUID().toString()
+        def description = UUID.randomUUID().toString()
+        def configs = Sets.newHashSet(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString()
+        )
+        def dependencies = Sets.newHashSet(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString()
+        )
+        def setupFile = UUID.randomUUID().toString()
+        com.netflix.genie.common.dto.Application v3Application
+        Application v4Application
+
+        when:
+        v3Application = new com.netflix.genie.common.dto.Application.Builder(
+                name,
+                user,
+                version,
+                status
+        )
+                .withId(id)
+                .withCreated(created)
+                .withUpdated(updated)
+                .withType(type)
+                .withTags(tags)
+                .withMetadata(metadata)
+                .withDescription(description)
+                .withConfigs(configs)
+                .withDependencies(dependencies)
+                .withSetupFile(setupFile)
+                .build()
+        v4Application = DtoAdapters.toV4Application(v3Application)
+
+        then:
+        v4Application.getMetadata().getStatus() == status
+        v4Application.getMetadata().getType().orElse(null) == type
+        v4Application.getMetadata().getMetadata().isPresent()
+        v4Application.getMetadata().getTags().size() == 2
+        v4Application.getMetadata().getDescription().orElse(null) == description
+        v4Application.getMetadata().getVersion().orElse(null) == version
+        v4Application.getMetadata().getUser() == user
+        v4Application.getMetadata().getName() == name
+        v4Application.getId() == id
+        v4Application.getResources().getSetupFile().orElse(null) == setupFile
+        v4Application.getResources().getConfigs() == configs
+        v4Application.getResources().getDependencies() == dependencies
+        v4Application.getCreated() == created
+        v4Application.getUpdated() == updated
+    }
+
     def "Can convert V4 Application to V3 Application"() {
         def id = UUID.randomUUID().toString()
         def name = UUID.randomUUID().toString()

--- a/genie-web/src/test/groovy/com/netflix/genie/web/controllers/DtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/controllers/DtoConvertersSpec.groovy
@@ -31,13 +31,13 @@ import spock.lang.Specification
 import java.time.Instant
 
 /**
- * Specifications for the {@link DtoAdapters} class which handles converting between v3 and v4 DTOs for API
+ * Specifications for the {@link DtoConverters} class which handles converting between v3 and v4 DTOs for API
  * backwards compatibility.
  *
  * @author tgianos
  * @since 4.0.0
  */
-class DtoAdaptersSpec extends Specification {
+class DtoConvertersSpec extends Specification {
 
     def "Can convert V3 Application to V4 Application Request"() {
         def id = UUID.randomUUID().toString()
@@ -48,8 +48,8 @@ class DtoAdaptersSpec extends Specification {
         def tags = Sets.newHashSet(
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
-                DtoAdapters.GENIE_ID_PREFIX + id,
-                DtoAdapters.GENIE_NAME_PREFIX + name
+                DtoConverters.GENIE_ID_PREFIX + id,
+                DtoConverters.GENIE_NAME_PREFIX + name
         )
         def metadata = "{\"" + UUID.randomUUID().toString() + "\":\"" + UUID.randomUUID().toString() + "\"}"
         def type = UUID.randomUUID().toString()
@@ -83,7 +83,7 @@ class DtoAdaptersSpec extends Specification {
                 .withDependencies(dependencies)
                 .withSetupFile(setupFile)
                 .build()
-        applicationRequest = DtoAdapters.toV4ApplicationRequest(v3Application)
+        applicationRequest = DtoConverters.toV4ApplicationRequest(v3Application)
 
         then:
         applicationRequest.getMetadata().getStatus() == status
@@ -106,7 +106,7 @@ class DtoAdaptersSpec extends Specification {
                 version,
                 status
         ).build()
-        applicationRequest = DtoAdapters.toV4ApplicationRequest(v3Application)
+        applicationRequest = DtoConverters.toV4ApplicationRequest(v3Application)
 
         then:
         applicationRequest.getMetadata().getStatus() == status
@@ -134,8 +134,8 @@ class DtoAdaptersSpec extends Specification {
         def tags = Sets.newHashSet(
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
-                DtoAdapters.GENIE_ID_PREFIX + id,
-                DtoAdapters.GENIE_NAME_PREFIX + name
+                DtoConverters.GENIE_ID_PREFIX + id,
+                DtoConverters.GENIE_NAME_PREFIX + name
         )
         def metadata = "{\"" + UUID.randomUUID().toString() + "\":\"" + UUID.randomUUID().toString() + "\"}"
         def type = UUID.randomUUID().toString()
@@ -171,7 +171,7 @@ class DtoAdaptersSpec extends Specification {
                 .withDependencies(dependencies)
                 .withSetupFile(setupFile)
                 .build()
-        v4Application = DtoAdapters.toV4Application(v3Application)
+        v4Application = DtoConverters.toV4Application(v3Application)
 
         then:
         v4Application.getMetadata().getStatus() == status
@@ -236,7 +236,7 @@ class DtoAdaptersSpec extends Specification {
                         .withVersion(version)
                         .build()
         )
-        v3Application = DtoAdapters.toV3Application(v4Application)
+        v3Application = DtoConverters.toV3Application(v4Application)
 
         then:
         v3Application.getStatus() == status
@@ -244,8 +244,8 @@ class DtoAdaptersSpec extends Specification {
         v3Application.getMetadata().isPresent()
         v3Application.getTags().size() == 4
         v3Application.getTags().containsAll(tags)
-        v3Application.getTags().contains(DtoAdapters.GENIE_ID_PREFIX + id)
-        v3Application.getTags().contains(DtoAdapters.GENIE_NAME_PREFIX + name)
+        v3Application.getTags().contains(DtoConverters.GENIE_ID_PREFIX + id)
+        v3Application.getTags().contains(DtoConverters.GENIE_NAME_PREFIX + name)
         v3Application.getDescription().orElse(null) == description
         v3Application.getVersion() == version
         v3Application.getUser() == user
@@ -263,17 +263,17 @@ class DtoAdaptersSpec extends Specification {
                 null,
                 new ApplicationMetadata.Builder(name, user, status).build()
         )
-        v3Application = DtoAdapters.toV3Application(v4Application)
+        v3Application = DtoConverters.toV3Application(v4Application)
 
         then:
         v3Application.getStatus() == status
         !v3Application.getType().isPresent()
         !v3Application.getMetadata().isPresent()
         v3Application.getTags().size() == 2
-        v3Application.getTags().contains(DtoAdapters.GENIE_ID_PREFIX + id)
-        v3Application.getTags().contains(DtoAdapters.GENIE_NAME_PREFIX + name)
+        v3Application.getTags().contains(DtoConverters.GENIE_ID_PREFIX + id)
+        v3Application.getTags().contains(DtoConverters.GENIE_NAME_PREFIX + name)
         !v3Application.getDescription().isPresent()
-        v3Application.getVersion() == DtoAdapters.NO_VERSION_SPECIFIED
+        v3Application.getVersion() == DtoConverters.NO_VERSION_SPECIFIED
         v3Application.getUser() == user
         v3Application.getName() == name
         v3Application.getId().orElse(null) == id
@@ -291,8 +291,8 @@ class DtoAdaptersSpec extends Specification {
         def tags = Sets.newHashSet(
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
-                DtoAdapters.GENIE_ID_PREFIX + id,
-                DtoAdapters.GENIE_NAME_PREFIX + name
+                DtoConverters.GENIE_ID_PREFIX + id,
+                DtoConverters.GENIE_NAME_PREFIX + name
         )
         def metadata = "{\"" + UUID.randomUUID().toString() + "\":\"" + UUID.randomUUID().toString() + "\"}"
         def description = UUID.randomUUID().toString()
@@ -324,7 +324,7 @@ class DtoAdaptersSpec extends Specification {
                 .withDependencies(dependencies)
                 .withSetupFile(setupFile)
                 .build()
-        clusterRequest = DtoAdapters.toV4ClusterRequest(v3Cluster)
+        clusterRequest = DtoConverters.toV4ClusterRequest(v3Cluster)
 
         then:
         clusterRequest.getMetadata().getStatus() == status
@@ -346,7 +346,7 @@ class DtoAdaptersSpec extends Specification {
                 version,
                 status
         ).build()
-        clusterRequest = DtoAdapters.toV4ClusterRequest(v3Cluster)
+        clusterRequest = DtoConverters.toV4ClusterRequest(v3Cluster)
 
         then:
         clusterRequest.getMetadata().getStatus() == status
@@ -371,8 +371,8 @@ class DtoAdaptersSpec extends Specification {
         def tags = Sets.newHashSet(
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
-                DtoAdapters.GENIE_ID_PREFIX + id,
-                DtoAdapters.GENIE_NAME_PREFIX + name
+                DtoConverters.GENIE_ID_PREFIX + id,
+                DtoConverters.GENIE_NAME_PREFIX + name
         )
         def metadata = "{\"" + UUID.randomUUID().toString() + "\":\"" + UUID.randomUUID().toString() + "\"}"
         def description = UUID.randomUUID().toString()
@@ -404,7 +404,7 @@ class DtoAdaptersSpec extends Specification {
                 .withDependencies(dependencies)
                 .withSetupFile(setupFile)
                 .build()
-        v4Cluster = DtoAdapters.toV4Cluster(v3Cluster)
+        v4Cluster = DtoConverters.toV4Cluster(v3Cluster)
 
         then:
         v4Cluster.getMetadata().getStatus() == status
@@ -464,15 +464,15 @@ class DtoAdaptersSpec extends Specification {
                         .withVersion(version)
                         .build()
         )
-        v3Cluster = DtoAdapters.toV3Cluster(v4Cluster)
+        v3Cluster = DtoConverters.toV3Cluster(v4Cluster)
 
         then:
         v3Cluster.getStatus() == status
         v3Cluster.getMetadata().isPresent()
         v3Cluster.getTags().size() == 4
         v3Cluster.getTags().containsAll(tags)
-        v3Cluster.getTags().contains(DtoAdapters.GENIE_ID_PREFIX + id)
-        v3Cluster.getTags().contains(DtoAdapters.GENIE_NAME_PREFIX + name)
+        v3Cluster.getTags().contains(DtoConverters.GENIE_ID_PREFIX + id)
+        v3Cluster.getTags().contains(DtoConverters.GENIE_NAME_PREFIX + name)
         v3Cluster.getDescription().orElse(null) == description
         v3Cluster.getVersion() == version
         v3Cluster.getUser() == user
@@ -490,16 +490,16 @@ class DtoAdaptersSpec extends Specification {
                 null,
                 new ClusterMetadata.Builder(name, user, status).build()
         )
-        v3Cluster = DtoAdapters.toV3Cluster(v4Cluster)
+        v3Cluster = DtoConverters.toV3Cluster(v4Cluster)
 
         then:
         v3Cluster.getStatus() == status
         !v3Cluster.getMetadata().isPresent()
         v3Cluster.getTags().size() == 2
-        v3Cluster.getTags().contains(DtoAdapters.GENIE_ID_PREFIX + id)
-        v3Cluster.getTags().contains(DtoAdapters.GENIE_NAME_PREFIX + name)
+        v3Cluster.getTags().contains(DtoConverters.GENIE_ID_PREFIX + id)
+        v3Cluster.getTags().contains(DtoConverters.GENIE_NAME_PREFIX + name)
         !v3Cluster.getDescription().isPresent()
-        v3Cluster.getVersion() == DtoAdapters.NO_VERSION_SPECIFIED
+        v3Cluster.getVersion() == DtoConverters.NO_VERSION_SPECIFIED
         v3Cluster.getUser() == user
         v3Cluster.getName() == name
         v3Cluster.getId().orElse(null) == id
@@ -517,8 +517,8 @@ class DtoAdaptersSpec extends Specification {
         def tags = Sets.newHashSet(
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
-                DtoAdapters.GENIE_ID_PREFIX + id,
-                DtoAdapters.GENIE_NAME_PREFIX + name
+                DtoConverters.GENIE_ID_PREFIX + id,
+                DtoConverters.GENIE_NAME_PREFIX + name
         )
         def binary = UUID.randomUUID().toString()
         def defaultBinaryArgument = UUID.randomUUID().toString()
@@ -558,7 +558,7 @@ class DtoAdaptersSpec extends Specification {
                 .withSetupFile(setupFile)
                 .withMemory(memory)
                 .build()
-        commandRequest = DtoAdapters.toV4CommandRequest(v3Command)
+        commandRequest = DtoConverters.toV4CommandRequest(v3Command)
 
         then:
         commandRequest.getMetadata().getStatus() == status
@@ -587,7 +587,7 @@ class DtoAdaptersSpec extends Specification {
                 executable,
                 checkDelay
         ).build()
-        commandRequest = DtoAdapters.toV4CommandRequest(v3Command)
+        commandRequest = DtoConverters.toV4CommandRequest(v3Command)
 
         then:
         commandRequest.getMetadata().getStatus() == status
@@ -615,8 +615,8 @@ class DtoAdaptersSpec extends Specification {
         def version = UUID.randomUUID().toString()
         def status = CommandStatus.DEPRECATED
         def tags = Sets.newHashSet(
-                DtoAdapters.GENIE_ID_PREFIX + id,
-                DtoAdapters.GENIE_NAME_PREFIX + name,
+                DtoConverters.GENIE_ID_PREFIX + id,
+                DtoConverters.GENIE_NAME_PREFIX + name,
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString()
         )
@@ -662,7 +662,7 @@ class DtoAdaptersSpec extends Specification {
                 .withDescription(description)
                 .withMemory(memory)
                 .build()
-        v4Command = DtoAdapters.toV4Command(v3Command)
+        v4Command = DtoConverters.toV4Command(v3Command)
 
         then:
         v4Command.getId() == id
@@ -675,8 +675,8 @@ class DtoAdaptersSpec extends Specification {
         v4Command.getMetadata().getUser() == user
         v4Command.getMetadata().getVersion().orElse(null) == version
         v4Command.getMetadata().getTags().size() == 2
-        !v4Command.getMetadata().getTags().contains(DtoAdapters.GENIE_ID_PREFIX + id)
-        !v4Command.getMetadata().getTags().contains(DtoAdapters.GENIE_NAME_PREFIX + name)
+        !v4Command.getMetadata().getTags().contains(DtoConverters.GENIE_ID_PREFIX + id)
+        !v4Command.getMetadata().getTags().contains(DtoConverters.GENIE_NAME_PREFIX + name)
         v4Command.getMetadata().getStatus() == status
         v4Command.getMetadata().getDescription().orElse(null) == description
         v4Command.getMetadata().getMetadata().orElse(null) == GenieObjectMapper.getMapper().readTree(metadata)
@@ -695,7 +695,7 @@ class DtoAdaptersSpec extends Specification {
         )
                 .withId(id)
                 .build()
-        v4Command = DtoAdapters.toV4Command(v3Command)
+        v4Command = DtoConverters.toV4Command(v3Command)
 
         then:
         v4Command.getId() == id
@@ -768,15 +768,15 @@ class DtoAdaptersSpec extends Specification {
                 memory,
                 checkDelay
         )
-        v3Command = DtoAdapters.toV3Command(v4Command)
+        v3Command = DtoConverters.toV3Command(v4Command)
 
         then:
         v3Command.getStatus() == status
         v3Command.getMetadata().isPresent()
         v3Command.getTags().size() == 4
         v3Command.getTags().containsAll(tags)
-        v3Command.getTags().contains(DtoAdapters.GENIE_ID_PREFIX + id)
-        v3Command.getTags().contains(DtoAdapters.GENIE_NAME_PREFIX + name)
+        v3Command.getTags().contains(DtoConverters.GENIE_ID_PREFIX + id)
+        v3Command.getTags().contains(DtoConverters.GENIE_NAME_PREFIX + name)
         v3Command.getDescription().orElse(null) == description
         v3Command.getVersion() == version
         v3Command.getUser() == user
@@ -800,16 +800,16 @@ class DtoAdaptersSpec extends Specification {
                 null,
                 checkDelay
         )
-        v3Command = DtoAdapters.toV3Command(v4Command)
+        v3Command = DtoConverters.toV3Command(v4Command)
 
         then:
         v3Command.getStatus() == status
         !v3Command.getMetadata().isPresent()
         v3Command.getTags().size() == 2
-        v3Command.getTags().contains(DtoAdapters.GENIE_ID_PREFIX + id)
-        v3Command.getTags().contains(DtoAdapters.GENIE_NAME_PREFIX + name)
+        v3Command.getTags().contains(DtoConverters.GENIE_ID_PREFIX + id)
+        v3Command.getTags().contains(DtoConverters.GENIE_NAME_PREFIX + name)
         !v3Command.getDescription().isPresent()
-        v3Command.getVersion() == DtoAdapters.NO_VERSION_SPECIFIED
+        v3Command.getVersion() == DtoConverters.NO_VERSION_SPECIFIED
         v3Command.getUser() == user
         v3Command.getName() == name
         v3Command.getId().orElse(null) == id
@@ -875,7 +875,7 @@ class DtoAdaptersSpec extends Specification {
         )
 
         when:
-        def v3JobRequest = DtoAdapters.toV3JobRequest(jobRequest)
+        def v3JobRequest = DtoConverters.toV3JobRequest(jobRequest)
 
         then:
         v3JobRequest.getId().orElse(UUID.randomUUID().toString()) == id
@@ -899,8 +899,8 @@ class DtoAdaptersSpec extends Specification {
         v3JobRequest.getEmail().orElse(UUID.randomUUID().toString()) == email
         v3JobRequest.getCommandCriteria() == commandCriterion.getTags()
         v3JobRequest.getClusterCriterias().size() == 2
-        v3JobRequest.getClusterCriterias().get(0).getTags() == DtoAdapters.toV3CriterionTags(clusterCriteria.get(0))
-        v3JobRequest.getClusterCriterias().get(1).getTags() == DtoAdapters.toV3CriterionTags(clusterCriteria.get(1))
+        v3JobRequest.getClusterCriterias().get(0).getTags() == DtoConverters.toV3CriterionTags(clusterCriteria.get(0))
+        v3JobRequest.getClusterCriterias().get(1).getTags() == DtoConverters.toV3CriterionTags(clusterCriteria.get(1))
     }
 
     def "Can convert V3 Job Request to V4"() {
@@ -912,8 +912,8 @@ class DtoAdaptersSpec extends Specification {
                 new ClusterCriteria(Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())),
                 new ClusterCriteria(
                         Sets.newHashSet(
-                                DtoAdapters.GENIE_ID_PREFIX + UUID.randomUUID().toString(),
-                                DtoAdapters.GENIE_NAME_PREFIX + UUID.randomUUID().toString()
+                                DtoConverters.GENIE_ID_PREFIX + UUID.randomUUID().toString(),
+                                DtoConverters.GENIE_NAME_PREFIX + UUID.randomUUID().toString()
                         )
                 )
         )
@@ -960,7 +960,7 @@ class DtoAdaptersSpec extends Specification {
                 .build()
 
         when:
-        def v4JobRequest = DtoAdapters.toV4JobRequest(v3JobRequest)
+        def v4JobRequest = DtoConverters.toV4JobRequest(v3JobRequest)
 
         then:
         v4JobRequest.getRequestedId().orElse(null) == id

--- a/genie-web/src/test/groovy/com/netflix/genie/web/jpa/entities/v4/EntityDtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/jpa/entities/v4/EntityDtoConvertersSpec.groovy
@@ -239,5 +239,6 @@ class EntityDtoConvertersSpec extends Specification {
         command.getMemory().orElseGet(RandomSuppliers.INT) == memory
         command.getMetadata().getMetadata().isPresent()
         GenieObjectMapper.getMapper().writeValueAsString(command.getMetadata().getMetadata().get()) == metadata
+        command.getCheckDelay() == checkDelay
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/jpa/entities/v4/EntityDtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/jpa/entities/v4/EntityDtoConvertersSpec.groovy
@@ -1,0 +1,243 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.jpa.entities.v4
+
+import com.google.common.collect.Lists
+import com.google.common.collect.Sets
+import com.netflix.genie.common.dto.ApplicationStatus
+import com.netflix.genie.common.dto.ClusterStatus
+import com.netflix.genie.common.dto.CommandStatus
+import com.netflix.genie.common.util.GenieObjectMapper
+import com.netflix.genie.test.suppliers.RandomSuppliers
+import com.netflix.genie.web.jpa.entities.*
+import org.apache.commons.lang3.StringUtils
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link EntityDtoConverters}.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+class EntityDtoConvertersSpec extends Specification {
+
+    def "Can convert application entity to application v4 dto"() {
+        def entity = new ApplicationEntity()
+        def name = UUID.randomUUID().toString()
+        entity.setName(name)
+        def user = UUID.randomUUID().toString()
+        entity.setUser(user)
+        def version = UUID.randomUUID().toString()
+        entity.setVersion(version)
+        def id = UUID.randomUUID().toString()
+        entity.setUniqueId(id)
+        def created = entity.getCreated()
+        def updated = entity.getUpdated()
+        def description = UUID.randomUUID().toString()
+        entity.setDescription(description)
+        def metadata = "[\"" + UUID.randomUUID().toString() + "\"]"
+        entity.setMetadata(metadata)
+        def tags = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        Set<TagEntity> tagEntities = tags.collect(
+                {
+                    new TagEntity(it)
+                }
+        )
+        entity.setTags(tagEntities)
+        def configs = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        Set<FileEntity> configEntities = configs.collect(
+                {
+                    new FileEntity(it)
+                }
+        )
+        entity.setConfigs(configEntities)
+        def setupFile = UUID.randomUUID().toString()
+        def setupFileEntity = new FileEntity()
+        setupFileEntity.setFile(setupFile)
+        entity.setSetupFile(setupFileEntity)
+        def dependencies = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        Set<FileEntity> dependencyEntities = dependencies.collect(
+                {
+                    new FileEntity(it)
+                }
+        )
+        entity.setDependencies(dependencyEntities)
+        entity.setStatus(ApplicationStatus.ACTIVE)
+
+        when:
+        def application = EntityDtoConverters.toV4ApplicationDto(entity)
+
+        then:
+        application.getId() == id
+        application.getMetadata().getName() == name
+        application.getMetadata().getUser() == user
+        application.getMetadata().getVersion().orElseGet(RandomSuppliers.STRING) == version
+        application.getCreated() == created
+        application.getUpdated() == updated
+        application.getMetadata().getDescription().orElseGet(RandomSuppliers.STRING) == description
+        application.getMetadata().getTags() == tags
+        application.getResources().getConfigs() == configs
+        application.getResources().getSetupFile().orElseGet(RandomSuppliers.STRING) == setupFile
+        application.getResources().getDependencies() == dependencies
+        application.getMetadata().getStatus() == ApplicationStatus.ACTIVE
+        application.getMetadata().getMetadata().isPresent()
+        GenieObjectMapper.getMapper().writeValueAsString(application.getMetadata().getMetadata().get()) == metadata
+    }
+
+    def "Can convert cluster entity to v4 cluster dto"() {
+        def entity = new ClusterEntity()
+        def name = UUID.randomUUID().toString()
+        entity.setName(name)
+        def user = UUID.randomUUID().toString()
+        entity.setUser(user)
+        def version = UUID.randomUUID().toString()
+        entity.setVersion(version)
+        entity.setStatus(ClusterStatus.TERMINATED)
+        def id = UUID.randomUUID().toString()
+        entity.setUniqueId(id)
+        def created = entity.getCreated()
+        def updated = entity.getUpdated()
+        def description = UUID.randomUUID().toString()
+        entity.setDescription(description)
+        def metadata = "[\"" + UUID.randomUUID().toString() + "\"]"
+        entity.setMetadata(metadata)
+        def tags = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        final Set<TagEntity> tagEntities = tags.collect(
+                {
+                    def tagEntity = new TagEntity()
+                    tagEntity.setTag(it)
+                    tagEntity
+                }
+        )
+        entity.setTags(tagEntities)
+        def configs = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        final Set<FileEntity> configEntities = configs.collect(
+                {
+                    def fileEntity = new FileEntity()
+                    fileEntity.setFile(it)
+                    fileEntity
+                }
+        )
+        entity.setConfigs(configEntities)
+        def dependencies = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        final Set<FileEntity> dependencyEntities = dependencies.collect(
+                {
+                    def fileEntity = new FileEntity()
+                    fileEntity.setFile(it)
+                    fileEntity
+                }
+        )
+        entity.setDependencies(dependencyEntities)
+        def setupFile = UUID.randomUUID().toString()
+        entity.setSetupFile(new FileEntity(setupFile))
+
+        when:
+        def cluster = EntityDtoConverters.toV4ClusterDto(entity)
+
+        then:
+        cluster.getId() == id
+        cluster.getMetadata().getName() == name
+        cluster.getMetadata().getUser() == user
+        cluster.getMetadata().getVersion().orElseGet(RandomSuppliers.STRING) == version
+        cluster.getMetadata().getDescription().orElseGet(RandomSuppliers.STRING) == description
+        cluster.getMetadata().getStatus() == ClusterStatus.TERMINATED
+        cluster.getCreated() == created
+        cluster.getUpdated() == updated
+        cluster.getMetadata().getTags() == tags
+        cluster.getResources().getConfigs() == configs
+        cluster.getResources().getDependencies() == dependencies
+        cluster.getResources().getSetupFile().orElseGet(RandomSuppliers.STRING) == setupFile
+        cluster.getMetadata().getMetadata().isPresent()
+        GenieObjectMapper.getMapper().writeValueAsString(cluster.getMetadata().getMetadata().get()) == metadata
+    }
+
+    def "Can convert command entity to v4 command dto"() {
+        def entity = new CommandEntity()
+        def id = UUID.randomUUID().toString()
+        entity.setUniqueId(id)
+        def name = UUID.randomUUID().toString()
+        entity.setName(name)
+        def user = UUID.randomUUID().toString()
+        entity.setUser(user)
+        def version = UUID.randomUUID().toString()
+        entity.setVersion(version)
+        def description = UUID.randomUUID().toString()
+        entity.setDescription(description)
+        def created = entity.getCreated()
+        def updated = entity.getUpdated()
+        entity.setStatus(CommandStatus.DEPRECATED)
+        def metadata = "[\"" + UUID.randomUUID().toString() + "\"]"
+        entity.setMetadata(metadata)
+        def tags = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        final Set<TagEntity> tagEntities = tags.collect(
+                {
+                    new TagEntity(it)
+                }
+        )
+        entity.setTags(tagEntities)
+        def configs = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        final Set<FileEntity> configEntities = configs.collect(
+                {
+                    new FileEntity(it)
+                }
+        )
+        entity.setConfigs(configEntities)
+        def dependencies = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        final Set<FileEntity> dependencyEntities = dependencies.collect(
+                {
+                    new FileEntity(it)
+                }
+        )
+        entity.setDependencies(dependencyEntities)
+        def setupFile = UUID.randomUUID().toString()
+        final FileEntity setupFileEntity = new FileEntity()
+        setupFileEntity.setFile(setupFile)
+        entity.setSetupFile(setupFileEntity)
+        def executable = Lists.newArrayList(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString()
+        )
+        entity.setExecutable(StringUtils.join(executable, ' '))
+        def checkDelay = 2180234L
+        entity.setCheckDelay(checkDelay)
+        def memory = 10_241
+        entity.setMemory(memory)
+
+        when:
+        def command = EntityDtoConverters.toV4CommandDto(entity)
+
+        then:
+        command.getId() == id
+        command.getMetadata().getName() == name
+        command.getMetadata().getUser() == user
+        command.getMetadata().getVersion().orElseGet(RandomSuppliers.STRING) == version
+        command.getMetadata().getStatus() == CommandStatus.DEPRECATED
+        command.getMetadata().getDescription().orElseGet(RandomSuppliers.STRING) == description
+        command.getCreated() == created
+        command.getUpdated() == updated
+        command.getExecutable() == executable
+        command.getMetadata().getTags() == tags
+        command.getResources().getSetupFile().orElseGet(RandomSuppliers.STRING) == setupFile
+        command.getResources().getConfigs() == configs
+        command.getResources().getDependencies() == dependencies
+        command.getMemory().orElseGet(RandomSuppliers.INT) == memory
+        command.getMetadata().getMetadata().isPresent()
+        GenieObjectMapper.getMapper().writeValueAsString(command.getMetadata().getMetadata().get()) == metadata
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/jpa/services/JpaBaseServiceSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/jpa/services/JpaBaseServiceSpec.groovy
@@ -17,11 +17,8 @@
  */
 package com.netflix.genie.web.jpa.services
 
-import com.google.common.collect.Sets
 import com.netflix.genie.common.exceptions.GenieNotFoundException
-import com.netflix.genie.common.exceptions.GenieServerException
 import com.netflix.genie.test.categories.UnitTest
-import com.netflix.genie.web.jpa.entities.TagEntity
 import com.netflix.genie.web.jpa.repositories.JpaFileRepository
 import com.netflix.genie.web.jpa.repositories.JpaTagRepository
 import com.netflix.genie.web.services.FileService
@@ -78,101 +75,5 @@ class JpaBaseServiceSpec extends Specification {
 
         then:
         thrown(GenieNotFoundException)
-    }
-
-    def "Can set the final tags for an entity"() {
-        def id = UUID.randomUUID().toString()
-        def name = UUID.randomUUID().toString()
-
-        def genieIdTag = JpaBaseService.GENIE_ID_TAG_NAMESPACE + id
-        def genieNameTag = JpaBaseService.GENIE_NAME_TAG_NAMESPACE + name
-
-        def idTagEntity = new TagEntity()
-        idTagEntity.setTag(genieIdTag)
-
-        def nameTagEntity = new TagEntity()
-        nameTagEntity.setTag(genieNameTag)
-
-        def tagEntity1 = new TagEntity()
-        tagEntity1.setTag(UUID.randomUUID().toString())
-
-        def tagEntity2 = new TagEntity()
-        tagEntity2.setTag(UUID.randomUUID().toString())
-
-        def nameTagEntity2 = new TagEntity()
-        nameTagEntity2.setTag(JpaBaseService.GENIE_NAME_TAG_NAMESPACE + UUID.randomUUID().toString())
-
-        def tagService = Mock(TagService.class) {
-            3 * createTagIfNotExists(genieIdTag)
-            2 * createTagIfNotExists(genieNameTag)
-        }
-        def jpaTagRepository = Mock(JpaTagRepository.class) {
-            3 * findByTag(genieIdTag) >> Optional.of(idTagEntity)
-            2 * findByTag(genieNameTag) >> Optional.of(nameTagEntity)
-        }
-        def service = new JpaBaseService(
-                tagService,
-                jpaTagRepository,
-                Mock(FileService),
-                Mock(JpaFileRepository)
-        )
-
-        def expectedTags = Sets.newHashSet(idTagEntity, nameTagEntity, tagEntity1, tagEntity2)
-        def noGenieTags = Sets.newHashSet(tagEntity1, tagEntity2)
-        def nameTags = Sets.newHashSet(nameTagEntity, tagEntity1, tagEntity2)
-        def twoNameTags = Sets.newHashSet(nameTagEntity, nameTagEntity2, tagEntity1, tagEntity2)
-        def idTags = Sets.newHashSet(idTagEntity, tagEntity1, tagEntity2)
-
-        when:
-        service.setFinalTags(noGenieTags, id, name)
-
-        then:
-        noGenieTags == expectedTags
-
-        when:
-        service.setFinalTags(nameTags, id, name)
-
-        then:
-        nameTags == expectedTags
-
-        when:
-        service.setFinalTags(twoNameTags, id, name)
-
-        then:
-        twoNameTags == expectedTags
-
-        when:
-        service.setFinalTags(idTags, id, name)
-
-        then:
-        idTags == expectedTags
-    }
-
-    def "When there are two id tags trying to set final tags throws an exception"() {
-        def service = new JpaBaseService(
-                Mock(TagService),
-                Mock(JpaTagRepository),
-                Mock(FileService),
-                Mock(JpaFileRepository)
-        )
-
-        def idTag1 = JpaBaseService.GENIE_ID_TAG_NAMESPACE + UUID.randomUUID().toString()
-        def idTag2 = JpaBaseService.GENIE_ID_TAG_NAMESPACE + UUID.randomUUID().toString()
-
-        def idEntity1 = new TagEntity()
-        idEntity1.setTag(idTag1)
-
-        def idEntity2 = new TagEntity()
-        idEntity2.setTag(idTag2)
-
-        when:
-        service.setFinalTags(
-                Sets.newHashSet(idEntity1, idEntity2),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString()
-        )
-
-        then:
-        thrown(GenieServerException)
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/ClusterLoadBalancerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/ClusterLoadBalancerSpec.groovy
@@ -17,8 +17,8 @@
  */
 package com.netflix.genie.web.services
 
-import com.netflix.genie.common.dto.Cluster
 import com.netflix.genie.common.dto.JobRequest
+import com.netflix.genie.common.dto.v4.Cluster
 import com.netflix.genie.common.exceptions.GenieException
 import com.netflix.genie.test.categories.UnitTest
 import lombok.NonNull

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobSpecificationServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobSpecificationServiceImplSpec.groovy
@@ -20,9 +20,7 @@ package com.netflix.genie.web.services.impl
 import com.google.common.collect.Lists
 import com.google.common.collect.Maps
 import com.google.common.collect.Sets
-import com.netflix.genie.common.dto.Cluster
 import com.netflix.genie.common.dto.ClusterStatus
-import com.netflix.genie.common.dto.Command
 import com.netflix.genie.common.dto.CommandStatus
 import com.netflix.genie.common.dto.v4.*
 import com.netflix.genie.common.jobs.JobConstants
@@ -38,6 +36,8 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.apache.commons.lang3.StringUtils
 import org.junit.experimental.categories.Category
 import spock.lang.Specification
+
+import java.time.Instant
 
 /**
  * Specifications for the {@link JobSpecificationServiceImpl} class.
@@ -86,41 +86,48 @@ class JobSpecificationServiceImplSpec extends Specification {
                 new ExecutionResourceCriteria(clusterCriteria, commandCriterion, null),
                 null
         )
-        def cluster1 = new Cluster.Builder(
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                ClusterStatus.UP
+        def cluster1 = new Cluster(
+                cluster1Id,
+                Instant.now(),
+                Instant.now(),
+                new ExecutionEnvironment(null, null, null),
+                new ClusterMetadata.Builder(
+                        UUID.randomUUID().toString(),
+                        UUID.randomUUID().toString(),
+                        ClusterStatus.UP
+                ).withTags(clusterTags).build()
         )
-                .withId(cluster1Id)
-                .withTags(clusterTags)
-                .build()
-        def cluster2 = new Cluster.Builder(
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                ClusterStatus.UP
+        def cluster2 = new Cluster(
+                cluster2Id,
+                Instant.now(),
+                Instant.now(),
+                new ExecutionEnvironment(null, null, null),
+                new ClusterMetadata.Builder(
+                        UUID.randomUUID().toString(),
+                        UUID.randomUUID().toString(),
+                        ClusterStatus.UP
+                ).withTags(clusterTags).build()
         )
-                .withId(cluster2Id)
-                .withTags(clusterTags)
-                .build()
 
         def clusters = Sets.newHashSet(cluster1, cluster2)
         def executableBinary = UUID.randomUUID().toString()
         def executableArgument0 = UUID.randomUUID().toString()
         def executableArgument1 = UUID.randomUUID().toString()
-        def executable = executableBinary + ' ' + executableArgument0 + ' ' + executableArgument1 + ' '
-        def command = new Command.Builder(
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                CommandStatus.ACTIVE,
+        def executable = Lists.newArrayList(executableBinary, executableArgument0, executableArgument1)
+        def command = new Command(
+                commandId,
+                Instant.now(),
+                Instant.now(),
+                new ExecutionEnvironment(null, null, null),
+                new CommandMetadata.Builder(
+                        UUID.randomUUID().toString(),
+                        UUID.randomUUID().toString(),
+                        CommandStatus.ACTIVE
+                ).withTags(commandTags).build(),
                 executable,
+                null,
                 100L
         )
-                .withId(commandId)
-                .withTags(commandTags)
-                .build()
 
         def jobCommandArgs = Lists.newArrayList(executableBinary, executableArgument0, executableArgument1)
         jobCommandArgs.addAll(commandArgs)
@@ -231,26 +238,31 @@ class JobSpecificationServiceImplSpec extends Specification {
                 new ExecutionResourceCriteria(clusterCriteria, commandCriterion, null),
                 null
         )
-        def cluster = new Cluster.Builder(
-                clusterName,
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                ClusterStatus.UP
+        def cluster = new Cluster(
+                clusterId,
+                Instant.now(),
+                Instant.now(),
+                new ExecutionEnvironment(null, null, null),
+                new ClusterMetadata.Builder(
+                        clusterName,
+                        UUID.randomUUID().toString(),
+                        ClusterStatus.UP
+                ).withTags(clusterTags).build()
         )
-                .withId(clusterId)
-                .withTags(clusterTags)
-                .build()
-        def command = new Command.Builder(
-                commandName,
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                CommandStatus.ACTIVE,
-                UUID.randomUUID().toString(),
+        def command = new Command(
+                commandId,
+                Instant.now(),
+                Instant.now(),
+                new ExecutionEnvironment(null, null, null),
+                new CommandMetadata.Builder(
+                        commandName,
+                        UUID.randomUUID().toString(),
+                        CommandStatus.ACTIVE
+                ).withTags(commandTags).build(),
+                Lists.newArrayList(UUID.randomUUID().toString()),
+                null,
                 100L
         )
-                .withId(commandId)
-                .withTags(commandTags)
-                .build()
 
         when:
         def envVariables = service.generateEnvironmentVariables(jobId, jobRequest, cluster, command)

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobStateServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobStateServiceImplSpec.groovy
@@ -18,10 +18,10 @@
 package com.netflix.genie.web.services.impl
 
 import com.google.common.collect.Lists
-import com.netflix.genie.common.dto.Application
-import com.netflix.genie.common.dto.Cluster
-import com.netflix.genie.common.dto.Command
 import com.netflix.genie.common.dto.JobRequest
+import com.netflix.genie.common.dto.v4.Application
+import com.netflix.genie.common.dto.v4.Cluster
+import com.netflix.genie.common.dto.v4.Command
 import com.netflix.genie.test.categories.UnitTest
 import com.netflix.genie.web.events.GenieEventBus
 import com.netflix.genie.web.services.JobStateService
@@ -31,6 +31,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.experimental.categories.Category
 import org.springframework.scheduling.TaskScheduler
 import spock.lang.Specification
+
 /**
  * Test JobStateService
  *

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
@@ -21,10 +21,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.collect.ImmutableSet
 import com.google.common.collect.Lists
 import com.google.common.collect.Sets
-import com.netflix.genie.common.dto.Cluster
 import com.netflix.genie.common.dto.ClusterCriteria
 import com.netflix.genie.common.dto.ClusterStatus
 import com.netflix.genie.common.dto.JobRequest
+import com.netflix.genie.common.dto.v4.Cluster
+import com.netflix.genie.common.dto.v4.ClusterMetadata
+import com.netflix.genie.common.dto.v4.ExecutionEnvironment
 import com.netflix.genie.common.util.GenieObjectMapper
 import com.netflix.genie.test.categories.UnitTest
 import com.netflix.genie.web.services.ClusterLoadBalancer
@@ -45,6 +47,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.nio.file.Paths
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 /**
@@ -61,15 +64,65 @@ class ScriptLoadBalancerSpec extends Specification {
 
     @Shared
     def clustersGood = Sets.newHashSet(
-            new Cluster.Builder("a", "b", "c", ClusterStatus.UP).withId("2").build(),
-            new Cluster.Builder("d", "e", "f", ClusterStatus.UP).withId("0").build(),
-            new Cluster.Builder("g", "h", "i", ClusterStatus.UP).withId("1").build()
+            new Cluster(
+                    "2",
+                    Instant.now(),
+                    Instant.now(),
+                    new ExecutionEnvironment(null, null, null),
+                    new ClusterMetadata.Builder(
+                            "a",
+                            "b",
+                            ClusterStatus.UP
+                    ).withVersion("c").build()
+            ),
+            new Cluster(
+                    "0",
+                    Instant.now(),
+                    Instant.now(),
+                    new ExecutionEnvironment(null, null, null),
+                    new ClusterMetadata.Builder(
+                            "d",
+                            "e",
+                            ClusterStatus.UP
+                    ).withVersion("f").build()
+            ),
+            new Cluster(
+                    "1",
+                    Instant.now(),
+                    Instant.now(),
+                    new ExecutionEnvironment(null, null, null),
+                    new ClusterMetadata.Builder(
+                            "g",
+                            "h",
+                            ClusterStatus.UP
+                    ).withVersion("i").build()
+            )
     )
 
     @Shared
     def clustersBad = Sets.newHashSet(
-            new Cluster.Builder("j", "k", "l", ClusterStatus.UP).withId("3").build(),
-            new Cluster.Builder("m", "n", "o", ClusterStatus.UP).withId("4").build()
+            new Cluster(
+                    "3",
+                    Instant.now(),
+                    Instant.now(),
+                    new ExecutionEnvironment(null, null, null),
+                    new ClusterMetadata.Builder(
+                            "j",
+                            "k",
+                            ClusterStatus.UP
+                    ).withVersion("l").build()
+            ),
+            new Cluster(
+                    "4",
+                    Instant.now(),
+                    Instant.now(),
+                    new ExecutionEnvironment(null, null, null),
+                    new ClusterMetadata.Builder(
+                            "m",
+                            "n",
+                            ClusterStatus.UP
+                    ).withVersion("o").build()
+            )
     )
 
     @Shared
@@ -230,7 +283,7 @@ class ScriptLoadBalancerSpec extends Specification {
 
         then: "Can successfully find a cluster"
         cluster != null
-        cluster.getId().get() == "1"
+        cluster.getId() == "1"
         1 * registry.timer(
                 ScriptLoadBalancer.SELECT_TIMER_NAME,
                 ImmutableSet.of(Tag.of(MetricsConstants.TagKeys.STATUS, ScriptLoadBalancer.STATUS_TAG_FOUND))

--- a/genie-web/src/test/java/com/netflix/genie/web/jobs/JobKillReasonFileTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jobs/JobKillReasonFileTest.java
@@ -27,11 +27,11 @@ public class JobKillReasonFileTest {
     @Test
     public void serializeThenLoad() throws IOException {
 
-        final JobKillReasonFile orignalJobKillReasonFile = new JobKillReasonFile(KILL_REASON_STRING);
+        final JobKillReasonFile originalJobKillReasonFile = new JobKillReasonFile(KILL_REASON_STRING);
 
-        Assert.assertEquals(KILL_REASON_STRING, orignalJobKillReasonFile.getKillReason());
+        Assert.assertEquals(KILL_REASON_STRING, originalJobKillReasonFile.getKillReason());
 
-        final byte[] bytes = GenieObjectMapper.getMapper().writeValueAsBytes(orignalJobKillReasonFile);
+        final byte[] bytes = GenieObjectMapper.getMapper().writeValueAsBytes(originalJobKillReasonFile);
 
         final JobKillReasonFile loadedJobKillReasonFile
             = GenieObjectMapper.getMapper().readValue(bytes, JobKillReasonFile.class);

--- a/genie-web/src/test/java/com/netflix/genie/web/jobs/JobLauncherUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jobs/JobLauncherUnitTests.java
@@ -18,10 +18,10 @@
 package com.netflix.genie.web.jobs;
 
 import com.google.common.collect.Lists;
-import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.test.categories.UnitTest;

--- a/genie-web/src/test/java/com/netflix/genie/web/jobs/workflow/impl/InitialSetupTaskUnitTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jobs/workflow/impl/InitialSetupTaskUnitTest.java
@@ -26,6 +26,7 @@ import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.dto.v4.CommandMetadata;
 import com.netflix.genie.common.jobs.JobConstants;
 import com.netflix.genie.test.categories.UnitTest;
+import com.netflix.genie.web.controllers.DtoConverters;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.junit.Assert;
@@ -168,14 +169,14 @@ public class InitialSetupTaskUnitTest {
             );
 
         final StringWriter mockWriter = new StringWriter();
-        this.initialSetupTask.createJobDirEnvironmentVariables(mockWriter, tempDir.getRoot().getAbsolutePath());
+        this.initialSetupTask.createJobDirEnvironmentVariables(mockWriter, this.tempDir.getRoot().getAbsolutePath());
         this.initialSetupTask.createApplicationEnvironmentVariables(mockWriter);
         this.initialSetupTask.createCommandEnvironmentVariables(mockWriter, mockCommand);
         this.initialSetupTask.createClusterEnvironmentVariables(mockWriter, mockCluster);
         this.initialSetupTask.createJobEnvironmentVariables(mockWriter, jobId, jobName, memory);
         this.initialSetupTask.createJobRequestEnvironmentVariables(mockWriter, mockJobRequest);
 
-        final String expextedOutput = ""
+        final String expectedOutput = ""
             + "export GENIE_JOB_DIR=\"" + tempDir.getRoot().getAbsolutePath() + "\"\n"
             + "\n"
             + "export GENIE_APPLICATION_DIR=\"${GENIE_JOB_DIR}/genie/applications\"\n"
@@ -186,7 +187,8 @@ public class InitialSetupTaskUnitTest {
             + "\n"
             + "export GENIE_COMMAND_NAME=\"" + commandName + "\"\n"
             + "\n"
-            + "export GENIE_COMMAND_TAGS=\"" + commandTag1 + "," + commandTag2 + "\"\n"
+            + "export GENIE_COMMAND_TAGS=\"" + commandTag1 + "," + commandTag2 + "," + DtoConverters.GENIE_ID_PREFIX
+            + commandId + "," + DtoConverters.GENIE_NAME_PREFIX + commandName + "\"\n"
             + "\n"
             + "export GENIE_CLUSTER_DIR=\"${GENIE_JOB_DIR}/genie/cluster/" + clusterId + "\"\n"
             + "\n"
@@ -194,7 +196,8 @@ public class InitialSetupTaskUnitTest {
             + "\n"
             + "export GENIE_CLUSTER_NAME=\"" + clusterName + "\"\n"
             + "\n"
-            + "export GENIE_CLUSTER_TAGS=\"" + clusterTag2 + "," + clusterTag1 + "\"\n"
+            + "export GENIE_CLUSTER_TAGS=\"" + clusterTag2 + "," + clusterTag1 + "," + DtoConverters.GENIE_ID_PREFIX
+            + clusterId + "," + DtoConverters.GENIE_NAME_PREFIX + clusterName + "\"\n"
             + "\n"
             + "export GENIE_JOB_ID=\"" + jobId + "\"\n"
             + "\n"
@@ -214,7 +217,7 @@ public class InitialSetupTaskUnitTest {
             + "export GENIE_REQUESTED_CLUSTER_TAGS_2=\"" + cltCritTag3 + "\"\n"
             + "\n";
 
-        Assert.assertEquals(expextedOutput, mockWriter.getString());
+        Assert.assertEquals(expectedOutput, mockWriter.getString());
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/jobs/workflow/impl/InitialSetupTaskUnitTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jobs/workflow/impl/InitialSetupTaskUnitTest.java
@@ -18,12 +18,14 @@
 package com.netflix.genie.web.jobs.workflow.impl;
 
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.ClusterCriteria;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.JobRequest;
-import com.netflix.genie.test.categories.UnitTest;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.ClusterMetadata;
+import com.netflix.genie.common.dto.v4.Command;
+import com.netflix.genie.common.dto.v4.CommandMetadata;
 import com.netflix.genie.common.jobs.JobConstants;
+import com.netflix.genie.test.categories.UnitTest;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.junit.Assert;
@@ -134,15 +136,20 @@ public class InitialSetupTaskUnitTest {
         final String cltCritTag3 = "foo";
 
         final Cluster mockCluster = Mockito.mock(Cluster.class);
-        Mockito.when(mockCluster.getId()).thenReturn(java.util.Optional.of(clusterId));
+        Mockito.when(mockCluster.getId()).thenReturn(clusterId);
 
-        Mockito.when(mockCluster.getName()).thenReturn(clusterName);
-        Mockito.when(mockCluster.getTags()).thenReturn(new HashSet<>(Arrays.asList(clusterTag1, clusterTag2)));
+        final ClusterMetadata clusterMetadata = Mockito.mock(ClusterMetadata.class);
+        Mockito.when(mockCluster.getMetadata()).thenReturn(clusterMetadata);
+        Mockito.when(clusterMetadata.getName()).thenReturn(clusterName);
+        Mockito.when(clusterMetadata.getTags()).thenReturn(Sets.newHashSet(clusterTag1, clusterTag2));
 
         final Command mockCommand = Mockito.mock(Command.class);
-        Mockito.when(mockCommand.getId()).thenReturn(java.util.Optional.of(commandId));
-        Mockito.when(mockCommand.getId()).thenReturn(java.util.Optional.of(commandName));
-        Mockito.when(mockCommand.getTags()).thenReturn(new HashSet<>(Arrays.asList(commandTag2, commandTag1)));
+        Mockito.when(mockCommand.getId()).thenReturn(commandId);
+
+        final CommandMetadata commandMetadata = Mockito.mock(CommandMetadata.class);
+        Mockito.when(mockCommand.getMetadata()).thenReturn(commandMetadata);
+        Mockito.when(commandMetadata.getName()).thenReturn(commandName);
+        Mockito.when(commandMetadata.getTags()).thenReturn(Sets.newHashSet(commandTag2, commandTag1));
 
         final JobRequest mockJobRequest = Mockito.mock(JobRequest.class);
         Mockito
@@ -173,11 +180,11 @@ public class InitialSetupTaskUnitTest {
             + "\n"
             + "export GENIE_APPLICATION_DIR=\"${GENIE_JOB_DIR}/genie/applications\"\n"
             + "\n"
-            + "export GENIE_COMMAND_DIR=\"${GENIE_JOB_DIR}/genie/command/" + commandName + "\"\n"
+            + "export GENIE_COMMAND_DIR=\"${GENIE_JOB_DIR}/genie/command/" + commandId + "\"\n"
             + "\n"
-            + "export GENIE_COMMAND_ID=\"" + commandName + "\"\n"
+            + "export GENIE_COMMAND_ID=\"" + commandId + "\"\n"
             + "\n"
-            + "export GENIE_COMMAND_NAME=\"null\"\n"
+            + "export GENIE_COMMAND_NAME=\"" + commandName + "\"\n"
             + "\n"
             + "export GENIE_COMMAND_TAGS=\"" + commandTag1 + "," + commandTag2 + "\"\n"
             + "\n"

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/ApplicationEntityUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/ApplicationEntityUnitTests.java
@@ -64,7 +64,7 @@ public class ApplicationEntityUnitTests extends EntityTestsBase {
         Assert.assertNull(entity.getStatus());
         Assert.assertNull(entity.getName());
         Assert.assertNull(entity.getUser());
-        Assert.assertNull(entity.getVersion());
+        Assert.assertFalse(entity.getVersion().isPresent());
         Assert.assertNotNull(entity.getDependencies());
         Assert.assertTrue(entity.getDependencies().isEmpty());
         Assert.assertNotNull(entity.getConfigs());
@@ -82,7 +82,6 @@ public class ApplicationEntityUnitTests extends EntityTestsBase {
     public void testValidate() {
         this.a.setName(NAME);
         this.a.setUser(USER);
-        this.a.setVersion(VERSION);
         this.a.setStatus(ApplicationStatus.ACTIVE);
         this.validate(this.a);
     }
@@ -102,15 +101,6 @@ public class ApplicationEntityUnitTests extends EntityTestsBase {
     @Test(expected = ConstraintViolationException.class)
     public void testValidateNoUser() {
         this.a.setUser("");
-        this.validate(this.a);
-    }
-
-    /**
-     * Make sure validation works on with failure from super class.
-     */
-    @Test(expected = ConstraintViolationException.class)
-    public void testValidateNoVersion() {
-        this.a.setVersion(" ");
         this.validate(this.a);
     }
 

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/BaseEntityUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/BaseEntityUnitTests.java
@@ -63,7 +63,7 @@ public class BaseEntityUnitTests extends EntityTestsBase {
         Assert.assertNotNull(local.getUniqueId());
         Assert.assertNull(local.getName());
         Assert.assertNull(local.getUser());
-        Assert.assertNull(local.getVersion());
+        Assert.assertFalse(local.getVersion().isPresent());
         Assert.assertFalse(local.getDescription().isPresent());
         Assert.assertFalse(local.getSetupFile().isPresent());
     }
@@ -105,7 +105,7 @@ public class BaseEntityUnitTests extends EntityTestsBase {
     /**
      * Test to make sure validation works and throws exception when no name entered.
      */
-    @Test(expected = ConstraintViolationException.class)
+    @Test
     public void testValidateNoVersion() {
         this.b.setVersion("");
         this.validate(this.b);
@@ -151,9 +151,9 @@ public class BaseEntityUnitTests extends EntityTestsBase {
     @Test
     public void testSetVersion() {
         final BaseEntity local = new BaseEntity();
-        Assert.assertNull(local.getVersion());
+        Assert.assertFalse(local.getVersion().isPresent());
         local.setVersion(VERSION);
-        Assert.assertEquals(VERSION, local.getVersion());
+        Assert.assertThat(local.getVersion().orElse(UUID.randomUUID().toString()), Matchers.is(VERSION));
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/ClusterEntityUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/ClusterEntityUnitTests.java
@@ -74,7 +74,7 @@ public class ClusterEntityUnitTests extends EntityTestsBase {
         Assert.assertNull(entity.getName());
         Assert.assertNull(entity.getStatus());
         Assert.assertNull(entity.getUser());
-        Assert.assertNull(entity.getVersion());
+        Assert.assertFalse(entity.getVersion().isPresent());
         Assert.assertNotNull(entity.getConfigs());
         Assert.assertTrue(entity.getConfigs().isEmpty());
         Assert.assertNotNull(entity.getDependencies());
@@ -108,15 +108,6 @@ public class ClusterEntityUnitTests extends EntityTestsBase {
     @Test(expected = ConstraintViolationException.class)
     public void testValidateNoUser() {
         this.c.setUser(" ");
-        this.validate(this.c);
-    }
-
-    /**
-     * Make sure validation works on with failure from super class.
-     */
-    @Test(expected = ConstraintViolationException.class)
-    public void testValidateNoVersion() {
-        this.c.setVersion("");
         this.validate(this.c);
     }
 

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/CommandEntityUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/CommandEntityUnitTests.java
@@ -80,7 +80,7 @@ public class CommandEntityUnitTests extends EntityTestsBase {
         Assert.assertNull(entity.getName());
         Assert.assertNull(entity.getStatus());
         Assert.assertNull(entity.getUser());
-        Assert.assertNull(entity.getVersion());
+        Assert.assertFalse(entity.getVersion().isPresent());
         Assert.assertNotNull(entity.getConfigs());
         Assert.assertTrue(entity.getConfigs().isEmpty());
         Assert.assertNotNull(entity.getDependencies());
@@ -123,7 +123,7 @@ public class CommandEntityUnitTests extends EntityTestsBase {
     /**
      * Make sure validation works on with failure from super class.
      */
-    @Test(expected = ConstraintViolationException.class)
+    @Test
     public void testValidateNoVersion() {
         this.c.setVersion("");
         this.validate(this.c);

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/JobEntityUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/JobEntityUnitTests.java
@@ -68,7 +68,6 @@ public class JobEntityUnitTests extends EntityTestsBase {
     public void testDefaultConstructor() {
         final JobEntity localJobEntity = new JobEntity();
         Assert.assertNotNull(localJobEntity.getUniqueId());
-        Assert.assertEquals(JobEntity.DEFAULT_VERSION, localJobEntity.getVersion());
     }
 
     /**
@@ -79,7 +78,7 @@ public class JobEntityUnitTests extends EntityTestsBase {
         Assert.assertNotNull(this.jobEntity.getUniqueId());
         Assert.assertEquals(NAME, this.jobEntity.getName());
         Assert.assertEquals(USER, this.jobEntity.getUser());
-        Assert.assertEquals(VERSION, this.jobEntity.getVersion());
+        Assert.assertThat(this.jobEntity.getVersion().orElse(UUID.randomUUID().toString()), Matchers.is(VERSION));
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaApplicationServiceImplIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaApplicationServiceImplIntegrationTests.java
@@ -21,9 +21,11 @@ import com.github.fge.jsonpatch.JsonPatch;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Application;
 import com.netflix.genie.common.dto.ApplicationStatus;
-import com.netflix.genie.common.dto.Command;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.ApplicationMetadata;
+import com.netflix.genie.common.dto.v4.ApplicationRequest;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.common.util.GenieObjectMapper;
@@ -97,37 +99,37 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testGetApplication() throws GenieException {
         final Application app = this.appService.getApplication(APP_1_ID);
-        Assert.assertEquals(APP_1_ID, app.getId().orElseGet(RandomSuppliers.STRING));
-        Assert.assertEquals(APP_1_NAME, app.getName());
-        Assert.assertEquals(APP_1_USER, app.getUser());
-        Assert.assertEquals(APP_1_VERSION, app.getVersion());
-        Assert.assertEquals(APP_1_STATUS, app.getStatus());
-        Assert.assertFalse(app.getType().isPresent());
-        Assert.assertEquals(3, app.getTags().size());
-        Assert.assertEquals(2, app.getConfigs().size());
-        Assert.assertEquals(2, app.getDependencies().size());
+        Assert.assertEquals(APP_1_ID, app.getId());
+        Assert.assertEquals(APP_1_NAME, app.getMetadata().getName());
+        Assert.assertEquals(APP_1_USER, app.getMetadata().getUser());
+        Assert.assertEquals(APP_1_VERSION, app.getMetadata().getVersion().orElseGet(RandomSuppliers.STRING));
+        Assert.assertEquals(APP_1_STATUS, app.getMetadata().getStatus());
+        Assert.assertFalse(app.getMetadata().getType().isPresent());
+        Assert.assertEquals(1, app.getMetadata().getTags().size());
+        Assert.assertEquals(2, app.getResources().getConfigs().size());
+        Assert.assertEquals(2, app.getResources().getDependencies().size());
 
         final Application app2 = this.appService.getApplication(APP_2_ID);
-        Assert.assertEquals(APP_2_ID, app2.getId().orElseGet(RandomSuppliers.STRING));
-        Assert.assertEquals(APP_2_NAME, app2.getName());
-        Assert.assertEquals(APP_2_USER, app2.getUser());
-        Assert.assertEquals(APP_2_VERSION, app2.getVersion());
-        Assert.assertEquals(APP_2_STATUS, app2.getStatus());
-        Assert.assertThat(app2.getType().orElseGet(RandomSuppliers.STRING), Matchers.is(APP_2_TYPE));
-        Assert.assertEquals(4, app2.getTags().size());
-        Assert.assertEquals(2, app2.getConfigs().size());
-        Assert.assertEquals(1, app2.getDependencies().size());
+        Assert.assertEquals(APP_2_ID, app2.getId());
+        Assert.assertEquals(APP_2_NAME, app2.getMetadata().getName());
+        Assert.assertEquals(APP_2_USER, app2.getMetadata().getUser());
+        Assert.assertEquals(APP_2_VERSION, app2.getMetadata().getVersion().orElseGet(RandomSuppliers.STRING));
+        Assert.assertEquals(APP_2_STATUS, app2.getMetadata().getStatus());
+        Assert.assertThat(app2.getMetadata().getType().orElseGet(RandomSuppliers.STRING), Matchers.is(APP_2_TYPE));
+        Assert.assertEquals(2, app2.getMetadata().getTags().size());
+        Assert.assertEquals(2, app2.getResources().getConfigs().size());
+        Assert.assertEquals(1, app2.getResources().getDependencies().size());
 
         final Application app3 = this.appService.getApplication(APP_3_ID);
-        Assert.assertEquals(APP_3_ID, app3.getId().orElseGet(RandomSuppliers.STRING));
-        Assert.assertEquals(APP_3_NAME, app3.getName());
-        Assert.assertEquals(APP_3_USER, app3.getUser());
-        Assert.assertEquals(APP_3_VERSION, app3.getVersion());
-        Assert.assertEquals(APP_3_STATUS, app3.getStatus());
-        Assert.assertThat(app3.getType().orElseGet(RandomSuppliers.STRING), Matchers.is(APP_3_TYPE));
-        Assert.assertEquals(3, app3.getTags().size());
-        Assert.assertEquals(1, app3.getConfigs().size());
-        Assert.assertEquals(2, app3.getDependencies().size());
+        Assert.assertEquals(APP_3_ID, app3.getId());
+        Assert.assertEquals(APP_3_NAME, app3.getMetadata().getName());
+        Assert.assertEquals(APP_3_USER, app3.getMetadata().getUser());
+        Assert.assertEquals(APP_3_VERSION, app3.getMetadata().getVersion().orElseGet(RandomSuppliers.STRING));
+        Assert.assertEquals(APP_3_STATUS, app3.getMetadata().getStatus());
+        Assert.assertThat(app3.getMetadata().getType().orElseGet(RandomSuppliers.STRING), Matchers.is(APP_3_TYPE));
+        Assert.assertEquals(1, app3.getMetadata().getTags().size());
+        Assert.assertEquals(1, app3.getResources().getConfigs().size());
+        Assert.assertEquals(2, app3.getResources().getDependencies().size());
     }
 
     /**
@@ -147,10 +149,7 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     public void testGetApplicationsByName() {
         final Page<Application> apps = this.appService.getApplications(APP_2_NAME, null, null, null, null, PAGEABLE);
         Assert.assertEquals(1, apps.getNumberOfElements());
-        Assert.assertThat(
-            apps.getContent().get(0).getId().orElseGet(RandomSuppliers.STRING),
-            Matchers.is(APP_2_ID)
-        );
+        Assert.assertThat(apps.getContent().get(0).getId(), Matchers.is(APP_2_ID));
     }
 
     /**
@@ -160,8 +159,8 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     public void testGetApplicationsByUser() {
         final Page<Application> apps = this.appService.getApplications(null, APP_1_USER, null, null, null, PAGEABLE);
         Assert.assertEquals(2, apps.getNumberOfElements());
-        Assert.assertEquals(APP_3_ID, apps.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(APP_1_ID, apps.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new));
+        Assert.assertEquals(APP_3_ID, apps.getContent().get(0).getId());
+        Assert.assertEquals(APP_1_ID, apps.getContent().get(1).getId());
     }
 
     /**
@@ -172,8 +171,8 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
         final Set<ApplicationStatus> statuses = Sets.newHashSet(ApplicationStatus.ACTIVE, ApplicationStatus.INACTIVE);
         final Page<Application> apps = this.appService.getApplications(null, null, statuses, null, null, PAGEABLE);
         Assert.assertEquals(2, apps.getNumberOfElements());
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(APP_1_ID, apps.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new));
+        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId());
+        Assert.assertEquals(APP_1_ID, apps.getContent().get(1).getId());
     }
 
     /**
@@ -184,20 +183,14 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
         final Set<String> tags = Sets.newHashSet("prod");
         Page<Application> apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
         Assert.assertEquals(3, apps.getNumberOfElements());
-        Assert.assertEquals(APP_3_ID, apps.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(APP_1_ID, apps.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new));
+        Assert.assertEquals(APP_3_ID, apps.getContent().get(0).getId());
+        Assert.assertEquals(APP_2_ID, apps.getContent().get(1).getId());
+        Assert.assertEquals(APP_1_ID, apps.getContent().get(2).getId());
 
         tags.add("yarn");
         apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
         Assert.assertEquals(1, apps.getNumberOfElements());
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new));
-
-        tags.clear();
-        tags.add("genie.name:spark");
-        apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
-        Assert.assertEquals(1, apps.getNumberOfElements());
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new));
+        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId());
 
         tags.add("somethingThatWouldNeverReallyExist");
         apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
@@ -206,9 +199,9 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
         tags.clear();
         apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
         Assert.assertEquals(3, apps.getNumberOfElements());
-        Assert.assertEquals(APP_3_ID, apps.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(APP_1_ID, apps.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new));
+        Assert.assertEquals(APP_3_ID, apps.getContent().get(0).getId());
+        Assert.assertEquals(APP_2_ID, apps.getContent().get(1).getId());
+        Assert.assertEquals(APP_1_ID, apps.getContent().get(2).getId());
     }
 
     /**
@@ -228,7 +221,7 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     public void testGetApplicationsByType() {
         final Page<Application> apps = this.appService.getApplications(null, null, null, null, APP_2_TYPE, PAGEABLE);
         Assert.assertEquals(1, apps.getNumberOfElements());
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new));
+        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId());
     }
 
     /**
@@ -239,36 +232,24 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
         //Default to order by Updated
         final Page<Application> applications = this.appService.getApplications(null, null, null, null, null, PAGEABLE);
         Assert.assertEquals(3, applications.getNumberOfElements());
-        Assert.assertEquals(
-            APP_3_ID, applications.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            APP_2_ID, applications.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            APP_1_ID, applications.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(APP_3_ID, applications.getContent().get(0).getId());
+        Assert.assertEquals(APP_2_ID, applications.getContent().get(1).getId());
+        Assert.assertEquals(APP_1_ID, applications.getContent().get(2).getId());
     }
 
     /**
      * Test the get applications method with ascending sort.
      */
     @Test
-    public void testGetApplicationssAscending() {
+    public void testGetApplicationsAscending() {
         //Default to order by Updated
         final Pageable ascendingPage = PageRequest.of(0, 10, Sort.Direction.ASC, "updated");
         final Page<Application> applications
             = this.appService.getApplications(null, null, null, null, null, ascendingPage);
         Assert.assertEquals(3, applications.getNumberOfElements());
-        Assert.assertEquals(
-            APP_1_ID, applications.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            APP_2_ID, applications.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            APP_3_ID, applications.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(APP_1_ID, applications.getContent().get(0).getId());
+        Assert.assertEquals(APP_2_ID, applications.getContent().get(1).getId());
+        Assert.assertEquals(APP_3_ID, applications.getContent().get(2).getId());
     }
 
     /**
@@ -279,15 +260,9 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
         //Default to order by Updated
         final Page<Application> applications = this.appService.getApplications(null, null, null, null, null, PAGEABLE);
         Assert.assertEquals(3, applications.getNumberOfElements());
-        Assert.assertEquals(
-            APP_3_ID, applications.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            APP_2_ID, applications.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            APP_1_ID, applications.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(APP_3_ID, applications.getContent().get(0).getId());
+        Assert.assertEquals(APP_2_ID, applications.getContent().get(1).getId());
+        Assert.assertEquals(APP_1_ID, applications.getContent().get(2).getId());
     }
 
     /**
@@ -299,15 +274,9 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
         final Page<Application> applications
             = this.appService.getApplications(null, null, null, null, null, orderByNamePage);
         Assert.assertEquals(3, applications.getNumberOfElements());
-        Assert.assertEquals(
-            APP_1_ID, applications.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            APP_3_ID, applications.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            APP_2_ID, applications.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(APP_1_ID, applications.getContent().get(0).getId());
+        Assert.assertEquals(APP_3_ID, applications.getContent().get(1).getId());
+        Assert.assertEquals(APP_2_ID, applications.getContent().get(2).getId());
     }
 
     /**
@@ -327,18 +296,25 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testCreateApplication() throws GenieException {
         final String id = UUID.randomUUID().toString();
-        final Application app = new Application
-            .Builder(APP_1_NAME, APP_1_USER, APP_1_VERSION, ApplicationStatus.ACTIVE)
-            .withId(id)
+        final ApplicationRequest app = new ApplicationRequest.Builder(
+            new ApplicationMetadata.Builder(
+                APP_1_NAME,
+                APP_1_USER,
+                ApplicationStatus.ACTIVE
+            )
+                .withVersion(APP_1_VERSION)
+                .build()
+        )
+            .withRequestedId(id)
             .build();
         final String createdId = this.appService.createApplication(app);
         Assert.assertThat(createdId, Matchers.is(id));
         final Application created = this.appService.getApplication(id);
         Assert.assertNotNull(created);
-        Assert.assertEquals(id, created.getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(APP_1_NAME, created.getName());
-        Assert.assertEquals(APP_1_USER, created.getUser());
-        Assert.assertEquals(ApplicationStatus.ACTIVE, created.getStatus());
+        Assert.assertEquals(id, created.getId());
+        Assert.assertEquals(APP_1_NAME, created.getMetadata().getName());
+        Assert.assertEquals(APP_1_USER, created.getMetadata().getUser());
+        Assert.assertEquals(ApplicationStatus.ACTIVE, created.getMetadata().getStatus());
         this.appService.deleteApplication(id);
         try {
             this.appService.getApplication(id);
@@ -358,18 +334,25 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
      */
     @Test
     public void testCreateApplicationNoId() throws GenieException {
-        final Application app = new Application
-            .Builder(APP_1_NAME, APP_1_USER, APP_1_VERSION, ApplicationStatus.ACTIVE)
+        final ApplicationRequest app = new ApplicationRequest.Builder(
+            new ApplicationMetadata.Builder(
+                APP_1_NAME,
+                APP_1_USER,
+                ApplicationStatus.ACTIVE
+            )
+                .withVersion(APP_1_VERSION)
+                .build()
+        )
             .build();
         final String id = this.appService.createApplication(app);
         final Application created = this.appService.getApplication(id);
         Assert.assertNotNull(created);
-        Assert.assertEquals(APP_1_NAME, created.getName());
-        Assert.assertEquals(APP_1_USER, created.getUser());
-        Assert.assertEquals(ApplicationStatus.ACTIVE, created.getStatus());
-        this.appService.deleteApplication(created.getId().orElseThrow(IllegalArgumentException::new));
+        Assert.assertEquals(APP_1_NAME, created.getMetadata().getName());
+        Assert.assertEquals(APP_1_USER, created.getMetadata().getUser());
+        Assert.assertEquals(ApplicationStatus.ACTIVE, created.getMetadata().getStatus());
+        this.appService.deleteApplication(created.getId());
         try {
-            this.appService.getApplication(created.getId().orElseThrow(IllegalArgumentException::new));
+            this.appService.getApplication(created.getId());
             Assert.fail();
         } catch (final GenieException ge) {
             Assert.assertEquals(
@@ -387,31 +370,37 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testUpdateApplication() throws GenieException {
         final Application getApp = this.appService.getApplication(APP_1_ID);
-        Assert.assertEquals(APP_1_USER, getApp.getUser());
-        Assert.assertEquals(ApplicationStatus.INACTIVE, getApp.getStatus());
-        Assert.assertEquals(3, getApp.getTags().size());
-        final Instant updateTime = getApp.getUpdated().orElseThrow(IllegalArgumentException::new);
+        Assert.assertEquals(APP_1_USER, getApp.getMetadata().getUser());
+        Assert.assertEquals(ApplicationStatus.INACTIVE, getApp.getMetadata().getStatus());
+        Assert.assertEquals(1, getApp.getMetadata().getTags().size());
+        final Instant updateTime = getApp.getUpdated();
 
         final Set<String> tags = Sets.newHashSet("prod", "tez", "yarn", "hadoop");
-        tags.addAll(getApp.getTags());
-        final Application.Builder updateApp = new Application
-            .Builder(getApp.getName(), APP_2_USER, getApp.getVersion(), ApplicationStatus.ACTIVE)
-            .withId(getApp.getId().orElseThrow(IllegalArgumentException::new))
-            .withCreated(getApp.getCreated().orElseThrow(IllegalArgumentException::new))
-            .withUpdated(getApp.getUpdated().orElseThrow(IllegalArgumentException::new))
-            .withTags(tags)
-            .withConfigs(getApp.getConfigs())
-            .withDependencies(getApp.getDependencies());
+        tags.addAll(getApp.getMetadata().getTags());
+        final Application updateApp = new Application(
+            getApp.getId(),
+            getApp.getCreated(),
+            getApp.getUpdated(),
+            getApp.getResources(),
+            new ApplicationMetadata.Builder(
+                getApp.getMetadata().getName(),
+                APP_2_USER,
+                ApplicationStatus.ACTIVE
+            )
+                .withVersion(getApp.getMetadata().getVersion().orElse(null))
+                .withDescription(getApp.getMetadata().getDescription().orElse(null))
+                .withType(getApp.getMetadata().getType().orElse(null))
+                .withTags(tags)
+                .build()
+        );
 
-        getApp.getDescription().ifPresent(updateApp::withDescription);
-        getApp.getSetupFile().ifPresent(updateApp::withSetupFile);
-        this.appService.updateApplication(APP_1_ID, updateApp.build());
+        this.appService.updateApplication(APP_1_ID, updateApp);
 
         final Application updated = this.appService.getApplication(APP_1_ID);
         Assert.assertNotEquals(updated.getUpdated(), Matchers.is(updateTime));
-        Assert.assertEquals(APP_2_USER, updated.getUser());
-        Assert.assertEquals(ApplicationStatus.ACTIVE, updated.getStatus());
-        Assert.assertEquals(6, updated.getTags().size());
+        Assert.assertEquals(APP_2_USER, updated.getMetadata().getUser());
+        Assert.assertEquals(ApplicationStatus.ACTIVE, updated.getMetadata().getStatus());
+        Assert.assertEquals(tags, updated.getMetadata().getTags());
     }
 
     /**
@@ -422,31 +411,15 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testUpdateCreateAndUpdate() throws GenieException {
         final Application init = this.appService.getApplication(APP_1_ID);
-        final Instant created = init.getCreated().orElseThrow(IllegalArgumentException::new);
-        final Instant updated = init.getUpdated().orElseThrow(IllegalArgumentException::new);
+        final Instant created = init.getCreated();
+        final Instant updated = init.getUpdated();
 
-        final Application.Builder updateApp = new Application.Builder(
-            init.getName(), init.getUser(), init.getVersion(), init.getStatus()
-        )
-            .withId(init.getId().orElseThrow(IllegalArgumentException::new))
-            .withCreated(Instant.now())
-            .withUpdated(Instant.EPOCH)
-            .withTags(init.getTags())
-            .withConfigs(init.getConfigs())
-            .withDependencies(init.getDependencies());
-
-        init.getDescription().ifPresent(updateApp::withDescription);
-        init.getSetupFile().ifPresent(updateApp::withSetupFile);
-
-        this.appService.updateApplication(APP_1_ID, updateApp.build());
+        this.appService.updateApplication(APP_1_ID, init);
 
         final Application updatedApp = this.appService.getApplication(APP_1_ID);
-        Assert.assertEquals(created, updatedApp.getCreated().orElseThrow(IllegalArgumentException::new));
+        Assert.assertEquals(created, updatedApp.getCreated());
         Assert.assertThat(updatedApp.getUpdated(), Matchers.not(updated));
         Assert.assertNotEquals(Instant.EPOCH, updatedApp.getUpdated());
-        Assert.assertEquals(init.getTags(), updatedApp.getTags());
-        Assert.assertEquals(init.getConfigs(), updatedApp.getConfigs());
-        Assert.assertEquals(init.getDependencies(), updatedApp.getDependencies());
     }
 
     /**
@@ -458,17 +431,18 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testPatchApplication() throws GenieException, IOException {
         final Application getApp = this.appService.getApplication(APP_1_ID);
-        Assert.assertEquals(APP_1_USER, getApp.getUser());
-        final Instant updateTime = getApp.getUpdated().orElseThrow(IllegalArgumentException::new);
+        Assert.assertEquals(APP_1_USER, getApp.getMetadata().getUser());
+        final Instant updateTime = getApp.getUpdated();
 
-        final String patchString = "[{ \"op\": \"replace\", \"path\": \"/user\", \"value\": \"" + APP_2_USER + "\" }]";
+        final String patchString
+            = "[{ \"op\": \"replace\", \"path\": \"/metadata/user\", \"value\": \"" + APP_2_USER + "\" }]";
         final JsonPatch patch = JsonPatch.fromJson(GenieObjectMapper.getMapper().readTree(patchString));
 
         this.appService.patchApplication(APP_1_ID, patch);
 
         final Application updated = this.appService.getApplication(APP_1_ID);
         Assert.assertNotEquals(updated.getUpdated(), Matchers.is(updateTime));
-        Assert.assertEquals(APP_2_USER, updated.getUser());
+        Assert.assertEquals(APP_2_USER, updated.getMetadata().getUser());
     }
 
     /**
@@ -680,10 +654,10 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
 
         final Set<String> newTags = Sets.newHashSet(newTag1, newTag2, newTag3);
 
-        Assert.assertEquals(3, this.appService.getTagsForApplication(APP_1_ID).size());
+        Assert.assertEquals(1, this.appService.getTagsForApplication(APP_1_ID).size());
         this.appService.addTagsForApplication(APP_1_ID, newTags);
         final Set<String> finalTags = this.appService.getTagsForApplication(APP_1_ID);
-        Assert.assertEquals(6, finalTags.size());
+        Assert.assertEquals(4, finalTags.size());
         Assert.assertTrue(finalTags.contains(newTag1));
         Assert.assertTrue(finalTags.contains(newTag2));
         Assert.assertTrue(finalTags.contains(newTag3));
@@ -702,10 +676,10 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
 
         final Set<String> newTags = Sets.newHashSet(newTag1, newTag2, newTag3);
 
-        Assert.assertEquals(3, this.appService.getTagsForApplication(APP_1_ID).size());
+        Assert.assertEquals(1, this.appService.getTagsForApplication(APP_1_ID).size());
         this.appService.updateTagsForApplication(APP_1_ID, newTags);
         final Set<String> finalTags = this.appService.getTagsForApplication(APP_1_ID);
-        Assert.assertEquals(5, finalTags.size());
+        Assert.assertEquals(3, finalTags.size());
         Assert.assertTrue(finalTags.contains(newTag1));
         Assert.assertTrue(finalTags.contains(newTag2));
         Assert.assertTrue(finalTags.contains(newTag3));
@@ -718,8 +692,7 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
      */
     @Test
     public void testGetTagsForApplication() throws GenieException {
-        Assert.assertEquals(3,
-            this.appService.getTagsForApplication(APP_1_ID).size());
+        Assert.assertEquals(1, this.appService.getTagsForApplication(APP_1_ID).size());
     }
 
     /**
@@ -729,9 +702,9 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
      */
     @Test
     public void testRemoveAllTagsForApplication() throws GenieException {
-        Assert.assertEquals(3, this.appService.getTagsForApplication(APP_1_ID).size());
+        Assert.assertEquals(1, this.appService.getTagsForApplication(APP_1_ID).size());
         this.appService.removeAllTagsForApplication(APP_1_ID);
-        Assert.assertEquals(2, this.appService.getTagsForApplication(APP_1_ID).size());
+        Assert.assertEquals(0, this.appService.getTagsForApplication(APP_1_ID).size());
     }
 
     /**
@@ -742,7 +715,7 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testRemoveTagForApplication() throws GenieException {
         final Set<String> tags = this.appService.getTagsForApplication(APP_1_ID);
-        Assert.assertEquals(3, tags.size());
+        Assert.assertEquals(1, tags.size());
         this.appService.removeTagForApplication(APP_1_ID, "prod");
         Assert.assertFalse(this.appService.getTagsForApplication(APP_1_ID).contains("prod"));
     }
@@ -756,9 +729,7 @@ public class JpaApplicationServiceImplIntegrationTests extends DBUnitTestBase {
     public void testGetCommandsForApplication() throws GenieException {
         final Set<Command> commands = this.appService.getCommandsForApplication(APP_1_ID, null);
         Assert.assertEquals(1, commands.size());
-        Assert.assertEquals(
-            COMMAND_1_ID, commands.iterator().next().getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_1_ID, commands.iterator().next().getId());
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaApplicationServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaApplicationServiceImplUnitTests.java
@@ -32,7 +32,6 @@ import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.web.jpa.entities.ApplicationEntity;
 import com.netflix.genie.web.jpa.entities.CommandEntity;
-import com.netflix.genie.web.jpa.entities.TagEntity;
 import com.netflix.genie.web.jpa.repositories.JpaApplicationRepository;
 import com.netflix.genie.web.jpa.repositories.JpaCommandRepository;
 import com.netflix.genie.web.jpa.repositories.JpaFileRepository;
@@ -64,7 +63,6 @@ public class JpaApplicationServiceImplUnitTests {
 
     private JpaApplicationRepository jpaApplicationRepository;
     private JpaApplicationServiceImpl appService;
-    private JpaTagRepository jpaTagRepository;
 
     /**
      * Setup the tests.
@@ -72,10 +70,9 @@ public class JpaApplicationServiceImplUnitTests {
     @Before
     public void setup() {
         this.jpaApplicationRepository = Mockito.mock(JpaApplicationRepository.class);
-        this.jpaTagRepository = Mockito.mock(JpaTagRepository.class);
         this.appService = new JpaApplicationServiceImpl(
             Mockito.mock(TagService.class),
-            this.jpaTagRepository,
+            Mockito.mock(JpaTagRepository.class),
             Mockito.mock(FileService.class),
             Mockito.mock(JpaFileRepository.class),
             this.jpaApplicationRepository,
@@ -114,9 +111,6 @@ public class JpaApplicationServiceImplUnitTests {
             .withRequestedId(APP_1_ID)
             .build();
 
-        Mockito
-            .when(this.jpaTagRepository.findByTag(Mockito.anyString()))
-            .thenReturn(Optional.of(new TagEntity(UUID.randomUUID().toString())));
         Mockito
             .when(this.jpaApplicationRepository.save(Mockito.any(ApplicationEntity.class)))
             .thenThrow(new DuplicateKeyException("Duplicate Key"));

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaCommandServiceImplIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaCommandServiceImplIntegrationTests.java
@@ -549,11 +549,13 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
             }
         }
         Assert.assertTrue(found);
-        Set<Command> appCommands = this.appService.getCommandsForApplication(APP_1_ID, null);
+        // TODO: Fix once Command service goes to V4
+        Set<com.netflix.genie.common.dto.v4.Command> appCommands
+            = this.appService.getCommandsForApplication(APP_1_ID, null);
         Assert.assertEquals(1, appCommands.size());
         found = false;
-        for (final Command command : appCommands) {
-            if (COMMAND_1_ID.equals(command.getId().orElseThrow(IllegalArgumentException::new))) {
+        for (final com.netflix.genie.common.dto.v4.Command command : appCommands) {
+            if (COMMAND_1_ID.equals(command.getId())) {
                 found = true;
                 break;
             }
@@ -754,17 +756,19 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
 
         final List<String> appIds = new ArrayList<>();
         appIds.add(APP_1_ID);
-        final Set<Command> preCommands = this.appService.getCommandsForApplication(APP_1_ID, null);
+        final Set<com.netflix.genie.common.dto.v4.Command> preCommands
+            = this.appService.getCommandsForApplication(APP_1_ID, null);
         Assert.assertEquals(1, preCommands.size());
         Assert.assertEquals(1, preCommands
             .stream()
-            .filter(command -> COMMAND_1_ID.equals(command.getId().orElseGet(RandomSuppliers.STRING)))
+            .filter(command -> COMMAND_1_ID.equals(command.getId()))
             .count()
         );
 
         this.service.addApplicationsForCommand(COMMAND_2_ID, appIds);
 
-        final Set<Command> savedCommands = this.appService.getCommandsForApplication(APP_1_ID, null);
+        final Set<com.netflix.genie.common.dto.v4.Command> savedCommands
+            = this.appService.getCommandsForApplication(APP_1_ID, null);
         Assert.assertEquals(2, savedCommands.size());
         Assert.assertThat(
             this.service.getApplicationsForCommand(COMMAND_2_ID)
@@ -785,17 +789,19 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         Assert.assertTrue(this.service.getApplicationsForCommand(COMMAND_2_ID).isEmpty());
 
         final List<String> appIds = Lists.newArrayList(APP_1_ID);
-        final Set<Command> preCommands = this.appService.getCommandsForApplication(APP_1_ID, null);
+        final Set<com.netflix.genie.common.dto.v4.Command> preCommands
+            = this.appService.getCommandsForApplication(APP_1_ID, null);
         Assert.assertEquals(1, preCommands.size());
         Assert.assertEquals(1, preCommands
             .stream()
-            .filter(command -> COMMAND_1_ID.equals(command.getId().orElseThrow(IllegalArgumentException::new)))
+            .filter(command -> COMMAND_1_ID.equals(command.getId()))
             .count()
         );
 
         this.service.setApplicationsForCommand(COMMAND_2_ID, appIds);
 
-        final Set<Command> savedCommands = this.appService.getCommandsForApplication(APP_1_ID, null);
+        final Set<com.netflix.genie.common.dto.v4.Command> savedCommands
+            = this.appService.getCommandsForApplication(APP_1_ID, null);
         Assert.assertEquals(2, savedCommands.size());
         Assert.assertEquals(
             1,

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaCommandServiceImplIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaCommandServiceImplIntegrationTests.java
@@ -22,13 +22,14 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.CommandStatus;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
+import com.netflix.genie.common.dto.v4.CommandMetadata;
+import com.netflix.genie.common.dto.v4.CommandRequest;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.util.GenieObjectMapper;
 import com.netflix.genie.test.categories.IntegrationTest;
-import com.netflix.genie.test.suppliers.RandomSuppliers;
 import com.netflix.genie.web.services.ApplicationService;
 import com.netflix.genie.web.services.ClusterService;
 import com.netflix.genie.web.services.CommandService;
@@ -68,7 +69,7 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     private static final String COMMAND_1_NAME = "pig_13_prod";
     private static final String COMMAND_1_USER = "tgianos";
     private static final String COMMAND_1_VERSION = "1.2.3";
-    private static final String COMMAND_1_EXECUTABLE = "pig";
+    private static final List<String> COMMAND_1_EXECUTABLE = Lists.newArrayList("pig");
     private static final long COMMAND_1_CHECK_DELAY = 18000L;
     private static final CommandStatus COMMAND_1_STATUS = CommandStatus.ACTIVE;
 
@@ -76,14 +77,14 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     private static final String COMMAND_2_NAME = "hive_11_prod";
     private static final String COMMAND_2_USER = "amsharma";
     private static final String COMMAND_2_VERSION = "4.5.6";
-    private static final String COMMAND_2_EXECUTABLE = "hive";
+    private static final List<String> COMMAND_2_EXECUTABLE = Lists.newArrayList("hive");
     private static final CommandStatus COMMAND_2_STATUS = CommandStatus.INACTIVE;
 
     private static final String COMMAND_3_ID = "command3";
     private static final String COMMAND_3_NAME = "pig_11_prod";
     private static final String COMMAND_3_USER = "tgianos";
     private static final String COMMAND_3_VERSION = "7.8.9";
-    private static final String COMMAND_3_EXECUTABLE = "pig";
+    private static final List<String> COMMAND_3_EXECUTABLE = Lists.newArrayList("pig");
     private static final CommandStatus COMMAND_3_STATUS = CommandStatus.DEPRECATED;
 
     private static final Pageable PAGE = PageRequest.of(0, 10, Sort.Direction.DESC, "updated");
@@ -105,37 +106,37 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testGetCommand() throws GenieException {
         final Command command1 = this.service.getCommand(COMMAND_1_ID);
-        Assert.assertEquals(COMMAND_1_ID, command1.getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(COMMAND_1_NAME, command1.getName());
-        Assert.assertEquals(COMMAND_1_USER, command1.getUser());
-        Assert.assertEquals(COMMAND_1_VERSION, command1.getVersion());
-        Assert.assertEquals(COMMAND_1_STATUS, command1.getStatus());
+        Assert.assertEquals(COMMAND_1_ID, command1.getId());
+        Assert.assertEquals(COMMAND_1_NAME, command1.getMetadata().getName());
+        Assert.assertEquals(COMMAND_1_USER, command1.getMetadata().getUser());
+        Assert.assertEquals(COMMAND_1_VERSION, command1.getMetadata().getVersion().orElse(null));
+        Assert.assertEquals(COMMAND_1_STATUS, command1.getMetadata().getStatus());
         Assert.assertEquals(COMMAND_1_EXECUTABLE, command1.getExecutable());
-        Assert.assertEquals(5, command1.getTags().size());
-        Assert.assertEquals(2, command1.getConfigs().size());
-        Assert.assertEquals(0, command1.getDependencies().size());
+        Assert.assertEquals(3, command1.getMetadata().getTags().size());
+        Assert.assertEquals(2, command1.getResources().getConfigs().size());
+        Assert.assertEquals(0, command1.getResources().getDependencies().size());
 
         final Command command2 = this.service.getCommand(COMMAND_2_ID);
-        Assert.assertEquals(COMMAND_2_ID, command2.getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(COMMAND_2_NAME, command2.getName());
-        Assert.assertEquals(COMMAND_2_USER, command2.getUser());
-        Assert.assertEquals(COMMAND_2_VERSION, command2.getVersion());
-        Assert.assertEquals(COMMAND_2_STATUS, command2.getStatus());
+        Assert.assertEquals(COMMAND_2_ID, command2.getId());
+        Assert.assertEquals(COMMAND_2_NAME, command2.getMetadata().getName());
+        Assert.assertEquals(COMMAND_2_USER, command2.getMetadata().getUser());
+        Assert.assertEquals(COMMAND_2_VERSION, command2.getMetadata().getVersion().orElse(null));
+        Assert.assertEquals(COMMAND_2_STATUS, command2.getMetadata().getStatus());
         Assert.assertEquals(COMMAND_2_EXECUTABLE, command2.getExecutable());
-        Assert.assertEquals(4, command2.getTags().size());
-        Assert.assertEquals(1, command2.getConfigs().size());
-        Assert.assertEquals(1, command2.getDependencies().size());
+        Assert.assertEquals(2, command2.getMetadata().getTags().size());
+        Assert.assertEquals(1, command2.getResources().getConfigs().size());
+        Assert.assertEquals(1, command2.getResources().getDependencies().size());
 
         final Command command3 = this.service.getCommand(COMMAND_3_ID);
-        Assert.assertEquals(COMMAND_3_ID, command3.getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(COMMAND_3_NAME, command3.getName());
-        Assert.assertEquals(COMMAND_3_USER, command3.getUser());
-        Assert.assertEquals(COMMAND_3_VERSION, command3.getVersion());
-        Assert.assertEquals(COMMAND_3_STATUS, command3.getStatus());
+        Assert.assertEquals(COMMAND_3_ID, command3.getId());
+        Assert.assertEquals(COMMAND_3_NAME, command3.getMetadata().getName());
+        Assert.assertEquals(COMMAND_3_USER, command3.getMetadata().getUser());
+        Assert.assertEquals(COMMAND_3_VERSION, command3.getMetadata().getVersion().orElse(null));
+        Assert.assertEquals(COMMAND_3_STATUS, command3.getMetadata().getStatus());
         Assert.assertEquals(COMMAND_3_EXECUTABLE, command3.getExecutable());
-        Assert.assertEquals(5, command3.getTags().size());
-        Assert.assertEquals(1, command3.getConfigs().size());
-        Assert.assertEquals(2, command3.getDependencies().size());
+        Assert.assertEquals(3, command3.getMetadata().getTags().size());
+        Assert.assertEquals(1, command3.getResources().getConfigs().size());
+        Assert.assertEquals(2, command3.getResources().getDependencies().size());
     }
 
     /**
@@ -145,9 +146,7 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     public void testGetCommandsByName() {
         final Page<Command> commands = this.service.getCommands(COMMAND_2_NAME, null, null, null, PAGE);
         Assert.assertEquals(1, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_2_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_2_ID, commands.getContent().get(0).getId());
     }
 
     /**
@@ -157,12 +156,8 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     public void testGetCommandsByUserName() {
         final Page<Command> commands = this.service.getCommands(null, COMMAND_1_USER, null, null, PAGE);
         Assert.assertEquals(2, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_3_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_1_ID, commands.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_3_ID, commands.getContent().get(0).getId());
+        Assert.assertEquals(COMMAND_1_ID, commands.getContent().get(1).getId());
     }
 
     /**
@@ -173,12 +168,8 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         final Set<CommandStatus> statuses = Sets.newHashSet(CommandStatus.INACTIVE, CommandStatus.DEPRECATED);
         final Page<Command> commands = this.service.getCommands(null, null, statuses, null, PAGE);
         Assert.assertEquals(2, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_2_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_3_ID, commands.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_2_ID, commands.getContent().get(0).getId());
+        Assert.assertEquals(COMMAND_3_ID, commands.getContent().get(1).getId());
     }
 
     /**
@@ -189,33 +180,21 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         final Set<String> tags = Sets.newHashSet("prod");
         Page<Command> commands = this.service.getCommands(null, null, null, tags, PAGE);
         Assert.assertEquals(3, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_2_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_3_ID, commands.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_1_ID, commands.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_2_ID, commands.getContent().get(0).getId());
+        Assert.assertEquals(COMMAND_3_ID, commands.getContent().get(1).getId());
+        Assert.assertEquals(COMMAND_1_ID, commands.getContent().get(2).getId());
 
         tags.add("pig");
         commands = this.service.getCommands(null, null, null, tags, PAGE);
         Assert.assertEquals(2, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_3_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_1_ID, commands.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_3_ID, commands.getContent().get(0).getId());
+        Assert.assertEquals(COMMAND_1_ID, commands.getContent().get(1).getId());
 
         tags.clear();
         tags.add("hive");
         commands = this.service.getCommands(null, null, null, tags, PAGE);
         Assert.assertEquals(1, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_2_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_2_ID, commands.getContent().get(0).getId());
 
         tags.add("somethingThatWouldNeverReallyExist");
         commands = this.service.getCommands(null, null, null, tags, PAGE);
@@ -224,15 +203,9 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         tags.clear();
         commands = this.service.getCommands(null, null, null, tags, PAGE);
         Assert.assertEquals(3, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_2_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_3_ID, commands.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_1_ID, commands.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_2_ID, commands.getContent().get(0).getId());
+        Assert.assertEquals(COMMAND_3_ID, commands.getContent().get(1).getId());
+        Assert.assertEquals(COMMAND_1_ID, commands.getContent().get(2).getId());
     }
 
     /**
@@ -243,15 +216,9 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         //Default to order by Updated
         final Page<Command> commands = this.service.getCommands(null, null, null, null, PAGE);
         Assert.assertEquals(3, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_2_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_3_ID, commands.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_1_ID, commands.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_2_ID, commands.getContent().get(0).getId());
+        Assert.assertEquals(COMMAND_3_ID, commands.getContent().get(1).getId());
+        Assert.assertEquals(COMMAND_1_ID, commands.getContent().get(2).getId());
     }
 
     /**
@@ -263,15 +230,9 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         //Default to order by Updated
         final Page<Command> commands = this.service.getCommands(null, null, null, null, ascending);
         Assert.assertEquals(3, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_1_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_3_ID, commands.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_2_ID, commands.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_1_ID, commands.getContent().get(0).getId());
+        Assert.assertEquals(COMMAND_3_ID, commands.getContent().get(1).getId());
+        Assert.assertEquals(COMMAND_2_ID, commands.getContent().get(2).getId());
     }
 
     /**
@@ -282,15 +243,9 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         final Pageable name = PageRequest.of(0, 10, Sort.Direction.DESC, "name");
         final Page<Command> commands = this.service.getCommands(null, null, null, null, name);
         Assert.assertEquals(3, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_1_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_3_ID, commands.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_2_ID, commands.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_1_ID, commands.getContent().get(0).getId());
+        Assert.assertEquals(COMMAND_3_ID, commands.getContent().get(1).getId());
+        Assert.assertEquals(COMMAND_2_ID, commands.getContent().get(2).getId());
     }
 
     /**
@@ -301,15 +256,9 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         final Pageable invalid = PageRequest.of(0, 10, Sort.Direction.DESC, "I'mNotAValidField");
         final Page<Command> commands = this.service.getCommands(null, null, null, null, invalid);
         Assert.assertEquals(3, commands.getNumberOfElements());
-        Assert.assertEquals(
-            COMMAND_2_ID, commands.getContent().get(0).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_3_ID, commands.getContent().get(1).getId().orElseThrow(IllegalArgumentException::new)
-        );
-        Assert.assertEquals(
-            COMMAND_1_ID, commands.getContent().get(2).getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(COMMAND_2_ID, commands.getContent().get(0).getId());
+        Assert.assertEquals(COMMAND_3_ID, commands.getContent().get(1).getId());
+        Assert.assertEquals(COMMAND_1_ID, commands.getContent().get(2).getId());
     }
 
     /**
@@ -320,24 +269,27 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testCreateCommand() throws GenieException {
         final String id = UUID.randomUUID().toString();
-        final Command command = new Command.Builder(
-            COMMAND_1_NAME,
-            COMMAND_1_USER,
-            COMMAND_1_VERSION,
-            CommandStatus.ACTIVE,
-            COMMAND_1_EXECUTABLE,
-            COMMAND_1_CHECK_DELAY
+        final CommandRequest command = new CommandRequest.Builder(
+            new CommandMetadata.Builder(
+                COMMAND_1_NAME,
+                COMMAND_1_USER,
+                CommandStatus.ACTIVE
+            )
+                .withVersion(COMMAND_1_VERSION)
+                .build(),
+            COMMAND_1_EXECUTABLE
         )
-            .withId(id)
+            .withRequestedId(id)
+            .withCheckDelay(COMMAND_1_CHECK_DELAY)
             .build();
         final String createdId = this.service.createCommand(command);
         Assert.assertThat(createdId, Matchers.is(id));
         final Command created = this.service.getCommand(id);
         Assert.assertNotNull(this.service.getCommand(id));
-        Assert.assertEquals(id, created.getId().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(COMMAND_1_NAME, created.getName());
-        Assert.assertEquals(COMMAND_1_USER, created.getUser());
-        Assert.assertEquals(CommandStatus.ACTIVE, created.getStatus());
+        Assert.assertEquals(id, created.getId());
+        Assert.assertEquals(COMMAND_1_NAME, created.getMetadata().getName());
+        Assert.assertEquals(COMMAND_1_USER, created.getMetadata().getUser());
+        Assert.assertEquals(CommandStatus.ACTIVE, created.getMetadata().getStatus());
         Assert.assertEquals(COMMAND_1_EXECUTABLE, created.getExecutable());
         Assert.assertThat(COMMAND_1_CHECK_DELAY, Matchers.is(created.getCheckDelay()));
         Assert.assertFalse(created.getMemory().isPresent());
@@ -361,28 +313,31 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testCreateCommandNoId() throws GenieException {
         final int memory = 512;
-        final Command command = new Command.Builder(
-            COMMAND_1_NAME,
-            COMMAND_1_USER,
-            COMMAND_1_VERSION,
-            CommandStatus.ACTIVE,
-            COMMAND_1_EXECUTABLE,
-            COMMAND_1_CHECK_DELAY
+        final CommandRequest command = new CommandRequest.Builder(
+            new CommandMetadata.Builder(
+                COMMAND_1_NAME,
+                COMMAND_1_USER,
+                CommandStatus.ACTIVE
+            )
+                .withVersion(COMMAND_1_VERSION)
+                .build(),
+            COMMAND_1_EXECUTABLE
         )
             .withMemory(memory)
+            .withCheckDelay(COMMAND_1_CHECK_DELAY)
             .build();
         final String id = this.service.createCommand(command);
         final Command created = this.service.getCommand(id);
-        Assert.assertNotNull(this.service.getCommand(created.getId().orElseThrow(IllegalArgumentException::new)));
-        Assert.assertEquals(COMMAND_1_NAME, created.getName());
-        Assert.assertEquals(COMMAND_1_USER, created.getUser());
-        Assert.assertEquals(CommandStatus.ACTIVE, created.getStatus());
+        Assert.assertNotNull(this.service.getCommand(created.getId()));
+        Assert.assertEquals(COMMAND_1_NAME, created.getMetadata().getName());
+        Assert.assertEquals(COMMAND_1_USER, created.getMetadata().getUser());
+        Assert.assertEquals(CommandStatus.ACTIVE, created.getMetadata().getStatus());
         Assert.assertEquals(COMMAND_1_EXECUTABLE, created.getExecutable());
         Assert.assertThat(COMMAND_1_CHECK_DELAY, Matchers.is(created.getCheckDelay()));
         Assert.assertThat(created.getMemory().orElse(memory + 1), Matchers.is(memory));
-        this.service.deleteCommand(created.getId().orElseThrow(IllegalArgumentException::new));
+        this.service.deleteCommand(created.getId());
         try {
-            this.service.getCommand(created.getId().orElseThrow(IllegalArgumentException::new));
+            this.service.getCommand(created.getId());
             Assert.fail("Should have thrown exception");
         } catch (final GenieException ge) {
             Assert.assertEquals(
@@ -400,39 +355,40 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testUpdateCommand() throws GenieException {
         final Command command = this.service.getCommand(COMMAND_1_ID);
-        Assert.assertEquals(COMMAND_1_USER, command.getUser());
-        Assert.assertEquals(CommandStatus.ACTIVE, command.getStatus());
-        Assert.assertEquals(5, command.getTags().size());
+        Assert.assertEquals(COMMAND_1_USER, command.getMetadata().getUser());
+        Assert.assertEquals(CommandStatus.ACTIVE, command.getMetadata().getStatus());
+        Assert.assertEquals(3, command.getMetadata().getTags().size());
         Assert.assertFalse(command.getMemory().isPresent());
         final Set<String> tags = Sets.newHashSet("yarn", "hadoop");
-        tags.addAll(command.getTags());
+        tags.addAll(command.getMetadata().getTags());
 
         final int memory = 1_024;
-        final Command.Builder updateCommand = new Command.Builder(
-            command.getName(),
-            COMMAND_2_USER,
-            command.getVersion(),
-            CommandStatus.INACTIVE,
+        final Command updateCommand = new Command(
+            command.getId(),
+            command.getCreated(),
+            command.getUpdated(),
+            command.getResources(),
+            new CommandMetadata.Builder(
+                command.getMetadata().getName(),
+                COMMAND_2_USER,
+                CommandStatus.INACTIVE
+            )
+                .withVersion(command.getMetadata().getVersion().orElse(null))
+                .withMetadata(command.getMetadata().getMetadata().orElse(null))
+                .withDescription(command.getMetadata().getDescription().orElse(null))
+                .withTags(tags)
+                .build(),
             command.getExecutable(),
+            memory,
             command.getCheckDelay()
-        )
-            .withId(command.getId().orElseThrow(IllegalArgumentException::new))
-            .withCreated(command.getCreated().orElseThrow(IllegalArgumentException::new))
-            .withUpdated(command.getUpdated().orElseThrow(IllegalArgumentException::new))
-            .withTags(tags)
-            .withConfigs(command.getConfigs())
-            .withDependencies(command.getDependencies())
-            .withMemory(memory);
+        );
 
-        command.getDescription().ifPresent(updateCommand::withDescription);
-        command.getSetupFile().ifPresent(updateCommand::withSetupFile);
-
-        this.service.updateCommand(COMMAND_1_ID, updateCommand.build());
+        this.service.updateCommand(COMMAND_1_ID, updateCommand);
 
         final Command updated = this.service.getCommand(COMMAND_1_ID);
-        Assert.assertEquals(COMMAND_2_USER, updated.getUser());
-        Assert.assertEquals(CommandStatus.INACTIVE, updated.getStatus());
-        Assert.assertEquals(7, updated.getTags().size());
+        Assert.assertEquals(COMMAND_2_USER, updated.getMetadata().getUser());
+        Assert.assertEquals(CommandStatus.INACTIVE, updated.getMetadata().getStatus());
+        Assert.assertEquals(5, updated.getMetadata().getTags().size());
         Assert.assertThat(updated.getMemory().orElse(memory + 1), Matchers.is(memory));
     }
 
@@ -444,18 +400,29 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     @Test(expected = ConstraintViolationException.class)
     public void testUpdateCommandWithInvalidCommand() throws GenieException {
         final Command command = this.service.getCommand(COMMAND_1_ID);
-        Assert.assertEquals(COMMAND_1_USER, command.getUser());
-        Assert.assertEquals(CommandStatus.ACTIVE, command.getStatus());
-        Assert.assertEquals(5, command.getTags().size());
+        Assert.assertEquals(COMMAND_1_USER, command.getMetadata().getUser());
+        Assert.assertEquals(CommandStatus.ACTIVE, command.getMetadata().getStatus());
+        Assert.assertEquals(3, command.getMetadata().getTags().size());
 
-        final Command updateCommand = new Command.Builder(
-            command.getName(),
-            "", //invalid
-            command.getVersion(),
-            CommandStatus.INACTIVE,
+        final Command updateCommand = new Command(
+            command.getId(),
+            command.getCreated(),
+            command.getUpdated(),
+            command.getResources(),
+            new CommandMetadata.Builder(
+                command.getMetadata().getName(),
+                "", //invalid
+                CommandStatus.INACTIVE
+            )
+                .withVersion(command.getMetadata().getVersion().orElse(null))
+                .withMetadata(command.getMetadata().getMetadata().orElse(null))
+                .withDescription(command.getMetadata().getDescription().orElse(null))
+                .withTags(command.getMetadata().getTags())
+                .build(),
             command.getExecutable(),
+            null,
             command.getCheckDelay()
-        ).build();
+        );
 
         this.service.updateCommand(COMMAND_1_ID, updateCommand);
     }
@@ -468,33 +435,25 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testUpdateCreateAndUpdate() throws GenieException {
         final Command init = this.service.getCommand(COMMAND_1_ID);
-        final Instant created = init.getCreated().orElseThrow(IllegalArgumentException::new);
-        final Instant updated = init.getUpdated().orElseThrow(IllegalArgumentException::new);
+        final Instant created = init.getCreated();
+        final Instant updated = init.getUpdated();
 
-        final Command.Builder updateCommand = new Command.Builder(
-            init.getName(),
-            init.getUser(),
-            init.getVersion(),
-            init.getStatus(),
+        final Command updateCommand = new Command(
+            init.getId(),
+            Instant.now(),
+            Instant.EPOCH,
+            init.getResources(),
+            init.getMetadata(),
             init.getExecutable(),
+            init.getMemory().orElse(null),
             init.getCheckDelay()
-        )
-            .withId(init.getId().orElseThrow(IllegalArgumentException::new))
-            .withCreated(Instant.now())
-            .withUpdated(Instant.EPOCH)
-            .withTags(init.getTags())
-            .withConfigs(init.getConfigs())
-            .withDependencies(init.getDependencies());
+        );
 
-        init.getDescription().ifPresent(updateCommand::withDescription);
-        init.getSetupFile().ifPresent(updateCommand::withSetupFile);
-
-        this.service.updateCommand(COMMAND_1_ID, updateCommand.build());
+        this.service.updateCommand(COMMAND_1_ID, updateCommand);
         final Command updatedCommand = this.service.getCommand(COMMAND_1_ID);
-        Assert.assertEquals(created, updatedCommand.getCreated().orElseThrow(IllegalArgumentException::new));
-        Assert.assertNotEquals(updated, updatedCommand.getUpdated().orElseThrow(IllegalArgumentException::new));
-        Assert.assertNotEquals(Instant.EPOCH, updatedCommand.getUpdated().orElseThrow(IllegalArgumentException::new));
-        Assert.assertEquals(init.getDependencies(), updatedCommand.getDependencies());
+        Assert.assertEquals(created, updatedCommand.getCreated());
+        Assert.assertNotEquals(updated, updatedCommand.getUpdated());
+        Assert.assertNotEquals(Instant.EPOCH, updatedCommand.getUpdated());
     }
 
     /**
@@ -506,18 +465,18 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     @Test
     public void testPatchCommand() throws GenieException, IOException {
         final Command getCommand = this.service.getCommand(COMMAND_1_ID);
-        Assert.assertThat(getCommand.getName(), Matchers.is(COMMAND_1_NAME));
-        final Instant updateTime = getCommand.getUpdated().orElseThrow(IllegalArgumentException::new);
+        Assert.assertThat(getCommand.getMetadata().getName(), Matchers.is(COMMAND_1_NAME));
+        final Instant updateTime = getCommand.getUpdated();
 
         final String patchString
-            = "[{ \"op\": \"replace\", \"path\": \"/name\", \"value\": \"" + COMMAND_2_NAME + "\" }]";
+            = "[{ \"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"" + COMMAND_2_NAME + "\" }]";
         final JsonPatch patch = JsonPatch.fromJson(GenieObjectMapper.getMapper().readTree(patchString));
 
         this.service.patchCommand(COMMAND_1_ID, patch);
 
         final Command updated = this.service.getCommand(COMMAND_1_ID);
         Assert.assertNotEquals(updated.getUpdated(), Matchers.is(updateTime));
-        Assert.assertThat(updated.getName(), Matchers.is(COMMAND_2_NAME));
+        Assert.assertThat(updated.getMetadata().getName(), Matchers.is(COMMAND_2_NAME));
     }
 
     /**
@@ -543,7 +502,7 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         Assert.assertEquals(3, commands.size());
         boolean found = false;
         for (final Command command : commands) {
-            if (COMMAND_1_ID.equals(command.getId().orElseThrow(IllegalArgumentException::new))) {
+            if (COMMAND_1_ID.equals(command.getId())) {
                 found = true;
                 break;
             }
@@ -569,7 +528,7 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
         Assert.assertEquals(2, commands.size());
         found = false;
         for (final Command command : commands) {
-            if (COMMAND_1_ID.equals(command.getId().orElseThrow(IllegalArgumentException::new))) {
+            if (COMMAND_1_ID.equals(command.getId())) {
                 found = true;
                 break;
             }
@@ -771,10 +730,7 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
             = this.appService.getCommandsForApplication(APP_1_ID, null);
         Assert.assertEquals(2, savedCommands.size());
         Assert.assertThat(
-            this.service.getApplicationsForCommand(COMMAND_2_ID)
-                .get(0)
-                .getId()
-                .orElseGet(RandomSuppliers.STRING),
+            this.service.getApplicationsForCommand(COMMAND_2_ID).get(0).getId(),
             Matchers.is(APP_1_ID)
         );
     }
@@ -807,7 +763,7 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
             1,
             this.service.getApplicationsForCommand(COMMAND_2_ID)
                 .stream()
-                .filter(application -> APP_1_ID.equals(application.getId().orElseThrow(IllegalArgumentException::new)))
+                .filter(application -> APP_1_ID.equals(application.getId()))
                 .count()
         );
     }
@@ -821,7 +777,7 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     public void testGetApplicationsForCommand() throws GenieException {
         Assert.assertEquals(1, this.service.getApplicationsForCommand(COMMAND_1_ID)
             .stream()
-            .filter(application -> APP_1_ID.equals(application.getId().orElseThrow(IllegalArgumentException::new)))
+            .filter(application -> APP_1_ID.equals(application.getId()))
             .count()
         );
     }
@@ -863,10 +819,10 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
 
         final Set<String> newTags = Sets.newHashSet(newTag1, newTag2, newTag3);
 
-        Assert.assertEquals(5, this.service.getTagsForCommand(COMMAND_1_ID).size());
+        Assert.assertEquals(3, this.service.getTagsForCommand(COMMAND_1_ID).size());
         this.service.addTagsForCommand(COMMAND_1_ID, newTags);
         final Set<String> finalTags = this.service.getTagsForCommand(COMMAND_1_ID);
-        Assert.assertEquals(8, finalTags.size());
+        Assert.assertEquals(6, finalTags.size());
         Assert.assertTrue(finalTags.contains(newTag1));
         Assert.assertTrue(finalTags.contains(newTag2));
         Assert.assertTrue(finalTags.contains(newTag3));
@@ -885,10 +841,10 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
 
         final Set<String> newTags = Sets.newHashSet(newTag1, newTag2, newTag3);
 
-        Assert.assertEquals(5, this.service.getTagsForCommand(COMMAND_1_ID).size());
+        Assert.assertEquals(3, this.service.getTagsForCommand(COMMAND_1_ID).size());
         this.service.updateTagsForCommand(COMMAND_1_ID, newTags);
         final Set<String> finalTags = this.service.getTagsForCommand(COMMAND_1_ID);
-        Assert.assertEquals(5, finalTags.size());
+        Assert.assertEquals(3, finalTags.size());
         Assert.assertTrue(finalTags.contains(newTag1));
         Assert.assertTrue(finalTags.contains(newTag2));
         Assert.assertTrue(finalTags.contains(newTag3));
@@ -901,8 +857,7 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
      */
     @Test
     public void testGetTagsForCommand() throws GenieException {
-        Assert.assertEquals(5,
-            this.service.getTagsForCommand(COMMAND_1_ID).size());
+        Assert.assertEquals(3, this.service.getTagsForCommand(COMMAND_1_ID).size());
     }
 
     /**
@@ -912,9 +867,9 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
      */
     @Test
     public void testRemoveAllTagsForCommand() throws GenieException {
-        Assert.assertEquals(5, this.service.getTagsForCommand(COMMAND_1_ID).size());
+        Assert.assertEquals(3, this.service.getTagsForCommand(COMMAND_1_ID).size());
         this.service.removeAllTagsForCommand(COMMAND_1_ID);
-        Assert.assertEquals(2, this.service.getTagsForCommand(COMMAND_1_ID).size());
+        Assert.assertEquals(0, this.service.getTagsForCommand(COMMAND_1_ID).size());
     }
 
     /**
@@ -938,9 +893,7 @@ public class JpaCommandServiceImplIntegrationTests extends DBUnitTestBase {
     public void testGetCommandsForCommand() throws GenieException {
         final Set<Cluster> clusters = this.service.getClustersForCommand(COMMAND_1_ID, null);
         Assert.assertEquals(1, clusters.size());
-        Assert.assertEquals(
-            CLUSTER_1_ID, clusters.iterator().next().getId().orElseThrow(IllegalArgumentException::new)
-        );
+        Assert.assertEquals(CLUSTER_1_ID, clusters.iterator().next().getId());
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaFileServiceImplIntegrationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaFileServiceImplIntegrationTest.java
@@ -19,8 +19,10 @@ package com.netflix.genie.web.jpa.services;
 
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Application;
 import com.netflix.genie.common.dto.ApplicationStatus;
+import com.netflix.genie.common.dto.v4.ApplicationMetadata;
+import com.netflix.genie.common.dto.v4.ApplicationRequest;
+import com.netflix.genie.common.dto.v4.ExecutionEnvironment;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.test.categories.IntegrationTest;
 import com.netflix.genie.web.jpa.entities.FileEntity;
@@ -99,15 +101,19 @@ public class JpaFileServiceImplIntegrationTest extends DBUnitTestBase {
         this.fileService.createFileIfNotExists(file1);
         this.fileService.createFileIfNotExists(file4);
 
-        final Application app = new Application.Builder(
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            ApplicationStatus.ACTIVE
-        )
-            .withDependencies(Sets.newHashSet(file2))
-            .withConfigs(Sets.newHashSet(file3))
-            .withSetupFile(file5)
+        final ApplicationRequest app = new ApplicationRequest.Builder(
+            new ApplicationMetadata.Builder(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                ApplicationStatus.ACTIVE
+            ).build())
+            .withResources(
+                new ExecutionEnvironment(
+                    Sets.newHashSet(file3),
+                    Sets.newHashSet(file2),
+                    file5
+                )
+            )
             .build();
 
         final String appId = this.applicationService.createApplication(app);

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImplUnitTests.java
@@ -176,7 +176,10 @@ public class JpaJobPersistenceServiceImplUnitTests {
         // Make sure id supplied is used to create the JobRequest
         Assert.assertEquals(JOB_1_ID, argument.getValue().getUniqueId());
         Assert.assertEquals(JOB_1_USER, argument.getValue().getUser());
-        Assert.assertEquals(JOB_1_VERSION, argument.getValue().getVersion());
+        Assert.assertThat(
+            argument.getValue().getVersion().orElse(UUID.randomUUID().toString()),
+            Matchers.is(JOB_1_VERSION)
+        );
         Assert.assertEquals(JOB_1_NAME, argument.getValue().getName());
         final int actualCpu = argument.getValue().getCpuRequested().orElseThrow(IllegalArgumentException::new);
         Assert.assertThat(actualCpu, Matchers.is(cpu));

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaTagServiceImplIntegrationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaTagServiceImplIntegrationTest.java
@@ -19,8 +19,9 @@ package com.netflix.genie.web.jpa.services;
 
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Application;
 import com.netflix.genie.common.dto.ApplicationStatus;
+import com.netflix.genie.common.dto.v4.ApplicationMetadata;
+import com.netflix.genie.common.dto.v4.ApplicationRequest;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.test.categories.IntegrationTest;
 import com.netflix.genie.web.jpa.entities.TagEntity;
@@ -94,14 +95,15 @@ public class JpaTagServiceImplIntegrationTest extends DBUnitTestBase {
         final String tag2 = UUID.randomUUID().toString();
         this.tagService.createTagIfNotExists(tag1);
 
-        final Application app = new Application.Builder(
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            ApplicationStatus.ACTIVE
-        )
-            .withTags(Sets.newHashSet(tag2))
-            .build();
+        final ApplicationRequest app = new ApplicationRequest.Builder(
+            new ApplicationMetadata.Builder(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                ApplicationStatus.ACTIVE
+            )
+                .withTags(Sets.newHashSet(tag2))
+                .build()
+        ).build();
 
         this.applicationService.createApplication(app);
 

--- a/genie-web/src/test/java/com/netflix/genie/web/security/AbstractAPISecurityIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/security/AbstractAPISecurityIntegrationTests.java
@@ -62,7 +62,9 @@ public abstract class AbstractAPISecurityIntegrationTests {
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
             ApplicationStatus.ACTIVE
-        ).build();
+        )
+            .withId(UUID.randomUUID().toString())
+            .build();
 
     private static final Cluster CLUSTER =
         new Cluster.Builder(
@@ -70,7 +72,9 @@ public abstract class AbstractAPISecurityIntegrationTests {
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
             ClusterStatus.UP
-        ).build();
+        )
+            .withId(UUID.randomUUID().toString())
+            .build();
 
     private static final Command COMMAND =
         new Command.Builder(
@@ -80,7 +84,9 @@ public abstract class AbstractAPISecurityIntegrationTests {
             CommandStatus.ACTIVE,
             UUID.randomUUID().toString(),
             1000L
-        ).build();
+        )
+            .withId(UUID.randomUUID().toString())
+            .build();
 
     private static final String APPLICATIONS_API = "/api/v3/applications";
     private static final String CLUSTERS_API = "/api/v3/clusters";

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.Application;
+import com.netflix.genie.common.dto.ApplicationStatus;
 import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.Job;
@@ -28,6 +29,8 @@ import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.common.dto.v4.ApplicationMetadata;
+import com.netflix.genie.common.dto.v4.ExecutionEnvironment;
 import com.netflix.genie.common.exceptions.GenieConflictException;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
@@ -36,6 +39,7 @@ import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
 import com.netflix.genie.common.exceptions.GenieUserLimitExceededException;
 import com.netflix.genie.test.categories.UnitTest;
+import com.netflix.genie.web.controllers.DtoAdapters;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.ApplicationService;
 import com.netflix.genie.web.services.ClusterLoadBalancer;
@@ -62,6 +66,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import javax.annotation.Nullable;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -617,10 +622,21 @@ public class JobCoordinatorServiceImplUnitTests {
 
         Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
 
-        final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(Optional.of(applicationId));
+        final com.netflix.genie.common.dto.v4.Application v4Application
+            = new com.netflix.genie.common.dto.v4.Application(
+            applicationId,
+            Instant.now(),
+            Instant.now(),
+            new ExecutionEnvironment(null, null, null),
+            new ApplicationMetadata.Builder(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                ApplicationStatus.ACTIVE
+            ).build()
+        );
 
-        Mockito.when(this.applicationService.getApplication(applicationId)).thenReturn(application);
+        Mockito.when(this.applicationService.getApplication(applicationId)).thenReturn(v4Application);
+        final Application application = DtoAdapters.toV3Application(v4Application);
 
         Mockito.when(this.jobStateService.getUsedMemory()).thenReturn(0);
 

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
@@ -20,16 +20,16 @@ package com.netflix.genie.web.services.impl;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Application;
 import com.netflix.genie.common.dto.ApplicationStatus;
-import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.common.dto.v4.Application;
 import com.netflix.genie.common.dto.v4.ApplicationMetadata;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.dto.v4.ExecutionEnvironment;
 import com.netflix.genie.common.exceptions.GenieConflictException;
 import com.netflix.genie.common.exceptions.GenieException;
@@ -39,7 +39,6 @@ import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
 import com.netflix.genie.common.exceptions.GenieUserLimitExceededException;
 import com.netflix.genie.test.categories.UnitTest;
-import com.netflix.genie.web.controllers.DtoAdapters;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.ApplicationService;
 import com.netflix.genie.web.services.ClusterLoadBalancer;
@@ -392,8 +391,8 @@ public class JobCoordinatorServiceImplUnitTests {
         final Command command = Mockito.mock(Command.class);
         final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
         clustersCommandsMap.put(cluster, commandId);
-        Mockito.when(cluster.getId()).thenReturn(Optional.of(clusterId));
-        Mockito.when(command.getId()).thenReturn(Optional.of(commandId));
+        Mockito.when(cluster.getId()).thenReturn(clusterId);
+        Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.empty());
 
         Mockito
@@ -404,7 +403,7 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String applicationId = UUID.randomUUID().toString();
         final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(Optional.of(applicationId));
+        Mockito.when(application.getId()).thenReturn(applicationId);
         final List<Application> applications = Lists.newArrayList(application);
 
         Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
@@ -492,10 +491,10 @@ public class JobCoordinatorServiceImplUnitTests {
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster1 = Mockito.mock(Cluster.class);
         final Cluster cluster2 = Mockito.mock(Cluster.class);
-        Mockito.when(cluster1.getId()).thenReturn(Optional.of(clusterId));
+        Mockito.when(cluster1.getId()).thenReturn(clusterId);
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(Optional.of(commandId));
+        Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.empty());
         final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
         clustersCommandsMap.put(cluster1, commandId);
@@ -519,7 +518,7 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String applicationId = UUID.randomUUID().toString();
         final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(Optional.of(applicationId));
+        Mockito.when(application.getId()).thenReturn(applicationId);
         final List<Application> applications = Lists.newArrayList(application);
 
         Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
@@ -606,9 +605,9 @@ public class JobCoordinatorServiceImplUnitTests {
         final Cluster cluster = Mockito.mock(Cluster.class);
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(Optional.of(commandId));
+        Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.empty());
-        Mockito.when(cluster.getId()).thenReturn(Optional.of(clusterId));
+        Mockito.when(cluster.getId()).thenReturn(clusterId);
         final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
         clustersCommandsMap.put(cluster, commandId);
 
@@ -622,8 +621,7 @@ public class JobCoordinatorServiceImplUnitTests {
 
         Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
 
-        final com.netflix.genie.common.dto.v4.Application v4Application
-            = new com.netflix.genie.common.dto.v4.Application(
+        final Application application = new Application(
             applicationId,
             Instant.now(),
             Instant.now(),
@@ -635,8 +633,7 @@ public class JobCoordinatorServiceImplUnitTests {
             ).build()
         );
 
-        Mockito.when(this.applicationService.getApplication(applicationId)).thenReturn(v4Application);
-        final Application application = DtoAdapters.toV3Application(v4Application);
+        Mockito.when(this.applicationService.getApplication(applicationId)).thenReturn(application);
 
         Mockito.when(this.jobStateService.getUsedMemory()).thenReturn(0);
 
@@ -714,10 +711,10 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
-        Mockito.when(cluster.getId()).thenReturn(Optional.of(clusterId));
+        Mockito.when(cluster.getId()).thenReturn(clusterId);
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(Optional.of(commandId));
+        Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.empty());
         final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
         clustersCommandsMap.put(cluster, commandId);
@@ -734,7 +731,7 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String applicationId = UUID.randomUUID().toString();
         final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(Optional.of(applicationId));
+        Mockito.when(application.getId()).thenReturn(applicationId);
         final List<Application> applications = Lists.newArrayList(application);
 
         Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
@@ -803,10 +800,10 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
-        Mockito.when(cluster.getId()).thenReturn(Optional.of(clusterId));
+        Mockito.when(cluster.getId()).thenReturn(clusterId);
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(Optional.of(commandId));
+        Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
         final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
         clustersCommandsMap.put(cluster, commandId);
@@ -823,7 +820,7 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String applicationId = UUID.randomUUID().toString();
         final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(Optional.of(applicationId));
+        Mockito.when(application.getId()).thenReturn(applicationId);
         final List<Application> applications = Lists.newArrayList(application);
 
         Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
@@ -911,10 +908,10 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
-        Mockito.when(cluster.getId()).thenReturn(Optional.of(clusterId));
+        Mockito.when(cluster.getId()).thenReturn(clusterId);
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(Optional.of(commandId));
+        Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
         final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
         clustersCommandsMap.put(cluster, commandId);
@@ -931,7 +928,7 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String applicationId = UUID.randomUUID().toString();
         final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(Optional.of(applicationId));
+        Mockito.when(application.getId()).thenReturn(applicationId);
         final List<Application> applications = Lists.newArrayList(application);
 
         Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
@@ -1001,10 +998,10 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
-        Mockito.when(cluster.getId()).thenReturn(Optional.of(clusterId));
+        Mockito.when(cluster.getId()).thenReturn(clusterId);
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(Optional.of(commandId));
+        Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
         final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
         clustersCommandsMap.put(cluster, commandId);
@@ -1021,7 +1018,7 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String applicationId = UUID.randomUUID().toString();
         final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(Optional.of(applicationId));
+        Mockito.when(application.getId()).thenReturn(applicationId);
         final List<Application> applications = Lists.newArrayList(application);
 
         Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
@@ -1094,10 +1091,10 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
-        Mockito.when(cluster.getId()).thenReturn(Optional.of(clusterId));
+        Mockito.when(cluster.getId()).thenReturn(clusterId);
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(Optional.of(commandId));
+        Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
         final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
         clustersCommandsMap.put(cluster, commandId);
@@ -1114,7 +1111,7 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String applicationId = UUID.randomUUID().toString();
         final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(Optional.of(applicationId));
+        Mockito.when(application.getId()).thenReturn(applicationId);
         final List<Application> applications = Lists.newArrayList(application);
 
         Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
@@ -1196,10 +1193,10 @@ public class JobCoordinatorServiceImplUnitTests {
 
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
-        Mockito.when(cluster.getId()).thenReturn(Optional.of(clusterId));
+        Mockito.when(cluster.getId()).thenReturn(clusterId);
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(Optional.of(commandId));
+        Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
         final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
         clustersCommandsMap.put(cluster, commandId);

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/LocalJobRunnerUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/LocalJobRunnerUnitTests.java
@@ -18,18 +18,22 @@
 package com.netflix.genie.web.services.impl;
 
 import com.google.common.collect.Lists;
-import com.netflix.genie.common.dto.Application;
 import com.netflix.genie.common.dto.ApplicationStatus;
-import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.ClusterStatus;
-import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.CommandStatus;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Application;
+import com.netflix.genie.common.dto.v4.ApplicationMetadata;
+import com.netflix.genie.common.dto.v4.Cluster;
+import com.netflix.genie.common.dto.v4.ClusterMetadata;
+import com.netflix.genie.common.dto.v4.Command;
+import com.netflix.genie.common.dto.v4.CommandMetadata;
+import com.netflix.genie.common.dto.v4.ExecutionEnvironment;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.common.jobs.JobConstants;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.web.events.GenieEventBus;
-import com.netflix.genie.common.jobs.JobConstants;
 import com.netflix.genie.web.jobs.workflow.WorkflowTask;
 import com.netflix.genie.web.services.JobPersistenceService;
 import com.netflix.genie.web.services.JobSubmitterService;
@@ -47,6 +51,7 @@ import org.springframework.core.io.Resource;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -98,9 +103,9 @@ public class LocalJobRunnerUnitTests {
         jobWorkflowTasks.add(task1);
         jobWorkflowTasks.add(this.task2);
 
-        tmpFolder = this.folder.newFolder();
+        this.tmpFolder = this.folder.newFolder();
         final Resource baseWorkingDirResource = Mockito.mock(Resource.class);
-        Mockito.when(baseWorkingDirResource.getFile()).thenReturn(tmpFolder);
+        Mockito.when(baseWorkingDirResource.getFile()).thenReturn(this.tmpFolder);
 
         final MeterRegistry registry = Mockito.mock(MeterRegistry.class);
         Mockito.when(registry.timer(Mockito.anyString())).thenReturn(Mockito.mock(Timer.class));
@@ -133,15 +138,36 @@ public class LocalJobRunnerUnitTests {
         final String app2 = UUID.randomUUID().toString();
         final String app3 = UUID.randomUUID().toString();
         final List<Application> applications = Lists.newArrayList(
-            new Application.Builder(placeholder, placeholder, placeholder, ApplicationStatus.ACTIVE)
-                .withId(app3)
-                .build(),
-            new Application.Builder(placeholder, placeholder, placeholder, ApplicationStatus.ACTIVE)
-                .withId(app1)
-                .build(),
-            new Application.Builder(placeholder, placeholder, placeholder, ApplicationStatus.ACTIVE)
-                .withId(app2)
-                .build()
+            new Application(
+                app3,
+                Instant.now(),
+                Instant.now(),
+                new ExecutionEnvironment(null, null, null),
+                new ApplicationMetadata
+                    .Builder(placeholder, placeholder, ApplicationStatus.ACTIVE)
+                    .withVersion(placeholder)
+                    .build()
+            ),
+            new Application(
+                app1,
+                Instant.now(),
+                Instant.now(),
+                new ExecutionEnvironment(null, null, null),
+                new ApplicationMetadata
+                    .Builder(placeholder, placeholder, ApplicationStatus.ACTIVE)
+                    .withVersion(placeholder)
+                    .build()
+            ),
+            new Application(
+                app2,
+                Instant.now(),
+                Instant.now(),
+                new ExecutionEnvironment(null, null, null),
+                new ApplicationMetadata
+                    .Builder(placeholder, placeholder, ApplicationStatus.ACTIVE)
+                    .withVersion(placeholder)
+                    .build()
+            )
         );
 
         final JobRequest jobRequest = new JobRequest.Builder(
@@ -155,25 +181,24 @@ public class LocalJobRunnerUnitTests {
             .withApplications(Lists.newArrayList(app3, app1, app2))
             .build();
 
-        final Cluster cluster = new Cluster.Builder(
-            CLUSTER_NAME,
-            USER,
-            VERSION,
-            ClusterStatus.UP
-        )
-            .withId(CLUSTER_ID)
-            .build();
+        final Cluster cluster = new Cluster(
+            CLUSTER_ID,
+            Instant.now(),
+            Instant.now(),
+            new ExecutionEnvironment(null, null, null),
+            new ClusterMetadata.Builder(CLUSTER_NAME, USER, ClusterStatus.UP).withVersion(VERSION).build()
+        );
 
-        final Command command = new Command.Builder(
-            COMMAND_NAME,
-            USER,
-            VERSION,
-            CommandStatus.ACTIVE,
-            "foo",
+        final Command command = new Command(
+            COMMAND_ID,
+            Instant.now(),
+            Instant.now(),
+            new ExecutionEnvironment(null, null, null),
+            new CommandMetadata.Builder(COMMAND_NAME, USER, CommandStatus.ACTIVE).withVersion(VERSION).build(),
+            Lists.newArrayList("foo"),
+            null,
             5000L
-        )
-            .withId(COMMAND_ID)
-            .build();
+        );
 
         final int memory = 2438;
 

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/RandomizedClusterLoadBalancerImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/RandomizedClusterLoadBalancerImplUnitTests.java
@@ -18,8 +18,8 @@
 package com.netflix.genie.web.services.impl;
 
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Cluster;
 import com.netflix.genie.common.dto.JobRequest;
+import com.netflix.genie.common.dto.v4.Cluster;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.test.categories.UnitTest;
 import org.junit.Assert;

--- a/genie-web/src/test/resources/application-db-mysql.yml
+++ b/genie-web/src/test/resources/application-db-mysql.yml
@@ -18,7 +18,7 @@
 
 spring:
   datasource:
-    url: jdbc:mysql://127.0.0.1/genie?useUnicode=yes&characterEncoding=UTF-8&useLegacyDatetimeCode=false
+    url: jdbc:mysql://127.0.0.1/genie?useUnicode=yes&characterEncoding=UTF-8&useLegacyDatetimeCode=false&serverTimezone=UTC
     username: root
     password:
     hikari:

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaApplicationServiceImplIntegrationTests/init.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaApplicationServiceImplIntegrationTests/init.xml
@@ -84,70 +84,14 @@
         created="2014-08-08 01:45:00"
         updated="2014-08-08 01:45:00"
         entity_version="0"
-        tag="genie.id:app1"
+        tag="prod"
     />
     <tags
         id="1"
         created="2014-08-08 01:45:00"
         updated="2014-08-08 01:45:00"
         entity_version="0"
-        tag="genie.name:tez"
-    />
-    <tags
-        id="2"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:45:00"
-        entity_version="0"
-        tag="prod"
-    />
-    <tags
-        id="3"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:45:00"
-        entity_version="0"
-        tag="genie.id:app2"
-    />
-    <tags
-        id="4"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:45:00"
-        entity_version="0"
-        tag="genie.name:spark"
-    />
-    <tags
-        id="5"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:45:00"
-        entity_version="0"
         tag="yarn"
-    />
-    <tags
-        id="6"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:45:00"
-        entity_version="0"
-        tag="genie.id:app3"
-    />
-    <tags
-        id="7"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:45:00"
-        entity_version="0"
-        tag="genie.name:storm"
-    />
-    <tags
-        id="8"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:45:00"
-        entity_version="0"
-        tag="genie.id:command1"
-    />
-    <tags
-        id="9"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:45:00"
-        entity_version="0"
-        tag="genie.name:pig_13_prod"
     />
 
     <applications
@@ -181,14 +125,6 @@
         application_id="0"
         tag_id="0"
     />
-    <applications_tags
-        application_id="0"
-        tag_id="1"
-    />
-    <applications_tags
-        application_id="0"
-        tag_id="2"
-    />
 
     <applications
         id="1"
@@ -216,19 +152,11 @@
     />
     <applications_tags
         application_id="1"
-        tag_id="3"
+        tag_id="0"
     />
     <applications_tags
         application_id="1"
-        tag_id="4"
-    />
-    <applications_tags
-        application_id="1"
-        tag_id="2"
-    />
-    <applications_tags
-        application_id="1"
-        tag_id="5"
+        tag_id="1"
     />
 
     <applications
@@ -257,15 +185,7 @@
     />
     <applications_tags
         application_id="2"
-        tag_id="6"
-    />
-    <applications_tags
-        application_id="2"
-        tag_id="7"
-    />
-    <applications_tags
-        application_id="2"
-        tag_id="2"
+        tag_id="0"
     />
 
     <commands
@@ -280,15 +200,6 @@
         executable="pig"
         check_delay="10000"
         status="INACTIVE"
-    />
-
-    <commands_tags
-        command_id="0"
-        tag_id="8"
-    />
-    <commands_tags
-        command_id="0"
-        tag_id="9"
     />
 
     <commands_applications command_id="0" application_id="0" application_order="0"/>

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaClusterServiceImplIntegrationTests/init.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaClusterServiceImplIntegrationTests/init.xml
@@ -45,151 +45,81 @@
     />
 
     <tags
-        id="1"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie.id:command1"
-    />
-    <tags
-        id="2"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie:name:pig_13_prod"
-    />
-    <tags
-        id="3"
+        id="0"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="pig"
     />
     <tags
-        id="4"
+        id="1"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="prod"
     />
     <tags
-        id="5"
+        id="2"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="tez"
     />
     <tags
-        id="6"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie.id:command2"
-    />
-    <tags
-        id="7"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie:name:hive_11_prod"
-    />
-    <tags
-        id="8"
+        id="3"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="hive"
     />
     <tags
-        id="9"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie.id:cluster1"
-    />
-    <tags
-        id="10"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie.name:h2prod"
-    />
-    <tags
-        id="11"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie.id:cluster2"
-    />
-    <tags
-        id="12"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie:name:h2query"
-    />
-    <tags
-        id="13"
+        id="4"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="query"
     />
     <tags
-        id="14"
+        id="5"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="sla"
     />
     <tags
-        id="15"
+        id="6"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="adhoc"
     />
     <tags
-        id="16"
+        id="7"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="yarn"
     />
     <tags
-        id="17"
+        id="8"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="0.15.0"
     />
     <tags
-        id="18"
+        id="9"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="spark"
     />
     <tags
-        id="19"
+        id="10"
         created="2014-08-08 01:47:00"
         updated="2014-08-08 01:59:00"
         entity_version="0"
         tag="deprecated"
-    />
-    <tags
-        id="20"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie.id:command3"
-    />
-    <tags
-        id="21"
-        created="2014-08-08 01:47:00"
-        updated="2014-08-08 01:59:00"
-        entity_version="0"
-        tag="genie:name:pig_11_prod"
     />
 
     <commands
@@ -215,23 +145,15 @@
     />
     <commands_tags
         command_id="1"
+        tag_id="0"
+    />
+    <commands_tags
+        command_id="1"
         tag_id="1"
     />
     <commands_tags
         command_id="1"
         tag_id="2"
-    />
-    <commands_tags
-        command_id="1"
-        tag_id="3"
-    />
-    <commands_tags
-        command_id="1"
-        tag_id="4"
-    />
-    <commands_tags
-        command_id="1"
-        tag_id="5"
     />
 
     <commands
@@ -253,19 +175,11 @@
     />
     <commands_tags
         command_id="2"
-        tag_id="6"
+        tag_id="3"
     />
     <commands_tags
         command_id="2"
-        tag_id="7"
-    />
-    <commands_tags
-        command_id="2"
-        tag_id="8"
-    />
-    <commands_tags
-        command_id="2"
-        tag_id="4"
+        tag_id="1"
     />
 
     <commands
@@ -287,23 +201,15 @@
     />
     <commands_tags
         command_id="3"
-        tag_id="19"
+        tag_id="10"
     />
     <commands_tags
         command_id="3"
-        tag_id="20"
+        tag_id="0"
     />
     <commands_tags
         command_id="3"
-        tag_id="21"
-    />
-    <commands_tags
-        command_id="3"
-        tag_id="3"
-    />
-    <commands_tags
-        command_id="3"
-        tag_id="4"
+        tag_id="1"
     />
 
     <clusters
@@ -331,23 +237,15 @@
     />
     <clusters_tags
         cluster_id="1"
-        tag_id="9"
-    />
-    <clusters_tags
-        cluster_id="1"
-        tag_id="10"
-    />
-    <clusters_tags
-        cluster_id="1"
-        tag_id="8"
-    />
-    <clusters_tags
-        cluster_id="1"
         tag_id="3"
     />
     <clusters_tags
         cluster_id="1"
-        tag_id="4"
+        tag_id="0"
+    />
+    <clusters_tags
+        cluster_id="1"
+        tag_id="1"
     />
 
     <clusters_commands
@@ -387,23 +285,15 @@
     />
     <clusters_tags
         cluster_id="2"
-        tag_id="11"
-    />
-    <clusters_tags
-        cluster_id="2"
-        tag_id="12"
-    />
-    <clusters_tags
-        cluster_id="2"
-        tag_id="8"
-    />
-    <clusters_tags
-        cluster_id="2"
         tag_id="3"
     />
     <clusters_tags
         cluster_id="2"
-        tag_id="13"
+        tag_id="0"
+    />
+    <clusters_tags
+        cluster_id="2"
+        tag_id="4"
     />
 
     <clusters_commands
@@ -427,11 +317,11 @@
     />
     <criteria_tags
         criterion_id="0"
-        tag_id="3"
+        tag_id="0"
     />
     <criteria_tags
         criterion_id="0"
-        tag_id="17"
+        tag_id="8"
     />
     <jobs
         id="1"
@@ -466,11 +356,11 @@
     />
     <criteria_tags
         criterion_id="1"
-        tag_id="14"
+        tag_id="5"
     />
     <criteria_tags
         criterion_id="1"
-        tag_id="16"
+        tag_id="7"
     />
     <jobs_cluster_criteria
         job_id="1"
@@ -483,11 +373,11 @@
     />
     <criteria_tags
         criterion_id="2"
-        tag_id="15"
+        tag_id="6"
     />
     <criteria_tags
         criterion_id="2"
-        tag_id="16"
+        tag_id="7"
     />
     <jobs_cluster_criteria
         job_id="1"
@@ -500,7 +390,7 @@
     />
     <criteria_tags
         criterion_id="3"
-        tag_id="18"
+        tag_id="9"
     />
     <jobs
         id="2"
@@ -535,11 +425,11 @@
     />
     <criteria_tags
         criterion_id="4"
-        tag_id="14"
+        tag_id="5"
     />
     <criteria_tags
         criterion_id="4"
-        tag_id="16"
+        tag_id="7"
     />
     <jobs_cluster_criteria
         job_id="2"
@@ -551,11 +441,11 @@
     />
     <criteria_tags
         criterion_id="5"
-        tag_id="15"
+        tag_id="6"
     />
     <criteria_tags
         criterion_id="5"
-        tag_id="16"
+        tag_id="7"
     />
     <jobs_cluster_criteria
         job_id="2"

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaClusterServiceImplIntegrationTests/init.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaClusterServiceImplIntegrationTests/init.xml
@@ -212,6 +212,40 @@
         tag_id="1"
     />
 
+    <commands
+        id="4"
+        created="2014-08-08 01:47:00"
+        updated="2014-08-08 01:59:00"
+        entity_version="0"
+        unique_id="command4"
+        genie_user="tgianos"
+        name="pig_13_prod"
+        version="1.2.3"
+        executable="pig"
+        check_delay="15000"
+        status="ACTIVE"
+    />
+    <commands_configs
+        command_id="4"
+        file_id="1"
+    />
+    <commands_configs
+        command_id="4"
+        file_id="2"
+    />
+    <commands_tags
+        command_id="4"
+        tag_id="0"
+    />
+    <commands_tags
+        command_id="4"
+        tag_id="1"
+    />
+    <commands_tags
+        command_id="4"
+        tag_id="2"
+    />
+
     <clusters
         id="1"
         created="2014-07-08 01:49:00"
@@ -298,18 +332,23 @@
 
     <clusters_commands
         cluster_id="2"
-        command_id="1"
+        command_id="4"
         command_order="0"
     />
     <clusters_commands
         cluster_id="2"
-        command_id="2"
+        command_id="1"
         command_order="1"
     />
     <clusters_commands
         cluster_id="2"
-        command_id="3"
+        command_id="2"
         command_order="2"
+    />
+    <clusters_commands
+        cluster_id="2"
+        command_id="3"
+        command_order="3"
     />
 
     <criteria

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaCommandServiceImplIntegrationTests/init.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaCommandServiceImplIntegrationTests/init.xml
@@ -59,116 +59,46 @@
     />
 
     <tags
-        id="1"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.id:app1"
-    />
-    <tags
-        id="2"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.name:tez"
-    />
-    <tags
-        id="3"
+        id="0"
         created="2014-08-08 01:45:00"
         updated="2014-08-08 01:50:00"
         entity_version="0"
         tag="prod"
     />
     <tags
-        id="4"
+        id="1"
         created="2014-08-08 01:45:00"
         updated="2014-08-08 01:50:00"
         entity_version="0"
         tag="yarn"
     />
     <tags
-        id="5"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.id:command1"
-    />
-    <tags
-        id="6"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.name:pig_13_prod"
-    />
-    <tags
-        id="7"
+        id="2"
         created="2014-08-08 01:45:00"
         updated="2014-08-08 01:50:00"
         entity_version="0"
         tag="pig"
     />
     <tags
-        id="8"
+        id="3"
         created="2014-08-08 01:45:00"
         updated="2014-08-08 01:50:00"
         entity_version="0"
         tag="tez"
     />
     <tags
-        id="9"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.id:command2"
-    />
-    <tags
-        id="10"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.name:hive_11_prod"
-    />
-    <tags
-        id="11"
+        id="4"
         created="2014-08-08 01:45:00"
         updated="2014-08-08 01:50:00"
         entity_version="0"
         tag="hive"
     />
     <tags
-        id="12"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.id:command3"
-    />
-    <tags
-        id="13"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.name:pig_11_prod"
-    />
-    <tags
-        id="14"
+        id="5"
         created="2014-08-08 01:45:00"
         updated="2014-08-08 01:50:00"
         entity_version="0"
         tag="deprecated"
-    />
-    <tags
-        id="15"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.id:cluster1"
-    />
-    <tags
-        id="16"
-        created="2014-08-08 01:45:00"
-        updated="2014-08-08 01:50:00"
-        entity_version="0"
-        tag="genie.name:h2prod"
     />
 
     <applications
@@ -200,19 +130,11 @@
     />
     <applications_tags
         application_id="1"
+        tag_id="0"
+    />
+    <applications_tags
+        application_id="1"
         tag_id="1"
-    />
-    <applications_tags
-        application_id="1"
-        tag_id="2"
-    />
-    <applications_tags
-        application_id="1"
-        tag_id="3"
-    />
-    <applications_tags
-        application_id="1"
-        tag_id="4"
     />
 
     <commands
@@ -238,23 +160,15 @@
     />
     <commands_tags
         command_id="1"
-        tag_id="5"
+        tag_id="2"
     />
     <commands_tags
         command_id="1"
-        tag_id="6"
-    />
-    <commands_tags
-        command_id="1"
-        tag_id="7"
+        tag_id="0"
     />
     <commands_tags
         command_id="1"
         tag_id="3"
-    />
-    <commands_tags
-        command_id="1"
-        tag_id="8"
     />
 
     <commands_applications
@@ -286,19 +200,11 @@
     />
     <commands_tags
         command_id="2"
-        tag_id="9"
+        tag_id="4"
     />
     <commands_tags
         command_id="2"
-        tag_id="10"
-    />
-    <commands_tags
-        command_id="2"
-        tag_id="11"
-    />
-    <commands_tags
-        command_id="2"
-        tag_id="3"
+        tag_id="0"
     />
 
     <commands
@@ -328,23 +234,15 @@
         file_id="6"/>
     <commands_tags
         command_id="3"
-        tag_id="14"
+        tag_id="5"
     />
     <commands_tags
         command_id="3"
-        tag_id="12"
+        tag_id="2"
     />
     <commands_tags
         command_id="3"
-        tag_id="13"
-    />
-    <commands_tags
-        command_id="3"
-        tag_id="7"
-    />
-    <commands_tags
-        command_id="3"
-        tag_id="3"
+        tag_id="0"
     />
 
     <clusters
@@ -364,35 +262,30 @@
     />
     <clusters_tags
         cluster_id="1"
-        tag_id="15"
+        tag_id="4"
     />
     <clusters_tags
         cluster_id="1"
-        tag_id="16"
+        tag_id="2"
     />
     <clusters_tags
         cluster_id="1"
-        tag_id="11"
-    />
-    <clusters_tags
-        cluster_id="1"
-        tag_id="7"
-    />
-    <clusters_tags
-        cluster_id="1"
-        tag_id="3"
+        tag_id="0"
     />
 
     <clusters_commands
         cluster_id="1"
         command_id="1"
-        command_order="0"/>
+        command_order="0"
+    />
     <clusters_commands
         cluster_id="1"
         command_id="2"
-        command_order="2"/>
+        command_order="2"
+    />
     <clusters_commands
         cluster_id="1"
         command_id="3"
-        command_order="1"/>
+        command_order="1"
+    />
 </dataset>


### PR DESCRIPTION
The bulk of this pull request revolves around porting the resource services (`clusters`, `commands`, `applications`) and the various other services which use these resources over to the newer V4 DTO objects while maintaining backwards compatibility with the V3 API.

This means all requests talking to the V3 APIs still act on the existing data structures externally but internally everything acts on the V4 data structures.

The final commit in this PR switches the cluster and command resolution query to leverage the new V4 criterion fields for better flexibility and options for users when selecting resources. This isn't exposed to the outside world yet via REST API as there is no V4 API yet but the `Agent` could start leveraging it if it so desired. Again backwards compatibility was attempted to be maintained.