### PR TITLE
Fix the preserve block of the gitPublish gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -429,7 +429,8 @@ gitPublish {
     }
 
     preserve {
-        "**/*"
+        include "**/*"
+        exclude "docs/${project.version}/"
     }
 
     commitMessage = "Documentation generated for ${project.version} by Travis Build ${System.env.TRAVIS_BUILD_NUMBER}".toString()


### PR DESCRIPTION
When this port was originally done the plugin version was 0.x.x and preserve worked with "**/*". It looks like when the plugin went to 1.0.x preserve was changed to have an `include`/`exclude` syntax which defaulted to excluding (deleting) everything previously in the repo root. This was blowing away the OSS website in the gh-pages branch. This now allows everything except the version docs to be kept while the version docs are replaced.