### PR TITLE
Move `@Configuration` classes in `genie-web` module to be auto configured

### DIFF
--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -89,6 +89,7 @@ dependencies {
 
 license {
     exclude "*.yml"
+    exclude "META-INF/spring.factories"
     exclude "genie-banner.txt"
     exclude "db/**/*.sql"
     exclude "**/com/netflix/genie/web/jpa/entities/*_.java"

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/EventConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/EventConfig.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.configs;
 
 import com.netflix.genie.web.events.GenieEventBusImpl;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.SimpleApplicationEventMulticaster;
@@ -42,6 +43,7 @@ public class EventConfig {
      * @return The application event multicaster to use
      */
     @Bean
+    @ConditionalOnMissingBean(GenieEventBusImpl.class)
     public GenieEventBusImpl applicationEventMulticaster(
         @Qualifier("genieSyncTaskExecutor") final SyncTaskExecutor syncTaskExecutor,
         @Qualifier("genieAsyncTaskExecutor") final AsyncTaskExecutor asyncTaskExecutor

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/GRPCServerConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/GRPCServerConfig.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.configs;
 import com.netflix.genie.web.properties.JobFileSyncRpcProperties;
 import lombok.extern.slf4j.Slf4j;
 import net.devh.springboot.autoconfigure.grpc.server.GrpcServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -54,6 +55,7 @@ public class GRPCServerConfig {
      * @return The properties instance
      */
     @Bean
+    @ConditionalOnMissingBean(JobFileSyncRpcProperties.class)
     @ConfigurationProperties(prefix = "genie.grpc.server.services.job-file-sync")
     public JobFileSyncRpcProperties jobFileSyncRpcProperties() {
         return new JobFileSyncRpcProperties();

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/PropertiesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/PropertiesConfig.java
@@ -21,6 +21,7 @@ import com.netflix.genie.web.properties.DataServiceRetryProperties;
 import com.netflix.genie.web.properties.HealthProperties;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.properties.S3FileTransferProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,6 +42,7 @@ public class PropertiesConfig {
      */
     @Bean
     @ConfigurationProperties("genie.jobs")
+    @ConditionalOnMissingBean(JobsProperties.class)
     public JobsProperties jobsProperties() {
         return new JobsProperties();
     }
@@ -52,6 +54,7 @@ public class PropertiesConfig {
      */
     @Bean
     @ConfigurationProperties("genie.data.service.retry")
+    @ConditionalOnMissingBean(DataServiceRetryProperties.class)
     public DataServiceRetryProperties dataServiceRetryProperties() {
         return new DataServiceRetryProperties();
     }
@@ -63,6 +66,7 @@ public class PropertiesConfig {
      */
     @Bean
     @ConfigurationProperties("genie.health")
+    @ConditionalOnMissingBean(HealthProperties.class)
     public HealthProperties healthProperties() {
         return new HealthProperties();
     }
@@ -74,6 +78,7 @@ public class PropertiesConfig {
      */
     @Bean
     @ConfigurationProperties("genie.s3filetransfer")
+    @ConditionalOnMissingBean(S3FileTransferProperties.class)
     public S3FileTransferProperties s3FileTransferProperties() {
         return new S3FileTransferProperties();
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -111,6 +111,7 @@ public class ServicesConfig {
      * @return A job kill service instance.
      */
     @Bean
+    @ConditionalOnMissingBean(JobKillService.class)
     public JobKillService jobKillService(
         final GenieHostInfo genieHostInfo,
         final JobSearchService jobSearchService,
@@ -137,6 +138,7 @@ public class ServicesConfig {
      * @return A randomized cluster load balancer instance.
      */
     @Bean
+    @ConditionalOnMissingBean(ClusterLoadBalancer.class)
     public ClusterLoadBalancer clusterLoadBalancer() {
         return new RandomizedClusterLoadBalancerImpl();
     }
@@ -186,6 +188,7 @@ public class ServicesConfig {
      * @return An instance of the JobSubmitterService.
      */
     @Bean
+    @ConditionalOnMissingBean(JobSubmitterService.class)
     public JobSubmitterService jobSubmitterService(
         final JobPersistenceService jobPersistenceService,
         final GenieEventBus genieEventBus,
@@ -219,6 +222,7 @@ public class ServicesConfig {
      * @return An instance of the JobCoordinatorService.
      */
     @Bean
+    @ConditionalOnMissingBean(JobCoordinatorService.class)
     public JobCoordinatorService jobCoordinatorService(
         final JobPersistenceService jobPersistenceService,
         final JobKillService jobKillService,
@@ -254,6 +258,7 @@ public class ServicesConfig {
      * @return The attachment service to use
      */
     @Bean
+    @ConditionalOnMissingBean(AttachmentService.class)
     public AttachmentService attachmentService(final JobsProperties jobsProperties) {
         return new FileSystemAttachmentService(jobsProperties.getLocations().getAttachments());
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ValidationConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ValidationConfig.java
@@ -40,7 +40,7 @@ public class ValidationConfig {
      * @return The bean validator
      */
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(Validator.class)
     public Validator localValidatorFactoryBean() {
         return new LocalValidatorFactoryBean();
     }
@@ -51,7 +51,7 @@ public class ValidationConfig {
      * @return The method validation processor
      */
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(MethodValidationPostProcessor.class)
     public MethodValidationPostProcessor methodValidationPostProcessor() {
         return new MethodValidationPostProcessor();
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsMvcConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsMvcConfig.java
@@ -21,6 +21,8 @@ import com.amazonaws.util.EC2MetadataUtils;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration;
 import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnvironment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +37,7 @@ import java.net.UnknownHostException;
  * @since 3.0.0
  */
 @Configuration
+@AutoConfigureAfter(ContextCredentialsAutoConfiguration.class)
 @ConditionalOnAwsCloudEnvironment
 @Slf4j
 public class AwsMvcConfig {

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsS3Config.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/aws/AwsS3Config.java
@@ -31,6 +31,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,6 +49,11 @@ import java.util.UUID;
  */
 @Configuration
 @ConditionalOnBean(AWSCredentialsProvider.class)
+@AutoConfigureAfter(
+    name = {
+        "org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration"
+    }
+)
 @Slf4j
 public class AwsS3Config {
 

--- a/genie-web/src/main/resources/META-INF/spring.factories
+++ b/genie-web/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,13 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.netflix.genie.web.configs.EventConfig,\
+  com.netflix.genie.web.configs.GRPCServerConfig,\
+  com.netflix.genie.web.configs.JobConfig,\
+  com.netflix.genie.web.configs.LeadershipConfig,\
+  com.netflix.genie.web.configs.MvcConfig,\
+  com.netflix.genie.web.configs.PropertiesConfig,\
+  com.netflix.genie.web.configs.ServicesConfig,\
+  com.netflix.genie.web.configs.SwaggerConfig,\
+  com.netflix.genie.web.configs.TaskConfig,\
+  com.netflix.genie.web.configs.ValidationConfig,\
+  com.netflix.genie.web.configs.aws.AwsMvcConfig,\
+  com.netflix.genie.web.configs.aws.AwsS3Config


### PR DESCRIPTION
This commit changes the `@Configuration` classes contained in the `genie-web` module to be Spring Boot Auto Configuration classes. This allows greater control for consumers of the jar to control behavior of these configurations (easier to override beans or ignore configurations completely) while simultaneously allowing us to control when the configuration is applied (e.g. after Spring Cloud AWS has configured the credentials bean). Integration with internal boot resources should be simpler.

To make this work even better we might want to explore moving away from classpath scanning for beans entirely but for now that's too big of a change and I'm committing this to unblock internal Boot 2 integration testing.