### PR TITLE
Split command executable in database

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/dto/v4/Command.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/v4/Command.java
@@ -50,7 +50,7 @@ public class Command extends CommonResource {
     @NotEmpty(message = "At least one executable entry is required")
     private final ImmutableList<
         @NotEmpty(message = "A default executable element shouldn't be an empty string")
-        @Size(max = 255, message = "Executable elements can only be 255 characters") String> executable;
+        @Size(max = 1024, message = "Executable elements can only be 1024 characters") String> executable;
     @Min(
         value = 1,
         message = "The minimum amount of memory if desired is 1 MB. Probably should be much more than that"

--- a/genie-ddl/src/main/sql/mysql/load-3.2.x-job-data-to-3.3.0.mysql.sql
+++ b/genie-ddl/src/main/sql/mysql/load-3.2.x-job-data-to-3.3.0.mysql.sql
@@ -572,33 +572,5 @@ SELECT
   'Finished loading data into jobs_applications table' AS '';
 
 SELECT
-  CURRENT_TIMESTAMP     AS '',
-  'Dropping old tables' AS '';
-
-DROP TABLE IF EXISTS
-`job_metadata_320`,
-`job_executions_320`,
-`jobs_applications_320`,
-`jobs_320`,
-`job_requests_320`,
-`application_configs_320`,
-`application_dependencies_320`,
-`cluster_configs_320`,
-`cluster_dependencies_320`,
-`command_configs_320`,
-`command_dependencies_320`,
-`commands_applications_320`,
-`clusters_commands_320`,
-`applications_320`,
-`clusters_320`,
-`commands_320`;
-
-SELECT
-  CURRENT_TIMESTAMP              AS '',
-  'Finished dropping old tables' AS '';
-
-DROP TABLE IF EXISTS `criteria_tags_tmp`;
-
-SELECT
   CURRENT_TIMESTAMP                                                     AS '',
   'Finished loading data from old 3.2.0 jobs tables to 3.3.0 job table' AS '';

--- a/genie-ddl/src/main/sql/postgresql/load-3.2.x-job-data-to-3.3.0.postgresql.sql
+++ b/genie-ddl/src/main/sql/postgresql/load-3.2.x-job-data-to-3.3.0.postgresql.sql
@@ -531,30 +531,4 @@ SELECT
 
 SELECT
   CURRENT_TIMESTAMP,
-  'Dropping old tables';
-
-DROP TABLE IF EXISTS
-job_metadata_320,
-job_executions_320,
-jobs_applications_320,
-jobs_320,
-job_requests_320,
-application_configs_320,
-application_dependencies_320,
-cluster_configs_320,
-cluster_dependencies_320,
-command_configs_320,
-command_dependencies_320,
-commands_applications_320,
-clusters_commands_320,
-applications_320,
-clusters_320,
-commands_320;
-
-SELECT
-  CURRENT_TIMESTAMP,
-  'Finished dropping old tables';
-
-SELECT
-  CURRENT_TIMESTAMP,
   'Finished loading data from old 3.2.0 jobs tables to 3.3.0 job table';

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
@@ -305,7 +305,7 @@ public final class DtoConverters {
             v3Command.getUpdated().orElse(Instant.now()),
             resources,
             metadataBuilder.build(),
-            Lists.newArrayList(StringUtils.split(v3Command.getExecutable(), ' ')),
+            Lists.newArrayList(StringUtils.split(v3Command.getExecutable())),
             v3Command.getMemory().orElse(null),
             v3Command.getCheckDelay()
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/CommandEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/CommandEntity.java
@@ -26,7 +26,9 @@ import lombok.ToString;
 
 import javax.annotation.Nullable;
 import javax.persistence.Basic;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -38,6 +40,7 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.ArrayList;
@@ -67,11 +70,17 @@ public class CommandEntity extends BaseEntity {
     @NotNull(message = "No command status entered and is required.")
     private CommandStatus status;
 
-    @Basic(optional = false)
-    @Column(name = "executable", nullable = false)
-    @NotBlank(message = "No executable entered for command and is required.")
-    @Size(max = 255, message = "Max length in database is 255 characters")
-    private String executable;
+    @ElementCollection
+    @CollectionTable(
+        name = "command_executable_arguments",
+        joinColumns = {
+            @JoinColumn(name = "command_id", nullable = false)
+        }
+    )
+    @Column(name = "argument", length = 1024, nullable = false)
+    @OrderColumn(name = "argument_order", nullable = false)
+    @NotEmpty(message = "No executable arguments entered. At least one is required.")
+    private List<@NotBlank @Size(max = 1024) String> executable = new ArrayList<>();
 
     @Basic(optional = false)
     @Column(name = "check_delay", nullable = false)
@@ -140,6 +149,16 @@ public class CommandEntity extends BaseEntity {
      */
     public CommandEntity() {
         super();
+    }
+
+    /**
+     * Set the executable and any default arguments for this command.
+     *
+     * @param executable The executable and default arguments which can't be blank and there must be at least one
+     */
+    public void setExecutable(@NotEmpty final List<@NotBlank @Size(max = 1024) String> executable) {
+        this.executable.clear();
+        this.executable.addAll(executable);
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
@@ -51,6 +51,7 @@ import javax.persistence.PrePersist;
 import javax.persistence.Table;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.Instant;
@@ -247,9 +248,9 @@ public class JobEntity extends BaseEntity implements
             @JoinColumn(name = "job_id", nullable = false, updatable = false)
         }
     )
-    @Column(name = "argument", length = 2048, nullable = false, updatable = false)
+    @Column(name = "argument", length = 10_000, nullable = false, updatable = false)
     @OrderColumn(name = "argument_order", nullable = false, updatable = false)
-    private List<String> commandArgs = new ArrayList<>();
+    private List<@NotBlank @Size(max = 10_000) String> commandArgs = new ArrayList<>();
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/EntityDtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/EntityDtoConverters.java
@@ -20,7 +20,6 @@ package com.netflix.genie.web.jpa.entities.v4;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.netflix.genie.common.dto.v4.Application;
 import com.netflix.genie.common.dto.v4.ApplicationMetadata;
 import com.netflix.genie.common.dto.v4.Cluster;
@@ -38,7 +37,6 @@ import com.netflix.genie.web.jpa.entities.FileEntity;
 import com.netflix.genie.web.jpa.entities.TagEntity;
 import com.netflix.genie.web.jpa.entities.projections.BaseProjection;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.stream.Collectors;
 
@@ -145,7 +143,7 @@ public final class EntityDtoConverters {
                 commandEntity.getSetupFile().isPresent() ? commandEntity.getSetupFile().get().getFile() : null
             ),
             metadataBuilder.build(),
-            Lists.newArrayList(StringUtils.split(commandEntity.getExecutable(), ' ')),
+            commandEntity.getExecutable(),
             commandEntity.getMemory().orElse(null),
             commandEntity.getCheckDelay()
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaCommandServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaCommandServiceImpl.java
@@ -54,7 +54,6 @@ import com.netflix.genie.web.services.CommandService;
 import com.netflix.genie.web.services.FileService;
 import com.netflix.genie.web.services.TagService;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -564,8 +563,7 @@ public class JpaCommandServiceImpl extends JpaBaseService implements CommandServ
         final CommandEntity entity = new CommandEntity();
         entity.setUniqueId(request.getRequestedId().orElse(UUID.randomUUID().toString()));
         entity.setCheckDelay(request.getCheckDelay().orElse(com.netflix.genie.common.dto.Command.DEFAULT_CHECK_DELAY));
-        // TODO: Once entity executable saved as List modify this
-        entity.setExecutable(StringUtils.join(request.getExecutable(), ' '));
+        entity.setExecutable(request.getExecutable());
         request.getMemory().ifPresent(entity::setMemory);
         this.setEntityResources(entity, resources);
         this.setEntityTags(entity, metadata);
@@ -587,8 +585,7 @@ public class JpaCommandServiceImpl extends JpaBaseService implements CommandServ
         this.setEntityCommandMetadata(entity, metadata);
 
         entity.setCheckDelay(dto.getCheckDelay());
-        // TODO: Once entity executable saved as List modify this
-        entity.setExecutable(StringUtils.join(dto.getExecutable(), ' '));
+        entity.setExecutable(dto.getExecutable());
         entity.setMemory(dto.getMemory().orElse(null));
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaServiceUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaServiceUtils.java
@@ -43,6 +43,7 @@ import com.netflix.genie.web.jpa.entities.projections.JobMetadataProjection;
 import com.netflix.genie.web.jpa.entities.projections.JobProjection;
 import com.netflix.genie.web.jpa.entities.projections.JobRequestProjection;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.stream.Collectors;
 
@@ -131,7 +132,7 @@ public final class JpaServiceUtils {
             commandEntity.getUser(),
             commandEntity.getVersion().orElse(NO_VERSION_SUPPLIED),
             commandEntity.getStatus(),
-            commandEntity.getExecutable(),
+            StringUtils.join(commandEntity.getExecutable(), ' '),
             commandEntity.getCheckDelay()
         )
             .withId(commandEntity.getUniqueId())

--- a/genie-web/src/main/resources/db/migration/mysql/V4_0_0__Genie_4.sql
+++ b/genie-web/src/main/resources/db/migration/mysql/V4_0_0__Genie_4.sql
@@ -34,6 +34,71 @@ DROP TABLE IF EXISTS
 `clusters_320`,
 `commands_320`;
 
+CREATE TABLE `command_executable_arguments` (
+  `command_id`     BIGINT(20)    NOT NULL,
+  `argument`       VARCHAR(1024) NOT NULL,
+  `argument_order` INT(11)       NOT NULL,
+  PRIMARY KEY (`command_id`, `argument_order`),
+  KEY `COMMAND_EXECUTABLE_ARGUMENTS_COMMAND_ID_INDEX` (`command_id`),
+  CONSTRAINT `COMMAND_EXECUTABLE_ARGUMENTS_COMMAND_ID_FK` FOREIGN KEY (`command_id`) REFERENCES `commands` (`id`)
+    ON DELETE CASCADE
+)
+  ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  DEFAULT COLLATE = utf8_bin
+  ROW_FORMAT = DYNAMIC;
+
+DELIMITER $$
+CREATE PROCEDURE GENIE_SPLIT_COMMANDS_330()
+  BEGIN
+    DECLARE `done` INT DEFAULT FALSE;
+    DECLARE `command_id` BIGINT(20);
+    DECLARE `command_executable` VARCHAR(255);
+
+    DECLARE `commands_cursor` CURSOR FOR
+      SELECT
+        `id`,
+        `executable`
+      FROM `commands`;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    START TRANSACTION;
+    OPEN `commands_cursor`;
+    READ_LOOP: LOOP
+      SET `done` = FALSE;
+
+      FETCH `commands_cursor`
+      INTO `command_id`, `command_executable`;
+
+      IF `done`
+      THEN
+        LEAVE READ_LOOP;
+      END IF;
+
+      SET @argument_order = 0;
+      SET @command_executable_local = `command_executable`;
+      COMMAND_EXECUTABLE_LOOP: WHILE LENGTH(@command_executable_local) > 0 DO
+        SET @argument = SUBSTRING_INDEX(@command_executable_local, ' ', 1);
+        SET @command_executable_local = TRIM(LEADING @argument FROM @command_executable_local);
+        SET @command_executable_local = TRIM(LEADING ' ' FROM @command_executable_local);
+        IF LENGTH(@argument) > 0
+        THEN
+          INSERT INTO `command_executable_arguments`
+          VALUES (`command_id`, @argument, @argument_order);
+          SET @argument_order = @argument_order + 1;
+        END IF;
+      END WHILE COMMAND_EXECUTABLE_LOOP;
+
+    END LOOP READ_LOOP;
+    CLOSE `commands_cursor`;
+    COMMIT;
+  END;
+$$
+DELIMITER ;
+
+CALL GENIE_SPLIT_COMMANDS_330();
+DROP PROCEDURE GENIE_SPLIT_COMMANDS_330;
+
 ALTER TABLE `applications`
   CHANGE `version` `version` VARCHAR(255) DEFAULT NULL;
 
@@ -41,7 +106,8 @@ ALTER TABLE `clusters`
   CHANGE `version` `version` VARCHAR(255) DEFAULT NULL;
 
 ALTER TABLE `commands`
-  CHANGE `version` `version` VARCHAR(255) DEFAULT NULL;
+  CHANGE `version` `version` VARCHAR(255) DEFAULT NULL,
+  DROP COLUMN `executable`;
 
 ALTER TABLE `jobs`
   CHANGE `version` `version` VARCHAR(255) DEFAULT NULL;

--- a/genie-web/src/test/groovy/com/netflix/genie/web/jpa/entities/v4/EntityDtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/jpa/entities/v4/EntityDtoConvertersSpec.groovy
@@ -25,9 +25,7 @@ import com.netflix.genie.common.dto.CommandStatus
 import com.netflix.genie.common.util.GenieObjectMapper
 import com.netflix.genie.test.suppliers.RandomSuppliers
 import com.netflix.genie.web.jpa.entities.*
-import org.apache.commons.lang3.StringUtils
 import spock.lang.Specification
-
 /**
  * Specifications for {@link EntityDtoConverters}.
  *
@@ -213,7 +211,7 @@ class EntityDtoConvertersSpec extends Specification {
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString()
         )
-        entity.setExecutable(StringUtils.join(executable, ' '))
+        entity.setExecutable(executable)
         def checkDelay = 2180234L
         entity.setCheckDelay(checkDelay)
         def memory = 10_241

--- a/genie-web/src/test/groovy/com/netflix/genie/web/jpa/services/JpaServiceUtilsSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/jpa/services/JpaServiceUtilsSpec.groovy
@@ -220,7 +220,7 @@ class JpaServiceUtilsSpec extends Specification {
         final FileEntity setupFileEntity = new FileEntity()
         setupFileEntity.setFile(setupFile)
         entity.setSetupFile(setupFileEntity)
-        def executable = UUID.randomUUID().toString()
+        def executable = Lists.newArrayList(UUID.randomUUID().toString())
         entity.setExecutable(executable)
         def checkDelay = 2180234L
         entity.setCheckDelay(checkDelay)
@@ -239,7 +239,7 @@ class JpaServiceUtilsSpec extends Specification {
         command.getDescription().orElseGet(RandomSuppliers.STRING) == description
         command.getCreated().orElseGet(RandomSuppliers.INSTANT) == created
         command.getUpdated().orElseGet(RandomSuppliers.INSTANT) == updated
-        command.getExecutable() == executable
+        command.getExecutable() == StringUtils.join(executable, ' ')
         command.getCheckDelay() == checkDelay
         command.getTags() == tags
         command.getSetupFile().orElseGet(RandomSuppliers.STRING) == setupFile

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/CommandEntityUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/CommandEntityUnitTests.java
@@ -24,6 +24,7 @@ import com.netflix.genie.common.dto.CommandStatus;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.test.suppliers.RandomSuppliers;
+import org.apache.commons.lang.StringUtils;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,7 +47,7 @@ import java.util.UUID;
 public class CommandEntityUnitTests extends EntityTestsBase {
     private static final String NAME = "pig13";
     private static final String USER = "tgianos";
-    private static final String EXECUTABLE = "/bin/pig13";
+    private static final List<String> EXECUTABLE = Lists.newArrayList("/bin/pig13", "-Dblah");
     private static final String VERSION = "1.0";
     private static final long CHECK_DELAY = 18083L;
     private static final int MEMORY = 10_240;
@@ -75,7 +76,7 @@ public class CommandEntityUnitTests extends EntityTestsBase {
     public void testDefaultConstructor() {
         final CommandEntity entity = new CommandEntity();
         Assert.assertFalse(entity.getSetupFile().isPresent());
-        Assert.assertNull(entity.getExecutable());
+        Assert.assertThat(entity.getExecutable(), Matchers.empty());
         Assert.assertThat(entity.getCheckDelay(), Matchers.is(Command.DEFAULT_CHECK_DELAY));
         Assert.assertNull(entity.getName());
         Assert.assertNull(entity.getStatus());
@@ -133,8 +134,26 @@ public class CommandEntityUnitTests extends EntityTestsBase {
      * Make sure validation works on with failure from command.
      */
     @Test(expected = ConstraintViolationException.class)
-    public void testValidateNoExecutable() {
-        this.c.setExecutable("    ");
+    public void testValidateEmptyExecutable() {
+        this.c.setExecutable(Lists.newArrayList());
+        this.validate(this.c);
+    }
+
+    /**
+     * Make sure validation works on with failure from command.
+     */
+    @Test(expected = ConstraintViolationException.class)
+    public void testValidateBlankExecutable() {
+        this.c.setExecutable(Lists.newArrayList("    "));
+        this.validate(this.c);
+    }
+
+    /**
+     * Make sure validation works on with failure from command.
+     */
+    @Test(expected = ConstraintViolationException.class)
+    public void testValidateExecutableArgumentTooLong() {
+        this.c.setExecutable(Lists.newArrayList(StringUtils.leftPad("", 1025, 'e')));
         this.validate(this.c);
     }
 

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaApplicationServiceImplIntegrationTests/init.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaApplicationServiceImplIntegrationTests/init.xml
@@ -197,10 +197,15 @@
         genie_user="tgianos"
         name="pig_13_prod"
         version="1.2.3"
-        executable="pig"
         check_delay="10000"
         status="INACTIVE"
     />
 
     <commands_applications command_id="0" application_id="0" application_order="0"/>
+
+    <command_executable_arguments
+        command_id="0"
+        argument="pig"
+        argument_order="0"
+    />
 </dataset>

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaClusterServiceImplIntegrationTests/init.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaClusterServiceImplIntegrationTests/init.xml
@@ -131,7 +131,6 @@
         genie_user="tgianos"
         name="pig_13_prod"
         version="1.2.3"
-        executable="pig"
         check_delay="15000"
         status="ACTIVE"
     />
@@ -155,6 +154,11 @@
         command_id="1"
         tag_id="2"
     />
+    <command_executable_arguments
+        command_id="1"
+        argument="pig"
+        argument_order="0"
+    />
 
     <commands
         id="2"
@@ -165,7 +169,6 @@
         genie_user="amsharma"
         name="hive_11_prod"
         version="4.5.6"
-        executable="hive"
         check_delay="16000"
         status="INACTIVE"
     />
@@ -181,6 +184,11 @@
         command_id="2"
         tag_id="1"
     />
+    <command_executable_arguments
+        command_id="2"
+        argument="hive"
+        argument_order="0"
+    />
 
     <commands
         id="3"
@@ -191,7 +199,6 @@
         genie_user="tgianos"
         name="pig_11_prod"
         version="7.8.9"
-        executable="pig"
         check_delay="17000"
         status="DEPRECATED"
     />
@@ -211,6 +218,11 @@
         command_id="3"
         tag_id="1"
     />
+    <command_executable_arguments
+        command_id="3"
+        argument="pig"
+        argument_order="0"
+    />
 
     <commands
         id="4"
@@ -221,7 +233,6 @@
         genie_user="tgianos"
         name="pig_13_prod"
         version="1.2.3"
-        executable="pig"
         check_delay="15000"
         status="ACTIVE"
     />
@@ -244,6 +255,11 @@
     <commands_tags
         command_id="4"
         tag_id="2"
+    />
+    <command_executable_arguments
+        command_id="4"
+        argument="pig"
+        argument_order="0"
     />
 
     <clusters

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaCommandServiceImplIntegrationTests/init.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaCommandServiceImplIntegrationTests/init.xml
@@ -146,7 +146,6 @@
         genie_user="tgianos"
         name="pig_13_prod"
         version="1.2.3"
-        executable="pig"
         check_delay="18000"
         status="ACTIVE"
     />
@@ -170,6 +169,11 @@
         command_id="1"
         tag_id="3"
     />
+    <command_executable_arguments
+        command_id="1"
+        argument="pig"
+        argument_order="0"
+    />
 
     <commands_applications
         command_id="1"
@@ -186,7 +190,6 @@
         genie_user="amsharma"
         name="hive_11_prod"
         version="4.5.6"
-        executable="hive"
         check_delay="19000"
         status="INACTIVE"
     />
@@ -206,6 +209,11 @@
         command_id="2"
         tag_id="0"
     />
+    <command_executable_arguments
+        command_id="2"
+        argument="hive"
+        argument_order="0"
+    />
 
     <commands
         id="3"
@@ -216,7 +224,6 @@
         genie_user="tgianos"
         name="pig_11_prod"
         version="7.8.9"
-        executable="pig"
         check_delay="20000"
         status="DEPRECATED"
         metadata=
@@ -243,6 +250,11 @@
     <commands_tags
         command_id="3"
         tag_id="0"
+    />
+    <command_executable_arguments
+        command_id="3"
+        argument="pig"
+        argument_order="0"
     />
 
     <clusters

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImplIntegrationTests/init.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImplIntegrationTests/init.xml
@@ -333,7 +333,6 @@
         genie_user="tgianos"
         name="spark"
         version="1.6.0"
-        executable="spark"
         check_delay="10000"
         status="ACTIVE"
     />
@@ -345,6 +344,11 @@
     <commands_tags
         command_id="1"
         tag_id="5"
+    />
+    <command_executable_arguments
+        command_id="1"
+        argument="spark"
+        argument_order="0"
     />
 
     <commands_applications command_id="1" application_id="1" application_order="0"/>

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImplIntegrationTests/init.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImplIntegrationTests/init.xml
@@ -333,7 +333,6 @@
         genie_user="tgianos"
         name="spark"
         version="1.6.0"
-        executable="spark"
         check_delay="10000"
         status="ACTIVE"
     />
@@ -345,6 +344,12 @@
     <commands_tags
         command_id="1"
         tag_id="5"
+    />
+
+    <command_executable_arguments
+        command_id="1"
+        argument="spark"
+        argument_order="0"
     />
 
     <commands_applications command_id="1" application_id="1" application_order="0"/>

--- a/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/cleanup.xml
+++ b/genie-web/src/test/resources/com/netflix/genie/web/jpa/services/cleanup.xml
@@ -24,6 +24,7 @@
     <commands_configs/>
     <commands_dependencies/>
     <commands_tags/>
+    <command_executable_arguments/>
     <jobs_configs/>
     <jobs_dependencies/>
     <jobs_tags/>


### PR DESCRIPTION
This PR brings consistency between the command args for a job and the default executable arguments of a command by storing the command executable arguments in the database in a one to many table.