### PR TITLE
Make user job limit properties dynamic/fast

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/properties/JobsUsersProperties.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/properties/JobsUsersProperties.java
@@ -33,5 +33,4 @@ import org.springframework.validation.annotation.Validated;
 public class JobsUsersProperties {
     private boolean creationEnabled;
     private boolean runAsUserEnabled;
-    private JobsUsersActiveLimitProperties activeLimit = new JobsUsersActiveLimitProperties();
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/configs/ServicesConfigTest.java
@@ -36,6 +36,7 @@ import com.netflix.genie.core.jpa.services.JpaJobPersistenceServiceImpl;
 import com.netflix.genie.core.jpa.services.JpaJobSearchServiceImpl;
 import com.netflix.genie.core.jpa.services.JpaTagServiceImpl;
 import com.netflix.genie.core.properties.JobsProperties;
+import com.netflix.genie.core.properties.JobsUsersActiveLimitProperties;
 import com.netflix.genie.core.services.ApplicationService;
 import com.netflix.genie.core.services.AttachmentService;
 import com.netflix.genie.core.services.ClusterLoadBalancer;
@@ -63,6 +64,7 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
 import org.apache.commons.exec.Executor;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ServiceLocatorFactoryBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -413,17 +415,18 @@ public class ServicesConfigTest {
     /**
      * Get an instance of the JobCoordinatorService.
      *
-     * @param jobPersistenceService implementation of job persistence service interface.
-     * @param jobKillService        The job kill service to use.
-     * @param jobStateService       implementation of job state service interface
-     * @param jobSearchService      implementation of job search service interface
-     * @param jobsProperties        The jobs properties to use
-     * @param applicationService    Implementation of application service interface
-     * @param clusterService        Implementation of cluster service interface
-     * @param commandService        Implementation of command service interface
-     * @param clusterLoadBalancers  Implementations of the cluster load balancer interface
-     * @param registry              The registry to use
-     * @param hostName              The host name to use
+     * @param jobPersistenceService                  implementation of job persistence service interface.
+     * @param jobKillService                         The job kill service to use.
+     * @param jobStateService                        implementation of job state service interface
+     * @param jobSearchService                       implementation of job search service interface
+     * @param jobsProperties                         The jobs properties to use
+     * @param jobsUsersActiveLimitPropertiesProvider The user limits dynamic properties provider
+     * @param applicationService                     Implementation of application service interface
+     * @param clusterService                         Implementation of cluster service interface
+     * @param commandService                         Implementation of command service interface
+     * @param clusterLoadBalancers                   Implementations of the cluster load balancer interface
+     * @param registry                               The registry to use
+     * @param hostName                               The host name to use
      * @return An instance of the JobCoordinatorService.
      */
     @Bean
@@ -433,6 +436,7 @@ public class ServicesConfigTest {
         final JobStateService jobStateService,
         final JobSearchService jobSearchService,
         final JobsProperties jobsProperties,
+        final ObjectFactory<JobsUsersActiveLimitProperties> jobsUsersActiveLimitPropertiesProvider,
         final ApplicationService applicationService,
         final ClusterService clusterService,
         final CommandService commandService,
@@ -448,6 +452,7 @@ public class ServicesConfigTest {
             jobKillService,
             jobStateService,
             jobsProperties,
+            jobsUsersActiveLimitPropertiesProvider,
             applicationService,
             jobSearchService,
             clusterService,

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -131,15 +131,15 @@ to work.
 |false
 
 |genie.jobs.users.activeLimit.enabled
-|Enables the per-user active job limit. The number of jobs is controlled by the `genie.jobs.users.activeLimit.count` property.
+|(Dynamic) Enables the per-user active job limit. The number of jobs is controlled by the `genie.jobs.users.activeLimit.count` property.
 |false
 
 |genie.jobs.users.activeLimit.count
-|The maximum number of active jobs a user is allowed to have. Once a user hits this limit, jobs submitted are rejected. This property is ignored unless `genie.jobs.users.activeLimit.enabled` is set to true. This limit applies to users that don't have an override set via `genie.jobs.users.activeLimit.overrides.<user-name>`.
+|(Dynamic) The maximum number of active jobs a user is allowed to have. Once a user hits this limit, jobs submitted are rejected. This property is ignored unless `genie.jobs.users.activeLimit.enabled` is set to true. This limit applies to users that don't have an override set via `genie.jobs.users.activeLimit.overrides.<user-name>`.
 |100
 
 |genie.jobs.users.activeLimit.overrides.<user-name>
-|The maximum number of active jobs that user 'user-name' is allowed to have. This property is ignored unless `genie.jobs.users.activeLimit.enabled` is set to true.
+|(Dynamic) The maximum number of active jobs that user 'user-name' is allowed to have. This property is ignored unless `genie.jobs.users.activeLimit.enabled` is set to true.
 |-
 
 |genie.jobs.completionCheckBackOff.minInterval

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/PropertiesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/PropertiesConfig.java
@@ -20,10 +20,12 @@ package com.netflix.genie.web.configs;
 import com.netflix.genie.core.properties.DataServiceRetryProperties;
 import com.netflix.genie.core.properties.HealthProperties;
 import com.netflix.genie.core.properties.JobsProperties;
+import com.netflix.genie.core.properties.JobsUsersActiveLimitProperties;
 import com.netflix.genie.core.properties.S3FileTransferProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 
 /**
  * Configuration for creating beans for Genie Properties.
@@ -76,5 +78,19 @@ public class PropertiesConfig {
     @ConfigurationProperties("genie.s3filetransfer")
     public S3FileTransferProperties s3FileTransferProperties() {
         return new S3FileTransferProperties();
+    }
+
+    /**
+     * Subset of properties concerned with per-user number of active jobs.
+     * Notice the 'prototype' scope. If this bean is injected via {@link javax.inject.Provider} or Spring's
+     * {@code ObjectFactory}, then values are bound every time, i.e., fast/dynamic properties behavior.
+     *
+     * @return The active job user limit property structure
+     */
+    @Bean
+    @Scope("prototype")
+    @ConfigurationProperties("genie.jobs.users.activeLimit")
+    public JobsUsersActiveLimitProperties jobsUsersActiveLimitProperties() {
+        return new JobsUsersActiveLimitProperties();
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -35,6 +35,7 @@ import com.netflix.genie.core.jpa.services.JpaJobPersistenceServiceImpl;
 import com.netflix.genie.core.jpa.services.JpaJobSearchServiceImpl;
 import com.netflix.genie.core.jpa.services.JpaTagServiceImpl;
 import com.netflix.genie.core.properties.JobsProperties;
+import com.netflix.genie.core.properties.JobsUsersActiveLimitProperties;
 import com.netflix.genie.core.services.ApplicationService;
 import com.netflix.genie.core.services.AttachmentService;
 import com.netflix.genie.core.services.ClusterLoadBalancer;
@@ -63,6 +64,7 @@ import com.netflix.genie.core.services.impl.RandomizedClusterLoadBalancerImpl;
 import com.netflix.spectator.api.Registry;
 import org.apache.commons.exec.Executor;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ServiceLocatorFactoryBean;
@@ -368,17 +370,19 @@ public class ServicesConfig {
     /**
      * Get an instance of the JobCoordinatorService.
      *
-     * @param jobPersistenceService implementation of job persistence service interface
-     * @param jobKillService        The job kill service to use
-     * @param jobStateService       The running job metrics service to use
-     * @param jobSearchService      Implementation of job search service interface
-     * @param jobsProperties        The jobs properties to use
-     * @param applicationService    Implementation of application service interface
-     * @param clusterService        Implementation of cluster service interface
-     * @param commandService        Implementation of command service interface
-     * @param clusterLoadBalancers  Implementations of the cluster load balancer interface in invocation order
-     * @param registry              The metrics registry to use
-     * @param hostName              The host this Genie instance is running on
+     * @param jobPersistenceService                  implementation of job persistence service interface
+     * @param jobKillService                         The job kill service to use
+     * @param jobStateService                        The running job metrics service to use
+     * @param jobSearchService                       Implementation of job search service interface
+     * @param jobsProperties                         The jobs properties to use
+     * @param jobsUsersActiveLimitPropertiesProvider The user limits dynamic properties provider
+     * @param applicationService                     Implementation of application service interface
+     * @param clusterService                         Implementation of cluster service interface
+     * @param commandService                         Implementation of command service interface
+     * @param clusterLoadBalancers                   Implementations of the cluster load balancer interface in
+     *                                               invocation order
+     * @param registry                               The metrics registry to use
+     * @param hostName                               The host this Genie instance is running on
      * @return An instance of the JobCoordinatorService.
      */
     @Bean
@@ -388,6 +392,7 @@ public class ServicesConfig {
         @Qualifier("jobMonitoringCoordinator") final JobStateService jobStateService,
         final JobSearchService jobSearchService,
         final JobsProperties jobsProperties,
+        final ObjectFactory<JobsUsersActiveLimitProperties> jobsUsersActiveLimitPropertiesProvider,
         final ApplicationService applicationService,
         final ClusterService clusterService,
         final CommandService commandService,
@@ -403,6 +408,7 @@ public class ServicesConfig {
             jobKillService,
             jobStateService,
             jobsProperties,
+            jobsUsersActiveLimitPropertiesProvider,
             applicationService,
             jobSearchService,
             clusterService,

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/PropertiesConfigIntegrationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/PropertiesConfigIntegrationTest.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.configs;
 import com.netflix.genie.core.properties.DataServiceRetryProperties;
 import com.netflix.genie.core.properties.HealthProperties;
 import com.netflix.genie.core.properties.JobsProperties;
+import com.netflix.genie.core.properties.JobsUsersActiveLimitProperties;
 import com.netflix.genie.test.categories.IntegrationTest;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -52,6 +53,9 @@ public class PropertiesConfigIntegrationTest {
     @Autowired
     private HealthProperties healthProperties;
 
+    @Autowired
+    private JobsUsersActiveLimitProperties jobsUsersActiveLimitProperties;
+
     /**
      * Verify than beans get autowired, and that (non-default) values correspond to the expected set via properties
      * file.
@@ -66,11 +70,6 @@ public class PropertiesConfigIntegrationTest {
         Assert.assertThat(jobsProperties.getMax().getStdOutSize(), Matchers.is(512L));
         Assert.assertThat(jobsProperties.getMemory().getMaxSystemMemory(), Matchers.is(1024));
         Assert.assertThat(jobsProperties.getUsers().isCreationEnabled(), Matchers.is(true));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().isEnabled(), Matchers.is(true));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getCount(), Matchers.is(15));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("Jane"), Matchers.is(100));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("John"), Matchers.is(200));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("not-special"), Matchers.is(15));
 
         Assert.assertNotNull(dataServiceRetryProperties);
         Assert.assertThat(dataServiceRetryProperties.getInitialInterval(), Matchers.is(200L));
@@ -78,5 +77,11 @@ public class PropertiesConfigIntegrationTest {
         Assert.assertNotNull(healthProperties);
         Assert.assertThat(healthProperties.getMaxCpuLoadPercent(), Matchers.is(33.3));
         Assert.assertThat(healthProperties.getMaxCpuLoadConsecutiveOccurrences(), Matchers.is(5));
+
+        Assert.assertThat(jobsUsersActiveLimitProperties.isEnabled(), Matchers.is(true));
+        Assert.assertThat(jobsUsersActiveLimitProperties.getCount(), Matchers.is(15));
+        Assert.assertThat(jobsUsersActiveLimitProperties.getUserLimit("Jane"), Matchers.is(100));
+        Assert.assertThat(jobsUsersActiveLimitProperties.getUserLimit("John"), Matchers.is(200));
+        Assert.assertThat(jobsUsersActiveLimitProperties.getUserLimit("not-special"), Matchers.is(15));
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -47,6 +47,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -238,6 +239,7 @@ public class ServicesConfigUnitTests {
     /**
      * Can get a bean for Job Coordinator Service.
      */
+    @SuppressWarnings("unchecked") // For ObjectFactory
     @Test
     public void canGetJobCoordinatorServiceBean() {
         Assert.assertNotNull(
@@ -247,6 +249,7 @@ public class ServicesConfigUnitTests {
                 Mockito.mock(JobStateService.class),
                 Mockito.mock(JobSearchService.class),
                 new JobsProperties(),
+                Mockito.mock(ObjectFactory.class),
                 Mockito.mock(ApplicationService.class),
                 Mockito.mock(ClusterService.class),
                 Mockito.mock(CommandService.class),
@@ -260,6 +263,7 @@ public class ServicesConfigUnitTests {
     /**
      * Can't get a bean for Job Coordinator Service.
      */
+    @SuppressWarnings("unchecked") // For ObjectFactory
     @Test(expected = IllegalStateException.class)
     public void cantGetJobCoordinatorServiceBeanWhenNoClusterLoadBalancers() {
         Assert.assertNotNull(
@@ -269,6 +273,7 @@ public class ServicesConfigUnitTests {
                 Mockito.mock(JobStateService.class),
                 Mockito.mock(JobSearchService.class),
                 new JobsProperties(),
+                Mockito.mock(ObjectFactory.class),
                 Mockito.mock(ApplicationService.class),
                 Mockito.mock(ClusterService.class),
                 Mockito.mock(CommandService.class),


### PR DESCRIPTION
In order to be able to tweak concurrent job limit without release and deployment, make this group of property dynamic.
This is implemented by declaring this group as a standalone bean (as opposed to the natural nesting) and accessing it through a provider.

The combination of `@Scope("prototype")` and `@ConfigurationProperties` ensures the properties reflect changes to the environment, while at the same time avoid re-binding unnecessarily.