### PR TITLE
Customize Agent logging configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ configure(javaProjects) {
             // https://curator.apache.org/zk-compatibility.html
             dependency("org.apache.zookeeper:zookeeper:3.4.12")
             dependency("org.bitbucket.b_c:jose4j:0.6.3")
+            dependency("org.codehaus.janino:janino:2.5.16")
             dependency("org.dbunit:dbunit:2.5.4")
             dependencySet(group: "org.jruby", version: "9.1.14.0") {
                 entry "jruby-complete"

--- a/genie-agent/build.gradle
+++ b/genie-agent/build.gradle
@@ -1,8 +1,11 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 apply plugin: "org.springframework.boot"
 
 license {
     exclude "*.yml"
     exclude "*.xml"
+    exclude "*.txt"
 }
 
 dependencies {
@@ -55,5 +58,13 @@ def genieVersion = project.version.toString()
 jar {
     manifest {
         attributes("Implementation-Version": genieVersion)
+    }
+}
+
+processResources {
+    filesMatching("**/*.txt") {
+        filter ReplaceTokens, tokens: [
+                "genie.version": project.version.toString()
+        ]
     }
 }

--- a/genie-agent/build.gradle
+++ b/genie-agent/build.gradle
@@ -2,6 +2,7 @@ apply plugin: "org.springframework.boot"
 
 license {
     exclude "*.yml"
+    exclude "*.xml"
 }
 
 dependencies {
@@ -26,6 +27,7 @@ dependencies {
     compile("javax.el:javax.el-api")
     compile("org.apache.commons:commons-lang3")
     compile("org.glassfish:javax.el")
+    compile("org.codehaus.janino:janino:")
 
     /*******************************
      * Provided Dependencies

--- a/genie-agent/src/main/java/com/netflix/genie/agent/cli/GenieAgentRunnner.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/cli/GenieAgentRunnner.java
@@ -54,7 +54,7 @@ public class GenieAgentRunnner implements CommandLineRunner, ExitCodeGenerator {
         try {
             internalRun(args);
         } catch (final Throwable t) {
-            log.error("Agent execution failed with exception", t);
+            UserConsole.getLogger().error("Agent execution failed with exception", t);
         }
     }
 
@@ -80,6 +80,8 @@ public class GenieAgentRunnner implements CommandLineRunner, ExitCodeGenerator {
             throw new IllegalArgumentException("Invalid command -- commands available: " + availableCommandsString);
         }
 
+        UserConsole.getLogger().info("Initializing command {}", commandName);
+
         log.info("Initializing command: {}", commandName);
         exitCode = ExitCode.COMMAND_INIT_FAIL;
         final AgentCommand command = commandFactory.get(commandName);
@@ -91,7 +93,7 @@ public class GenieAgentRunnner implements CommandLineRunner, ExitCodeGenerator {
 
     @Override
     public int getExitCode() {
-        log.info("Terminating with code: {} ({})", exitCode.getCode(), exitCode.getMessage());
+        UserConsole.getLogger().info("Terminating with code: {} ({})", exitCode.getCode(), exitCode.getMessage());
         return exitCode.getCode();
     }
 }

--- a/genie-agent/src/main/java/com/netflix/genie/agent/cli/UserConsole.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/cli/UserConsole.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.cli;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utilities for interacting with the user terminal/console.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public final class UserConsole {
+
+    /**
+     * The name of this logger must match the one explicitly whitelisted in the underlying logger configuration
+     * consumed by Spring.
+     */
+    private static final String CONSOLE_LOGGER_NAME = "genie-agent";
+    private static final Logger LOGGER = LoggerFactory.getLogger(CONSOLE_LOGGER_NAME);
+
+    private UserConsole() {
+    }
+
+    /**
+     * Get the LOGGER visible to user on the console.
+     * All other LOGGER messages are logged on file only to avoid interfering with the job console output.
+     *
+     * @return a special Logger whose messages are visible on the user terminal.
+     */
+    public static Logger getLogger() {
+        return LOGGER;
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/listeners/LoggingListener.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/listeners/LoggingListener.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.agent.execution.statemachine.listeners;
 
+import com.netflix.genie.agent.cli.UserConsole;
 import com.netflix.genie.agent.execution.statemachine.Events;
 import com.netflix.genie.agent.execution.statemachine.States;
 import lombok.extern.slf4j.Slf4j;
@@ -96,12 +97,17 @@ public class LoggingListener implements JobExecutionListener {
      */
     @Override
     public void transition(final Transition<States, Events> transition) {
+        UserConsole.getLogger().info(
+            "Transitioning from: {} to: {}",
+            getStateNameString(transition.getSource()),
+            getStateNameString(transition.getTarget())
+        );
         log.debug(
             "Triggered {} transition from {} to {} ({} actions)",
             transition.getKind(),
             getStateNameString(transition.getSource()),
             getStateNameString(transition.getTarget()),
-            transition.getActions() != null ? transition.getActions().size() : "0"
+            transition.getActions() != null ? transition.getActions().size() : 0
         );
     }
 
@@ -138,8 +144,8 @@ public class LoggingListener implements JobExecutionListener {
      */
     @Override
     public void stateMachineStarted(final StateMachine<States, Events> stateMachine) {
-        log.info(
-            "State machine started"
+        UserConsole.getLogger().info(
+            "Agent execution state machine started"
         );
     }
 

--- a/genie-agent/src/main/resources/application.yml
+++ b/genie-agent/src/main/resources/application.yml
@@ -12,3 +12,5 @@ cloud:
 spring:
   jmx:
     enabled: false
+  banner:
+    location: classpath:genie-agent-banner.txt

--- a/genie-agent/src/main/resources/genie-agent-banner.txt
+++ b/genie-agent/src/main/resources/genie-agent-banner.txt
@@ -1,0 +1,2 @@
+
+⭐️ 🧞  Genie Agent v@genie.version@ ⭐️

--- a/genie-agent/src/main/resources/genie-agent-console-appender.xml
+++ b/genie-agent/src/main/resources/genie-agent-console-appender.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Variation of Boot console appender.
+  Filters out every message except for the ones explicitly targeted to user/console.
+-->
+
+<included>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+      <evaluator>
+        <expression>return "${CONSOLE_FILTER_LOGGER_NAME}".equals(logger);</expression>
+      </evaluator>
+      <OnMismatch>DENY</OnMismatch>
+      <OnMatch>NEUTRAL</OnMatch>
+    </filter>
+    <encoder>
+      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+</included>

--- a/genie-agent/src/main/resources/genie-agent-file-appender.xml
+++ b/genie-agent/src/main/resources/genie-agent-file-appender.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Variation of Boot file appender.
+  Rotates based on size (so that log files shared with developers can't get too large)
+-->
+
+<included>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <file>${LOG_FILE}</file>
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>${LOG_FILE_SIZE_ROLL_TRESHOLD}</maxFileSize>
+    </triggeringPolicy>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern>${LOG_FILE_ROLLED}</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>5</maxIndex>
+    </rollingPolicy>
+  </appender>
+</included>

--- a/genie-agent/src/main/resources/logback-spring.xml
+++ b/genie-agent/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  This file is a variation of the default configuration loaded by Boot.
+  Because this file is present, the default is not loaded.
+  This configuration is the same as base.xml found here:
+  See: https://github.com/spring-projects/spring-boot/blob/2.0.x/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/
+  but with customized appenders.
+-->
+<configuration debug="false">
+
+  <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+
+  <property name="LOG_FILE" value="/tmp/genie-agent-${PID}.log"/>
+  <property name="LOG_FILE_ROLLED" value="/tmp/genie-agent-${PID}.%i.log.zip"/>
+  <property name="LOG_FILE_SIZE_ROLL_TRESHOLD" value="1GB"/>
+  <include resource="genie-agent-file-appender.xml" />
+
+  <property name="CONSOLE_FILTER_LOGGER_NAME" value="genie-agent"/>
+  <include resource="genie-agent-console-appender.xml" />
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
+    <appender-ref ref="FILE" />
+  </root>
+
+</configuration>

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/UserConsoleSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/UserConsoleSpec.groovy
@@ -1,0 +1,32 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.cli
+
+import org.slf4j.Logger
+import spock.lang.Specification
+
+class UserConsoleSpec extends Specification {
+    def "GetLogger"() {
+        when:
+        Logger logger = UserConsole.getLogger()
+
+        then:
+        logger != null
+    }
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/listeners/LoggingListenerSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/listeners/LoggingListenerSpec.groovy
@@ -117,9 +117,9 @@ class LoggingListenerSpec extends Specification {
 
         then:
         1 * transition.getKind() >> TransitionKind.EXTERNAL
-        1 * transition.getSource() >> state
-        1 * transition.getTarget() >> state
-        2 * state.getId() >> States.CONFIGURE_AGENT
+        2 * transition.getSource() >> state
+        2 * transition.getTarget() >> state
+        4 * state.getId() >> States.CONFIGURE_AGENT
         2 * transition.getActions() >> Lists.newArrayList()
     }
 
@@ -129,9 +129,9 @@ class LoggingListenerSpec extends Specification {
 
         then:
         1 * transition.getKind() >> TransitionKind.EXTERNAL
-        1 * transition.getSource() >> nullState
-        1 * transition.getTarget() >> state
-        1 * state.getId() >> States.CONFIGURE_AGENT
+        2 * transition.getSource() >> nullState
+        2 * transition.getTarget() >> state
+        2 * state.getId() >> States.CONFIGURE_AGENT
         1 * transition.getActions() >> null
     }
 


### PR DESCRIPTION
Console: only log a very specific logger, intended for high visibility user messages.
File: log everything to file.