### PR TITLE
Fix GitHub publish

### DIFF
--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile("io.springfox:springfox-swagger2")
     compile("io.springfox:springfox-swagger-ui")
     compile("io.springfox:springfox-bean-validators")
-    compile("javax.persistence:javax.persistence-api:2.2")
+    compile("javax.persistence:javax.persistence-api")
     compile("net.devh:grpc-server-spring-boot-autoconfigure")
     compile("net.devh:grpc-server-spring-boot-starter")
     compile("org.apache.commons:commons-exec")

--- a/travis/buildViaTravis.sh
+++ b/travis/buildViaTravis.sh
@@ -16,15 +16,15 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   ./gradlew --no-daemon javadoc asciidoc dockerBuildAllImages
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew --no-daemon -Prelease.travisBranch=$TRAVIS_BRANCH -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" snapshot codeCoverageReport coveralls publishGhPages dockerPush
+  ./gradlew --no-daemon -Prelease.travisBranch=$TRAVIS_BRANCH -Prelease.travisci=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" snapshot codeCoverageReport coveralls gitPublishPush dockerPush
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in
   *-rc\.*)
-    ./gradlew --no-daemon -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" candidate codeCoverageReport coveralls publishGhPages dockerPush
+    ./gradlew --no-daemon -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" candidate codeCoverageReport coveralls gitPublishPush dockerPush
     ;;
   *)
-    ./gradlew --no-daemon -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" final codeCoverageReport coveralls publishGhPages dockerPush
+    ./gradlew --no-daemon -Prelease.travisci=true -Prelease.useLastTag=true -PbintrayUser="${bintrayUser}" -PbintrayKey="${bintrayKey}" -PsonatypeUsername="${sonatypeUsername}" -PsonatypePassword="${sonatypePassword}" final codeCoverageReport coveralls gitPublishPush dockerPush
     ;;
   esac
 else


### PR DESCRIPTION
Previous PR #781 left out updating the gradle targets for the actual build scripts. This PR fixes that and has one more commit for removing a redundant version declaration in a build script.