### PR TITLE
Fix ArchivalService conditional bean generation logic

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/cli/ExitCode.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/cli/ExitCode.java
@@ -18,6 +18,8 @@
 
 package com.netflix.genie.agent.cli;
 
+import lombok.Getter;
+
 /**
  * Exit codes for Genie agent.
  *
@@ -76,19 +78,13 @@ public enum ExitCode {
         EXIT_CODE_HELP_MESSAGE = stringBuilder.toString();
     }
 
+    @Getter
     private final int code;
+    @Getter
     private final String message;
 
     ExitCode(final int code, final String message) {
         this.code = code;
         this.message = message;
-    }
-
-    int getCode() {
-        return code;
-    }
-
-    String getMessage() {
-        return message;
     }
 }

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/NoOpArchivalServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/NoOpArchivalServiceImpl.java
@@ -22,8 +22,8 @@ import com.netflix.genie.agent.execution.exceptions.ArchivalException;
 import com.netflix.genie.agent.execution.services.ArchivalService;
 import lombok.extern.slf4j.Slf4j;
 
-import java.nio.file.Path;
 import java.net.URI;
+import java.nio.file.Path;
 
 /**
  * Implementation of ArchivalService which does no archival.
@@ -36,9 +36,10 @@ class NoOpArchivalServiceImpl implements ArchivalService {
 
     /**
      * No archival is done.
+     *
      * @param path      path to the file/dir to archive
      * @param targetURI target uri for the archival location
-     * @throws ArchivalException
+     * @throws ArchivalException On error
      */
     @Override
     public void archive(final Path path, final URI targetURI) throws ArchivalException {

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/ServicesAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/ServicesAutoConfiguration.java
@@ -113,24 +113,26 @@ public class ServicesAutoConfiguration {
 
     /**
      * Provide a lazy {@link ArchivalService} bean if AmazonS3 client exists.
+     *
      * @param amazonS3 Amazon S3 client instance
-     * @return A {@link ArchivalService} instance
+     * @return A {@link S3ArchivalServiceImpl} instance
      */
     @Bean
     @Lazy
     @ConditionalOnBean(AmazonS3.class)
-    public ArchivalService archivalService(final AmazonS3 amazonS3) {
+    public S3ArchivalServiceImpl s3ArchivalService(final AmazonS3 amazonS3) {
         return new S3ArchivalServiceImpl(amazonS3);
     }
 
     /**
      * Provide a lazy {@link ArchivalService} bean if one does not already exist.
+     *
      * @return A {@link ArchivalService} instance
      */
     @Bean
     @Lazy
     @ConditionalOnMissingBean(ArchivalService.class)
-    public ArchivalService archivalService() {
+    public NoOpArchivalServiceImpl noOpArchivalService() {
         return new NoOpArchivalServiceImpl();
     }
 }


### PR DESCRIPTION
Introduced in #778 the autoconfig logic was failing to create any `ArchivalService` bean regardless of conditions. It appears that naming the beans the same and exposing them both as `ArchivalService` led to some internal confusion in the Boot auto configuration evaluation. Neither bean method ever got invoked.

Once this was "fixed" I didn't dig much deeper into the internal machinations as it's time sensitive to get this fix out. There is still an issue with the S3 client generation but that is a bigger issue and we can go forward with this code and the feature effectively turned off for now.

Was able to recreate the issue in the build integration tests so I went ahead an added rudimentary "smoke" tests for each of our current commands. These tests just make sure that the application can bootstrap enough in each case to attempt the command business logic. The behavior within each of the subcommands beyond invocation is not tested.