### PR TITLE
Upgrade to git publish plugin for documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ env:
     - secure: g8oRT4YUr2VyO6h8+Pm+MvSgPyfEtd+ndCxF70F0SUj5eNV9SFt7yYOn6V6Mxx9eEyZMQSdPed+70+94Nd8yD+cjIGHNnlvKt6V/Q4i09XxhT3/ZiM8B9qRd1eGON0mEaU5Bl+918CGEIVCVsfLPGLVpItaSz2Tda46EDOdRHO8=
     - secure: c0LFCj1KBTEIFSWlpRGgaei86bfrpnSr8qmMOu/S4dl2JRnCnW9AHmrmQzYhd5NlNPugOAncYk9lnkxA7xqtDlv/Ih4YKBaeP924hwLWO//0tKgxhF1dr0dHI+bRKURvcSyLXFDNFjuXUrw4SalBLbZCmiNFzJLMmy2Lvs9UTso=
     - secure: Nv1mMLy2XX+bYziq536KbNg/mAVDTaLw3q3bKP2Mil3JVicXxYVbkEo+DK2O4rsuT7JNbyroN6/3x7xT9qBo4X7vzCjU91QUAxq5t0SmG0FW+oAIApHWTum307b5XS2UyqV/88gg1O6g9or3bKmDLUsJ1A/+fsASozA207a7zls=
-    - secure: "azkmD+d2nSitHJS8AB/L2aAJyiUDBa8tQX4c/gzC/dZHkSUBslyAbGz7OyLWt31JF1WdlNpoWel1gp2/nNoi8W5s46N5z9yYMbGONJUAqaUNWYDfjrLqRtUDPAoo39zARUfsuKPu9Bqt+ZEjb5jiHwj9CRBoejkdbFdPdMNziwA="
     - secure: "GNQsJ9ylRN9UXWQ20+Ba7NrgmO9SykkLUzO30x0RpicH+uphSPXs785cQuDgPheRs0eTisco/31m7PeqfdS/4KuJ/BI2FwLuCt3uTKvhYgSr/rd7iVb4ldHChmfAjSF+cytLKQd2xPvOveTbX4+/mQfdH0f7WXyxA/zpu18nHPk="
     - secure: "RWtT5UaOQsNaR4x74Lq3UYVaXfY+j+O5eYmPTHhQ6z+mG/cFxZF+2f4W/yHh8WRB+eMvjG0DWb48cEnHSzTC41wsg0fbEu1T7Iv0OglnZVbkzEG+JsyDsqRm4r/HsjXopNIcR+lQ5gpE85PLVTaOdzgH7W44nlo581bR0dkV88o="
