### PR TITLE
Make per-user limit on number of jobs dynamic (master)

### DIFF
--- a/genie-app/src/main/resources/application.yml
+++ b/genie-app/src/main/resources/application.yml
@@ -65,9 +65,9 @@ genie:
     users:
       creationEnabled: false
       runAsUserEnabled: false
-      active-limit:
-        enabled: false
-        count: 100
+    active-limit:
+      enabled: false
+      count: 100
   leader:
     enabled: false
   mail:

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -142,15 +142,15 @@ rights for this to work.
 to work.
 |false
 
-|genie.jobs.users.active-limit.enabled
+|genie.jobs.active-limit.enabled
 |Enables the per-user active job limit. The number of jobs is controlled by the `genie.jobs.users.active-limit.count` property.
 |false
 
-|genie.jobs.users.active-limit.count
+|genie.jobs.active-limit.count
 |The maximum number of active jobs a user is allowed to have. Once a user hits this limit, jobs submitted are rejected. This is property is ignored unless `genie.jobs.users.active-limit.enabled` is set to true. This limit applies to users that don't have an override set via `genie.jobs.users.active-limit.overrides.<user-name>`.
 |100
 
-|genie.jobs.users.active-limit.overrides.<user-name>
+|genie.jobs.active-limit.overrides.<user-name>
 |(Dynamic) The maximum number of active jobs that user 'user-name' is allowed to have. This is property is ignored unless `genie.jobs.users.active-limit.enabled` is set to true.
 |-
 

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -151,7 +151,7 @@ to work.
 |100
 
 |genie.jobs.users.active-limit.overrides.<user-name>
-|The maximum number of active jobs that user 'user-name' is allowed to have. This is property is ignored unless `genie.jobs.users.active-limit.enabled` is set to true.
+|(Dynamic) The maximum number of active jobs that user 'user-name' is allowed to have. This is property is ignored unless `genie.jobs.users.active-limit.enabled` is set to true.
 |-
 
 |genie.jobs.completion-check-back-off.min-interval

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -102,7 +102,7 @@ https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Gu
 https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#relaxed-binding[property binding]
 
 |genie.jobs.users.activeLimit.*
-|genie.jobs.users.active-limit.*
+|genie.jobs.active-limit.*
 |Modifications to how Spring handled
 https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#relaxed-binding[property binding]
 

--- a/genie-test-web/src/main/resources/application.yml
+++ b/genie-test-web/src/main/resources/application.yml
@@ -65,9 +65,9 @@ genie:
     users:
       creationEnabled: false
       runAsUserEnabled: false
-      active-limit:
-        enabled: false
-        count: 100
+    active-limit:
+      enabled: false
+      count: 100
   leader:
     enabled: false
   mail:

--- a/genie-war/src/main/resources/application.yml
+++ b/genie-war/src/main/resources/application.yml
@@ -65,9 +65,9 @@ genie:
     users:
       creationEnabled: false
       runAsUserEnabled: false
-      active-limit:
-        enabled: false
-        count: 100
+    active-limit:
+      enabled: false
+      count: 100
   leader:
     enabled: false
   mail:

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/JobsActiveLimitProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/JobsActiveLimitProperties.java
@@ -28,21 +28,21 @@ import javax.validation.constraints.Min;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Properties related to user limits in number of active jobs.
+ * Properties related to number of active jobs per user.
  *
  * @author mprimi
  * @since 3.1.0
  */
-@ConfigurationProperties(prefix = JobsUsersActiveLimitProperties.PROPERTY_PREFIX)
+@ConfigurationProperties(prefix = JobsActiveLimitProperties.PROPERTY_PREFIX)
 @Getter
 @Setter
 @Validated
