### PR TITLE
Provide default job folder for V4 jobs

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ControllerUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ControllerUtils.java
@@ -40,8 +40,8 @@ public final class ControllerUtils {
 
     /**
      * Get the remaining path from a given request. e.g. if the request went to a method with the matching pattern of
-     * /api/v3/jobs/output/** and the request was /api/v3/jobs/output/blah.txt the return value of this method would be
-     * blah.txt.
+     * /api/v3/jobs/{id}/output/** and the request was /api/v3/jobs/{id}/output/blah.txt the return value of this
+     * method would be blah.txt.
      *
      * @param request The http servlet request.
      * @return The remaining path

--- a/genie-web/src/test/java/com/netflix/genie/web/resources/handlers/GenieResourceHttpRequestHandlerUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/resources/handlers/GenieResourceHttpRequestHandlerUnitTests.java
@@ -66,6 +66,58 @@ public class GenieResourceHttpRequestHandlerUnitTests {
     }
 
     /**
+     * Make sure the job directory used as a mock for all V4 output requests is created after construction.
+     *
+     * @throws IOException on error
+     */
+    @Test
+    public void v4DummyJobDirectoryIsCreated() throws IOException {
+        Mockito
+            .verify(this.jobFileService, Mockito.times(1))
+            .createJobDirectory(GenieResourceHttpRequestHandler.V4_MOCK_JOB_ID);
+        Mockito
+            .verify(this.jobFileService, Mockito.times(1))
+            .updateFile(
+                GenieResourceHttpRequestHandler.V4_MOCK_JOB_ID,
+                JobConstants.GENIE_JOB_LAUNCHER_SCRIPT,
+                0L,
+                new byte[0]
+            );
+        Mockito
+            .verify(this.jobFileService, Mockito.times(1))
+            .updateFile(
+                GenieResourceHttpRequestHandler.V4_MOCK_JOB_ID,
+                JobConstants.STDOUT_LOG_FILE_NAME,
+                0L,
+                new byte[0]
+            );
+        Mockito
+            .verify(this.jobFileService, Mockito.times(1))
+            .updateFile(
+                GenieResourceHttpRequestHandler.V4_MOCK_JOB_ID,
+                JobConstants.STDERR_LOG_FILE_NAME,
+                0L,
+                new byte[0]
+            );
+    }
+
+    /**
+     * Make sure if the job directory used as a mock for all V4 output requests can't be created the system will still
+     * run.
+     *
+     * @throws IOException on error
+     */
+    @Test
+    public void v4DummyJobDirectoryIsNotCreated() throws IOException {
+        Mockito
+            .doThrow(new IOException("Expected"))
+            .when(this.jobFileService)
+            .createJobDirectory(GenieResourceHttpRequestHandler.V4_MOCK_JOB_ID);
+
+        new GenieResourceHttpRequestHandler(this.directoryWriter, this.jobFileService);
+    }
+
+    /**
      * Make sure we can't handle any requests for resources without a resource location to look in.
      *
      * @throws ServletException on error


### PR DESCRIPTION
This commit adds a default dummy V4 job folder to the system at startup. Since V4 logging isn't fully fleshed out/solved yet current requests through V3 UI for a V4 job output would cause errors. This update creates a dummy folder that enables smoother behavior for users. They'll never see real logs but at least it won't throw a lot of errors or try to forward around the system. Job forwarding look up is short circuited if the job is flagged as V4 to save extra hops.