### PR TITLE
Add error handling to Job Specification gRPC API

### DIFF
--- a/genie-proto/src/main/proto/genie.proto
+++ b/genie-proto/src/main/proto/genie.proto
@@ -146,7 +146,10 @@ message JobSpecificationError {
     enum Type {
         UNKNOWN = 0;
         NO_CLUSTER_FOUND = 1;
-        NO_SPECIFICATION_FOUND = 2;
+        NO_COMMAND_FOUND = 2;
+        NO_APPLICATION_FOUND = 3;
+        NO_JOB_FOUND = 4;
+        NO_SPECIFICATION_FOUND = 5;
     }
     Type type = 1;
     string message = 2;

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaIdRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/repositories/JpaIdRepository.java
@@ -30,5 +30,5 @@ import org.springframework.data.repository.NoRepositoryBean;
  * @since 3.3.0
  */
 @NoRepositoryBean
-interface JpaIdRepository<E extends IdEntity> extends JpaRepository<E, Long>, JpaSpecificationExecutor {
+interface JpaIdRepository<E extends IdEntity> extends JpaRepository<E, Long>, JpaSpecificationExecutor<E> {
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaBaseService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaBaseService.java
@@ -20,15 +20,22 @@ package com.netflix.genie.web.jpa.services;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.internal.dto.v4.ExecutionEnvironment;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieRuntimeException;
+import com.netflix.genie.web.jpa.entities.ApplicationEntity;
+import com.netflix.genie.web.jpa.entities.ClusterEntity;
+import com.netflix.genie.web.jpa.entities.CommandEntity;
 import com.netflix.genie.web.jpa.entities.FileEntity;
 import com.netflix.genie.web.jpa.entities.TagEntity;
 import com.netflix.genie.web.jpa.entities.UniqueIdEntity;
+import com.netflix.genie.web.jpa.repositories.JpaApplicationRepository;
+import com.netflix.genie.web.jpa.repositories.JpaClusterRepository;
+import com.netflix.genie.web.jpa.repositories.JpaCommandRepository;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -45,19 +52,31 @@ class JpaBaseService {
 
     private final JpaTagPersistenceService tagPersistenceService;
     private final JpaFilePersistenceService filePersistenceService;
+    private final JpaApplicationRepository applicationRepository;
+    private final JpaClusterRepository clusterRepository;
+    private final JpaCommandRepository commandRepository;
 
     /**
      * Constructor.
      *
-     * @param tagPersistenceService  The tag service to use
-     * @param filePersistenceService The file service to use
+     * @param tagPersistenceService  The tag persistence service to use
+     * @param filePersistenceService The file persistence service to use
+     * @param applicationRepository  Application repository to use
+     * @param clusterRepository      Cluster repository to use
+     * @param commandRepository      Command repository to use
      */
     JpaBaseService(
         final JpaTagPersistenceService tagPersistenceService,
-        final JpaFilePersistenceService filePersistenceService
+        final JpaFilePersistenceService filePersistenceService,
+        final JpaApplicationRepository applicationRepository,
+        final JpaClusterRepository clusterRepository,
+        final JpaCommandRepository commandRepository
     ) {
         this.tagPersistenceService = tagPersistenceService;
         this.filePersistenceService = filePersistenceService;
+        this.applicationRepository = applicationRepository;
+        this.clusterRepository = clusterRepository;
+        this.commandRepository = commandRepository;
     }
 
     /**
@@ -171,5 +190,38 @@ class JpaBaseService {
      */
     void setEntityTags(final Set<String> tags, final Consumer<Set<TagEntity>> tagsConsumer) {
         tagsConsumer.accept(this.createAndGetTagEntities(tags));
+    }
+
+    /**
+     * Retrieve an application entity. If this API is called within an active transaction the returned entity will
+     * remain attached to the persistence context, otherwise it will be detached and any modifications will be lost.
+     *
+     * @param id The id of the application to retrieve from the database
+     * @return The {@link ApplicationEntity} if a match for the {@code id} is found or {@link Optional#empty()}
+     */
+    Optional<ApplicationEntity> getApplicationEntity(@NotBlank(message = "No application id entered") final String id) {
+        return this.applicationRepository.findByUniqueId(id);
+    }
+
+    /**
+     * Retrieve a cluster entity. If this API is called within an active transaction the returned entity will
+     * remain attached to the persistence context, otherwise it will be detached and any modifications will be lost.
+     *
+     * @param id The id of the cluster to retrieve from the database
+     * @return The {@link ClusterEntity} if a match for the {@code id} is found or {@link Optional#empty()}
+     */
+    Optional<ClusterEntity> getClusterEntity(@NotBlank(message = "No cluster id entered") final String id) {
+        return this.clusterRepository.findByUniqueId(id);
+    }
+
+    /**
+     * Retrieve a command entity. If this API is called within an active transaction the returned entity will
+     * remain attached to the persistence context, otherwise it will be detached and any modifications will be lost.
+     *
+     * @param id The id of the command to retrieve from the database
+     * @return The {@link CommandEntity} if a match for the {@code id} is found or {@link Optional#empty()}
+     */
+    Optional<CommandEntity> getCommandEntity(@NotBlank(message = "No command id entered") final String id) {
+        return this.commandRepository.findByUniqueId(id);
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
@@ -100,34 +100,32 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
 
     private final JpaJobRepository jobRepository;
 
-    // TODO: Switch to services
-    private final JpaApplicationRepository applicationRepository;
-    private final JpaClusterRepository clusterRepository;
-    private final JpaCommandRepository commandRepository;
-
     /**
      * Constructor.
      *
-     * @param tagPersistenceService  The tag service to use
-     * @param filePersistenceService The file service to use
-     * @param jobRepository          The job repository to use
-     * @param applicationRepository  The application repository to use
-     * @param clusterRepository      The cluster repository to use
-     * @param commandRepository      The command repository to use
+     * @param tagPersistenceService  The {@link JpaTagPersistenceService} to use
+     * @param filePersistenceService The {@link JpaFilePersistenceService} to use
+     * @param applicationRepository  The {@link JpaApplicationRepository} to use
+     * @param clusterRepository      The {@link JpaClusterRepository} to use
+     * @param commandRepository      The {@link JpaCommandRepository} to use
+     * @param jobRepository          The {@link JpaJobRepository} to use
      */
     public JpaJobPersistenceServiceImpl(
         final JpaTagPersistenceService tagPersistenceService,
         final JpaFilePersistenceService filePersistenceService,
-        final JpaJobRepository jobRepository,
         final JpaApplicationRepository applicationRepository,
         final JpaClusterRepository clusterRepository,
-        final JpaCommandRepository commandRepository
+        final JpaCommandRepository commandRepository,
+        final JpaJobRepository jobRepository
     ) {
-        super(tagPersistenceService, filePersistenceService);
+        super(
+            tagPersistenceService,
+            filePersistenceService,
+            applicationRepository,
+            clusterRepository,
+            commandRepository
+        );
         this.jobRepository = jobRepository;
-        this.applicationRepository = applicationRepository;
-        this.clusterRepository = clusterRepository;
-        this.commandRepository = commandRepository;
     }
 
     /**
@@ -818,21 +816,19 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
         final String commandId,
         final List<String> applicationIds
     ) {
-        final ClusterEntity cluster = this.clusterRepository
-            .findByUniqueId(clusterId)
-            .orElseThrow(() -> new GenieClusterNotFoundException("Cannot find cluster with ID " + clusterId));
+        final ClusterEntity cluster = this.getClusterEntity(clusterId).orElseThrow(
+            () -> new GenieClusterNotFoundException("Cannot find cluster with ID " + clusterId)
+        );
 
-        final CommandEntity command = this.commandRepository
-            .findByUniqueId(commandId)
-            .orElseThrow(() -> new GenieCommandNotFoundException("Cannot find command with ID " + commandId));
+        final CommandEntity command = this.getCommandEntity(commandId).orElseThrow(
+            () -> new GenieCommandNotFoundException("Cannot find command with ID " + commandId)
+        );
 
         final List<ApplicationEntity> applications = Lists.newArrayList();
         for (final String applicationId : applicationIds) {
-            final ApplicationEntity application = this.applicationRepository
-                .findByUniqueId(applicationId)
-                .orElseThrow(
-                    () -> new GenieApplicationNotFoundException("Cannot find application with ID + " + applicationId)
-                );
+            final ApplicationEntity application = this.getApplicationEntity(applicationId).orElseThrow(
+                () -> new GenieApplicationNotFoundException("Cannot find application with ID + " + applicationId)
+            );
             applications.add(application);
         }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/jpa/services/JpaBaseServiceSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/jpa/services/JpaBaseServiceSpec.groovy
@@ -19,6 +19,9 @@ package com.netflix.genie.web.jpa.services
 
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieRuntimeException
 import com.netflix.genie.test.categories.UnitTest
+import com.netflix.genie.web.jpa.repositories.JpaApplicationRepository
+import com.netflix.genie.web.jpa.repositories.JpaClusterRepository
+import com.netflix.genie.web.jpa.repositories.JpaCommandRepository
 import org.junit.experimental.categories.Category
 import spock.lang.Specification
 
@@ -38,7 +41,10 @@ class JpaBaseServiceSpec extends Specification {
         }
         def service = new JpaBaseService(
                 Mock(JpaTagPersistenceService),
-                fileService
+                fileService,
+                Mock(JpaApplicationRepository),
+                Mock(JpaClusterRepository),
+                Mock(JpaCommandRepository)
         )
 
         when:
@@ -55,7 +61,10 @@ class JpaBaseServiceSpec extends Specification {
         }
         def service = new JpaBaseService(
                 tagService,
-                Mock(JpaFilePersistenceService)
+                Mock(JpaFilePersistenceService),
+                Mock(JpaApplicationRepository),
+                Mock(JpaClusterRepository),
+                Mock(JpaCommandRepository)
         )
 
         when:

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaApplicationPersistenceServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaApplicationPersistenceServiceImplUnitTests.java
@@ -33,6 +33,7 @@ import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.genie.web.jpa.entities.ApplicationEntity;
 import com.netflix.genie.web.jpa.entities.CommandEntity;
 import com.netflix.genie.web.jpa.repositories.JpaApplicationRepository;
+import com.netflix.genie.web.jpa.repositories.JpaClusterRepository;
 import com.netflix.genie.web.jpa.repositories.JpaCommandRepository;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,6 +71,7 @@ public class JpaApplicationPersistenceServiceImplUnitTests {
             Mockito.mock(JpaTagPersistenceService.class),
             Mockito.mock(JpaFilePersistenceService.class),
             this.jpaApplicationRepository,
+            Mockito.mock(JpaClusterRepository.class),
             Mockito.mock(JpaCommandRepository.class)
         );
     }

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaClusterPersistenceServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaClusterPersistenceServiceImplUnitTests.java
@@ -34,6 +34,7 @@ import com.netflix.genie.web.jpa.entities.ClusterEntity;
 import com.netflix.genie.web.jpa.entities.CommandEntity;
 import com.netflix.genie.web.jpa.entities.FileEntity;
 import com.netflix.genie.web.jpa.entities.projections.ClusterCommandsProjection;
+import com.netflix.genie.web.jpa.repositories.JpaApplicationRepository;
 import com.netflix.genie.web.jpa.repositories.JpaClusterRepository;
 import com.netflix.genie.web.jpa.repositories.JpaCommandRepository;
 import org.junit.Before;
@@ -79,6 +80,7 @@ public class JpaClusterPersistenceServiceImplUnitTests {
         this.service = new JpaClusterPersistenceServiceImpl(
             Mockito.mock(JpaTagPersistenceService.class),
             this.filePersistenceService,
+            Mockito.mock(JpaApplicationRepository.class),
             this.jpaClusterRepository,
             this.jpaCommandRepository
         );

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaCommandPersistenceServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaCommandPersistenceServiceImplUnitTests.java
@@ -78,9 +78,9 @@ public class JpaCommandPersistenceServiceImplUnitTests {
         this.service = new JpaCommandPersistenceServiceImpl(
             Mockito.mock(JpaTagPersistenceService.class),
             Mockito.mock(JpaFilePersistenceService.class),
-            this.jpaCommandRepository,
             this.jpaApplicationRepository,
-            Mockito.mock(JpaClusterRepository.class)
+            Mockito.mock(JpaClusterRepository.class),
+            this.jpaCommandRepository
         );
     }
 

--- a/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImplUnitTests.java
@@ -105,10 +105,10 @@ public class JpaJobPersistenceServiceImplUnitTests {
         this.jobPersistenceService = new JpaJobPersistenceServiceImpl(
             this.tagPersistenceService,
             this.filePersistenceService,
-            this.jobRepository,
             this.applicationRepository,
             this.clusterRepository,
-            this.commandRepository
+            this.commandRepository,
+            this.jobRepository
         );
     }
 


### PR DESCRIPTION
Flesh out some error handling that was left as `TODO` before with an initial implementation that at least throws exceptions instead of just empty if blocks.

Refactor some JPA services for reuse of repositories and logic.