### PR TITLE
Add clean up options for the job folder

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/cli/AgentOptionsArgumentsImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/cli/AgentOptionsArgumentsImpl.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.cli;
+
+import com.beust.jcommander.Parameter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementation of AgentOptions delegate.
+ */
+@Component
+public class AgentOptionsArgumentsImpl implements ArgumentDelegates.AgentOptions {
+
+    @Parameter(
+        names = {"--no-cleanup"},
+        description = "Don't remove the job folder"
+    )
+    private boolean noCleanup;
+
+    @Parameter(
+        names = {"--full-cleanup"},
+        description = "Remove the job folder"
+    )
+    private boolean fullCleanup;
+
+    @Override
+    public JobFolderCleanupOption getJobFolderCleanUpOption() {
+        if (noCleanup) {
+            return JobFolderCleanupOption.NO_CLEANUP;
+        } else if (fullCleanup) {
+            return JobFolderCleanupOption.DELETE_JOB_FOLDER;
+        } else {
+            return JobFolderCleanupOption.DELETE_DEPENDENCIES_ONLY;
+        }
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/cli/ArgumentDelegates.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/cli/ArgumentDelegates.java
@@ -98,4 +98,12 @@ public interface ArgumentDelegates {
         boolean isJobRequestedViaAPI();
     }
 
+    /**
+     * Options for specifying agent's behavior.
+     */
+    interface AgentOptions {
+
+        JobFolderCleanupOption getJobFolderCleanUpOption();
+
+    }
 }

--- a/genie-agent/src/main/java/com/netflix/genie/agent/cli/ExecCommand.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/cli/ExecCommand.java
@@ -132,14 +132,19 @@ class ExecCommand implements AgentCommand {
         @ParametersDelegate
         private final ArgumentDelegates.JobRequestArguments jobRequestArguments;
 
+        @ParametersDelegate
+        private final ArgumentDelegates.AgentOptions agentOptions;
+
         ExecCommandArguments(
             final ArgumentDelegates.ServerArguments serverArguments,
             final ArgumentDelegates.CacheArguments cacheArguments,
-            final ArgumentDelegates.JobRequestArguments jobRequestArguments
+            final ArgumentDelegates.JobRequestArguments jobRequestArguments,
+            final ArgumentDelegates.AgentOptions agentOptions
         ) {
             this.serverArguments = serverArguments;
             this.cacheArguments = cacheArguments;
             this.jobRequestArguments = jobRequestArguments;
+            this.agentOptions = agentOptions;
         }
 
         @Override

--- a/genie-agent/src/main/java/com/netflix/genie/agent/cli/JobFolderCleanupOption.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/cli/JobFolderCleanupOption.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.cli;
+
+/**
+ * Clean up options for handling the job folder on job completion.
+ *
+ * @author standon
+ * @since 4.0.0
+ */
+public enum JobFolderCleanupOption {
+    /**
+     * Delete the entire job folder.
+     */
+    DELETE_JOB_FOLDER,
+    /**
+     * Leave the job folder untouched.
+     */
+    NO_CLEANUP,
+    /**
+     * Delete only the application, cluster and command directories.
+     */
+    DELETE_DEPENDENCIES_ONLY;
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/AgentOptionsArgumentsImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/AgentOptionsArgumentsImplSpec.groovy
@@ -1,0 +1,69 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.cli
+
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.ParametersDelegate
+import com.netflix.genie.test.categories.UnitTest
+import org.junit.experimental.categories.Category
+import spock.lang.Specification
+
+@Category(UnitTest.class)
+class AgentOptionsArgumentsImplSpec extends Specification {
+
+    TestOptions options
+    JCommander jCommander
+
+    void setup() {
+        options = new TestOptions()
+        jCommander = new JCommander(options)
+    }
+
+    void cleanup() {
+    }
+
+    def "Defaults"() {
+        when:
+        jCommander.parse()
+
+        then:
+        options.agentOptionsArguments.getJobFolderCleanUpOption() == JobFolderCleanupOption.DELETE_DEPENDENCIES_ONLY
+    }
+
+    def "Parse Full clean up"() {
+        when:
+        jCommander.parse("--full-cleanup")
+
+        then:
+        options.agentOptionsArguments.getJobFolderCleanUpOption() == JobFolderCleanupOption.DELETE_JOB_FOLDER
+    }
+
+    def "Parse No clean up"() {
+        when:
+        jCommander.parse("--no-cleanup")
+
+        then:
+        options.agentOptionsArguments.getJobFolderCleanUpOption() == JobFolderCleanupOption.NO_CLEANUP
+    }
+
+    class TestOptions {
+        @ParametersDelegate
+        private ArgumentDelegates.AgentOptions agentOptionsArguments = new AgentOptionsArgumentsImpl()
+    }
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/ExecCommandArgumentsSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/ExecCommandArgumentsSpec.groovy
@@ -32,12 +32,14 @@ class ExecCommandArgumentsSpec extends Specification {
     ArgumentDelegates.ServerArguments serverArguments
     ArgumentDelegates.CacheArguments cacheArguments
     ArgumentDelegates.JobRequestArguments jobRequestArguments
+    ArgumentDelegates.AgentOptions agentOptions
 
     void setup() {
         serverArguments = new ServerArgumentsImpl()
         cacheArguments = new CacheArgumentsImpl()
         jobRequestArguments = new JobRequestArgumentsImpl()
-        options = new ExecCommand.ExecCommandArguments(serverArguments, cacheArguments, jobRequestArguments)
+        agentOptions = new AgentOptionsArgumentsImpl()
+        options = new ExecCommand.ExecCommandArguments(serverArguments, cacheArguments, jobRequestArguments, agentOptions)
         jCommander = new JCommander(options)
     }
 


### PR DESCRIPTION
Adding clean up options for handling the job folder on job completion. 
--no-cleanup - leaves the job folder as is
--full-cleanup - deletes the job folder
Default behavior - Delete the dependencies in the application, cluster and command folders