### PR TITLE
Work to support abstracting file interaction in agent

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/aws/s3/BucketProperties.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/aws/s3/BucketProperties.java
@@ -1,0 +1,118 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.aws.s3;
+
+import com.amazonaws.regions.Regions;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.cloud.aws.core.naming.AmazonResourceName;
+import org.springframework.validation.annotation.Validated;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+/**
+ * A property class which holds information about how to interact with a specific S3 Bucket.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Validated
+@Getter
+@Setter
+@EqualsAndHashCode(doNotUseGetters = true)
+@ToString(doNotUseGetters = true)
+public class BucketProperties {
+
+    /*
+     * See: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
+     */
+    private static final String IAM_SERVICE_NAMESPACE = "iam";
+
+    private AmazonResourceName roleARN;
+    private Regions region;
+
+    /**
+     * Get the {@link Regions} this bucket is in.
+     *
+     * @return The {@link Regions#getName()} wrapped in an {@link Optional}. If the optional is empty it indicates that
+     * the default or current region should be used
+     */
+    public Optional<String> getRegion() {
+        if (this.region == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(this.region.getName());
+        }
+    }
+
+    /**
+     * Set the AWS region from a string name representation e.g. us-east-1.
+     *
+     * @param region The name of the region to use
+     * @see Regions#fromName(String)
+     */
+    public void setRegion(@Nullable final String region) {
+        if (region != null) {
+            this.region = Regions.fromName(region);
+        } else {
+            this.region = null;
+        }
+    }
+
+    /**
+     * Get the ARN of the role to assume from this instance when working with the given bucket.
+     *
+     * @return The ARN wrapped in an {@link Optional}. If the {@link Optional} is empty no role should be assumed when
+     * working with this bucket
+     */
+    public Optional<String> getRoleARN() {
+        if (this.roleARN == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(this.roleARN.toString());
+        }
+    }
+
+    /**
+     * Set the ARN of the role to assume from this instance when working with the given bucket.
+     *
+     * @param roleARN The valid role ARN or null if no role assumption is needed.
+     * @throws IllegalArgumentException If the {@code roleARN} is not null and the value isn't a valid role ARN format
+     */
+    public void setRoleARN(@Nullable final String roleARN) {
+        if (roleARN != null) {
+            final AmazonResourceName arn = AmazonResourceName.fromString(roleARN);
+            final String awsService = arn.getService();
+            if (awsService.equals(IAM_SERVICE_NAMESPACE)) {
+                this.roleARN = arn;
+            } else {
+                throw new IllegalArgumentException(
+                    "ARN ("
+                        + roleARN
+                        + ") is valid format but incorrect service. Expected "
+                        + IAM_SERVICE_NAMESPACE
+                        + " but got "
+                        + awsService
+                );
+            }
+        }
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/aws/s3/S3ClientFactory.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/aws/s3/S3ClientFactory.java
@@ -1,0 +1,241 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.aws.s3;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.regions.AwsRegionProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.AmazonS3URI;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.google.common.annotations.VisibleForTesting;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An {@link AmazonS3} client factory class. Given {@link AmazonS3URI} instances and the configuration of the system
+ * this factory is expected to return a valid client instance for the S3 URI which can then be used to access that URI.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Slf4j
+public class S3ClientFactory {
+
+    @VisibleForTesting
+    static final String BUCKET_PROPERTIES_ROOT_KEY = "genie.aws.s3.buckets";
+
+    private final AWSCredentialsProvider awsCredentialsProvider;
+    private final Map<String, S3ClientKey> bucketToClientKey;
+    private final ConcurrentHashMap<S3ClientKey, AmazonS3> clientCache;
+    private final Map<String, BucketProperties> bucketProperties;
+    private final AWSSecurityTokenService stsClient;
+    private final Regions defaultRegion;
+
+    /**
+     * Constructor.
+     *
+     * @param awsCredentialsProvider The base AWS credentials provider to use for the generated S3 clients
+     * @param regionProvider         How this factory should determine the default {@link Regions}
+     * @param environment            The Spring application {@link Environment}
+     */
+    public S3ClientFactory(
+        final AWSCredentialsProvider awsCredentialsProvider,
+        final AwsRegionProvider regionProvider,
+        final Environment environment
+    ) {
+        this.awsCredentialsProvider = awsCredentialsProvider;
+
+        /*
+         * Use the Spring property binder to dynamically map properties under a common root into a map of key to object.
+         *
+         * In this case we're trying to get bucketName -> BucketProperties
+         *
+         * So if there were properties like:
+         * genie.aws.s3.buckets.someBucket1.roleARN = blah
+         * genie.aws.s3.buckets.someBucket2.region = us-east-1
+         * genie.aws.s3.buckets.someBucket2.roleARN = blah
+         *
+         * The result of this should be two entries in the map "bucket1" and "bucket2" mapping to property binding
+         * object instances of BucketProperties with the correct property set or null if option wasn't specified.
+         */
+        this.bucketProperties = Binder
+            .get(environment)
+            .bind(
+                BUCKET_PROPERTIES_ROOT_KEY,
+                Bindable.mapOf(String.class, BucketProperties.class)
+            )
+            .orElse(Collections.emptyMap());
+
+        // Set the initial size to the number of special cases defined in properties + 1 for the default client
+        // NOTE: Should we proactively create all necessary clients or be lazy about it? For now, lazy.
+        this.clientCache = new ConcurrentHashMap<>(this.bucketProperties.size() + 1);
+
+        String tmpRegion;
+        try {
+            tmpRegion = regionProvider.getRegion();
+        } catch (final SdkClientException e) {
+            tmpRegion = Regions.getCurrentRegion() != null
+                ? Regions.getCurrentRegion().getName()
+                : Regions.US_EAST_1.getName();
+            log.warn(
+                "Couldn't determine the AWS region from the provider ({}) supplied. Defaulting to {}",
+                regionProvider.toString(),
+                tmpRegion
+            );
+        }
+        this.defaultRegion = Regions.fromName(tmpRegion);
+
+        // Create a token service client to use if we ever need to assume a role
+        // TODO: Perhaps this should be just set to null if the bucket properties are empty as we'll never need it?
+        this.stsClient = AWSSecurityTokenServiceClientBuilder
+            .standard()
+            .withRegion(this.defaultRegion)
+            .withCredentials(this.awsCredentialsProvider)
+            .build();
+
+        this.bucketToClientKey = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Get an {@link AmazonS3} client instance appropriate for the given {@link AmazonS3URI}.
+     *
+     * @param s3URI The URI of the S3 resource this client is expected to access.
+     * @return A S3 client instance which should be used to access the S3 resource
+     */
+    public AmazonS3 getClient(final AmazonS3URI s3URI) {
+        final String bucketName = s3URI.getBucket();
+
+        final S3ClientKey s3ClientKey;
+
+        /*
+         * The purpose of the dual maps is to make sure we don't create an unnecessary number of S3 clients.
+         * If we made the client cache just bucketName -> client directly we'd have no way to make know if an already
+         * created instance for another bucket could be re-used for this bucket since it could be same region/role
+         * combination. This way we first map the bucket name to a key of role/region and then use that key
+         * to find a re-usable client for those dimensions.
+         */
+        s3ClientKey = this.bucketToClientKey.computeIfAbsent(
+            bucketName,
+            key -> {
+                // We've never seen this bucket before. Calculate the key.
+
+                /*
+                 * Region Resolution rules:
+                 * 1. Is it part of the S3 URI already? Use that
+                 * 2. Is it part of the properties passed in by admin/user Use that
+                 * 3. Fall back to whatever the default is for this process
+                 */
+                final Regions bucketRegion;
+                final String uriBucketRegion = s3URI.getRegion();
+                if (StringUtils.isNotBlank(uriBucketRegion)) {
+                    bucketRegion = Regions.fromName(uriBucketRegion);
+                } else {
+                    final String propertyBucketRegion = this.bucketProperties.containsKey(key)
+                        ? this.bucketProperties.get(key).getRegion().orElse(null)
+                        : null;
+
+                    if (StringUtils.isNotBlank(propertyBucketRegion)) {
+                        bucketRegion = Regions.fromName(propertyBucketRegion);
+                    } else {
+                        bucketRegion = this.defaultRegion;
+                    }
+                }
+
+                // Anything special in the bucket we need to reference
+                final String roleARN = this.bucketProperties.containsKey(key)
+                    ? this.bucketProperties.get(key).getRoleARN().orElse(null)
+                    : null;
+
+                return new S3ClientKey(bucketRegion, roleARN);
+            }
+        );
+
+        return this.clientCache.computeIfAbsent(s3ClientKey, this::buildS3Client);
+    }
+
+    private AmazonS3 buildS3Client(final S3ClientKey s3ClientKey) {
+        // TODO: Do something about allowing ClientConfiguration to be passed in
+        return AmazonS3ClientBuilder
+            .standard()
+            .withRegion(s3ClientKey.getRegion())
+            .withForceGlobalBucketAccessEnabled(true)
+            .withCredentials(
+                s3ClientKey
+                    .getRoleARN()
+                    .map(
+                        roleARN -> {
+                            // TODO: Perhaps rename with more detailed info?
+                            final String roleSession = "Genie-Agent-" + UUID.randomUUID().toString();
+
+                            return (AWSCredentialsProvider) new STSAssumeRoleSessionCredentialsProvider
+                                .Builder(roleARN, roleSession)
+                                .withStsClient(this.stsClient)
+                                .build();
+                        }
+                    )
+                    .orElse(this.awsCredentialsProvider)
+            )
+            .build();
+    }
+
+    /**
+     * A simple class used as a key to see if we already have a S3Client created for the combination of properties
+     * that make up this class.
+     *
+     * @author tgianos
+     * @since 4.0.0
+     */
+    @Getter
+    @EqualsAndHashCode(doNotUseGetters = true)
+    private static class S3ClientKey {
+        private final Regions region;
+        private final String roleARN;
+
+        /**
+         * Constructor.
+         *
+         * @param region  The region the S3 client is configured to access.
+         * @param roleARN The role the S3 client is configured to assume if any. Null if no assumption is necessary.
+         */
+        S3ClientKey(final Regions region, @Nullable final String roleARN) {
+            this.region = region;
+            this.roleARN = roleARN;
+        }
+
+        Optional<String> getRoleARN() {
+            return Optional.ofNullable(this.roleARN);
+        }
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/aws/s3/package-info.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/aws/s3/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * This package contains classes and utilities for working with the AWS S3 service.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.agent.aws.s3;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-agent/src/main/java/com/netflix/genie/agent/configs/AwsAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/configs/AwsAutoConfiguration.java
@@ -1,0 +1,172 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.configs;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.regions.AwsRegionProvider;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.regions.Regions;
+import com.netflix.genie.agent.aws.s3.S3ClientFactory;
+import com.netflix.genie.agent.execution.services.ArchivalService;
+import com.netflix.genie.agent.execution.services.impl.NoOpArchivalServiceImpl;
+import com.netflix.genie.agent.execution.services.impl.S3ArchivalServiceImpl;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextResourceLoaderAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
+
+import javax.annotation.Nullable;
+
+/**
+ * Spring Boot auto configuration for AWS related beans for the Genie Agent. Should be configured after all the
+ * Spring Cloud AWS context configurations are complete.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Configuration
+@AutoConfigureAfter(
+    {
+        ContextCredentialsAutoConfiguration.class,
+        ContextInstanceDataAutoConfiguration.class,
+        ContextRegionProviderAutoConfiguration.class,
+        ContextResourceLoaderAutoConfiguration.class,
+        ContextStackAutoConfiguration.class
+    }
+)
+@ConditionalOnBean(AWSCredentialsProvider.class)
+@Slf4j
+public class AwsAutoConfiguration {
+
+    /**
+     * Get an AWS region provider instance. The rules for this basically follow what Spring Cloud AWS does but uses
+     * the interface from the AWS SDK instead and provides a sensible default.
+     * <p>
+     * See: <a href="https://tinyurl.com/y9edl6yr">Spring Cloud AWS Region Documentation</a>
+     *
+     * @param auto         Binding for the {@code cloud.aws.region.auto} property with default value of {@code true}
+     * @param staticRegion Binding for the {@code cloud.aws.region.static} property with default value of {@code null}
+     * @return A region provider based on whether static was set by user, else auto, else default of us-east-1
+     */
+    @Bean
+    @ConditionalOnMissingBean(AwsRegionProvider.class)
+    public AwsRegionProvider awsRegionProvider(
+        @Value("${cloud.aws.region.auto:true}") final boolean auto,
+        @Nullable @Value("${cloud.aws.region.static:#{null}}") final String staticRegion
+    ) {
+        if (StringUtils.isNotBlank(staticRegion)) {
+            // Make sure we have a valid region. Will throw runtime exception if not.
+            final Regions region = Regions.fromName(staticRegion);
+            return new AwsRegionProvider() {
+                /**
+                 * Always return the static configured region.
+                 *
+                 * {@inheritDoc}
+                 */
+                @Override
+                public String getRegion() throws SdkClientException {
+                    return region.getName();
+                }
+            };
+        } else if (auto) {
+            return new DefaultAwsRegionProviderChain();
+        } else {
+            // Sensible default
+            return new AwsRegionProvider() {
+                /**
+                 * Always default to us-east-1.
+                 *
+                 * {@inheritDoc}
+                 */
+                @Override
+                public String getRegion() throws SdkClientException {
+                    return Regions.US_EAST_1.getName();
+                }
+            };
+        }
+    }
+
+    /**
+     * Provide a lazy {@link S3ClientFactory} instance if one is needed by the system.
+     *
+     * @param awsCredentialsProvider The {@link AWSCredentialsProvider} to use
+     * @param awsRegionProvider      The {@link AwsRegionProvider} to use
+     * @param environment            The Spring application {@link Environment} to bind properties from
+     * @return A {@link S3ClientFactory} instance
+     */
+    @Bean
+    @Lazy
+    @ConditionalOnMissingBean(S3ClientFactory.class)
+    public S3ClientFactory s3ClientFactory(
+        final AWSCredentialsProvider awsCredentialsProvider,
+        final AwsRegionProvider awsRegionProvider,
+        final Environment environment
+    ) {
+        return new S3ClientFactory(awsCredentialsProvider, awsRegionProvider, environment);
+    }
+
+    /**
+     * Provide a lazy S3 based {@link ArchivalService} bean if AWS credentials are present in the context.
+     *
+     * @param awsCredentialsProvider The credentials provider to use
+     * @param s3ClientFactory        The {@link S3ClientFactory} to use to get clients for buckets
+     * @return A {@link S3ArchivalServiceImpl} instance if credentials are valid else a {@link NoOpArchivalServiceImpl}
+     */
+    @Bean
+    @Lazy
+    public ArchivalService archivalService(
+        final AWSCredentialsProvider awsCredentialsProvider,
+        final S3ClientFactory s3ClientFactory
+    ) {
+        /*
+         * TODO: Spring Cloud AWS always provides a credentials provider once it is on the classpath.
+         *
+         * For this reason this block exists to proactively verify that the credentials provided will be valid at
+         * runtime in order to create a working S3 client later on. If the credentials don't work this will fall back
+         * to creating a No Op Archival service implementation.
+         *
+         * Long term we should just have one ArchivalServiceImpl which uses the ResourceLoader and this won't be
+         * necessary.
+         */
+        try {
+            awsCredentialsProvider.getCredentials();
+        } catch (final SdkClientException sdkClientException) {
+            log.warn(
+                "Attempted to validate AWS credentials and failed due to {}. Falling back to no op implementation",
+                sdkClientException.getMessage(),
+                sdkClientException
+            );
+
+            return new NoOpArchivalServiceImpl();
+        }
+
+        return new S3ArchivalServiceImpl(s3ClientFactory);
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/NoOpArchivalServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/NoOpArchivalServiceImpl.java
@@ -32,7 +32,7 @@ import java.nio.file.Path;
  * @since 4.0.0
  */
 @Slf4j
-class NoOpArchivalServiceImpl implements ArchivalService {
+public class NoOpArchivalServiceImpl implements ArchivalService {
 
     /**
      * No archival is done.

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/ServicesAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/ServicesAutoConfiguration.java
@@ -17,11 +17,8 @@
  */
 package com.netflix.genie.agent.execution.services.impl;
 
-import com.amazonaws.SdkClientException;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.netflix.genie.agent.cli.ArgumentDelegates;
+import com.netflix.genie.agent.configs.AwsAutoConfiguration;
 import com.netflix.genie.agent.execution.services.ArchivalService;
 import com.netflix.genie.agent.execution.services.DownloadService;
 import com.netflix.genie.agent.execution.services.FetchingCacheService;
@@ -31,9 +28,7 @@ import com.netflix.genie.agent.utils.locks.impl.FileLockFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -50,7 +45,7 @@ import java.io.IOException;
  * @since 4.0.0
  */
 @Configuration
-@AutoConfigureAfter(ContextCredentialsAutoConfiguration.class)
+@AutoConfigureAfter(AwsAutoConfiguration.class)
 @Slf4j
 public class ServicesAutoConfiguration {
 
@@ -117,57 +112,6 @@ public class ServicesAutoConfiguration {
     @ConditionalOnMissingBean(LaunchJobService.class)
     public LaunchJobService launchJobService() {
         return new LaunchJobServiceImpl();
-    }
-
-    /**
-     * Provide a lazy S3 based {@link ArchivalService} bean if AWS credentials are present in the context.
-     *
-     * @param awsCredentialsProvider The credentials provider to use
-     * @return A {@link S3ArchivalServiceImpl} instance if credentials are valid else a {@link NoOpArchivalServiceImpl}
-     */
-    @Bean
-    @Lazy
-    @ConditionalOnBean(AWSCredentialsProvider.class)
-    public ArchivalService archivalService(final AWSCredentialsProvider awsCredentialsProvider) {
-        /*
-         * TODO: Spring Cloud AWS always provides a credentials provider once it is on the classpath.
-         *
-         * For this reason this block exists to proactively verify that the credentials provided will be valid at
-         * runtime in order to create a working S3 client later on. If the credentials don't work this will fall back
-         * to creating a No Op Archival service implementation
-         */
-        try {
-            awsCredentialsProvider.getCredentials();
-        } catch (final SdkClientException sdkClientException) {
-            log.warn(
-                "Attempted to validate AWS credentials and failed due to {}. Falling back to no op implementation",
-                sdkClientException.getMessage(),
-                sdkClientException
-            );
-
-            return new NoOpArchivalServiceImpl();
-        }
-
-        /*
-         * TODO: This is a quick and dirty solution to get archival working. Fix/replace.
-         *
-         * For this to be a property solution we'd need to consider things like:
-         * - Role assumption
-         * - S3 Client pooling resources (thread pool)
-         * - Sharing of S3 client within app context
-         * - Exposing options for users
-         * - Whether archival is a system dependency and therefore we need one S3 client to upload to the "genie"
-         *   managed location and another to place a copy where the user specifies
-         * - Probably more stuff I can't think about right now
-         */
-
-        // Take all the defaults just override the Credentials Provider in case something special was done
-        final AmazonS3 amazonS3 = AmazonS3ClientBuilder
-            .standard()
-            .withCredentials(awsCredentialsProvider)
-            .build();
-
-        return new S3ArchivalServiceImpl(amazonS3);
     }
 
     /**

--- a/genie-agent/src/main/resources/META-INF/spring.factories
+++ b/genie-agent/src/main/resources/META-INF/spring.factories
@@ -2,6 +2,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.netflix.genie.agent.cli.CliAutoConfiguration,\
   com.netflix.genie.agent.cli.JCommanderAutoConfiguration,\
   com.netflix.genie.agent.configs.AgentAutoConfiguration,\
+  com.netflix.genie.agent.configs.AwsAutoConfiguration,\
   com.netflix.genie.agent.execution.ExecutionAutoConfiguration,\
   com.netflix.genie.agent.execution.services.impl.grpc.GRpcServicesAutoConfiguration,\
   com.netflix.genie.agent.execution.services.impl.ServicesAutoConfiguration,\

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/aws/s3/BucketPropertiesSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/aws/s3/BucketPropertiesSpec.groovy
@@ -1,0 +1,90 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.aws.s3
+
+import com.amazonaws.regions.Regions
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Specifications for {@link BucketProperties}.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+class BucketPropertiesSpec extends Specification {
+
+    def "Can build with defaults"() {
+        when:
+        def properties = new BucketProperties()
+
+        then:
+        !properties.getRegion().isPresent()
+        !properties.getRoleARN().isPresent()
+    }
+
+    def "Can set null values"() {
+        when:
+        def properties = new BucketProperties()
+        properties.setRegion(null)
+        properties.setRoleARN(null)
+
+        then:
+        !properties.getRegion().isPresent()
+        !properties.getRoleARN().isPresent()
+    }
+
+    def "Can't set illegal region"() {
+        def properties = new BucketProperties()
+
+        when:
+        properties.setRegion(UUID.randomUUID().toString())
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    @Unroll
+    def "Can't set illegal Role Arn #roleARN"() {
+        def properties = new BucketProperties()
+
+        when:
+        properties.setRoleARN(roleARN)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        roleARN                                       | _
+        UUID.randomUUID().toString()                  | _
+        "arn:aws:notIAM::accountNumber:role/someRole" | _
+    }
+
+    def "Can set legal values"() {
+        def properties = new BucketProperties()
+        def roleARN = "arn:aws:iam::accountNumber:role/someRole"
+
+        when:
+        properties.setRegion(Regions.US_EAST_1.getName())
+        properties.setRoleARN(roleARN)
+
+        then:
+        properties.getRegion().orElseThrow({ new IllegalArgumentException() }) == Regions.US_EAST_1.getName()
+        properties.getRoleARN().orElseThrow({ new IllegalArgumentException() }) == roleARN
+    }
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/aws/s3/S3ClientFactorySpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/aws/s3/S3ClientFactorySpec.groovy
@@ -1,0 +1,249 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.aws.s3
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.AwsRegionProvider
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.AmazonS3URI
+import org.springframework.mock.env.MockEnvironment
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link S3ClientFactory}.
+ *
+ * @author tgianos
+ * @since
+ */
+class S3ClientFactorySpec extends Specification {
+
+    def "Can construct with empty bucket mapping properties"() {
+        def environment = new MockEnvironment()
+        def credentialsProvider = Mock(AWSCredentialsProvider)
+        def regionProvider = Mock(AwsRegionProvider)
+
+        when:
+        def factory = new S3ClientFactory(credentialsProvider, regionProvider, environment)
+
+        then:
+        1 * regionProvider.getRegion() >> Regions.US_EAST_1.getName()
+        factory.defaultRegion == Regions.US_EAST_1
+        factory.bucketProperties.isEmpty()
+        factory.stsClient != null
+        factory.bucketToClientKey.isEmpty()
+        factory.clientCache.isEmpty()
+    }
+
+    def "Can construct with bucket mapping properties"() {
+        def environment = new MockEnvironment()
+        def credentialsProvider = Mock(AWSCredentialsProvider)
+        def regionProvider = Mock(AwsRegionProvider)
+
+        def bucket0Name = UUID.randomUUID().toString()
+        def bucket0Role = "arn:aws:iam::accountNumber:role/someRole"
+
+        def bucket1Name = UUID.randomUUID().toString()
+        def bucket1Region = Regions.EU_WEST_2.getName()
+
+        def bucket2Name = UUID.randomUUID().toString()
+        def bucket2Role = "arn:aws:iam::accountNumber:role/someRole"
+        def bucket2Region = Regions.US_WEST_2.getName()
+
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket0Name + ".roleARN",
+            bucket0Role
+        )
+
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket1Name + ".region",
+            bucket1Region
+        )
+
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket2Name + ".roleARN",
+            bucket2Role
+        )
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket2Name + ".region",
+            bucket2Region
+        )
+
+        when:
+        def factory = new S3ClientFactory(credentialsProvider, regionProvider, environment)
+
+        then:
+        1 * regionProvider.getRegion() >> Regions.US_EAST_1.getName()
+        factory.defaultRegion == Regions.US_EAST_1
+        factory.bucketProperties.size() == 3
+        factory.bucketProperties.containsKey(bucket0Name)
+        !factory.bucketProperties.get(bucket0Name).getRegion().isPresent()
+        factory.bucketProperties.get(bucket0Name).getRoleARN().orElse(null) == bucket0Role
+        factory.bucketProperties.containsKey(bucket1Name)
+        factory.bucketProperties.get(bucket1Name).getRegion().orElse(null) == bucket1Region
+        !factory.bucketProperties.get(bucket1Name).getRoleARN().isPresent()
+        factory.bucketProperties.containsKey(bucket2Name)
+        factory.bucketProperties.get(bucket2Name).getRegion().orElse(null) == bucket2Region
+        factory.bucketProperties.get(bucket2Name).getRoleARN().orElse(null) == bucket2Role
+        factory.stsClient != null
+        factory.bucketToClientKey.isEmpty()
+        factory.clientCache.isEmpty()
+    }
+
+    def "Can get clients for various scenarios"() {
+        def environment = new MockEnvironment()
+        def credentialsProvider = Mock(AWSCredentialsProvider)
+        def regionProvider = Mock(AwsRegionProvider)
+
+        def bucket0Name = UUID.randomUUID().toString()
+        def bucket0Role = "arn:aws:iam::accountNumber:role/someRole"
+
+        def bucket1Name = UUID.randomUUID().toString()
+        def bucket1Region = Regions.EU_WEST_2.getName()
+
+        def bucket2Name = UUID.randomUUID().toString()
+        def bucket2Role = "arn:aws:iam::accountNumber:role/someRole"
+        def bucket2Region = Regions.US_WEST_2.getName()
+
+        def bucket3Name = UUID.randomUUID().toString()
+        def bucket3Role = "arn:aws:iam::accountNumber:role2/someRole2"
+        def bucket3Region = Regions.US_WEST_2.getName()
+
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket0Name + ".roleARN",
+            bucket0Role
+        )
+
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket1Name + ".region",
+            bucket1Region
+        )
+
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket2Name + ".roleARN",
+            bucket2Role
+        )
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket2Name + ".region",
+            bucket2Region
+        )
+
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket3Name + ".roleARN",
+            bucket3Role
+        )
+        environment.withProperty(
+            S3ClientFactory.BUCKET_PROPERTIES_ROOT_KEY + "." + bucket3Name + ".region",
+            bucket3Region
+        )
+
+        def s3URI = Mock(AmazonS3URI)
+        def bucket4Name = UUID.randomUUID().toString()
+
+        when:
+        def factory = new S3ClientFactory(credentialsProvider, regionProvider, environment)
+
+        then:
+        1 * regionProvider.getRegion() >> Regions.US_EAST_1.getName()
+        factory.stsClient != null
+        factory.bucketToClientKey.isEmpty()
+        factory.clientCache.isEmpty()
+
+        when: "A client is requested for a bucket and region combination"
+        def amazonS3Client0 = factory.getClient(s3URI)
+
+        then: "A default role client is created and returned for the region"
+        1 * s3URI.getBucket() >> bucket4Name
+        1 * s3URI.getRegion() >> Regions.EU_CENTRAL_1.getName()
+        factory.bucketToClientKey.size() == 1
+        factory.clientCache.size() == 1
+
+        when: "The same bucket is requested"
+        def amazonS3Client1 = factory.getClient(s3URI)
+
+        then: "The same client is returned"
+        1 * s3URI.getBucket() >> bucket4Name
+        0 * s3URI.getRegion()
+        factory.bucketToClientKey.size() == 1
+        factory.clientCache.size() == 1
+        amazonS3Client0 == amazonS3Client1
+
+        when: "A different bucket in the same region is requested"
+        def amazonS3Client2 = factory.getClient(s3URI)
+
+        then: "The same client is returned"
+        1 * s3URI.getBucket() >> UUID.randomUUID().toString()
+        1 * s3URI.getRegion() >> Regions.EU_CENTRAL_1.getName()
+        factory.bucketToClientKey.size() == 2
+        factory.clientCache.size() == 1
+        amazonS3Client0 == amazonS3Client2
+
+        when: "A bucket which needs a role is requested"
+        def amazonS3Client3 = factory.getClient(s3URI)
+
+        then: "A new client with assume role is created"
+        1 * s3URI.getBucket() >> bucket2Name
+        1 * s3URI.getRegion() >> null
+        factory.bucketToClientKey.size() == 3
+        factory.clientCache.size() == 2
+        amazonS3Client0 != amazonS3Client3
+
+        when: "Same role and region but different bucket"
+        def amazonS3Client4 = factory.getClient(s3URI)
+
+        then: "The same client is returned"
+        1 * s3URI.getBucket() >> bucket0Name
+        1 * s3URI.getRegion() >> Regions.US_WEST_2.getName()
+        factory.bucketToClientKey.size() == 4
+        factory.clientCache.size() == 2
+        amazonS3Client0 != amazonS3Client4
+        amazonS3Client3 == amazonS3Client4
+
+        when: "No bucket region or role are provided"
+        def amazonS3Client5 = factory.getClient(s3URI)
+
+        then: "The default region is used in a new client"
+        1 * s3URI.getBucket() >> UUID.randomUUID().toString()
+        1 * s3URI.getRegion() >> null
+        factory.bucketToClientKey.size() == 5
+        factory.clientCache.size() == 3
+        amazonS3Client0 != amazonS3Client5
+        amazonS3Client3 != amazonS3Client5
+
+        when: "Another bucket with no region or role information is requested"
+        def amazonS3Client6 = factory.getClient(s3URI)
+
+        then: "The same default client is returned"
+        1 * s3URI.getBucket() >> UUID.randomUUID().toString()
+        1 * s3URI.getRegion() >> null
+        factory.bucketToClientKey.size() == 6
+        factory.clientCache.size() == 3
+        amazonS3Client0 != amazonS3Client6
+        amazonS3Client3 != amazonS3Client6
+        amazonS3Client5 == amazonS3Client6
+
+        when: "A bucket is requested in a region that already has a client but it's a different role than before"
+        def amazonS3Client7 = factory.getClient(s3URI)
+
+        then: "A new client is returned"
+        1 * s3URI.getBucket() >> bucket3Name
+        1 * s3URI.getRegion() >> null
+        factory.bucketToClientKey.size() == 7
+        factory.clientCache.size() == 4
+        amazonS3Client3 != amazonS3Client7
+    }
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/configs/AwsAutoConfigurationSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/configs/AwsAutoConfigurationSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.configs
+
+import com.amazonaws.SdkClientException
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.DefaultAwsRegionProviderChain
+import com.amazonaws.regions.Regions
+import com.netflix.genie.agent.aws.s3.S3ClientFactory
+import com.netflix.genie.agent.execution.services.impl.NoOpArchivalServiceImpl
+import com.netflix.genie.agent.execution.services.impl.S3ArchivalServiceImpl
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Specifications for {@link AwsAutoConfiguration}.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+class AwsAutoConfigurationSpec extends Specification {
+
+    @Unroll
+    def "Can create the expected AwsRegionProvider instance when auto is #auto and static is #staticRegion"() {
+        def config = new AwsAutoConfiguration()
+
+        when:
+        def regionProvider = config.awsRegionProvider(auto, staticRegion)
+
+        then:
+        if (!(regionProvider instanceof DefaultAwsRegionProviderChain)) {
+            regionProvider.getRegion() == expectedRegion
+        } else {
+            // We expect the default to be returned when these conditions are true
+            auto
+            staticRegion == null
+        }
+
+        where:
+        auto  | staticRegion                | expectedRegion
+        true  | Regions.US_WEST_2.getName() | Regions.US_WEST_2.getName()
+        true  | null                        | "shouldn't matter"
+        false | null                        | Regions.US_EAST_1.getName()
+    }
+
+    def "Can create correct archival service based on valid credentials or not"() {
+        def config = new AwsAutoConfiguration()
+        def awsCredentialsProvider = Mock(AWSCredentialsProvider)
+        def s3ClientFactory = Mock(S3ClientFactory)
+
+        when:
+        def archivalService = config.archivalService(awsCredentialsProvider, s3ClientFactory)
+
+        then:
+        1 * awsCredentialsProvider.getCredentials() >> { throw new SdkClientException("bad credentials") }
+        archivalService instanceof NoOpArchivalServiceImpl
+
+        when:
+        archivalService = config.archivalService(awsCredentialsProvider, s3ClientFactory)
+
+        then:
+        1 * awsCredentialsProvider.getCredentials() >> Mock(AWSCredentials)
+        archivalService instanceof S3ArchivalServiceImpl
+    }
+}


### PR DESCRIPTION
In the past we've used a variety of methods for working with agent files (dependencies, archive locations, etc). Sometimes we used the Spring `ResourceLoader` sometimes we used an `S3Client` based implementation we managed ourselves.

This led to several issues across the code base including inconsistency, different clients being used, lack of caching, lack of ability to assume roles for AWS, etc. Additionally from a pure design perspective every time we needed a new implementation of something like the `ArchivalService` we would need to write a new one for whatever technology the destination needs.

Spring Cloud AWS doesn't support role assumption either so it was very hard to access their S3 client and make modifications based on how that library is configured. Role assumption is critical in cross account access of AWS resources.

This PR contains the groundwork in a plan to hopefully fix most of these issues. An `S3ClientFactory` is added which based on a bucket name will determine if a client has already been created or not and whether that client needs to assume a role based on runtime properties provided by system administrators.

The `S3ArchivalServiceImpl` has been modified to leverage this factory instead of a single `AmazonS3` instance. Longer term once [this](https://github.com/spring-cloud/spring-cloud-aws/pull/390) PR is released by the Spring Cloud team we can register our own `ResourceResolver` for `SimpleStorageResource` and get rid of specific implementations of `ArchivalService`.

Opening this PR now to get feedback as well as get some code merged while waiting for blockers to free up.