### PR TITLE
Add V4 Job Flag

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
@@ -113,7 +113,8 @@ import java.util.Set;
         "requestedJobDirectoryLocation",
         "jobDirectoryLocation",
         "resolved",
-        "claimed"
+        "claimed",
+        "v4"
     },
     doNotUseGetters = true
 )
@@ -307,6 +308,10 @@ public class JobEntity extends BaseEntity implements
     @Basic(optional = false)
     @Column(name = "claimed", nullable = false)
     private boolean claimed;
+
+    @Basic(optional = false)
+    @Column(name = "v4", nullable = false)
+    private boolean v4;
 
     @Basic
     @Column(name = "requested_job_directory_location", length = 1024, updatable = false)

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaJobRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaJobRepository.java
@@ -55,7 +55,7 @@ public interface JpaJobRepository extends JpaBaseRepository<JobEntity> {
      * @param statuses The statuses to search
      * @return The job information requested
      */
-    Set<AgentHostnameProjection> findByStatusIn(final Set<JobStatus> statuses);
+    Set<AgentHostnameProjection> findDistinctByStatusInAndV4IsFalse(final Set<JobStatus> statuses);
 
     /**
      * Deletes all jobs for the given ids.

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
@@ -340,6 +340,9 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
         this.setRequestedAgentConfigFields(jobEntity, jobRequest.getRequestedAgentConfig());
         this.setRequestMetadataFields(jobEntity, jobRequestMetadata);
 
+        // Flag to signal to rest of system that this job is V4. Temporary until everything moved to v4
+        jobEntity.setV4(true);
+
         // Persist. Catch exception if the ID is reused
         try {
             final String id = this.jobRepository.save(jobEntity).getUniqueId();
@@ -695,6 +698,9 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
         jobExecution.getCheckDelay().ifPresent(jobEntity::setCheckDelay);
         jobExecution.getTimeout().ifPresent(jobEntity::setTimeout);
         jobExecution.getMemory().ifPresent(jobEntity::setMemoryUsed);
+
+        // Flag to signal to rest of system that this job is V3. Temporary until everything moved to v4
+        jobEntity.setV4(false);
 
         return jobEntity;
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImpl.java
@@ -225,16 +225,16 @@ public class JpaJobSearchServiceImpl implements JobSearchService {
      * {@inheritDoc}
      */
     @Override
-    public List<String> getAllHostsWithActiveJobs() {
+    public Set<String> getAllHostsWithActiveJobs() {
         log.debug("Called");
 
         return this.jobRepository
-            .findByStatusIn(JobStatus.getActiveStatuses())
+            .findDistinctByStatusInAndV4IsFalse(JobStatus.getActiveStatuses())
             .stream()
             .map(AgentHostnameProjection::getAgentHostname)
             .filter(Optional::isPresent)
             .map(Optional::get)
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobSearchService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobSearchService.java
@@ -101,8 +101,7 @@ public interface JobSearchService {
      *
      * @return The set of hosts with jobs currently in an active state
      */
-    // TODO: Change to set
-    List<String> getAllHostsWithActiveJobs();
+    Set<String> getAllHostsWithActiveJobs();
 
     /**
      * Get job information for given job id.

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
@@ -49,7 +49,10 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author tgianos
  * @since 3.0.0
  */
-@ConditionalOnProperty("genie.tasks.databaseCleanup.enabled")
+@ConditionalOnProperty(
+    value = "genie.tasks.databaseCleanup.enabled",
+    havingValue = "true"
+)
 @Component
 @Slf4j
 public class DatabaseCleanupTask extends LeadershipTask {

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/node/DiskCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/node/DiskCleanupTask.java
@@ -51,7 +51,10 @@ import java.util.concurrent.atomic.AtomicLong;
  * This task runs on every Genie node and is responsible for cleaning up the local disk so that space can be
  * recaptured.
  */
-@ConditionalOnProperty("genie.tasks.databaseCleanup.enabled")
+@ConditionalOnProperty(
+    value = "genie.tasks.databaseCleanup.enabled",
+    havingValue = "true"
+)
 @Component
 @Slf4j
 public class DiskCleanupTask implements Runnable {

--- a/genie-web/src/main/resources/db/migration/h2/V4_0_0__Genie_4.sql
+++ b/genie-web/src/main/resources/db/migration/h2/V4_0_0__Genie_4.sql
@@ -144,6 +144,8 @@ ALTER TABLE `jobs`
   ADD COLUMN `agent_pid` INT(11) DEFAULT NULL;
 ALTER TABLE `jobs`
   ADD COLUMN `claimed` BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE `jobs`
+  ADD COLUMN `v4` BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE `job_applications_requested`
   RENAME TO `job_requested_applications`;

--- a/genie-web/src/main/resources/db/migration/mysql/V4_0_0__Genie_4.sql
+++ b/genie-web/src/main/resources/db/migration/mysql/V4_0_0__Genie_4.sql
@@ -164,7 +164,8 @@ ALTER TABLE `jobs`
   ADD COLUMN    `resolved`                                   BOOLEAN       DEFAULT FALSE NOT NULL,
   ADD COLUMN    `agent_version`                              VARCHAR(255)  DEFAULT NULL,
   ADD COLUMN    `agent_pid`                                  INT(11)       DEFAULT NULL,
-  ADD COLUMN    `claimed`                                    BOOLEAN       DEFAULT FALSE NOT NULL;
+  ADD COLUMN    `claimed`                                    BOOLEAN       DEFAULT FALSE NOT NULL,
+  ADD COLUMN    `v4`                                         BOOLEAN       DEFAULT FALSE NOT NULL;
 
 ALTER TABLE `job_applications_requested` RENAME TO `job_requested_applications`;
 ALTER TABLE `job_requested_applications`

--- a/genie-web/src/main/resources/db/migration/postgresql/V4_0_0__Genie_4.sql
+++ b/genie-web/src/main/resources/db/migration/postgresql/V4_0_0__Genie_4.sql
@@ -149,7 +149,8 @@ ALTER TABLE jobs
   ADD COLUMN resolved                         BOOLEAN       DEFAULT FALSE NOT NULL,
   ADD COLUMN agent_version                    VARCHAR(255)  DEFAULT NULL,
   ADD COLUMN agent_pid                        INT           DEFAULT NULL,
-  ADD COLUMN claimed                          BOOLEAN       DEFAULT FALSE NOT NULL;
+  ADD COLUMN claimed                          BOOLEAN       DEFAULT FALSE NOT NULL,
+  ADD COLUMN v4                               BOOLEAN       DEFAULT FALSE NOT NULL;
 
 ALTER TABLE job_applications_requested RENAME TO job_requested_applications;
 ALTER TABLE job_requested_applications

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/JobEntityUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/entities/JobEntityUnitTests.java
@@ -908,6 +908,16 @@ public class JobEntityUnitTests extends EntityTestsBase {
     }
 
     /**
+     * Test setter/getter.
+     */
+    @Test
+    public void canSetV4() {
+        Assert.assertFalse(this.jobEntity.isV4());
+        this.jobEntity.setV4(true);
+        Assert.assertTrue(this.jobEntity.isV4());
+    }
+
+    /**
      * Test the toString method.
      */
     @Test

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceImplIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceImplIntegrationTests.java
@@ -305,6 +305,10 @@ public class JpaJobPersistenceImplIntegrationTests extends DBUnitTestBase {
         Assert.assertThat(this.tagRepository.count(), Matchers.is(25L));
         Assert.assertThat(this.fileRepository.count(), Matchers.is(15L));
 
+        Assert.assertFalse(
+            this.jobRepository.findByUniqueId(UNIQUE_ID).orElseThrow(IllegalArgumentException::new).isV4()
+        );
+
         this.validateJobRequest(this.jobSearchService.getJobRequest(UNIQUE_ID));
         this.validateJob(this.jobSearchService.getJob(UNIQUE_ID));
         this.validateJobExecution(this.jobSearchService.getJobExecution(UNIQUE_ID));
@@ -661,6 +665,7 @@ public class JpaJobPersistenceImplIntegrationTests extends DBUnitTestBase {
             .orElseThrow(() -> new GenieNotFoundException("No job with id " + id + " found when one was expected"));
 
         Assert.assertFalse(jobEntity.isResolved());
+        Assert.assertTrue(jobEntity.isV4());
 
         // Job Request Metadata Fields
         jobRequestMetadata.getApiClientMetadata().ifPresent(

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImplIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImplIntegrationTests.java
@@ -277,10 +277,9 @@ public class JpaJobSearchServiceImplIntegrationTests extends DBUnitTestBase {
         final String hostA = "a.netflix.com";
         final String hostB = "b.netflix.com";
 
-        final List<String> hostNames = this.service.getAllHostsWithActiveJobs();
+        final Set<String> hostNames = this.service.getAllHostsWithActiveJobs();
         Assert.assertThat(hostNames.size(), Matchers.is(2));
-        Assert.assertThat(hostNames, Matchers.hasItem(hostA));
-        Assert.assertThat(hostNames, Matchers.hasItem(hostB));
+        Assert.assertThat(hostNames, Matchers.hasItems(hostA, hostB));
     }
 
     /**


### PR DESCRIPTION
This PR adds a V4 boolean to the database jobs table.

This field is intended to be temporary during V4 development cycle to allow running of Jobs via old V3 job API path (on node) and via V4 Agent (cli) and be able to filter jobs at different points in this system by this distinction.

Longer term (when V4 API is ready) this field should be dropped from the database as job running will all be done via Agent one way or another.