### PR TITLE
Make job coordination use specification service

### DIFF
--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -91,53 +91,11 @@ published within the local JVM and available on the Actuator `/metrics` endpoint
 |JobCoordinatorServiceImpl
 |status, exceptionClass
 
-|genie.jobs.coordination.clusterCommandQuery.timer
-|Time taken to query the database and find clusters and commands matching the supplied criteria.
-|nanoseconds
-|JobCoordinatorServiceImpl
-|status, exceptionClass
-
-|genie.jobs.submit.localRunner.selectCluster.timer
-|Time taken to select a cluster using the load balancing strategy
-|nanoseconds
-|JobCoordinatorServiceImpl
-|status, exceptionClass
-
-|genie.jobs.submit.localRunner.selectCommand.timer
-|Time taken to resolve a command based on criteria and cluster
-|nanoseconds
-|JobCoordinatorServiceImpl
-|status, exceptionClass
-
-|genie.jobs.submit.localRunner.selectApplications.timer
-|Time taken to retrieve applications information for this task
-|nanoseconds
-|JobCoordinatorServiceImpl
-|status, exceptionClass
-
 |genie.jobs.submit.localRunner.setJobEnvironment.timer
 |Time taken to persist the job runtime information in the database
 |nanoseconds
 |JobCoordinatorServiceImpl
 |status, exceptionClass
-
-|genie.jobs.submit.selectCluster.loadBalancer.counter
-|Counter for cluster load balancer algorithms invocations
-|count
-|JobCoordinatorServiceImpl
-|class, status
-
-|genie.jobs.submit.selectCluster.noneSelected.counter
-|Number of times the cluster load balancing terminated without selecting a cluster
-|count
-|JobCoordinatorServiceImpl
-|-
-
-|genie.jobs.submit.selectCluster.noneFound.counter
-|Number of times the criteria for cluster selection does not match any cluster
-|count
-|JobCoordinatorServiceImpl
-|-
 
 |genie.jobs.running.gauge
 |Number of jobs currently running locally
@@ -438,6 +396,48 @@ published within the local JVM and available on the Actuator `/metrics` endpoint
 |count
 |DiskCleanupTask
 |-
+
+|genie.services.specification.clusterCommandQuery.timer
+|Time taken to query the database and find clusters and commands matching the supplied criteria.
+|nanoseconds
+|JobSpecificationServiceImpl
+|status, exceptionClass
+
+|genie.services.specification.loadBalancer.counter
+|Counter for cluster load balancer algorithms invocations
+|count
+|JobSpecificationServiceImpl
+|class, status
+
+|genie.services.specification.selectApplications.timer
+|Time taken to retrieve applications information for this task
+|nanoseconds
+|JobSpecificationServiceImpl
+|status, exceptionClass
+
+|genie.services.specification.selectCluster.timer
+|Time taken to select a cluster using the load balancing strategy
+|nanoseconds
+|JobSpecificationServiceImpl
+|status, exceptionClass
+
+|genie.services.specification.selectCluster.noneSelected.counter
+|Number of times the cluster load balancing terminated without selecting a cluster
+|count
+|JobSpecificationServiceImpl
+|-
+
+|genie.services.specification.selectCluster.noneFound.counter
+|Number of times the criteria for cluster selection does not match any cluster
+|count
+|JobSpecificationServiceImpl
+|-
+
+|genie.services.specification.selectCommand.timer
+|Time taken to resolve a command based on criteria and cluster
+|nanoseconds
+|JobSpecificationServiceImpl
+|status, exceptionClass
 
 |genie.health.endpoint.timer
 |Time taken for the Health endpoint to collect and aggregate state from health indicators

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -45,32 +45,32 @@ Health of the system is marked unhealthy if the CPU load of a system goes beyond
 |Whether or not to delete the dependencies directories for applications, cluster, command to save disk space after job completion
 |true
 
-|genie.jobs.clusters.loadBalancers.script.destination
+|genie.jobs.clusters.load-balancers.script.destination
 |The location on disk where the script source file should be stored after it is downloaded from
-`genie.jobs.clusters.loadBalancers.script.source`. The file will be given the same name.
+`genie.jobs.clusters.load-balancers.script.source`. The file will be given the same name.
 |file:///tmp/genie/loadbalancers/script/destination/
 
-|genie.jobs.clusters.loadBalancers.script.enabled
+|genie.jobs.clusters.load-balancers.script.enabled
 |Whether the script based load balancer should be enabled for the system or not.
-See also: `genie.jobs.clusters.loadBalancers.script.source`
-See also: `genie.jobs.clusters.loadBalancers.script.destination`
+See also: `genie.jobs.clusters.load-balancers.script.source`
+See also: `genie.jobs.clusters.load-balancers.script.destination`
 |false
 
-|genie.jobs.clusters.loadBalancers.script.order
+|genie.jobs.clusters.load-balancers.script.order
 |The order which the script load balancer should be evaluated. The lower this number the sooner it is evaluated. 0
 would be the first thing evaluated if nothing else is set to 0 as well. Must be < 2147483647 (Integer.MAX_VALUE). If
 no value set will be given Integer.MAX_VALUE - 1 (default).
 |2147483646
 
-|genie.jobs.clusters.loadBalancers.script.refreshRate
+|genie.jobs.clusters.load-balancers.script.refreshRate
 |How frequently to refresh the load balancer script (in milliseconds)
 |300000
 
-|genie.jobs.clusters.loadBalancers.script.source
+|genie.jobs.clusters.load-balancers.script.source
 |The location of the script the load balancer should load to evaluate which cluster to use for a job request
 |file:///tmp/genie/loadBalancers/script/source/loadBalance.js
 
-|genie.jobs.clusters.loadBalancers.script.timeout
+|genie.jobs.clusters.load-balancers.script.timeout
 |The amount of time (in milliseconds) that the system will attempt to run the cluster load balancer script before it
 forces a timeout
 |5000

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -64,6 +64,46 @@ for `Instant` serialization/deserialization.
 
 |===
 
+=== Metric Changes
+
+Switched to http://micrometer.io/[Micrometer]
+
+==== Renamed
+
+|===
+|Old Name |New Name |Reason
+
+
+|genie.jobs.coordination.clusterCommandQuery.timer
+|genie.services.specification.clusterCommandQuery.timer
+|Functionality moved to new service
+
+|genie.jobs.submit.selectCluster.loadBalancer.counter
+|genie.services.specification.loadBalancer.counter
+|Functionality moved to new service
+
+|genie.jobs.submit.localRunner.selectApplications.timer
+|genie.services.specification.selectApplications.timer
+|Functionality moved to new service
+
+|genie.jobs.submit.localRunner.selectCluster.timer
+|genie.services.specification.selectCluster.timer
+|Functionality moved to new service
+
+|genie.jobs.submit.selectCluster.noneSelected.counter
+|genie.services.specification.selectCluster.noneSelected.counter
+|Functionality moved to new service
+
+|genie.jobs.submit.selectCluster.noneFound.counter
+|genie.services.specification.selectCluster.noneFound.counter
+|Functionality moved to new service
+
+|genie.jobs.submit.localRunner.selectCommand.timer
+|genie.services.specification.selectCommand.timer
+|Functionality moved to new service
+
+|===
+
 == 3.3.0 Release Notes
 
 The following are the release notes for Genie 3.3.0.

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -46,6 +46,11 @@ https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Gu
 |Modifications to how Spring handled
 https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#relaxed-binding[property binding]
 
