### PR TITLE
Add job kill service

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/AgentJobKillService.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/AgentJobKillService.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.execution.services;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * Register an agent to listen for job kill messages from the server
+ * and respond to them.
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+public interface AgentJobKillService {
+    /**
+     * Start listening for job termination notification.
+     * @param jobId job id
+     */
+    void start(@NotBlank(message = "Job id cannot be blank") final String jobId);
+
+    /**
+     * Stop the service.
+     *
+     */
+    void stop();
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/KillService.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/KillService.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.execution.services;
+
+/**
+ * Service responsible for killing the job.
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+public interface KillService {
+    /**
+     * Perform all operations associated with killing the job.
+     */
+    void kill();
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/KillServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/KillServiceImpl.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.execution.services.impl;
+
+import com.netflix.genie.agent.execution.services.KillService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementation of {@link KillService}.
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+@Component
+@Lazy
+@Slf4j
+class KillServiceImpl implements KillService {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void kill() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobKillServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobKillServiceImpl.java
@@ -1,0 +1,138 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.execution.services.impl.grpc;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.netflix.genie.agent.execution.services.AgentJobKillService;
+import com.netflix.genie.agent.execution.services.KillService;
+import com.netflix.genie.proto.JobKillRegistrationRequest;
+import com.netflix.genie.proto.JobKillRegistrationResponse;
+import com.netflix.genie.proto.JobKillServiceGrpc;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.stereotype.Service;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * Implementation of the {@link AgentJobKillService}.
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+@Lazy
+@Service
+@Slf4j
+public class GRpcAgentJobKillServiceImpl implements AgentJobKillService {
+
+    private final JobKillServiceGrpc.JobKillServiceFutureStub client;
+    private final KillService killService;
+    private ListenableFuture<JobKillRegistrationResponse> jobKillFuture;
+    private boolean started;
+    private final TaskExecutor killTaskExecutor;
+
+
+    /**
+     * Constructor.
+     *
+     * @param client           The gRPC client to use to call the server
+     * @param killService      KillService for killing the agent
+     * @param killTaskExecutor A task executor to execute killing the agent
+     */
+    public GRpcAgentJobKillServiceImpl(
+        final JobKillServiceGrpc.JobKillServiceFutureStub client,
+        final KillService killService,
+        @Qualifier("sharedAgentTaskExecutor") final TaskExecutor killTaskExecutor
+    ) {
+        this.client = client;
+        this.killService = killService;
+        this.killTaskExecutor = killTaskExecutor;
+    }
+
+    @Override
+    public synchronized void start(@NotBlank(message = "Job id cannot be blank") final String jobId) {
+        //Service can be started only once
+        if (started) {
+           throw new IllegalStateException("Service can be started only once");
+        }
+
+        registerForRemoteKillNotification(jobId);
+        started = true;
+    }
+
+    @Override
+    public void stop() {
+        cancelPreviousAndUpdateJobKillFuture(null);
+    }
+
+    private void registerForRemoteKillNotification(final String jobId) {
+
+        final ListenableFuture<JobKillRegistrationResponse> future = this.client
+            .registerForKillNotification(
+                JobKillRegistrationRequest.newBuilder()
+                    .setJobId(jobId)
+                    .build()
+            );
+
+        cancelPreviousAndUpdateJobKillFuture(future);
+
+        Futures.addCallback(
+            future,
+            new JobKillFutureCallback(jobId),
+            this.killTaskExecutor
+        );
+    }
+
+    /* Cancel the current future */
+    private synchronized void cancelJobKillFuture() {
+        if (this.jobKillFuture != null) {
+            this.jobKillFuture.cancel(false);
+        }
+    }
+
+    /* Cancel current future and store the new future */
+    private synchronized void cancelPreviousAndUpdateJobKillFuture(
+        final ListenableFuture<JobKillRegistrationResponse> killFuture
+    ) {
+        cancelJobKillFuture();
+        this.jobKillFuture = killFuture;
+    }
+
+    private class JobKillFutureCallback implements FutureCallback<JobKillRegistrationResponse> {
+
+        private final String jobId;
+
+        JobKillFutureCallback(final String jobId) {
+            this.jobId = jobId;
+        }
+
+        @Override
+        public void onSuccess(final JobKillRegistrationResponse result) {
+            killService.kill();
+        }
+
+        @Override
+        public void onFailure(final Throwable t) {
+            registerForRemoteKillNotification(this.jobId);
+        }
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/rpc/GrpcConfig.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/rpc/GrpcConfig.java
@@ -21,6 +21,7 @@ package com.netflix.genie.agent.rpc;
 import com.netflix.genie.agent.cli.ArgumentDelegates;
 import com.netflix.genie.proto.HeartBeatServiceGrpc;
 import com.netflix.genie.proto.JobServiceGrpc;
+import com.netflix.genie.proto.JobKillServiceGrpc;
 import com.netflix.genie.proto.PingServiceGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -68,5 +69,13 @@ class GrpcConfig {
     @Scope("prototype")
     HeartBeatServiceGrpc.HeartBeatServiceStub heartBeatClient(final ManagedChannel channel) {
         return HeartBeatServiceGrpc.newStub(channel);
+    }
+
+    @Bean
+    @Scope("prototype")
+    JobKillServiceGrpc.JobKillServiceFutureStub jobKillClient(
+        final ManagedChannel channel
+    ) {
+        return JobKillServiceGrpc.newFutureStub(channel);
     }
 }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobKillServiceImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobKillServiceImplSpec.groovy
@@ -1,0 +1,170 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.execution.services.impl.grpc
+
+import com.netflix.genie.agent.execution.services.KillService
+import com.netflix.genie.agent.execution.services.impl.KillServiceImpl
+import com.netflix.genie.proto.JobKillRegistrationRequest
+import com.netflix.genie.proto.JobKillRegistrationResponse
+import com.netflix.genie.proto.JobKillServiceGrpc
+import com.netflix.genie.test.categories.UnitTest
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.grpc.stub.StreamObserver
+import io.grpc.testing.GrpcServerRule
+import org.junit.Rule
+import org.junit.experimental.categories.Category
+import org.springframework.core.task.TaskExecutor
+import spock.lang.Specification
+
+@Category(UnitTest.class)
+class GRpcAgentJobKillServiceImplSpec extends Specification {
+
+    @Rule
+    GrpcServerRule grpcServerRule = new GrpcServerRule().directExecutor()
+    String jobId
+    GRpcAgentJobKillServiceImpl service
+    JobKillServiceGrpc.JobKillServiceFutureStub client;
+    KillService killService
+    TaskExecutor killExecutor
+    TestJobKillService server
+
+    void setup() {
+        server = new TestJobKillService()
+        grpcServerRule.getServiceRegistry().addService(server)
+        jobId = UUID.randomUUID().toString()
+        client = JobKillServiceGrpc.newFutureStub(grpcServerRule.getChannel())
+        killService = Mock(KillServiceImpl)
+        killExecutor = Mock(TaskExecutor)
+        service = new GRpcAgentJobKillServiceImpl(client, killService, killExecutor)
+    }
+
+    void cleanup() {
+        service.stop()
+        grpcServerRule.getChannel().shutdownNow()
+    }
+
+    def "Starting service more than once throws Exception"() {
+
+        JobKillRegistrationRequest request =
+            JobKillRegistrationRequest.newBuilder().setJobId(jobId).build()
+
+        when:
+        service.start(jobId)
+
+        then:
+        noExceptionThrown()
+
+        when:
+        service.start(jobId)
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "Successfully handle kill notification from the service"() {
+
+        Runnable killCallback
+
+        when:
+        service.start(jobId)
+
+        then:
+        noExceptionThrown()
+
+        when:
+        server.sendKill()
+
+        then:
+        1 * killExecutor.execute(_ as Runnable) >> {
+            args -> killCallback = args[0]
+        }
+
+        when:
+        killCallback.run()
+
+        then:
+        1 * killService.kill()
+    }
+
+    def "Failure registering with the service followed by successful reregistration and kill notification"() {
+        Runnable killCallback
+
+        when:
+        service.start(jobId)
+
+        then:
+        noExceptionThrown()
+
+        when:
+        server.sendError()
+
+        then:
+        1 * killExecutor.execute(_ as Runnable) >> {
+            args -> killCallback = args[0]
+        }
+
+        when:
+        killCallback.run()
+
+        then:
+        0 * killService.kill()
+
+        when:
+        server.sendKill()
+
+        then: "onSuccess callback gets invoked"
+        1 * killExecutor.execute(_ as Runnable) >> {
+            args -> killCallback = args[0]
+        }
+
+        when:
+        killCallback.run()
+
+        then:
+        1 * killService.kill()
+    }
+
+    /**
+     * Mock service for testing.
+     */
+    private class TestJobKillService extends JobKillServiceGrpc.JobKillServiceImplBase {
+
+        StreamObserver<JobKillRegistrationResponse> killResponseObserver
+
+        @Override
+        void registerForKillNotification(
+                final JobKillRegistrationRequest request,
+                final StreamObserver<JobKillRegistrationResponse> responseObserver
+        ) {
+            killResponseObserver = responseObserver
+        }
+
+        void sendError() {
+            killResponseObserver.onError(new StatusRuntimeException(Status.UNAVAILABLE))
+        }
+
+        void sendKill() {
+            killResponseObserver.onNext(
+                JobKillRegistrationResponse.newBuilder().build()
+            )
+            killResponseObserver.onCompleted()
+        }
+    }
+}

--- a/genie-proto/src/main/proto/genie.proto
+++ b/genie-proto/src/main/proto/genie.proto
@@ -304,3 +304,14 @@ message AgentHeartBeat {
 
 message ServerHeartBeat {
 }
+
+service JobKillService {
+    rpc registerForKillNotification (JobKillRegistrationRequest) returns (JobKillRegistrationResponse);
+}
+
+message JobKillRegistrationRequest {
+    string job_id = 1;
+}
+
+message JobKillRegistrationResponse {
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
@@ -28,6 +28,7 @@ import com.netflix.genie.web.jpa.entities.projections.JobProjection;
 import com.netflix.genie.web.jpa.entities.projections.JobRequestProjection;
 import com.netflix.genie.web.jpa.entities.projections.JobSearchProjection;
 import com.netflix.genie.web.jpa.entities.projections.v4.JobSpecificationProjection;
+import com.netflix.genie.web.jpa.entities.projections.v4.IsV4JobProjection;
 import com.netflix.genie.web.jpa.entities.projections.v4.V4JobRequestProjection;
 import com.netflix.genie.web.jpa.specifications.JpaSpecificationUtils;
 import lombok.AccessLevel;
@@ -130,7 +131,8 @@ public class JobEntity extends BaseEntity implements
     JobCommandProjection,
     JobSearchProjection,
     V4JobRequestProjection,
-    JobSpecificationProjection {
+    JobSpecificationProjection,
+    IsV4JobProjection {
 
     private static final long serialVersionUID = 2849367731657512224L;
 

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/projections/v4/IsV4JobProjection.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/projections/v4/IsV4JobProjection.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.jpa.entities.projections.v4;
+
+/**
+ * Projection for capturing if the job was launched using Genie v4.
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+@Deprecated
+public interface IsV4JobProjection {
+    /**
+     * Job was launched using Genie v4.
+     *
+     * @return true if job was launched via Genie v4 else false
+     */
+    boolean isV4();
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
@@ -54,6 +54,7 @@ import com.netflix.genie.web.jpa.entities.FileEntity;
 import com.netflix.genie.web.jpa.entities.JobEntity;
 import com.netflix.genie.web.jpa.entities.projections.IdProjection;
 import com.netflix.genie.web.jpa.entities.projections.v4.JobSpecificationProjection;
+import com.netflix.genie.web.jpa.entities.projections.v4.IsV4JobProjection;
 import com.netflix.genie.web.jpa.entities.projections.v4.V4JobRequestProjection;
 import com.netflix.genie.web.jpa.entities.v4.EntityDtoConverters;
 import com.netflix.genie.web.jpa.repositories.JpaApplicationRepository;
@@ -461,6 +462,26 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
         return projection.isResolved()
             ? Optional.of(EntityDtoConverters.toJobSpecificationDto(projection))
             : Optional.empty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isV4(
+        @NotBlank(message = "Id is missing and is required") final String id
+    ) {
+        log.debug("Read v4 flag from db for job {} ", id);
+        return this.jobRepository
+            .findByUniqueId(id, IsV4JobProjection.class)
+            .orElseThrow(
+                () -> {
+                    final String errorMessage = "No job with id " + id + "exists. Unable to get v4 flag.";
+                    log.error(errorMessage);
+                    return new GenieJobNotFoundException(errorMessage);
+                }
+            ).isV4();
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcJobKillServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcJobKillServiceImpl.java
@@ -1,0 +1,113 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.rpc.grpc.services.impl.v4;
+
+import com.google.common.collect.Maps;
+import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.proto.JobKillRegistrationRequest;
+import com.netflix.genie.proto.JobKillRegistrationResponse;
+import com.netflix.genie.proto.JobKillServiceGrpc;
+import com.netflix.genie.web.rpc.grpc.interceptors.SimpleLoggingInterceptor;
+import com.netflix.genie.web.services.JobKillServiceV4;
+import com.netflix.genie.web.services.JobSearchService;
+import io.grpc.stub.StreamObserver;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.springboot.autoconfigure.grpc.server.GrpcService;
+
+import javax.validation.constraints.NotBlank;
+import java.util.Map;
+
+/**
+ * Service to kill agent jobs.
+ * TODO Register with HeartBeatService to listen for agent stream to become inactive and clean it up.
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+@GrpcService(
+    value = JobKillServiceGrpc.class,
+    interceptors = {
+        SimpleLoggingInterceptor.class,
+    }
+)
+@Slf4j
+public class GRpcJobKillServiceImpl
+    extends JobKillServiceGrpc.JobKillServiceImplBase
+    implements JobKillServiceV4 {
+
+    private final Map<String, StreamObserver<JobKillRegistrationResponse>> parkedJobKillResponseObservers =
+        Maps.newConcurrentMap();
+    private final JobSearchService jobSearchService;
+
+    /**
+     * Constructor.
+     *
+     * @param jobSearchService Job search service
+     */
+    public GRpcJobKillServiceImpl(final JobSearchService jobSearchService) {
+        this.jobSearchService = jobSearchService;
+    }
+
+    /**
+     * Register to be notified when a kill request for the job is received.
+     *
+     * @param request          Request to register for getting notified when server gets a job kill request.
+     * @param responseObserver The response observer
+     */
+    @Override
+    public void registerForKillNotification(
+        final JobKillRegistrationRequest request,
+        final StreamObserver<JobKillRegistrationResponse> responseObserver
+    ) {
+        parkedJobKillResponseObservers.put(request.getJobId(), responseObserver);
+    }
+
+    /**
+     * Kill the job with the given id if possible.
+     *
+     * @param jobId  id of job to kill
+     * @param reason brief reason for requesting the job be killed
+     * @throws GenieServerException in case there is no response observer
+     *                              found to communicate with the agent
+     */
+    @Override
+    public void killJob(final @NotBlank(message = "No job id entered. Unable to kill job.") String jobId,
+                        final @NotBlank(message = "No reason provided.") String reason) throws GenieException {
+
+        final StreamObserver<JobKillRegistrationResponse> responseObserver =
+            parkedJobKillResponseObservers.remove(jobId);
+
+        if (responseObserver == null) {
+            log.error("Job not killed. No response observer found for killing the job with id - {} ", jobId);
+            throw new GenieServerException(
+                "Job not killed. No response observer found for killing the job with id - {} " + jobId);
+        }
+
+        if (jobSearchService.getJobStatus(jobId).isFinished()) {
+            log.info("v4 job {} was already finished when the kill request came", jobId);
+        } else { //Non null response observer and an unfinished job. Send a kill to the agent
+            responseObserver.onNext(
+                JobKillRegistrationResponse.newBuilder().build()
+            );
+            responseObserver.onCompleted();
+
+            log.info("Agent notified for killing job {}", jobId);
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobKillServiceV4.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobKillServiceV4.java
@@ -23,21 +23,21 @@ import org.springframework.validation.annotation.Validated;
 import javax.validation.constraints.NotBlank;
 
 /**
- * Interface for services to kill jobs.
+ * Interface for services to kill V4 jobs.
  *
- * @author tgianos
- * @since 3.0.0
+ * @author standon
+ * @since 4.0.0
  */
 @Validated
-public interface JobKillService {
+public interface JobKillServiceV4 {
 
     /**
-     * Kill the job with the given id if possible. Should publish a JobFinishedEvent when done.
+     * Kill the job with the given id if possible.
      *
-     * @param id     id of job to kill
+     * @param jobId     id of job to kill
      * @param reason brief reason for requesting the job be killed
      * @throws GenieException if there is an error
      */
-    void killJob(@NotBlank(message = "No id entered. Unable to kill job.") final String id,
+    void killJob(@NotBlank(message = "No job id entered. Unable to kill job.") final String jobId,
                  @NotBlank(message = "No reason provided.") final String reason) throws GenieException;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobPersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobPersistenceService.java
@@ -251,4 +251,16 @@ public interface JobPersistenceService {
         @NotNull final JobStatus newStatus,
         @Nullable final String newStatusMessage
     );
+
+    /**
+     * Get whether the job is a v4 job.
+     *
+     * @param id The id of the job
+     * @return true if its a v4 job
+     * @throws GenieJobNotFoundException     If no job with {@code id} exists
+     */
+    boolean isV4(
+        @NotBlank(message = "Id is missing and is required") final String id
+    );
+
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobKillServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobKillServiceImpl.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl;
+
+import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.web.services.JobKillService;
+import com.netflix.genie.web.services.JobKillServiceV4;
+import com.netflix.genie.web.services.JobPersistenceService;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * Implementation of the JobKillService interface.
+ * Attempts to kill v3 jobs running on the local genie nodes.
+ * Attempts to kill v4 jobs running on remote agents.
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+@Slf4j
+public class JobKillServiceImpl implements JobKillService {
+
+    private final JobKillServiceV3 jobKillServiceV3;
+    private final JobKillServiceV4 jobKillServiceV4;
+    private final JobPersistenceService jobPersistenceService;
+
+    /**
+     * Constructor.
+     *
+     * @param jobKillServiceV3      Service to kill V3 jobs.
+     * @param jobKillServiceV4      Service to kill V4 jobs.
+     * @param jobPersistenceService Job persistence service
+     */
+    public JobKillServiceImpl(
+        final JobKillServiceV3 jobKillServiceV3,
+        final JobKillServiceV4 jobKillServiceV4,
+        final JobPersistenceService jobPersistenceService
+
+    ) {
+        this.jobKillServiceV3 = jobKillServiceV3;
+        this.jobKillServiceV4 = jobKillServiceV4;
+        this.jobPersistenceService = jobPersistenceService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void killJob(
+        @NotBlank(message = "No id entered. Unable to kill job.") final String id,
+        @NotBlank(message = "No reason provided.") final String reason
+    ) throws GenieException {
+
+        if (jobPersistenceService.isV4(id)) {
+            jobKillServiceV4.killJob(id, reason);
+        } else {
+            jobKillServiceV3.killJob(id, reason);
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobKillServiceV3.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobKillServiceV3.java
@@ -30,7 +30,6 @@ import com.netflix.genie.web.events.JobFinishedEvent;
 import com.netflix.genie.web.events.JobFinishedReason;
 import com.netflix.genie.web.events.KillJobEvent;
 import com.netflix.genie.web.jobs.JobKillReasonFile;
-import com.netflix.genie.web.services.JobKillService;
 import com.netflix.genie.web.services.JobSearchService;
 import com.netflix.genie.web.util.ProcessChecker;
 import com.netflix.genie.web.util.UnixProcessChecker;
@@ -50,13 +49,13 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 /**
- * Implementation of the JobKillService interface which attempts to kill jobs running on the local node.
+ * A JobKillService that attempts to kill genie 3.0 jobs running on the local node.
  *
  * @author tgianos
  * @since 3.0.0
  */
 @Slf4j
-public class LocalJobKillServiceImpl implements JobKillService {
+public class JobKillServiceV3 {
 
     private final String hostname;
     private final JobSearchService jobSearchService;
@@ -77,7 +76,7 @@ public class LocalJobKillServiceImpl implements JobKillService {
      * @param genieWorkingDir  The working directory where all job directories are created.
      * @param objectMapper     The Jackson ObjectMapper used to serialize from/to JSON
      */
-    public LocalJobKillServiceImpl(
+    public JobKillServiceV3(
         @NotBlank final String hostname,
         @NotNull final JobSearchService jobSearchService,
         @NotNull final Executor executor,
@@ -101,9 +100,12 @@ public class LocalJobKillServiceImpl implements JobKillService {
     }
 
     /**
-     * {@inheritDoc}
+     * Kill the job with the given id if possible. Should publish a JobFinishedEvent when done.
+     *
+     * @param id     id of job to kill
+     * @param reason brief reason for requesting the job be killed
+     * @throws GenieException if there is an error
      */
-    @Override
     public void killJob(
         @NotBlank(message = "No id entered. Unable to kill job.") final String id,
         @NotBlank(message = "No reason provided.") final String reason

--- a/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcJobKillServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcJobKillServiceImplSpec.groovy
@@ -1,0 +1,95 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.rpc.grpc.services.impl.v4
+
+import com.netflix.genie.common.dto.JobStatus
+import com.netflix.genie.common.exceptions.GenieServerException
+import com.netflix.genie.proto.*
+import com.netflix.genie.web.services.JobSearchService
+import io.grpc.stub.StreamObserver
+import spock.lang.Specification
+
+
+/**
+ * Specifications for the {@link GRpcJobKillServiceImpl} class.
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+class GRpcJobKillServiceImplSpec extends Specification {
+
+    GRpcJobKillServiceImpl service
+    String jobId
+    JobKillRegistrationRequest request
+    JobKillRegistrationResponse response
+    JobSearchService jobSearchService = Mock()
+    StreamObserver<SyncResponse> responseObserver = Mock()
+
+    void setup() {
+        jobId = UUID.randomUUID().toString()
+        request = JobKillRegistrationRequest.newBuilder().setJobId(jobId).build()
+        response = JobKillRegistrationResponse.newBuilder().build()
+        service = new GRpcJobKillServiceImpl(jobSearchService)
+    }
+
+    def "Can kill unfinished jobs and clean up response observer"() {
+
+        when:
+        service.registerForKillNotification(request, responseObserver)
+
+        then:
+        noExceptionThrown()
+
+        when:
+        service.killJob(jobId, "testing")
+
+        then:
+        1 * jobSearchService.getJobStatus(jobId) >> JobStatus.RUNNING
+        1 * responseObserver.onNext(response)
+        1 * responseObserver.onCompleted()
+
+        when:
+        service.killJob(jobId, "testing")
+
+        then:
+        thrown(GenieServerException)
+    }
+
+    def "For finished job do not interact with agent. Clean up response observer"() {
+
+        when:
+        service.registerForKillNotification(request, responseObserver)
+
+        then:
+        noExceptionThrown()
+
+        when:
+        service.killJob(jobId, "testing")
+
+        then:
+        1 * jobSearchService.getJobStatus(jobId) >> JobStatus.SUCCEEDED
+        0 * responseObserver.onNext(response)
+        0 * responseObserver.onCompleted()
+
+        when:
+        service.killJob(jobId, "testing")
+
+        then:
+        thrown(GenieServerException)
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobKillServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobKillServiceImplSpec.groovy
@@ -1,0 +1,97 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl
+
+import com.netflix.genie.common.exceptions.GenieServerException
+import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException
+import com.netflix.genie.test.categories.UnitTest
+import com.netflix.genie.web.services.JobKillServiceV4
+import com.netflix.genie.web.services.JobPersistenceService
+import org.junit.experimental.categories.Category
+import spock.lang.Specification
+
+/**
+ * Tests for JobKillServiceImpl
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+@Category(UnitTest.class)
+class JobKillServiceImplSpec extends Specification {
+    JobKillServiceV3 jobKillServiceV3
+    JobKillServiceImpl service
+    JobPersistenceService jobPersistenceService
+    JobKillServiceV4 jobKillServiceV4
+    String jobId
+
+    void setup() {
+        jobPersistenceService = Mock()
+        jobKillServiceV4 = Mock()
+        jobKillServiceV3 = Mock()
+        jobId = UUID.randomUUID().toString()
+        service = new JobKillServiceImpl (jobKillServiceV3, jobKillServiceV4, jobPersistenceService)
+    }
+
+    def "Invoke JobKillServiceV3 for a v3 job"() {
+
+        when:
+        service.killJob(jobId, "testing")
+
+        then:
+        1 * jobPersistenceService.isV4(jobId) >> false
+        0 * jobKillServiceV4.killJob(jobId, "testing")
+        1 * jobKillServiceV3.killJob(jobId, "testing")
+    }
+
+    def "Invoke JobKillServiceV4 for a v4 job"() {
+
+        when:
+        service.killJob(jobId, "testing")
+
+        then:
+        1 * jobPersistenceService.isV4(jobId) >> true
+        1 * jobKillServiceV4.killJob(jobId, "testing")
+        0 * jobKillServiceV3.killJob(jobId, "testing")
+    }
+
+    def "Percolate up the exception thrown by underlying services when killing a job"() {
+
+        when:
+        service.killJob(jobId, "testing")
+
+        then:
+        1 * jobPersistenceService.isV4(jobId) >> { throw new GenieJobNotFoundException()}
+        thrown(GenieJobNotFoundException)
+
+        when:
+        service.killJob(jobId, "testing")
+
+        then:
+        1 * jobPersistenceService.isV4(jobId) >> true
+        1 * jobKillServiceV4.killJob(jobId, "testing") >> { throw new GenieServerException("Error killing v4 job")}
+        thrown(GenieServerException)
+
+        when:
+        service.killJob(jobId, "testing")
+
+        then:
+        1 * jobPersistenceService.isV4(jobId) >> false
+        1 * jobKillServiceV3.killJob(jobId, "testing") >> { throw new GenieServerException("Error killing v3 job")}
+        thrown(GenieServerException)
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesAutoConfigurationUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesAutoConfigurationUnitTests.java
@@ -28,10 +28,12 @@ import com.netflix.genie.web.services.ApplicationPersistenceService;
 import com.netflix.genie.web.services.ClusterPersistenceService;
 import com.netflix.genie.web.services.CommandPersistenceService;
 import com.netflix.genie.web.services.JobKillService;
+import com.netflix.genie.web.services.JobKillServiceV4;
 import com.netflix.genie.web.services.JobPersistenceService;
 import com.netflix.genie.web.services.JobSearchService;
 import com.netflix.genie.web.services.JobSpecificationService;
 import com.netflix.genie.web.services.JobStateService;
+import com.netflix.genie.web.services.impl.JobKillServiceV3;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.exec.Executor;
 import org.junit.Assert;
@@ -128,6 +130,20 @@ public class ServicesAutoConfigurationUnitTests {
     public void canGetJobKillServiceBean() {
         Assert.assertNotNull(
             this.genieServicesAutoConfiguration.jobKillService(
+                Mockito.mock(JobKillServiceV3.class),
+                Mockito.mock(JobKillServiceV4.class),
+                Mockito.mock(JobPersistenceService.class)
+            )
+        );
+    }
+
+    /**
+     * Can get a bean for killing V3 jobs.
+     */
+    @Test
+    public void canGetJobKillServiceV3Bean() {
+        Assert.assertNotNull(
+            this.genieServicesAutoConfiguration.jobKillServiceV3(
                 new GenieHostInfo("localhost"),
                 this.jobSearchService,
                 Mockito.mock(Executor.class),

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobKillServiceV3UnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobKillServiceV3UnitTests.java
@@ -49,13 +49,13 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- * Unit tests for the LocalJobKillServiceImpl class.
+ * Unit tests for the JobKillServiceV3 class.
  *
  * @author tgianos
  * @since 3.0.0
  */
 @Category(UnitTest.class)
-public class LocalJobKillServiceImplUnitTests {
+public class JobKillServiceV3UnitTests {
 
     private static final String ID = UUID.randomUUID().toString();
     private static final String HOSTNAME = UUID.randomUUID().toString();
@@ -64,12 +64,13 @@ public class LocalJobKillServiceImplUnitTests {
     private CommandLine killCommand;
     private JobSearchService jobSearchService;
     private Executor executor;
-    private LocalJobKillServiceImpl service;
+    private JobKillServiceV3 service;
     private GenieEventBus genieEventBus;
     private FileSystemResource genieWorkingDir;
 
     /**
      * Setup for the tests.
+     *
      *
      * @throws IOException if the job directory cannot be created
      */
@@ -82,7 +83,7 @@ public class LocalJobKillServiceImplUnitTests {
         this.jobSearchService = Mockito.mock(JobSearchService.class);
         this.executor = Mockito.mock(Executor.class);
         this.genieEventBus = Mockito.mock(GenieEventBus.class);
-        this.service = new LocalJobKillServiceImpl(
+        this.service = new JobKillServiceV3(
             HOSTNAME,
             this.jobSearchService,
             this.executor,
@@ -218,7 +219,7 @@ public class LocalJobKillServiceImplUnitTests {
      */
     @Test
     public void canKillJobRunningAsUser() throws GenieException, IOException {
-        this.service = new LocalJobKillServiceImpl(
+        this.service = new JobKillServiceV3(
             HOSTNAME,
             this.jobSearchService,
             this.executor,


### PR DESCRIPTION
First draft of the job kill service. My intent was to

1. Have similar interfaces as defined for other services on the agent side
2. Get on the same page for the flow for a job kill. How will registration work? How will a kill from server be routed back to the agent?

No tests have been added yet. I have marked the outstanding questions in my head as TODO items. Please have a look and provide your feedback 