### PR TITLE
Fix conditionals on S3 Archival Implementation creation

### DIFF
--- a/genie-agent-app/src/main/resources/application.yml
+++ b/genie-agent-app/src/main/resources/application.yml
@@ -2,7 +2,7 @@
 cloud:
   aws:
     credentials:
-      instanceProfile: true
+      useDefaultAwsCredentialsChain: true
     region:
       auto: false
       static: us-east-1


### PR DESCRIPTION
Make `S3ArchivalServiceImpl` creation dependent on presence of `AwsCredentialsProvider` bean not `AmazonS3` bean.

Spring AWS cloud does not create a S3 bean by default. Instead if credentials are present it creates an `AwsCredentialsProvider` and then wires in a S3 client into the context `ResourceLoader`.  It does not expose this instance as a bean.

Previously our conditional was on `ConditionalOnMissingBean(AmazonS3.class)` but this wouldn't fire as no bean was created. Now the conditional is on the correct `AwsCredentialsProvider` bean.

Additionally there is a dependency on the `ContextCredentialsAutoConfiguration` being evaluated first otherwise the `AwsCredentialsProvider` bean isn't created and the evaluation doesn't match. `@AutoConfigureAfter` has been added to make sure this dependency graph is evaluated in the proper order.