### PR TITLE
Remove log message printed before logging system is initialized

### DIFF
--- a/genie-agent-app/src/main/java/com/netflix/genie/GenieAgentApplication.java
+++ b/genie-agent-app/src/main/java/com/netflix/genie/GenieAgentApplication.java
@@ -17,7 +17,6 @@
  */
 package com.netflix.genie;
 
-import com.netflix.genie.agent.cli.UserConsole;
 import com.netflix.genie.agent.cli.Util;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -53,7 +52,7 @@ public class GenieAgentApplication {
      * @param args command-line arguments
      */
     public static void main(final String[] args) {
-        UserConsole.getLogger().info("Starting Genie Agent");
+        System.err.println("Starting Genie Agent");
         System.exit(new GenieAgentApplication().run(args));
     }
 


### PR DESCRIPTION
This log message is printed before the application context is initialized and the logging subsystem configured.
This is a problem for 2 reasons
1) It looks different from all other log messages
2) It pollutes stdout with a message that does not come from the underlying command. This breaks use cases such as:
  presto --execute '...' > output.txt