+|genie.jobs.clusters.loadBalancers.script.*
+|genie.jobs.clusters.load-balancers.script.*
+|Modifications to how Spring handled
+https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#relaxed-binding[property binding]
+
 |===
 
 ==== Removed

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -46,6 +46,7 @@ import com.netflix.genie.web.services.JobCoordinatorService;
 import com.netflix.genie.web.services.JobKillService;
 import com.netflix.genie.web.services.JobPersistenceService;
 import com.netflix.genie.web.services.JobSearchService;
+import com.netflix.genie.web.services.JobSpecificationService;
 import com.netflix.genie.web.services.JobStateService;
 import com.netflix.genie.web.services.JobSubmitterService;
 import com.netflix.genie.web.services.MailService;
@@ -376,7 +377,7 @@ public class ServicesConfig {
      * @param applicationService    Implementation of application service interface
      * @param clusterService        Implementation of cluster service interface
      * @param commandService        Implementation of command service interface
-     * @param clusterLoadBalancers  Implementations of the cluster load balancer interface in invocation order
+     * @param specificationService  The job specification service to use
      * @param registry              The metrics registry to use
      * @param hostName              The host this Genie instance is running on
      * @return An instance of the JobCoordinatorService.
@@ -391,13 +392,10 @@ public class ServicesConfig {
         final ApplicationService applicationService,
         final ClusterService clusterService,
         final CommandService commandService,
-        final List<ClusterLoadBalancer> clusterLoadBalancers,
+        final JobSpecificationService specificationService,
         final MeterRegistry registry,
         final String hostName
     ) {
-        if (clusterLoadBalancers.isEmpty()) {
-            throw new IllegalStateException("Must have at least one active implementation of ClusterLoadBalancer");
-        }
         return new JobCoordinatorServiceImpl(
             jobPersistenceService,
             jobKillService,
@@ -407,7 +405,7 @@ public class ServicesConfig {
             jobSearchService,
             clusterService,
             commandService,
-            clusterLoadBalancers,
+            specificationService,
             registry,
             hostName
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
@@ -77,19 +77,16 @@ import java.util.stream.Collectors;
  * @since 3.1.0
  */
 @Component
-@ConditionalOnProperty(value = "genie.jobs.clusters.loadBalancers.script.enabled", havingValue = "true")
+@ConditionalOnProperty(value = ScriptLoadBalancer.SCRIPT_LOAD_BALANCER_PROPERTY_GROUP + "enabled", havingValue = "true")
 @Slf4j
 public class ScriptLoadBalancer implements ClusterLoadBalancer {
 
-    static final String SCRIPT_TIMEOUT_PROPERTY_KEY = "genie.jobs.clusters.loadBalancers.script.timeout";
-    static final String SCRIPT_FILE_SOURCE_PROPERTY_KEY
-        = "genie.jobs.clusters.loadBalancers.script.source";
-    static final String SCRIPT_FILE_DESTINATION_PROPERTY_KEY
-        = "genie.jobs.clusters.loadBalancers.script.destination";
-    static final String SCRIPT_REFRESH_RATE_PROPERTY_KEY
-        = "genie.jobs.clusters.loadBalancers.script.refreshRate";
-    static final String SCRIPT_LOAD_BALANCER_ORDER_PROPERTY_KEY
-        = "genie.jobs.clusters.loadBalancers.script.order";
+    static final String SCRIPT_LOAD_BALANCER_PROPERTY_GROUP = "genie.jobs.clusters.load-balancers.script.";
+    static final String SCRIPT_LOAD_BALANCER_ORDER_PROPERTY_KEY = SCRIPT_LOAD_BALANCER_PROPERTY_GROUP + "order";
+    static final String SCRIPT_REFRESH_RATE_PROPERTY_KEY = SCRIPT_LOAD_BALANCER_PROPERTY_GROUP + "refreshRate";
+    static final String SCRIPT_FILE_DESTINATION_PROPERTY_KEY = SCRIPT_LOAD_BALANCER_PROPERTY_GROUP + "destination";
+    static final String SCRIPT_FILE_SOURCE_PROPERTY_KEY = SCRIPT_LOAD_BALANCER_PROPERTY_GROUP + "source";
+    static final String SCRIPT_TIMEOUT_PROPERTY_KEY = SCRIPT_LOAD_BALANCER_PROPERTY_GROUP + "timeout";
     static final String SELECT_TIMER_NAME = "genie.jobs.clusters.loadBalancers.script.select.timer";
     static final String UPDATE_TIMER_NAME = "genie.jobs.clusters.loadBalancers.script.update.timer";
     static final String STATUS_TAG_OK = "ok";
@@ -172,7 +169,7 @@ public class ScriptLoadBalancer implements ClusterLoadBalancer {
         log.debug("Called");
         final Set<Tag> tags = Sets.newHashSet();
         try {
-            if (this.isConfigured.get() && this.script != null && this.script.get() != null) {
+            if (this.isConfigured.get() && this.script.get() != null) {
                 log.debug("Evaluating script for job {}", jobRequest.getId().orElse("without id"));
                 final Bindings bindings = new SimpleBindings();
                 // TODO: For now for backwards compatibility with balancer scripts continue writing Clusters out in

--- a/genie-web/src/main/resources/application.yml
+++ b/genie-web/src/main/resources/application.yml
@@ -27,7 +27,7 @@ genie:
       deleteArchiveFile: true
       deleteDependencies: true
     clusters:
-      loadBalancers:
+      load-balancers:
         script:
           destination: file:///tmp/genie/loadbalancers/script/destination/
           enabled: false

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -30,18 +30,17 @@ import com.netflix.genie.web.jpa.repositories.JpaJobRepository;
 import com.netflix.genie.web.jpa.repositories.JpaTagRepository;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.ApplicationService;
-import com.netflix.genie.web.services.ClusterLoadBalancer;
 import com.netflix.genie.web.services.ClusterService;
 import com.netflix.genie.web.services.CommandService;
 import com.netflix.genie.web.services.FileService;
 import com.netflix.genie.web.services.JobKillService;
 import com.netflix.genie.web.services.JobPersistenceService;
 import com.netflix.genie.web.services.JobSearchService;
+import com.netflix.genie.web.services.JobSpecificationService;
 import com.netflix.genie.web.services.JobStateService;
 import com.netflix.genie.web.services.TagService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.exec.Executor;
-import org.assertj.core.util.Lists;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -250,29 +249,7 @@ public class ServicesConfigUnitTests {
                 Mockito.mock(ApplicationService.class),
                 Mockito.mock(ClusterService.class),
                 Mockito.mock(CommandService.class),
-                Lists.newArrayList(Mockito.mock(ClusterLoadBalancer.class)),
-                Mockito.mock(MeterRegistry.class),
-                UUID.randomUUID().toString()
-            )
-        );
-    }
-
-    /**
-     * Can't get a bean for Job Coordinator Service.
-     */
-    @Test(expected = IllegalStateException.class)
-    public void cantGetJobCoordinatorServiceBeanWhenNoClusterLoadBalancers() {
-        Assert.assertNotNull(
-            this.servicesConfig.jobCoordinatorService(
-                Mockito.mock(JobPersistenceService.class),
-                Mockito.mock(JobKillService.class),
-                Mockito.mock(JobStateService.class),
-                Mockito.mock(JobSearchService.class),
-                new JobsProperties(),
-                Mockito.mock(ApplicationService.class),
-                Mockito.mock(ClusterService.class),
-                Mockito.mock(CommandService.class),
-                Lists.newArrayList(),
+                Mockito.mock(JobSpecificationService.class),
                 Mockito.mock(MeterRegistry.class),
                 UUID.randomUUID().toString()
             )

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
@@ -18,22 +18,19 @@
 package com.netflix.genie.web.services.impl;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.ApplicationStatus;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.dto.v4.Application;
-import com.netflix.genie.common.dto.v4.ApplicationMetadata;
 import com.netflix.genie.common.dto.v4.Cluster;
 import com.netflix.genie.common.dto.v4.Command;
 import com.netflix.genie.common.dto.v4.ExecutionEnvironment;
+import com.netflix.genie.common.dto.v4.JobSpecification;
 import com.netflix.genie.common.exceptions.GenieConflictException;
 import com.netflix.genie.common.exceptions.GenieException;
-import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
@@ -41,33 +38,26 @@ import com.netflix.genie.common.exceptions.GenieUserLimitExceededException;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.ApplicationService;
-import com.netflix.genie.web.services.ClusterLoadBalancer;
 import com.netflix.genie.web.services.ClusterService;
 import com.netflix.genie.web.services.CommandService;
 import com.netflix.genie.web.services.JobKillService;
 import com.netflix.genie.web.services.JobPersistenceService;
 import com.netflix.genie.web.services.JobSearchService;
+import com.netflix.genie.web.services.JobSpecificationService;
 import com.netflix.genie.web.services.JobStateService;
-import com.netflix.genie.web.util.MetricsConstants;
 import com.netflix.genie.web.util.MetricsUtils;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import javax.annotation.Nullable;
-import java.time.Instant;
+import java.io.File;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -101,23 +91,11 @@ public class JobCoordinatorServiceImplUnitTests {
     private ApplicationService applicationService;
     private ClusterService clusterService;
     private CommandService commandService;
-    private ClusterLoadBalancer clusterLoadBalancer1;
-    private ClusterLoadBalancer clusterLoadBalancer2;
-    private ClusterLoadBalancer clusterLoadBalancer3;
-    private ClusterLoadBalancer clusterLoadBalancer4;
+    private JobSpecificationService specificationService;
     private JobsProperties jobsProperties;
-    @Captor
-    private ArgumentCaptor<Set<Tag>> tagsCaptor;
     private MeterRegistry registry;
     private Timer coordinationTimer;
-    private Timer selectClusterTimer;
-    private Timer selectCommandTimer;
-    private Timer selectApplicationsTimer;
     private Timer setJobEnvironmentTimer;
-    private Timer clusterCommandQueryTimer;
-    private Counter noClusterSelectedCounter;
-    private Counter noMatchingClusterCounter;
-    private Counter loadBalancerCounter;
 
     /**
      * Setup for the tests.
@@ -136,10 +114,7 @@ public class JobCoordinatorServiceImplUnitTests {
         this.applicationService = Mockito.mock(ApplicationService.class);
         this.clusterService = Mockito.mock(ClusterService.class);
         this.commandService = Mockito.mock(CommandService.class);
-        this.clusterLoadBalancer1 = Mockito.mock(ClusterLoadBalancer.class);
-        this.clusterLoadBalancer2 = Mockito.mock(ClusterLoadBalancer.class);
-        this.clusterLoadBalancer3 = Mockito.mock(ClusterLoadBalancer.class);
-        this.clusterLoadBalancer4 = Mockito.mock(ClusterLoadBalancer.class);
+        this.specificationService = Mockito.mock(JobSpecificationService.class);
 
         this.registry = Mockito.mock(MeterRegistry.class);
         this.coordinationTimer = Mockito.mock(Timer.class);
@@ -151,33 +126,6 @@ public class JobCoordinatorServiceImplUnitTests {
                 )
             )
             .thenReturn(this.coordinationTimer);
-        this.selectClusterTimer = Mockito.mock(Timer.class);
-        Mockito
-            .when(
-                this.registry.timer(
-                    Mockito.eq(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME),
-                    Mockito.anySet()
-                )
-            )
-            .thenReturn(this.selectClusterTimer);
-        this.selectCommandTimer = Mockito.mock(Timer.class);
-        Mockito
-            .when(
-                this.registry.timer(
-                    Mockito.eq(JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME),
-                    Mockito.anySet()
-                )
-            )
-            .thenReturn(this.selectCommandTimer);
-        this.selectApplicationsTimer = Mockito.mock(Timer.class);
-        Mockito
-            .when(
-                this.registry.timer(
-                    Mockito.eq(JobCoordinatorServiceImpl.SELECT_APPLICATIONS_TIMER_NAME),
-                    Mockito.anySet()
-                )
-            )
-            .thenReturn(this.selectApplicationsTimer);
         this.setJobEnvironmentTimer = Mockito.mock(Timer.class);
         Mockito
             .when(
@@ -187,32 +135,6 @@ public class JobCoordinatorServiceImplUnitTests {
                 )
             )
             .thenReturn(this.setJobEnvironmentTimer);
-        this.noClusterSelectedCounter = Mockito.mock(Counter.class);
-        Mockito
-            .when(this.registry.counter("genie.jobs.submit.selectCluster.noneSelected.counter"))
-            .thenReturn(this.noClusterSelectedCounter);
-        this.noMatchingClusterCounter = Mockito.mock(Counter.class);
-        Mockito
-            .when(this.registry.counter("genie.jobs.submit.selectCluster.noneFound.counter"))
-            .thenReturn(this.noMatchingClusterCounter);
-        this.loadBalancerCounter = Mockito.mock(Counter.class);
-        Mockito
-            .when(
-                this.registry.counter(
-                    Mockito.eq(JobCoordinatorServiceImpl.SELECT_LOAD_BALANCER_COUNTER_NAME),
-                    Mockito.anySet()
-                )
-            )
-            .thenReturn(this.loadBalancerCounter);
-        this.clusterCommandQueryTimer = Mockito.mock(Timer.class);
-        Mockito
-            .when(
-                this.registry.timer(
-                    Mockito.eq(JobCoordinatorServiceImpl.CLUSTER_COMMAND_QUERY_TIMER_NAME),
-                    Mockito.anySet()
-                )
-            )
-            .thenReturn(this.clusterCommandQueryTimer);
 
         this.jobCoordinatorService = new JobCoordinatorServiceImpl(
             this.jobPersistenceService,
@@ -223,12 +145,7 @@ public class JobCoordinatorServiceImplUnitTests {
             this.jobSearchService,
             this.clusterService,
             this.commandService,
-            Lists.newArrayList(
-                this.clusterLoadBalancer1,
-                this.clusterLoadBalancer2,
-                this.clusterLoadBalancer3,
-                this.clusterLoadBalancer4
-            ),
+            this.specificationService,
             this.registry,
             HOST_NAME
         );
@@ -240,7 +157,7 @@ public class JobCoordinatorServiceImplUnitTests {
      * @throws GenieException If there is any problem
      */
     @Test(expected = GeniePreconditionException.class)
-    public void cantCoordinateJobIfNoClustersFound() throws GenieException {
+    public void cantCoordinateJobIfJobSpecificationResolutionFails() throws GenieException {
 
         final Set<String> commandCriteria = Sets.newHashSet(
             UUID.randomUUID().toString(),
@@ -252,69 +169,14 @@ public class JobCoordinatorServiceImplUnitTests {
         final JobMetadata jobMetadata = this.getJobMetadata();
 
         Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(Maps.newHashMap());
+            .when(
+                this.specificationService.resolveJobSpecification(
+                    Mockito.anyString(),
+                    Mockito.any(com.netflix.genie.common.dto.v4.JobRequest.class))
+            )
+            .thenThrow(new RuntimeException());
 
-        Mockito.verifyNoMoreInteractions(
-            this.selectApplicationsTimer,
-            this.selectClusterTimer,
-            this.setJobEnvironmentTimer
-        );
-
-        try {
-            this.jobCoordinatorService.coordinateJob(jobRequest, jobMetadata);
-        } finally {
-            Mockito
-                .verify(this.coordinationTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(
-                    JobCoordinatorServiceImpl.OVERALL_COORDINATION_TIMER_NAME,
-                    MetricsUtils.newFailureTagsSetForException(new GeniePreconditionException("test"))
-                );
-            Mockito
-                .verify(this.noMatchingClusterCounter, Mockito.times(1))
-                .increment();
-            Mockito
-                .verify(this.selectClusterTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(
-                    JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME,
-                    MetricsUtils.newFailureTagsSetForException(new GeniePreconditionException("test"))
-                );
-        }
-    }
-
-    /**
-     * Test the coordinate job method.
-     *
-     * @throws GenieException If there is any problem
-     */
-    @Test(expected = GeniePreconditionException.class)
-    public void cantCoordinateJobIfNoClustersSelected() throws GenieException {
-
-        final Set<String> commandCriteria = Sets.newHashSet(
-        );
-
-        final JobRequest jobRequest = this.getJobRequest(true, commandCriteria, null, null);
-        final JobMetadata jobMetadata = this.getJobMetadata();
-
-        final Map<Cluster, String> clusterCommandMap = Maps.newHashMap();
-        clusterCommandMap.put(Mockito.mock(Cluster.class), UUID.randomUUID().toString());
-        clusterCommandMap.put(Mockito.mock(Cluster.class), UUID.randomUUID().toString());
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clusterCommandMap);
-
-        Mockito.verifyNoMoreInteractions(
-            this.selectApplicationsTimer,
-            this.selectClusterTimer,
-            this.setJobEnvironmentTimer
-        );
+        Mockito.verifyNoMoreInteractions(this.setJobEnvironmentTimer);
 
         try {
             this.jobCoordinatorService.coordinateJob(jobRequest, jobMetadata);
@@ -328,44 +190,6 @@ public class JobCoordinatorServiceImplUnitTests {
                     JobCoordinatorServiceImpl.OVERALL_COORDINATION_TIMER_NAME,
                     MetricsUtils.newFailureTagsSetForException(new GeniePreconditionException("test"))
                 );
-            Mockito
-                .verify(this.noClusterSelectedCounter, Mockito.times(1))
-                .increment();
-            Mockito
-                .verify(this.registry, Mockito.times(4))
-                .counter(
-                    Mockito.eq(JobCoordinatorServiceImpl.SELECT_LOAD_BALANCER_COUNTER_NAME),
-                    this.tagsCaptor.capture()
-                );
-            final Set<Tag> finalTags = this.tagsCaptor.getAllValues().get(3);
-            Assert.assertThat(finalTags.size(), Matchers.is(2));
-            for (final Tag tag : finalTags) {
-                if (tag.getKey().equals(MetricsConstants.TagKeys.CLASS_NAME)) {
-                    Assert.assertThat(
-                        tag.getValue(),
-                        Matchers.startsWith("com.netflix.genie.web.services.ClusterLoadBalancer")
-                    );
-                } else if (tag.getKey().equals(MetricsConstants.TagKeys.STATUS)) {
-                    Assert.assertThat(tag.getValue(), Matchers.is("no preference"));
-                } else {
-                    Assert.fail();
-                }
-            }
-            Mockito
-                .verify(this.loadBalancerCounter, Mockito.times(4))
-                .increment();
-            Mockito
-                .verify(this.selectClusterTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(
-                    JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME,
-                    MetricsUtils.newFailureTagsSetForException(new GeniePreconditionException("test"))
-                );
-            Mockito
-                .verify(this.clusterCommandQueryTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
         }
     }
 
@@ -375,7 +199,7 @@ public class JobCoordinatorServiceImplUnitTests {
      * @throws GenieException If there is any problem
      */
     @Test
-    public void canCoordinateJobForSingleCluster() throws GenieException {
+    public void canCoordinateJob() throws GenieException {
         final Set<String> commandCriteria = Sets.newHashSet(
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
@@ -386,27 +210,62 @@ public class JobCoordinatorServiceImplUnitTests {
         final JobMetadata jobMetadata = this.getJobMetadata();
 
         final String clusterId = UUID.randomUUID().toString();
-        final String commandId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
-        final Command command = Mockito.mock(Command.class);
-        final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
-        clustersCommandsMap.put(cluster, commandId);
         Mockito.when(cluster.getId()).thenReturn(clusterId);
+        Mockito.when(this.clusterService.getCluster(clusterId)).thenReturn(cluster);
+
+        final String commandId = UUID.randomUUID().toString();
+        final Command command = Mockito.mock(Command.class);
         Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.empty());
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clustersCommandsMap);
-
         Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
 
-        final String applicationId = UUID.randomUUID().toString();
-        final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(applicationId);
-        final List<Application> applications = Lists.newArrayList(application);
+        final String application0Id = UUID.randomUUID().toString();
+        final Application application0 = Mockito.mock(Application.class);
+        Mockito.when(application0.getId()).thenReturn(application0Id);
+        Mockito.when(this.applicationService.getApplication(application0Id)).thenReturn(application0);
 
-        Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
+        final String application1Id = UUID.randomUUID().toString();
+        final Application application1 = Mockito.mock(Application.class);
+        Mockito.when(application1.getId()).thenReturn(application1Id);
+        Mockito.when(this.applicationService.getApplication(application1Id)).thenReturn(application1);
+
+        final JobSpecification jobSpecification = new JobSpecification(
+            null,
+            new JobSpecification.ExecutionResource(
+                jobRequest.getId().orElseThrow(IllegalArgumentException::new),
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                clusterId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                commandId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            Lists.newArrayList(
+                new JobSpecification.ExecutionResource(
+                    application0Id,
+                    new ExecutionEnvironment(null, null, null)
+                ),
+                new JobSpecification.ExecutionResource(
+                    application1Id,
+                    new ExecutionEnvironment(null, null, null)
+                )
+            ),
+            null,
+            false,
+            new File("/tmp/genie/jobs/" + JOB_1_ID)
+        );
+
+        Mockito
+            .when(
+                this.specificationService.resolveJobSpecification(
+                    Mockito.anyString(),
+                    Mockito.any(com.netflix.genie.common.dto.v4.JobRequest.class))
+            )
+            .thenReturn(jobSpecification);
 
         Mockito.when(this.jobStateService.getUsedMemory()).thenReturn(0);
 
@@ -423,17 +282,25 @@ public class JobCoordinatorServiceImplUnitTests {
         Mockito.verify(
             this.jobPersistenceService,
             Mockito.times(1)
-        ).updateJobWithRuntimeEnvironment(JOB_1_ID, clusterId, commandId, Lists.newArrayList(applicationId), MEMORY);
+        ).updateJobWithRuntimeEnvironment(
+            JOB_1_ID,
+            clusterId,
+            commandId,
+            Lists.newArrayList(application0Id, application1Id),
+            MEMORY
+        );
 
         Mockito.verify(
             this.jobStateService,
             Mockito.times(1)
-        ).schedule(JOB_1_ID, jobRequest, cluster, command, applications, MEMORY);
-
-        Mockito.verify(this.clusterLoadBalancer1, Mockito.never()).selectCluster(Mockito.any(), Mockito.any());
-        Mockito.verify(this.clusterLoadBalancer2, Mockito.never()).selectCluster(Mockito.any(), Mockito.any());
-        Mockito.verify(this.clusterLoadBalancer3, Mockito.never()).selectCluster(Mockito.any(), Mockito.any());
-        Mockito.verify(this.clusterLoadBalancer4, Mockito.never()).selectCluster(Mockito.any(), Mockito.any());
+        ).schedule(
+            JOB_1_ID,
+            jobRequest,
+            cluster,
+            command,
+            Lists.newArrayList(application0, application1),
+            MEMORY
+        );
 
         Mockito
             .verify(this.coordinationTimer, Mockito.times(1))
@@ -441,249 +308,6 @@ public class JobCoordinatorServiceImplUnitTests {
         Mockito
             .verify(this.registry, Mockito.times(1))
             .timer(JobCoordinatorServiceImpl.OVERALL_COORDINATION_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.noClusterSelectedCounter, Mockito.times(0)).increment();
-        Mockito
-            .verify(this.loadBalancerCounter, Mockito.times(0))
-            .increment();
-        Mockito
-            .verify(this.selectClusterTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.selectCommandTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.selectApplicationsTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_APPLICATIONS_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.setJobEnvironmentTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SET_JOB_ENVIRONMENT_TIMER_NAME, SUCCESS_TIMER_TAGS);
-    }
-
-    /**
-     * Test the coordinate job method.
-     *
-     * @throws GenieException If there is any problem
-     */
-    @Test
-    public void canCoordinateJobForMultipleClusters() throws GenieException {
-        final Set<String> commandCriteria = Sets.newHashSet(
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString()
-        );
-
-        final JobRequest jobRequest = this.getJobRequest(true, commandCriteria, null, null);
-        final JobMetadata jobMetadata = this.getJobMetadata();
-
-        final String clusterId = UUID.randomUUID().toString();
-        final Cluster cluster1 = Mockito.mock(Cluster.class);
-        final Cluster cluster2 = Mockito.mock(Cluster.class);
-        Mockito.when(cluster1.getId()).thenReturn(clusterId);
-        final String commandId = UUID.randomUUID().toString();
-        final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(commandId);
-        Mockito.when(command.getMemory()).thenReturn(Optional.empty());
-        final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
-        clustersCommandsMap.put(cluster1, commandId);
-        clustersCommandsMap.put(cluster2, UUID.randomUUID().toString());
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clustersCommandsMap);
-
-        Mockito
-            .when(this.clusterLoadBalancer1.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenReturn(null);
-        Mockito
-            .when(this.clusterLoadBalancer2.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenThrow(new RuntimeException());
-        Mockito
-            .when(this.clusterLoadBalancer3.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenReturn(cluster1);
-
-        Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
-
-        final String applicationId = UUID.randomUUID().toString();
-        final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(applicationId);
-        final List<Application> applications = Lists.newArrayList(application);
-
-        Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
-
-        Mockito.when(this.jobStateService.getUsedMemory()).thenReturn(0);
-
-        this.jobCoordinatorService.coordinateJob(jobRequest, jobMetadata);
-
-        Mockito.verify(this.jobPersistenceService, Mockito.times(1))
-            .createJob(
-                Mockito.any(JobRequest.class),
-                Mockito.any(JobMetadata.class),
-                Mockito.any(Job.class),
-                Mockito.any(JobExecution.class)
-            );
-
-        Mockito.verify(this.jobPersistenceService, Mockito.times(1))
-            .updateJobWithRuntimeEnvironment(JOB_1_ID, clusterId, commandId, Lists.newArrayList(applicationId), MEMORY);
-
-        Mockito.verify(this.jobStateService, Mockito.times(1)).schedule(JOB_1_ID, jobRequest, cluster1,
-            command, applications, MEMORY);
-
-        Mockito.verify(this.clusterLoadBalancer1, Mockito.times(1)).selectCluster(Mockito.any(), Mockito.any());
-        Mockito.verify(this.clusterLoadBalancer2, Mockito.times(1)).selectCluster(Mockito.any(), Mockito.any());
-        Mockito.verify(this.clusterLoadBalancer3, Mockito.times(1)).selectCluster(Mockito.any(), Mockito.any());
-        Mockito.verify(this.clusterLoadBalancer4, Mockito.never()).selectCluster(Mockito.any(), Mockito.any());
-
-        Mockito
-            .verify(this.coordinationTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.OVERALL_COORDINATION_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.noClusterSelectedCounter, Mockito.times(0)).increment();
-        Mockito
-            .verify(this.loadBalancerCounter, Mockito.times(3))
-            .increment();
-        Mockito
-            .verify(this.selectClusterTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.selectCommandTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.selectApplicationsTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_APPLICATIONS_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.setJobEnvironmentTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SET_JOB_ENVIRONMENT_TIMER_NAME, SUCCESS_TIMER_TAGS);
-    }
-
-    /**
-     * Test the coordinate job method.
-     *
-     * @throws GenieException If there is any problem
-     */
-    @Test
-    public void canCoordinateJobWithSubmittedApplications() throws GenieException {
-        final Set<String> commandCriteria = Sets.newHashSet(
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString()
-        );
-        final String applicationId = UUID.randomUUID().toString();
-
-        final JobRequest jobRequest
-            = this.getJobRequest(true, commandCriteria, null, Lists.newArrayList(applicationId));
-        final JobMetadata jobMetadata = this.getJobMetadata();
-
-        final String clusterId = UUID.randomUUID().toString();
-        final Cluster cluster = Mockito.mock(Cluster.class);
-        final String commandId = UUID.randomUUID().toString();
-        final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(commandId);
-        Mockito.when(command.getMemory()).thenReturn(Optional.empty());
-        Mockito.when(cluster.getId()).thenReturn(clusterId);
-        final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
-        clustersCommandsMap.put(cluster, commandId);
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clustersCommandsMap);
-
-        Mockito
-            .when(this.clusterLoadBalancer1.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenReturn(cluster);
-
-        Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
-
-        final Application application = new Application(
-            applicationId,
-            Instant.now(),
-            Instant.now(),
-            new ExecutionEnvironment(null, null, null),
-            new ApplicationMetadata.Builder(
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                ApplicationStatus.ACTIVE
-            ).build()
-        );
-
-        Mockito.when(this.applicationService.getApplication(applicationId)).thenReturn(application);
-
-        Mockito.when(this.jobStateService.getUsedMemory()).thenReturn(0);
-
-        this.jobCoordinatorService.coordinateJob(jobRequest, jobMetadata);
-
-        Mockito.verify(this.jobPersistenceService, Mockito.times(1))
-            .createJob(
-                Mockito.any(JobRequest.class),
-                Mockito.any(JobMetadata.class),
-                Mockito.any(Job.class),
-                Mockito.any(JobExecution.class)
-            );
-
-        Mockito
-            .verify(this.jobPersistenceService, Mockito.times(1))
-            .updateJobWithRuntimeEnvironment(JOB_1_ID, clusterId, commandId, Lists.newArrayList(applicationId), MEMORY);
-
-        Mockito
-            .verify(this.jobStateService, Mockito.times(1))
-            .schedule(JOB_1_ID, jobRequest, cluster, command, Lists.newArrayList(application), MEMORY);
-
-        Mockito
-            .verify(this.coordinationTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.OVERALL_COORDINATION_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.noClusterSelectedCounter, Mockito.times(0)).increment();
-        Mockito
-            .verify(this.loadBalancerCounter, Mockito.times(0))
-            .increment();
-        Mockito
-            .verify(this.selectClusterTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.selectCommandTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.selectApplicationsTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_APPLICATIONS_TIMER_NAME, SUCCESS_TIMER_TAGS);
         Mockito
             .verify(this.setJobEnvironmentTimer, Mockito.times(1))
             .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
@@ -712,29 +336,60 @@ public class JobCoordinatorServiceImplUnitTests {
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
         Mockito.when(cluster.getId()).thenReturn(clusterId);
+        Mockito.when(this.clusterService.getCluster(clusterId)).thenReturn(cluster);
+
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
         Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.empty());
-        final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
-        clustersCommandsMap.put(cluster, commandId);
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clustersCommandsMap);
-
-        Mockito
-            .when(this.clusterLoadBalancer1.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenReturn(cluster);
-
         Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
 
-        final String applicationId = UUID.randomUUID().toString();
-        final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(applicationId);
-        final List<Application> applications = Lists.newArrayList(application);
+        final String application0Id = UUID.randomUUID().toString();
+        final Application application0 = Mockito.mock(Application.class);
+        Mockito.when(application0.getId()).thenReturn(application0Id);
+        Mockito.when(this.applicationService.getApplication(application0Id)).thenReturn(application0);
 
-        Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
+        final String application1Id = UUID.randomUUID().toString();
+        final Application application1 = Mockito.mock(Application.class);
+        Mockito.when(application1.getId()).thenReturn(application1Id);
+        Mockito.when(this.applicationService.getApplication(application1Id)).thenReturn(application1);
+
+        final JobSpecification jobSpecification = new JobSpecification(
+            null,
+            new JobSpecification.ExecutionResource(
+                jobRequest.getId().orElseThrow(IllegalArgumentException::new),
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                clusterId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                commandId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            Lists.newArrayList(
+                new JobSpecification.ExecutionResource(
+                    application0Id,
+                    new ExecutionEnvironment(null, null, null)
+                ),
+                new JobSpecification.ExecutionResource(
+                    application1Id,
+                    new ExecutionEnvironment(null, null, null)
+                )
+            ),
+            null,
+            false,
+            new File("/tmp/genie/jobs/" + JOB_1_ID)
+        );
+
+        Mockito
+            .when(
+                this.specificationService.resolveJobSpecification(
+                    Mockito.anyString(),
+                    Mockito.any(com.netflix.genie.common.dto.v4.JobRequest.class))
+            )
+            .thenReturn(jobSpecification);
 
         try {
             this.jobCoordinatorService.coordinateJob(jobRequest, jobMetadata);
@@ -750,29 +405,6 @@ public class JobCoordinatorServiceImplUnitTests {
                     JobCoordinatorServiceImpl.OVERALL_COORDINATION_TIMER_NAME,
                     MetricsUtils.newFailureTagsSetForException(new GeniePreconditionException("test"))
                 );
-            Mockito
-                .verify(this.noClusterSelectedCounter, Mockito.times(0)).increment();
-            Mockito
-                .verify(this.loadBalancerCounter, Mockito.times(0))
-                .increment();
-            Mockito
-                .verify(this.selectClusterTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
-                .verify(this.selectCommandTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
-                .verify(this.selectApplicationsTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_APPLICATIONS_TIMER_NAME, SUCCESS_TIMER_TAGS);
             Mockito
                 .verify(this.setJobEnvironmentTimer, Mockito.times(1))
                 .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
@@ -801,36 +433,67 @@ public class JobCoordinatorServiceImplUnitTests {
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
         Mockito.when(cluster.getId()).thenReturn(clusterId);
+        Mockito.when(this.clusterService.getCluster(clusterId)).thenReturn(cluster);
+
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
         Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
-        final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
-        clustersCommandsMap.put(cluster, commandId);
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clustersCommandsMap);
-
-        Mockito
-            .when(this.clusterLoadBalancer1.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenReturn(cluster);
-
         Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
 
-        final String applicationId = UUID.randomUUID().toString();
-        final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(applicationId);
-        final List<Application> applications = Lists.newArrayList(application);
+        final String application0Id = UUID.randomUUID().toString();
+        final Application application0 = Mockito.mock(Application.class);
+        Mockito.when(application0.getId()).thenReturn(application0Id);
+        Mockito.when(this.applicationService.getApplication(application0Id)).thenReturn(application0);
 
-        Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
+        final String application1Id = UUID.randomUUID().toString();
+        final Application application1 = Mockito.mock(Application.class);
+        Mockito.when(application1.getId()).thenReturn(application1Id);
+        Mockito.when(this.applicationService.getApplication(application1Id)).thenReturn(application1);
+
+        final JobSpecification jobSpecification = new JobSpecification(
+            null,
+            new JobSpecification.ExecutionResource(
+                jobRequest.getId().orElseThrow(IllegalArgumentException::new),
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                clusterId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                commandId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            Lists.newArrayList(
+                new JobSpecification.ExecutionResource(
+                    application0Id,
+                    new ExecutionEnvironment(null, null, null)
+                ),
+                new JobSpecification.ExecutionResource(
+                    application1Id,
+                    new ExecutionEnvironment(null, null, null)
+                )
+            ),
+            null,
+            false,
+            new File("/tmp/genie/jobs/" + JOB_1_ID)
+        );
+
+        Mockito
+            .when(
+                this.specificationService.resolveJobSpecification(
+                    Mockito.anyString(),
+                    Mockito.any(com.netflix.genie.common.dto.v4.JobRequest.class))
+            )
+            .thenReturn(jobSpecification);
 
         Mockito
             .when(this.jobStateService.getUsedMemory())
             .thenReturn(this.jobsProperties.getMemory().getMaxSystemMemory());
 
         Mockito
-            .when(this.jobStateService.jobExists(Mockito.any()))
+            .when(this.jobStateService.jobExists(Mockito.anyString()))
             .thenReturn(true);
 
         try {
@@ -854,29 +517,6 @@ public class JobCoordinatorServiceImplUnitTests {
                     MetricsUtils.newFailureTagsSetForException(new GenieServerUnavailableException("test"))
                 );
             Mockito
-                .verify(this.noClusterSelectedCounter, Mockito.times(0)).increment();
-            Mockito
-                .verify(this.loadBalancerCounter, Mockito.times(0))
-                .increment();
-            Mockito
-                .verify(this.selectClusterTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
-                .verify(this.selectCommandTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
-                .verify(this.selectApplicationsTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_APPLICATIONS_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
                 .verify(this.setJobEnvironmentTimer, Mockito.times(1))
                 .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
             Mockito
@@ -892,7 +532,7 @@ public class JobCoordinatorServiceImplUnitTests {
      * @throws GenieException If there is any problem
      */
     @Test
-    public void canCoordinateJobUserJobLimitIsDisabled() throws GenieException {
+    public void canCoordinateIfJobUserJobLimitIsDisabled() throws GenieException {
         final int userActiveJobsLimit = 5;
         this.jobsProperties.getUsers().getActiveLimit().setEnabled(false);
         this.jobsProperties.getUsers().getActiveLimit().setCount(userActiveJobsLimit);
@@ -909,29 +549,60 @@ public class JobCoordinatorServiceImplUnitTests {
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
         Mockito.when(cluster.getId()).thenReturn(clusterId);
+        Mockito.when(this.clusterService.getCluster(clusterId)).thenReturn(cluster);
+
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
         Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
-        final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
-        clustersCommandsMap.put(cluster, commandId);
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clustersCommandsMap);
-
-        Mockito
-            .when(this.clusterLoadBalancer1.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenReturn(cluster);
-
         Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
 
-        final String applicationId = UUID.randomUUID().toString();
-        final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(applicationId);
-        final List<Application> applications = Lists.newArrayList(application);
+        final String application0Id = UUID.randomUUID().toString();
+        final Application application0 = Mockito.mock(Application.class);
+        Mockito.when(application0.getId()).thenReturn(application0Id);
+        Mockito.when(this.applicationService.getApplication(application0Id)).thenReturn(application0);
 
-        Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
+        final String application1Id = UUID.randomUUID().toString();
+        final Application application1 = Mockito.mock(Application.class);
+        Mockito.when(application1.getId()).thenReturn(application1Id);
+        Mockito.when(this.applicationService.getApplication(application1Id)).thenReturn(application1);
+
+        final JobSpecification jobSpecification = new JobSpecification(
+            null,
+            new JobSpecification.ExecutionResource(
+                jobRequest.getId().orElseThrow(IllegalArgumentException::new),
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                clusterId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                commandId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            Lists.newArrayList(
+                new JobSpecification.ExecutionResource(
+                    application0Id,
+                    new ExecutionEnvironment(null, null, null)
+                ),
+                new JobSpecification.ExecutionResource(
+                    application1Id,
+                    new ExecutionEnvironment(null, null, null)
+                )
+            ),
+            null,
+            false,
+            new File("/tmp/genie/jobs/" + JOB_1_ID)
+        );
+
+        Mockito
+            .when(
+                this.specificationService.resolveJobSpecification(
+                    Mockito.anyString(),
+                    Mockito.any(com.netflix.genie.common.dto.v4.JobRequest.class))
+            )
+            .thenReturn(jobSpecification);
 
         Mockito
             .when(this.jobSearchService.getActiveJobCountForUser(Mockito.any(String.class)))
@@ -945,29 +616,6 @@ public class JobCoordinatorServiceImplUnitTests {
         Mockito
             .verify(this.registry, Mockito.times(1))
             .timer(JobCoordinatorServiceImpl.OVERALL_COORDINATION_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.noClusterSelectedCounter, Mockito.times(0)).increment();
-        Mockito
-            .verify(this.loadBalancerCounter, Mockito.times(0))
-            .increment();
-        Mockito
-            .verify(this.selectClusterTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.selectCommandTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        Mockito
-            .verify(this.selectApplicationsTimer, Mockito.times(1))
-            .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-        Mockito
-            .verify(this.registry, Mockito.times(1))
-            .timer(JobCoordinatorServiceImpl.SELECT_APPLICATIONS_TIMER_NAME, SUCCESS_TIMER_TAGS);
         Mockito
             .verify(this.setJobEnvironmentTimer, Mockito.times(1))
             .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
@@ -999,29 +647,60 @@ public class JobCoordinatorServiceImplUnitTests {
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
         Mockito.when(cluster.getId()).thenReturn(clusterId);
+        Mockito.when(this.clusterService.getCluster(clusterId)).thenReturn(cluster);
+
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
         Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
-        final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
-        clustersCommandsMap.put(cluster, commandId);
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clustersCommandsMap);
-
-        Mockito
-            .when(this.clusterLoadBalancer1.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenReturn(cluster);
-
         Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
 
-        final String applicationId = UUID.randomUUID().toString();
-        final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(applicationId);
-        final List<Application> applications = Lists.newArrayList(application);
+        final String application0Id = UUID.randomUUID().toString();
+        final Application application0 = Mockito.mock(Application.class);
+        Mockito.when(application0.getId()).thenReturn(application0Id);
+        Mockito.when(this.applicationService.getApplication(application0Id)).thenReturn(application0);
 
-        Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
+        final String application1Id = UUID.randomUUID().toString();
+        final Application application1 = Mockito.mock(Application.class);
+        Mockito.when(application1.getId()).thenReturn(application1Id);
+        Mockito.when(this.applicationService.getApplication(application1Id)).thenReturn(application1);
+
+        final JobSpecification jobSpecification = new JobSpecification(
+            null,
+            new JobSpecification.ExecutionResource(
+                jobRequest.getId().orElseThrow(IllegalArgumentException::new),
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                clusterId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                commandId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            Lists.newArrayList(
+                new JobSpecification.ExecutionResource(
+                    application0Id,
+                    new ExecutionEnvironment(null, null, null)
+                ),
+                new JobSpecification.ExecutionResource(
+                    application1Id,
+                    new ExecutionEnvironment(null, null, null)
+                )
+            ),
+            null,
+            false,
+            new File("/tmp/genie/jobs/" + JOB_1_ID)
+        );
+
+        Mockito
+            .when(
+                this.specificationService.resolveJobSpecification(
+                    Mockito.anyString(),
+                    Mockito.any(com.netflix.genie.common.dto.v4.JobRequest.class))
+            )
+            .thenReturn(jobSpecification);
 
         Mockito
             .when(this.jobSearchService.getActiveJobCountForUser(Mockito.any(String.class)))
@@ -1041,29 +720,6 @@ public class JobCoordinatorServiceImplUnitTests {
                         new GenieUserLimitExceededException("test", "test", "test")
                     )
                 );
-            Mockito
-                .verify(this.noClusterSelectedCounter, Mockito.times(0)).increment();
-            Mockito
-                .verify(this.loadBalancerCounter, Mockito.times(0))
-                .increment();
-            Mockito
-                .verify(this.selectClusterTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
-                .verify(this.selectCommandTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
-                .verify(this.selectApplicationsTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_APPLICATIONS_TIMER_NAME, SUCCESS_TIMER_TAGS);
             Mockito
                 .verify(this.setJobEnvironmentTimer, Mockito.times(1))
                 .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
@@ -1092,31 +748,72 @@ public class JobCoordinatorServiceImplUnitTests {
         final String clusterId = UUID.randomUUID().toString();
         final Cluster cluster = Mockito.mock(Cluster.class);
         Mockito.when(cluster.getId()).thenReturn(clusterId);
+        Mockito.when(this.clusterService.getCluster(clusterId)).thenReturn(cluster);
+
         final String commandId = UUID.randomUUID().toString();
         final Command command = Mockito.mock(Command.class);
         Mockito.when(command.getId()).thenReturn(commandId);
         Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
-        final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
-        clustersCommandsMap.put(cluster, commandId);
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clustersCommandsMap);
-
-        Mockito
-            .when(this.clusterLoadBalancer1.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenReturn(cluster);
-
         Mockito.when(this.commandService.getCommand(commandId)).thenReturn(command);
 
-        final String applicationId = UUID.randomUUID().toString();
-        final Application application = Mockito.mock(Application.class);
-        Mockito.when(application.getId()).thenReturn(applicationId);
-        final List<Application> applications = Lists.newArrayList(application);
+        final String application0Id = UUID.randomUUID().toString();
+        final Application application0 = Mockito.mock(Application.class);
+        Mockito.when(application0.getId()).thenReturn(application0Id);
+        Mockito.when(this.applicationService.getApplication(application0Id)).thenReturn(application0);
 
-        Mockito.when(this.commandService.getApplicationsForCommand(commandId)).thenReturn(applications);
-        Mockito.doThrow(new RuntimeException()).when(jobStateService).schedule(JOB_1_ID, jobRequest, cluster,
-            command, applications, 1);
+        final String application1Id = UUID.randomUUID().toString();
+        final Application application1 = Mockito.mock(Application.class);
+        Mockito.when(application1.getId()).thenReturn(application1Id);
+        Mockito.when(this.applicationService.getApplication(application1Id)).thenReturn(application1);
+
+        final JobSpecification jobSpecification = new JobSpecification(
+            null,
+            new JobSpecification.ExecutionResource(
+                jobRequest.getId().orElseThrow(IllegalArgumentException::new),
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                clusterId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            new JobSpecification.ExecutionResource(
+                commandId,
+                new ExecutionEnvironment(null, null, null)
+            ),
+            Lists.newArrayList(
+                new JobSpecification.ExecutionResource(
+                    application0Id,
+                    new ExecutionEnvironment(null, null, null)
+                ),
+                new JobSpecification.ExecutionResource(
+                    application1Id,
+                    new ExecutionEnvironment(null, null, null)
+                )
+            ),
+            null,
+            false,
+            new File("/tmp/genie/jobs/" + JOB_1_ID)
+        );
+
+        Mockito
+            .when(
+                this.specificationService.resolveJobSpecification(
+                    Mockito.anyString(),
+                    Mockito.any(com.netflix.genie.common.dto.v4.JobRequest.class))
+            )
+            .thenReturn(jobSpecification);
+
+        Mockito
+            .doThrow(new RuntimeException())
+            .when(jobStateService)
+            .schedule(
+                JOB_1_ID,
+                jobRequest,
+                cluster,
+                command,
+                Lists.newArrayList(application0, application1),
+                1
+            );
         Mockito
             .when(this.jobStateService.getUsedMemory())
             .thenReturn(0);
@@ -1144,112 +841,11 @@ public class JobCoordinatorServiceImplUnitTests {
                     MetricsUtils.newFailureTagsSetForException(new RuntimeException("test"))
                 );
             Mockito
-                .verify(this.noClusterSelectedCounter, Mockito.times(0)).increment();
-            Mockito
-                .verify(this.loadBalancerCounter, Mockito.times(0))
-                .increment();
-            Mockito
-                .verify(this.selectClusterTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
-                .verify(this.selectCommandTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
-                .verify(this.selectApplicationsTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_APPLICATIONS_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
                 .verify(this.setJobEnvironmentTimer, Mockito.times(1))
                 .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
             Mockito
                 .verify(this.registry, Mockito.times(1))
                 .timer(JobCoordinatorServiceImpl.SET_JOB_ENVIRONMENT_TIMER_NAME, SUCCESS_TIMER_TAGS);
-        }
-    }
-
-    /**
-     * Test the coordinate job method.
-     *
-     * @throws GenieException If there is any problem
-     */
-    @Test(expected = GenieNotFoundException.class)
-    public void cantCoordinateJobIfNoCommand() throws GenieException {
-        final Set<String> commandCriteria = Sets.newHashSet(
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString(),
-            UUID.randomUUID().toString()
-        );
-
-        final JobRequest jobRequest = this.getJobRequest(false, commandCriteria, null, null);
-        final JobMetadata jobMetadata = this.getJobMetadata();
-
-        final String clusterId = UUID.randomUUID().toString();
-        final Cluster cluster = Mockito.mock(Cluster.class);
-        Mockito.when(cluster.getId()).thenReturn(clusterId);
-        final String commandId = UUID.randomUUID().toString();
-        final Command command = Mockito.mock(Command.class);
-        Mockito.when(command.getId()).thenReturn(commandId);
-        Mockito.when(command.getMemory()).thenReturn(Optional.of(1));
-        final Map<Cluster, String> clustersCommandsMap = Maps.newHashMap();
-        clustersCommandsMap.put(cluster, commandId);
-
-        Mockito
-            .when(this.clusterService.findClustersAndCommandsForJob(jobRequest))
-            .thenReturn(clustersCommandsMap);
-
-        Mockito
-            .when(this.clusterLoadBalancer1.selectCluster(clustersCommandsMap.keySet(), jobRequest))
-            .thenReturn(cluster);
-
-        Mockito
-            .when(this.commandService.getCommand(commandId))
-            .thenThrow(new GenieNotFoundException("No command with id " + commandId));
-
-        Mockito.verifyNoMoreInteractions(
-            this.selectApplicationsTimer,
-            this.setJobEnvironmentTimer
-        );
-
-        try {
-            this.jobCoordinatorService.coordinateJob(jobRequest, jobMetadata);
-        } finally {
-            Mockito
-                .verify(this.coordinationTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(
-                    JobCoordinatorServiceImpl.OVERALL_COORDINATION_TIMER_NAME,
-                    MetricsUtils.newFailureTagsSetForException(new GenieNotFoundException("test"))
-                );
-            Mockito
-                .verify(this.noClusterSelectedCounter, Mockito.times(0)).increment();
-            Mockito
-                .verify(this.loadBalancerCounter, Mockito.times(0))
-                .increment();
-            Mockito
-                .verify(this.selectClusterTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(JobCoordinatorServiceImpl.SELECT_CLUSTER_TIMER_NAME, SUCCESS_TIMER_TAGS);
-            Mockito
-                .verify(this.selectCommandTimer, Mockito.times(1))
-                .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
-            Mockito
-                .verify(this.registry, Mockito.times(1))
-                .timer(
-                    JobCoordinatorServiceImpl.SELECT_COMMAND_TIMER_NAME,
-                    MetricsUtils.newFailureTagsSetForException(new GenieNotFoundException("test"))
-                );
         }
     }
 
@@ -1264,11 +860,7 @@ public class JobCoordinatorServiceImplUnitTests {
         Mockito.when(request.getId()).thenReturn(Optional.empty());
         Mockito.verifyNoMoreInteractions(
             this.coordinationTimer,
-            this.selectApplicationsTimer,
-            this.setJobEnvironmentTimer,
-            this.selectClusterTimer,
-            this.selectCommandTimer,
-            this.loadBalancerCounter
+            this.setJobEnvironmentTimer
         );
         this.jobCoordinatorService.coordinateJob(request, Mockito.mock(JobMetadata.class));
     }
@@ -1282,18 +874,17 @@ public class JobCoordinatorServiceImplUnitTests {
     public void cantCoordinateIfJobAlreadyExists() throws GenieException {
         final JobRequest request = getJobRequest(false, Sets.newHashSet(), null, null);
         final JobMetadata metadata = Mockito.mock(JobMetadata.class);
-        Mockito.doThrow(GenieConflictException.class).when(jobPersistenceService)
-            .createJob(Mockito.eq(request), Mockito.eq(metadata),
+        Mockito
+            .doThrow(GenieConflictException.class)
+            .when(jobPersistenceService)
+            .createJob(
+                Mockito.eq(request),
+                Mockito.eq(metadata),
                 Mockito.any(Job.class),
-                Mockito.any(JobExecution.class));
+                Mockito.any(JobExecution.class)
+            );
 
-        Mockito.verifyNoMoreInteractions(
-            this.selectApplicationsTimer,
-            this.setJobEnvironmentTimer,
-            this.selectClusterTimer,
-            this.selectCommandTimer,
-            this.loadBalancerCounter
-        );
+        Mockito.verifyNoMoreInteractions(this.setJobEnvironmentTimer);
 
         try {
             this.jobCoordinatorService.coordinateJob(request, metadata);


### PR DESCRIPTION
This PR makes the job coordinator service for genie v3 leverage the same job specification service the agent relies on in order to reuse code/logic.

Also moved script load balancer properties to match Boot 2 property binding logic that was noticed during work porting internal wrapper to Boot 2.