### PR TITLE
Remove EC2 local hostname as option for hostname resolution

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/configs/aws/GenieAwsApiAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/aws/GenieAwsApiAutoConfiguration.java
@@ -30,9 +30,6 @@ import org.springframework.cloud.aws.context.annotation.ConditionalOnAwsCloudEnv
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
 /**
  * Beans and configuration specifically for MVC on AWS.
  *
@@ -51,26 +48,14 @@ public class GenieAwsApiAutoConfiguration {
      * environment.
      *
      * @return The {@link GenieHostInfo} instance
-     * @throws UnknownHostException  If all EC2 host instance calculation AND local resolution can't determine a
-     *                               hostname
      * @throws IllegalStateException If an instance can't be created
      */
     @Bean
     @ConditionalOnMissingBean(GenieHostInfo.class)
-    public GenieHostInfo genieHostInfo() throws UnknownHostException {
-        final String ec2LocalHostName = EC2MetadataUtils.getLocalHostName();
-        if (StringUtils.isNotBlank(ec2LocalHostName)) {
-            return new GenieHostInfo(ec2LocalHostName);
-        }
-
+    public GenieHostInfo genieHostInfo() {
         final String ec2Ipv4Address = EC2MetadataUtils.getPrivateIpAddress();
         if (StringUtils.isNotBlank(ec2Ipv4Address)) {
             return new GenieHostInfo(ec2Ipv4Address);
-        }
-
-        final String localHostname = InetAddress.getLocalHost().getCanonicalHostName();
-        if (StringUtils.isNotBlank(localHostname)) {
-            return new GenieHostInfo(localHostname);
         }
 
         throw new IllegalStateException("Unable to resolve Genie host info");

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/aws/GenieAwsApiAutoConfigurationUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/aws/GenieAwsApiAutoConfigurationUnitTests.java
@@ -24,8 +24,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import java.net.UnknownHostException;
+import org.springframework.cloud.aws.context.support.env.AwsCloudEnvironmentCheckUtils;
 
 /**
  * Unit tests for the {@link GenieAwsApiAutoConfiguration} class.
@@ -47,13 +46,21 @@ public class GenieAwsApiAutoConfigurationUnitTests {
     }
 
     /**
-     * Make sure we can get the {@link GenieHostInfo} instance even if EC2 metadata fails.
-     *
-     * @throws UnknownHostException When the fallback fails
+     * Make sure we can get the {@link GenieHostInfo}.
      */
     @Test
-    public void canGetGenieHostInfo() throws UnknownHostException {
-        final GenieHostInfo genieHostInfo = this.genieAwsApiAutoConfiguration.genieHostInfo();
-        Assert.assertThat(genieHostInfo.getHostname(), Matchers.notNullValue());
+    public void canGetGenieHostInfo() {
+        // Check to see if EC2 is available
+        if (AwsCloudEnvironmentCheckUtils.isRunningOnCloudEnvironment()) {
+            final GenieHostInfo genieHostInfo = this.genieAwsApiAutoConfiguration.genieHostInfo();
+            Assert.assertThat(genieHostInfo.getHostname(), Matchers.notNullValue());
+        } else {
+            try {
+                this.genieAwsApiAutoConfiguration.genieHostInfo();
+                Assert.fail("This test wasn't run on a box with AWS credentials and yet got an unexpected success");
+            } catch (final IllegalStateException ise) {
+                // Expected
+            }
+        }
     }
 }


### PR DESCRIPTION
In discussions with people it is preferred to just use the internal EC2 IP address to avoid
other potential issues. Now we'll just use the IPV4 address and fallback to whatever can be
found from InetAddress.getHostname otherwise. This will behave similar to Genie 3.x now.