### PR TITLE
Make active jobs user limit value customizable on a per-user basis

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/properties/JobsUsersActiveLimitProperties.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/properties/JobsUsersActiveLimitProperties.java
@@ -17,11 +17,13 @@
  */
 package com.netflix.genie.core.properties;
 
+import com.google.common.collect.Maps;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.Min;
+import java.util.Map;
 
 /**
  * Properties related to user limits in number of active jobs.
@@ -46,4 +48,16 @@ public class JobsUsersActiveLimitProperties {
     private boolean enabled = DEFAULT_ENABLED;
     @Min(value = 1)
     private int count = DEFAULT_COUNT;
+    private Map<String, Integer> overrides = Maps.newHashMap();
+
+    /**
+     * Get the maximum number of jobs a user is allowed to run concurrently.
+     * Checks whether the user has a special limit associated, and if not it returns the global default.
+     *
+     * @param user the user name
+     * @return the maximum number of jobs
+     */
+    public int getUserLimit(final String user) {
+        return overrides.getOrDefault(user, count);
+    }
 }

--- a/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/services/impl/JobCoordinatorServiceImpl.java
@@ -245,7 +245,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
             log.info("Checking if can run job {} from user {}", jobRequest.getId(), jobRequest.getUser());
             final JobsUsersActiveLimitProperties activeLimit = this.jobsProperties.getUsers().getActiveLimit();
             if (activeLimit.isEnabled()) {
-                final long activeJobsLimit = activeLimit.getCount();
+                final long activeJobsLimit = activeLimit.getUserLimit(jobRequest.getUser());
                 final long activeJobsCount = this.jobSearchService.getActiveJobCountForUser(jobRequest.getUser());
                 if (activeJobsCount >= activeJobsLimit) {
                     throw GenieUserLimitExceededException.createForActiveJobsLimit(

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -135,8 +135,12 @@ to work.
 |false
 
 |genie.jobs.users.activeLimit.count
-|The maximum number of active jobs a user is allowed to have. Once a user hits this limit, jobs submitted are rejected. This is property is ignored unless `genie.jobs.users.activeLimit.enabled` is set to true.
+|The maximum number of active jobs a user is allowed to have. Once a user hits this limit, jobs submitted are rejected. This property is ignored unless `genie.jobs.users.activeLimit.enabled` is set to true. This limit applies to users that don't have an override set via `genie.jobs.users.activeLimit.overrides.<user-name>`.
 |100
+
+|genie.jobs.users.activeLimit.overrides.<user-name>
+|The maximum number of active jobs that user 'user-name' is allowed to have. This property is ignored unless `genie.jobs.users.activeLimit.enabled` is set to true.
+|-
 
 |genie.jobs.completionCheckBackOff.minInterval
 |The minimum time between checks for job completion in milliseconds. Must be greater than zero.

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/PropertiesConfigIntegrationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/PropertiesConfigIntegrationTest.java
@@ -68,6 +68,9 @@ public class PropertiesConfigIntegrationTest {
         Assert.assertThat(jobsProperties.getUsers().isCreationEnabled(), Matchers.is(true));
         Assert.assertThat(jobsProperties.getUsers().getActiveLimit().isEnabled(), Matchers.is(true));
         Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getCount(), Matchers.is(15));
+        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("Jane"), Matchers.is(100));
+        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("John"), Matchers.is(200));
+        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("not-special"), Matchers.is(15));
 
         Assert.assertNotNull(dataServiceRetryProperties);
         Assert.assertThat(dataServiceRetryProperties.getInitialInterval(), Matchers.is(200L));

--- a/genie-web/src/test/resources/PropertiesConfigIntegrationTest.properties
+++ b/genie-web/src/test/resources/PropertiesConfigIntegrationTest.properties
@@ -22,6 +22,8 @@ genie.jobs.users.creationEnabled = true
 # Jobs users active limit properties
 genie.jobs.users.activeLimit.enabled = true
 genie.jobs.users.activeLimit.count = 15
+genie.jobs.users.activeLimit.overrides.Jane = 100
+genie.jobs.users.activeLimit.overrides.John = 200
 
 # Data service retry properties
 genie.data.service.retry.initialInterval = 200


### PR DESCRIPTION
The existing mechanism to limit the maximum number of jobs applies equally to all users.
This can result in having to configure its value to a 'known accepted worst case'. And that limit is then applied to everyone else.

The new mechanism allows to set a default value that applies to most users, plus a set of custom limits for individual users.
These limits can be higher or lower than the default.