-public class JobsUsersActiveLimitProperties implements EnvironmentAware {
+public class JobsActiveLimitProperties implements EnvironmentAware {
 
     /**
      * The property prefix for job user limiting.
      */
-    public static final String PROPERTY_PREFIX = "genie.jobs.users.active-limit";
+    public static final String PROPERTY_PREFIX = "genie.jobs.active-limit";
 
     /**
      * The property key for whether this feature is enabled or not.

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/JobsProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/JobsProperties.java
@@ -19,7 +19,6 @@ package com.netflix.genie.web.properties;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
@@ -30,38 +29,75 @@ import javax.validation.Valid;
  * @author tgianos
  * @since 3.0.0
  */
-@ConfigurationProperties(prefix = JobsProperties.PROPERTY_PREFIX)
 @Getter
 @Setter
 @Validated
 public class JobsProperties {
 
+    @Valid
+    private JobsCleanupProperties cleanup;
+    @Valid
+    private JobsForwardingProperties forwarding;
+    @Valid
+    private JobsLocationsProperties locations;
+    @Valid
+    private JobsMaxProperties max;
+    @Valid
+    private JobsMemoryProperties memory;
+    @Valid
+    private JobsUsersProperties users;
+    @Valid
+    private ExponentialBackOffTriggerProperties completionCheckBackOff;
+    @Valid
+    private JobsActiveLimitProperties activeLimit;
+
     /**
-     * The property prefix for all properties in this group.
+     * Constructor.
+     *
+     * @param cleanup                cleanup properties
+     * @param forwarding             forwarding properties
+     * @param locations              locations properties
+     * @param max                    max properties
+     * @param memory                 memory properties
+     * @param users                  users properties
+     * @param completionCheckBackOff completion back-off properties
+     * @param activeLimit            active limit properties
      */
-    public static final String PROPERTY_PREFIX = "genie.jobs";
+    public JobsProperties(
+        @Valid final JobsCleanupProperties cleanup,
+        @Valid final JobsForwardingProperties forwarding,
+        @Valid final JobsLocationsProperties locations,
+        @Valid final JobsMaxProperties max,
+        @Valid final JobsMemoryProperties memory,
+        @Valid final JobsUsersProperties users,
+        @Valid final ExponentialBackOffTriggerProperties completionCheckBackOff,
+        @Valid final JobsActiveLimitProperties activeLimit
+    ) {
+        this.cleanup = cleanup;
+        this.forwarding = forwarding;
+        this.locations = locations;
+        this.max = max;
+        this.memory = memory;
+        this.users = users;
+        this.completionCheckBackOff = completionCheckBackOff;
+        this.activeLimit = activeLimit;
+    }
 
-    @Valid
-    private JobsCleanupProperties cleanup = new JobsCleanupProperties();
-
-    @Valid
-    private JobsForwardingProperties forwarding = new JobsForwardingProperties();
-
-    @Valid
-    private JobsLocationsProperties locations = new JobsLocationsProperties();
-
-    @Valid
-    private JobsMaxProperties max = new JobsMaxProperties();
-
-    @Valid
-    private JobsMemoryProperties memory = new JobsMemoryProperties();
-
-    @Valid
-    private JobsUsersProperties users = new JobsUsersProperties();
-
-    @Valid
-    private ExponentialBackOffTriggerProperties completionCheckBackOff = new ExponentialBackOffTriggerProperties();
-
-    @Valid
-    private JobsActiveLimitProperties activeLimit = new JobsActiveLimitProperties();
+    /**
+     * Create a JobsProperties initialized with default values (for use in tests).
+     *
+     * @return a new {@link JobsProperties} instance.
+     */
+    public static JobsProperties getJobsPropertiesDefaults() {
+        return new JobsProperties(
+            new JobsCleanupProperties(),
+            new JobsForwardingProperties(),
+            new JobsLocationsProperties(),
+            new JobsMaxProperties(),
+            new JobsMemoryProperties(),
+            new JobsUsersProperties(),
+            new ExponentialBackOffTriggerProperties(),
+            new JobsActiveLimitProperties()
+        );
+    }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/JobsProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/JobsProperties.java
@@ -61,4 +61,7 @@ public class JobsProperties {
 
     @Valid
     private ExponentialBackOffTriggerProperties completionCheckBackOff = new ExponentialBackOffTriggerProperties();
+
+    @Valid
+    private JobsActiveLimitProperties activeLimit = new JobsActiveLimitProperties();
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/JobsUsersProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/JobsUsersProperties.java
@@ -22,8 +22,6 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.Valid;
-
 /**
  * Properties related to users running jobs.
  *
@@ -40,9 +38,6 @@ public class JobsUsersProperties {
      * The property prefix for all properties in this group.
      */
     public static final String PROPERTY_PREFIX = "genie.jobs.users";
-
     private boolean creationEnabled;
     private boolean runAsUserEnabled;
-    @Valid
-    private JobsUsersActiveLimitProperties activeLimit = new JobsUsersActiveLimitProperties();
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -38,7 +38,7 @@ import com.netflix.genie.common.internal.dto.v4.JobSpecification;
 import com.netflix.genie.common.internal.jobs.JobConstants;
 import com.netflix.genie.web.controllers.DtoConverters;
 import com.netflix.genie.web.properties.JobsProperties;
-import com.netflix.genie.web.properties.JobsUsersActiveLimitProperties;
+import com.netflix.genie.web.properties.JobsActiveLimitProperties;
 import com.netflix.genie.web.services.ApplicationPersistenceService;
 import com.netflix.genie.web.services.ClusterPersistenceService;
 import com.netflix.genie.web.services.CommandPersistenceService;
@@ -227,7 +227,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
             }
 
             log.info("Checking if can run job {} from user {}", jobRequest.getId(), jobRequest.getUser());
-            final JobsUsersActiveLimitProperties activeLimit = this.jobsProperties.getUsers().getActiveLimit();
+            final JobsActiveLimitProperties activeLimit = this.jobsProperties.getActiveLimit();
             if (activeLimit.isEnabled()) {
                 final long activeJobsLimit = activeLimit.getUserLimit(jobRequest.getUser());
                 final long activeJobsCount = this.jobSearchService.getActiveJobCountForUser(jobRequest.getUser());

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobSpecificationServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobSpecificationServiceImplSpec.groovy
@@ -148,7 +148,7 @@ class JobSpecificationServiceImplSpec extends Specification {
         def jobCommandArgs = Lists.newArrayList(executableBinary, executableArgument0, executableArgument1)
         jobCommandArgs.addAll(commandArgs)
 
-        def jobsProperties = new JobsProperties()
+        def jobsProperties = JobsProperties.getJobsPropertiesDefaults()
         Map<Cluster, String> clusterCommandMap = Maps.newHashMap()
         clusterCommandMap.put(cluster1, commandId)
         clusterCommandMap.put(cluster2, commandId)
@@ -218,7 +218,7 @@ class JobSpecificationServiceImplSpec extends Specification {
                 Mock(CommandPersistenceService),
                 Lists.newArrayList(),
                 Mock(MeterRegistry),
-                new JobsProperties()
+                JobsProperties.getJobsPropertiesDefaults()
         )
 
         expect:
@@ -238,7 +238,7 @@ class JobSpecificationServiceImplSpec extends Specification {
     }
 
     def "Can generate correct environment variables"() {
-        def jobsProperties = new JobsProperties()
+        def jobsProperties = JobsProperties.getJobsPropertiesDefaults()
         def service = new JobSpecificationServiceImpl(
                 Mock(ApplicationPersistenceService),
                 Mock(ClusterPersistenceService),
@@ -329,7 +329,7 @@ class JobSpecificationServiceImplSpec extends Specification {
     }
 
     def "Can convert V4 Criterion to V3 tags"() {
-        def jobsProperties = new JobsProperties()
+        def jobsProperties = JobsProperties.getJobsPropertiesDefaults()
         def service = new JobSpecificationServiceImpl(
                 Mock(ApplicationPersistenceService),
                 Mock(ClusterPersistenceService),
@@ -409,7 +409,7 @@ class JobSpecificationServiceImplSpec extends Specification {
         def timeout = 10835
 
 
-        def jobsProperties = new JobsProperties()
+        def jobsProperties = JobsProperties.getJobsPropertiesDefaults()
         def service = new JobSpecificationServiceImpl(
                 Mock(ApplicationPersistenceService),
                 Mock(ClusterPersistenceService),

--- a/genie-web/src/test/groovy/com/netflix/genie/web/tasks/job/JobCompletionServiceSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/tasks/job/JobCompletionServiceSpec.groovy
@@ -79,7 +79,7 @@ class JobCompletionServiceSpec extends Specification {
         jobSearchService = Mock(JobSearchService.class)
         mailService = Mock(MailService.class)
         genieFileTransferService = Mock(GenieFileTransferService.class)
-        jobsProperties = new JobsProperties()
+        jobsProperties = JobsProperties.getJobsPropertiesDefaults()
         counterTagsCaptures = new ArrayList<>()
         registry = Mock(MeterRegistry.class)
         errorCounter = Mock(Counter.class)

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/GenieApiAutoConfigurationUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/GenieApiAutoConfigurationUnitTests.java
@@ -108,7 +108,7 @@ public class GenieApiAutoConfigurationUnitTests {
     public void cantGetJobsDirWhenJobsDirInvalid() throws IOException {
         final ResourceLoader resourceLoader = Mockito.mock(ResourceLoader.class);
         final String jobsDirLocation = UUID.randomUUID().toString();
-        final JobsProperties jobsProperties = new JobsProperties();
+        final JobsProperties jobsProperties = JobsProperties.getJobsPropertiesDefaults();
         jobsProperties.getLocations().setJobs(jobsDirLocation);
 
         final Resource tmpResource = Mockito.mock(Resource.class);
@@ -159,7 +159,7 @@ public class GenieApiAutoConfigurationUnitTests {
     public void canGetJobsDir() throws IOException {
         final ResourceLoader resourceLoader = Mockito.mock(ResourceLoader.class);
         final String jobsDirLocation = UUID.randomUUID().toString() + "/";
-        final JobsProperties jobsProperties = new JobsProperties();
+        final JobsProperties jobsProperties = JobsProperties.getJobsPropertiesDefaults();
         jobsProperties.getLocations().setJobs(jobsDirLocation);
 
         final Resource jobsDirResource = Mockito.mock(Resource.class);

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/PropertyBindingIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/PropertyBindingIntegrationTests.java
@@ -72,9 +72,9 @@ public class PropertyBindingIntegrationTests {
         Assert.assertThat(jobsProperties.getActiveLimit().isEnabled(), Matchers.is(true));
         Assert.assertThat(jobsProperties.getActiveLimit().getCount(), Matchers.is(15));
         Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("JaneDoe"), Matchers.is(100));
-        Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("janedoe"), Matchers.is(15));
+        Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("janedoe"), Matchers.is(100));
         Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("John-Doe"), Matchers.is(200));
-        Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("john-doe"), Matchers.is(15));
+        Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("john-doe"), Matchers.is(200));
         Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("anyone else"), Matchers.is(15));
 
         Assert.assertNotNull(dataServiceRetryProperties);

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/PropertyBindingIntegrationTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/PropertyBindingIntegrationTests.java
@@ -69,13 +69,13 @@ public class PropertyBindingIntegrationTests {
         Assert.assertThat(jobsProperties.getMax().getStdOutSize(), Matchers.is(512L));
         Assert.assertThat(jobsProperties.getMemory().getMaxSystemMemory(), Matchers.is(1024));
         Assert.assertThat(jobsProperties.getUsers().isCreationEnabled(), Matchers.is(true));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().isEnabled(), Matchers.is(true));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getCount(), Matchers.is(15));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("JaneDoe"), Matchers.is(100));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("janedoe"), Matchers.is(15));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("John-Doe"), Matchers.is(200));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("john-doe"), Matchers.is(15));
-        Assert.assertThat(jobsProperties.getUsers().getActiveLimit().getUserLimit("anyone else"), Matchers.is(15));
+        Assert.assertThat(jobsProperties.getActiveLimit().isEnabled(), Matchers.is(true));
+        Assert.assertThat(jobsProperties.getActiveLimit().getCount(), Matchers.is(15));
+        Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("JaneDoe"), Matchers.is(100));
+        Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("janedoe"), Matchers.is(15));
+        Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("John-Doe"), Matchers.is(200));
+        Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("john-doe"), Matchers.is(15));
+        Assert.assertThat(jobsProperties.getActiveLimit().getUserLimit("anyone else"), Matchers.is(15));
 
         Assert.assertNotNull(dataServiceRetryProperties);
         Assert.assertThat(dataServiceRetryProperties.getInitialInterval(), Matchers.is(200L));

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesAutoConfigurationUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesAutoConfigurationUnitTests.java
@@ -112,7 +112,7 @@ public class ServicesAutoConfigurationUnitTests {
                 Mockito.mock(JobKillService.class),
                 Mockito.mock(JobStateService.class),
                 Mockito.mock(JobSearchService.class),
-                new JobsProperties(),
+                JobsProperties.getJobsPropertiesDefaults(),
                 Mockito.mock(ApplicationPersistenceService.class),
                 Mockito.mock(ClusterPersistenceService.class),
                 Mockito.mock(CommandPersistenceService.class),
@@ -147,7 +147,7 @@ public class ServicesAutoConfigurationUnitTests {
                 new GenieHostInfo("localhost"),
                 this.jobSearchService,
                 Mockito.mock(Executor.class),
-                new JobsProperties(),
+                JobsProperties.getJobsPropertiesDefaults(),
                 Mockito.mock(GenieEventBus.class),
                 Mockito.mock(FileSystemResource.class),
                 GenieObjectMapper.getMapper()

--- a/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/controllers/JobRestControllerUnitTests.java
@@ -105,7 +105,7 @@ public class JobRestControllerUnitTests {
         this.hostname = UUID.randomUUID().toString();
         this.restTemplate = Mockito.mock(RestTemplate.class);
         this.genieResourceHttpRequestHandler = Mockito.mock(GenieResourceHttpRequestHandler.class);
-        this.jobsProperties = new JobsProperties();
+        this.jobsProperties = JobsProperties.getJobsPropertiesDefaults();
 
         final MeterRegistry registry = Mockito.mock(MeterRegistry.class);
         final Counter counter = Mockito.mock(Counter.class);

--- a/genie-web/src/test/java/com/netflix/genie/web/health/GenieMemoryHealthIndicatorUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/health/GenieMemoryHealthIndicatorUnitTests.java
@@ -53,7 +53,7 @@ public class GenieMemoryHealthIndicatorUnitTests {
     @Before
     public void setup() {
         this.jobMetricsService = Mockito.mock(JobMetricsService.class);
-        jobsProperties = new JobsProperties();
+        jobsProperties = JobsProperties.getJobsPropertiesDefaults();
         jobsProperties.getMemory().setDefaultJobMemory(DEFAULT_JOB_MEMORY);
         jobsProperties.getMemory().setMaxSystemMemory(MAX_SYSTEM_MEMORY);
         jobsProperties.getMemory().setMaxJobMemory(MAX_JOB_MEMORY);

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/JobsActiveLimitPropertiesUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/JobsActiveLimitPropertiesUnitTests.java
@@ -26,21 +26,21 @@ import org.mockito.Mockito;
 import org.springframework.core.env.Environment;
 
 /**
- * Unit tests for JobsUsersActiveLimitProperties.
+ * Unit tests for JobsActiveLimitProperties.
  *
  * @author mprimi
  * @since 3.1.0
  */
 @Category(UnitTest.class)
-public class JobsUsersActiveLimitPropertiesUnitTests {
-    private JobsUsersActiveLimitProperties properties;
+public class JobsActiveLimitPropertiesUnitTests {
+    private JobsActiveLimitProperties properties;
 
     /**
      * Setup for the tests.
      */
     @Before
     public void setup() {
-        this.properties = new JobsUsersActiveLimitProperties();
+        this.properties = new JobsActiveLimitProperties();
     }
 
     /**
@@ -48,9 +48,9 @@ public class JobsUsersActiveLimitPropertiesUnitTests {
      */
     @Test
     public void canConstruct() {
-        Assert.assertEquals(JobsUsersActiveLimitProperties.DEFAULT_ENABLED, this.properties.isEnabled());
-        Assert.assertEquals(JobsUsersActiveLimitProperties.DEFAULT_COUNT, this.properties.getCount());
-        Assert.assertEquals(JobsUsersActiveLimitProperties.DEFAULT_COUNT, this.properties.getUserLimit("SomeUser"));
+        Assert.assertEquals(JobsActiveLimitProperties.DEFAULT_ENABLED, this.properties.isEnabled());
+        Assert.assertEquals(JobsActiveLimitProperties.DEFAULT_COUNT, this.properties.getCount());
+        Assert.assertEquals(JobsActiveLimitProperties.DEFAULT_COUNT, this.properties.getUserLimit("SomeUser"));
     }
 
     /**
@@ -83,7 +83,7 @@ public class JobsUsersActiveLimitPropertiesUnitTests {
         final Environment environment = Mockito.mock(Environment.class);
         Mockito
             .when(environment.getProperty(
-                JobsUsersActiveLimitProperties.USER_LIMIT_OVERRIDE_PROPERTY_PREFIX + userName,
+                JobsActiveLimitProperties.USER_LIMIT_OVERRIDE_PROPERTY_PREFIX + userName,
                 Integer.class,
                 this.properties.getCount())
             )

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/JobsPropertiesUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/JobsPropertiesUnitTests.java
@@ -33,6 +33,14 @@ import org.mockito.Mockito;
 @Category(UnitTest.class)
 public class JobsPropertiesUnitTests {
 
+    private JobsCleanupProperties cleanup;
+    private JobsMemoryProperties memory;
+    private JobsForwardingProperties forwarding;
+    private JobsLocationsProperties locations;
+    private JobsMaxProperties max;
+    private JobsUsersProperties users;
+    private ExponentialBackOffTriggerProperties completionBackOff;
+    private JobsActiveLimitProperties activeLimit;
     private JobsProperties properties;
 
     /**
@@ -40,7 +48,24 @@ public class JobsPropertiesUnitTests {
      */
     @Before
     public void setup() {
-        this.properties = new JobsProperties();
+        this.cleanup = Mockito.mock(JobsCleanupProperties.class);
+        this.memory = Mockito.mock(JobsMemoryProperties.class);
+        this.forwarding = Mockito.mock(JobsForwardingProperties.class);
+        this.locations = Mockito.mock(JobsLocationsProperties.class);
+        this.max = Mockito.mock(JobsMaxProperties.class);
+        this.users = Mockito.mock(JobsUsersProperties.class);
+        this.completionBackOff = Mockito.mock(ExponentialBackOffTriggerProperties.class);
+        this.activeLimit = Mockito.mock(JobsActiveLimitProperties.class);
+        this.properties = new JobsProperties(
+            cleanup,
+            forwarding,
+            locations,
+            max,
+            memory,
+            users,
+            completionBackOff,
+            activeLimit
+        );
     }
 
     /**
@@ -48,11 +73,14 @@ public class JobsPropertiesUnitTests {
      */
     @Test
     public void canConstruct() {
+        Assert.assertNotNull(this.properties.getCleanup());
         Assert.assertNotNull(this.properties.getMemory());
         Assert.assertNotNull(this.properties.getForwarding());
         Assert.assertNotNull(this.properties.getLocations());
         Assert.assertNotNull(this.properties.getMax());
         Assert.assertNotNull(this.properties.getUsers());
+        Assert.assertNotNull(this.properties.getCompletionCheckBackOff());
+        Assert.assertNotNull(this.properties.getActiveLimit());
     }
 
     /**
@@ -60,16 +88,13 @@ public class JobsPropertiesUnitTests {
      */
     @Test
     public void canSet() {
-        final JobsMemoryProperties memory = Mockito.mock(JobsMemoryProperties.class);
-        final JobsForwardingProperties forwarding = Mockito.mock(JobsForwardingProperties.class);
-        final JobsLocationsProperties locations = Mockito.mock(JobsLocationsProperties.class);
-        final JobsMaxProperties max = Mockito.mock(JobsMaxProperties.class);
-        final JobsUsersProperties users = Mockito.mock(JobsUsersProperties.class);
-
+        this.properties.setCleanup(cleanup);
         this.properties.setForwarding(forwarding);
         this.properties.setLocations(locations);
         this.properties.setMax(max);
         this.properties.setMemory(memory);
         this.properties.setUsers(users);
+        this.properties.setCompletionCheckBackOff(completionBackOff);
+        this.properties.setActiveLimit(activeLimit);
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/JobsUsersActiveLimitPropertiesUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/JobsUsersActiveLimitPropertiesUnitTests.java
@@ -22,6 +22,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+import org.springframework.core.env.Environment;
 
 /**
  * Unit tests for JobsUsersActiveLimitProperties.
@@ -48,6 +50,7 @@ public class JobsUsersActiveLimitPropertiesUnitTests {
     public void canConstruct() {
         Assert.assertEquals(JobsUsersActiveLimitProperties.DEFAULT_ENABLED, this.properties.isEnabled());
         Assert.assertEquals(JobsUsersActiveLimitProperties.DEFAULT_COUNT, this.properties.getCount());
+        Assert.assertEquals(JobsUsersActiveLimitProperties.DEFAULT_COUNT, this.properties.getUserLimit("SomeUser"));
     }
 
     /**
@@ -68,5 +71,25 @@ public class JobsUsersActiveLimitPropertiesUnitTests {
         final int newCountValue = 2 * this.properties.getCount();
         this.properties.setCount(newCountValue);
         Assert.assertEquals(newCountValue, this.properties.getCount());
+    }
+
+    /**
+     * Make sure environment is used when looking for a user-specific limit override.
+     */
+    @Test
+    public void testUserOverrides() {
+        final String userName = "SomeUser";
+        final int userLimit = 999;
+        final Environment environment = Mockito.mock(Environment.class);
+        Mockito
+            .when(environment.getProperty(
+                JobsUsersActiveLimitProperties.USER_LIMIT_OVERRIDE_PROPERTY_PREFIX + userName,
+                Integer.class,
+                this.properties.getCount())
+            )
+            .thenReturn(userLimit);
+        this.properties.setEnvironment(environment);
+
+        Assert.assertEquals(userLimit, this.properties.getUserLimit(userName));
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
@@ -107,7 +107,7 @@ public class JobCoordinatorServiceImplUnitTests {
         this.jobKillService = Mockito.mock(JobKillService.class);
         this.jobStateService = Mockito.mock(JobStateService.class);
         this.jobSearchService = Mockito.mock(JobSearchService.class);
-        this.jobsProperties = new JobsProperties();
+        this.jobsProperties = JobsProperties.getJobsPropertiesDefaults();
         this.jobsProperties.getLocations().setArchives(BASE_ARCHIVE_LOCATION);
         this.jobsProperties.getMemory().setDefaultJobMemory(MEMORY);
         this.jobsProperties.getActiveLimit().setEnabled(ACTIVE_JOBS_LIMIT_ENABLED);

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplUnitTests.java
@@ -110,7 +110,7 @@ public class JobCoordinatorServiceImplUnitTests {
         this.jobsProperties = new JobsProperties();
         this.jobsProperties.getLocations().setArchives(BASE_ARCHIVE_LOCATION);
         this.jobsProperties.getMemory().setDefaultJobMemory(MEMORY);
-        this.jobsProperties.getUsers().getActiveLimit().setEnabled(ACTIVE_JOBS_LIMIT_ENABLED);
+        this.jobsProperties.getActiveLimit().setEnabled(ACTIVE_JOBS_LIMIT_ENABLED);
         this.applicationPersistenceService = Mockito.mock(ApplicationPersistenceService.class);
         this.clusterPersistenceService = Mockito.mock(ClusterPersistenceService.class);
         this.commandPersistenceService = Mockito.mock(CommandPersistenceService.class);
@@ -546,8 +546,8 @@ public class JobCoordinatorServiceImplUnitTests {
     @Test
     public void canCoordinateIfJobUserJobLimitIsDisabled() throws GenieException {
         final int userActiveJobsLimit = 5;
-        this.jobsProperties.getUsers().getActiveLimit().setEnabled(false);
-        this.jobsProperties.getUsers().getActiveLimit().setCount(userActiveJobsLimit);
+        this.jobsProperties.getActiveLimit().setEnabled(false);
+        this.jobsProperties.getActiveLimit().setCount(userActiveJobsLimit);
 
         final Set<String> commandCriteria = Sets.newHashSet(
             UUID.randomUUID().toString(),
@@ -648,8 +648,8 @@ public class JobCoordinatorServiceImplUnitTests {
     @Test(expected = GenieUserLimitExceededException.class)
     public void cantCoordinateJobUserJobLimitIsExceeded() throws GenieException {
         final int userActiveJobsLimit = 5;
-        this.jobsProperties.getUsers().getActiveLimit().setEnabled(true);
-        this.jobsProperties.getUsers().getActiveLimit().setCount(userActiveJobsLimit);
+        this.jobsProperties.getActiveLimit().setEnabled(true);
+        this.jobsProperties.getActiveLimit().setCount(userActiveJobsLimit);
 
         final Set<String> commandCriteria = Sets.newHashSet(
             UUID.randomUUID().toString(),

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitorUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitorUnitTests.java
@@ -117,7 +117,7 @@ public class JobMonitorUnitTests {
             .when(this.registry.counter("genie.jobs.stdErrTooLarge.rate"))
             .thenReturn(this.stdErrTooLarge);
 
-        final JobsProperties outputMaxProperties = new JobsProperties();
+        final JobsProperties outputMaxProperties = JobsProperties.getJobsPropertiesDefaults();
         outputMaxProperties.getMax().setStdOutSize(MAX_STD_OUT_LENGTH);
         outputMaxProperties.getMax().setStdErrSize(MAX_STD_ERR_LENGTH);
 
@@ -281,7 +281,7 @@ public class JobMonitorUnitTests {
             this.executor,
             this.genieEventBus,
             this.registry,
-            new JobsProperties()
+            JobsProperties.getJobsPropertiesDefaults()
         );
 
         this.monitor.run();

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorUnitTests.java
@@ -119,7 +119,7 @@ public class JobMonitoringCoordinatorUnitTests {
             executor,
             new SimpleMeterRegistry(),
             jobsDir,
-            new JobsProperties(),
+            JobsProperties.getJobsPropertiesDefaults(),
             jobSubmitterService
         );
     }

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/node/DiskCleanupTaskUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/node/DiskCleanupTaskUnitTests.java
@@ -69,7 +69,7 @@ public class DiskCleanupTaskUnitTests {
      */
     @Test(expected = IOException.class)
     public void cantConstruct() throws IOException {
-        final JobsProperties properties = new JobsProperties();
+        final JobsProperties properties = JobsProperties.getJobsPropertiesDefaults();
         properties.getUsers().setRunAsUserEnabled(false);
         final Resource jobsDir = Mockito.mock(Resource.class);
         Mockito.when(jobsDir.exists()).thenReturn(false);
@@ -103,7 +103,7 @@ public class DiskCleanupTaskUnitTests {
                 scheduler,
                 jobsDir,
                 Mockito.mock(JobSearchService.class),
-                new JobsProperties(),
+                JobsProperties.getJobsPropertiesDefaults(),
                 Mockito.mock(Executor.class),
                 new SimpleMeterRegistry()
             )
@@ -128,7 +128,7 @@ public class DiskCleanupTaskUnitTests {
                 scheduler,
                 jobsDir,
                 Mockito.mock(JobSearchService.class),
-                new JobsProperties(),
+                JobsProperties.getJobsPropertiesDefaults(),
                 Mockito.mock(Executor.class),
                 new SimpleMeterRegistry()
             )
@@ -143,7 +143,7 @@ public class DiskCleanupTaskUnitTests {
      */
     @Test
     public void willScheduleOnUnixWithoutSudo() throws IOException {
-        final JobsProperties properties = new JobsProperties();
+        final JobsProperties properties = JobsProperties.getJobsPropertiesDefaults();
         properties.getUsers().setRunAsUserEnabled(false);
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
         final TaskScheduler scheduler = Mockito.mock(TaskScheduler.class);
@@ -171,7 +171,7 @@ public class DiskCleanupTaskUnitTests {
      */
     @Test
     public void canRunWithoutSudo() throws IOException, GenieException {
-        final JobsProperties jobsProperties = new JobsProperties();
+        final JobsProperties jobsProperties = JobsProperties.getJobsPropertiesDefaults();
         jobsProperties.getUsers().setRunAsUserEnabled(false);
 
         // Create some random junk file that should be ignored

--- a/genie-web/src/test/resources/PropertyBindingIntegrationTests.properties
+++ b/genie-web/src/test/resources/PropertyBindingIntegrationTests.properties
@@ -20,10 +20,10 @@ genie.jobs.memory.maxSystemMemory = 1024
 genie.jobs.users.creationEnabled = true
 
 # Jobs users active limit properties
-genie.jobs.users.activeLimit.enabled = true
-genie.jobs.users.activeLimit.count = 15
-genie.jobs.users.activeLimit.overrides.JaneDoe = 100
-genie.jobs.users.activeLimit.overrides.John-Doe = 200
+genie.jobs.active-limit.enabled = true
+genie.jobs.active-limit.count = 15
+genie.jobs.active-limit.overrides.JaneDoe = 100
+genie.jobs.active-limit.overrides.John-Doe = 200
 
 # Data service retry properties
 genie.data.service.retry.initialInterval = 200


### PR DESCRIPTION
Attempt to fetch the per-value limit from the environment, and fall back to the current or default if an override doesn't exist.