+    - secure: "a5QmXCWR7wwEf/poWSj3PDAb6VICKqTTw3qbNjQwSvCzaCYtZZmxLbruQQlKOyR6W4j2VMrp2Ip5xrBjlCrOTvkFymPY3L+EwbPxsXbO4uhzs43BNFLhDon/Duv3TRhnedkqP0s8hN1ylxCbcID0UUPXQGrhnu8mb5QlDUx2mr8="
 notifications:
   slack:
     secure: H5nS+GX6TYTU27ur6YFG5OgrQeUbzXLok5ub6+xcmyYEeVPpnQ1Gg/wKqTAGsP9j6tAkqPpxgYT9i9Do6eyTEplK6bTvQVyhilsEDtxGJbUO8XOE9TSo6jAe/lD3EB5l46gxFID+Hg9IkPii4LwEabP7PVehrB1JfNZ6QDgSRRM=

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,9 @@ buildscript {
 
 plugins {
     id "com.github.kt3k.coveralls" version "2.8.2"
-    id "nebula.netflixoss" version "5.1.1"
-    id "org.ajoberstar.github-pages" version "1.7.2"
+    id "nebula.netflixoss" version "6.0.3"
+    id "org.ajoberstar.grgit" version "3.0.0-beta.1"
+    id "org.ajoberstar.git-publish" version "1.0.1"
 }
 
 apply plugin: "nebula-aggregate-javadocs"
@@ -372,7 +373,6 @@ tasks.coveralls {
 task collectDocumentation(group: "documentation", description: "Copy the documentation from sub-projects") {
     dependsOn "aggregateJavadocs"
 
-    // TODO: Maybe make this dependent on output of asciidoc tasks?
     def restDocs = new File(project(":genie-web").buildDir, "asciidoc/html5")
     def referenceDocs = new File(project(":genie-docs").buildDir, "asciidoc/html5")
     def demoDocs = new File(project(":genie-demo").buildDir, "asciidoc/html5")
@@ -408,17 +408,11 @@ task collectDocumentation(group: "documentation", description: "Copy the documen
     }
 }
 
-githubPages {
-    credentials {
-        username = System.getenv("GH_TOKEN")
-        password = ""
-    }
+gitPublish {
 
-    deleteExistingFiles = false
+    branch = "gh-pages"
 
-    commitMessage = "Documentation generated for ${project.version} by Travis Build ${System.env.TRAVIS_BUILD_NUMBER}"
-
-    pages {
+    contents {
         into("docs/${project.version}/") {
             from "${project.buildDir}/docs/"
         }
@@ -432,15 +426,21 @@ githubPages {
             }
         }
     }
+
+    preserve {
+        "**/*"
+    }
+
+    commitMessage = "Documentation generated for ${project.version} by Travis Build ${System.env.TRAVIS_BUILD_NUMBER}".toString()
 }
 
-prepareGhPages {
+gitPublishCopy {
     // This also depends on asciidoctor task for some sub-projects but that dependency is reverse mapped in the
     // pertinent sub-project build file
     dependsOn tasks.collectDocumentation
 }
 
-publishGhPages {
+gitPublishPush {
     onlyIf {
         System.env."CI"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,23 +5,24 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
-        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:6.0.4'
-        classpath 'org.ajoberstar.grgit:grgit-gradle:3.0.0-beta.1'
-        classpath 'org.ajoberstar:gradle-git-publish:1.0.1'
+        classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2"
+        classpath "com.netflix.nebula:gradle-netflixoss-project-plugin:6.0.4"
+        classpath "org.ajoberstar.grgit:grgit-gradle:3.0.0-beta.1"
+        classpath "org.ajoberstar:gradle-git-publish:1.0.1"
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${spring_boot_version}"
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.8'
-        classpath 'gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.5.2'
-        classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.5'
-        classpath 'io.franzbecker:gradle-lombok:1.14'
+        classpath "org.asciidoctor:asciidoctor-gradle-plugin:1.5.8"
+        classpath "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.5.2"
+        classpath "com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
+        classpath "io.franzbecker:gradle-lombok:1.14"
     }
 }
-apply plugin: 'com.github.kt3k.coveralls'
-apply plugin: 'nebula.netflixoss'
-apply plugin: 'org.ajoberstar.grgit'
-apply plugin: 'org.ajoberstar.git-publish'
+
+apply plugin: "com.github.kt3k.coveralls"
+apply plugin: "nebula.netflixoss"
 apply plugin: "nebula-aggregate-javadocs"
+apply plugin: "org.ajoberstar.grgit"
+apply plugin: "org.ajoberstar.git-publish"
 
 ext.githubProjectName = rootProject.name
 
@@ -409,7 +410,7 @@ task collectDocumentation(group: "documentation", description: "Copy the documen
 }
 
 gitPublish {
-
+    
     branch = "gh-pages"
 
     contents {

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,26 @@
 buildscript {
     repositories {
+        gradlePluginPortal()
         jcenter()
     }
 
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:${spring_boot_version}")
-        classpath("org.asciidoctor:asciidoctor-gradle-plugin:1.5.8")
-        // As of July 7, 2018 upgrading this plugin to 1.5.x release conflicts with nebula for grgit
-        classpath("gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.4.17")
-        classpath("com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1")
-        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.5")
-        classpath "io.franzbecker:gradle-lombok:1.14"
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
+        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:6.0.4'
+        classpath 'org.ajoberstar.grgit:grgit-gradle:3.0.0-beta.1'
+        classpath 'org.ajoberstar:gradle-git-publish:1.0.1'
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:${spring_boot_version}"
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.8'
+        classpath 'gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.5.2'
+        classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.5'
+        classpath 'io.franzbecker:gradle-lombok:1.14'
     }
 }
-
-plugins {
-    id "com.github.kt3k.coveralls" version "2.8.2"
-    id "nebula.netflixoss" version "6.0.3"
-    id "org.ajoberstar.grgit" version "3.0.0-beta.1"
-    id "org.ajoberstar.git-publish" version "1.0.1"
-}
-
+apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'nebula.netflixoss'
+apply plugin: 'org.ajoberstar.grgit'
+apply plugin: 'org.ajoberstar.git-publish'
 apply plugin: "nebula-aggregate-javadocs"
 
 ext.githubProjectName = rootProject.name

--- a/genie-ui/build.gradle
+++ b/genie-ui/build.gradle
@@ -1,6 +1,12 @@
-plugins {
-    id "com.moowork.node" version "1.2.0"
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath 'com.moowork.gradle:gradle-node-plugin:1.2.0'
+    }
 }
+apply plugin: 'com.moowork.node'
 
 dependencies {
     /*******************************

--- a/genie-ui/build.gradle
+++ b/genie-ui/build.gradle
@@ -2,11 +2,13 @@ buildscript {
     repositories {
         gradlePluginPortal()
     }
+    
     dependencies {
-        classpath 'com.moowork.gradle:gradle-node-plugin:1.2.0'
+        classpath "com.moowork.gradle:gradle-node-plugin:1.2.0"
     }
 }
-apply plugin: 'com.moowork.node'
+
+apply plugin: "com.moowork.node"
 
 dependencies {
     /*******************************


### PR DESCRIPTION
Due to a conflict with jgit and the Nebula plugins this work has been stuck in various branches of my personal fork for a long time. The latest versions of `nebula.netflixoss` have resolved some of those `jgit` conflicts and @sghill helped me resolve some other issues to hopefully get this working.

Once this is merged it should get rid of the final gradle related warning we have lying around during the build.