### PR TITLE
Agent version filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ configure(javaProjects) {
             dependency("org.apache.commons:commons-configuration2:2.2")
             dependency("org.apache.commons:commons-exec:1.3")
             dependency("org.apache.tika:tika-core:1.20")
+            dependency("org.apache.maven:maven-artifact:3.5.4")
             // For some reason 3.5.3-beta was throwing error with 3.4.x server
             // https://issues.apache.org/jira/browse/ZOOKEEPER-2775
             // https://curator.apache.org/zk-compatibility.html

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/exceptions/HandshakeException.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/exceptions/HandshakeException.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.execution.exceptions;
+
+/**
+ * Failure to handshake with server.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class HandshakeException extends Exception {
+
+    /**
+     * Constructor with message.
+     *
+     * @param message a message
+     */
+    public HandshakeException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor with message and cause.
+     *
+     * @param message a message
+     * @param cause   a cause
+     */
+    public HandshakeException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/AgentJobService.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/AgentJobService.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.agent.execution.services;
 
 import com.netflix.genie.agent.execution.exceptions.ChangeJobStatusException;
+import com.netflix.genie.agent.execution.exceptions.HandshakeException;
 import com.netflix.genie.agent.execution.exceptions.JobIdUnavailableException;
 import com.netflix.genie.agent.execution.exceptions.JobReservationException;
 import com.netflix.genie.agent.execution.exceptions.JobSpecificationResolutionException;
@@ -39,6 +40,16 @@ import javax.validation.constraints.NotBlank;
 @Validated
 public interface AgentJobService {
 
+    /**
+     * Perform server handshake. Before going any further, ensure the server is reachable and that this agent is
+     * compatible with it.
+     *
+     * @param agentClientMetadata metadata about the client making this request
+     * @throws HandshakeException if the server rejects this client
+     */
+    void handshake(
+        @Valid AgentClientMetadata agentClientMetadata
+    ) throws HandshakeException;
 
     /**
      * Request a given job id to be reserved for this job, send along the job details, to be persisted by the server.

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/actions/StateMachineActionsAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/actions/StateMachineActionsAutoConfiguration.java
@@ -88,12 +88,18 @@ public class StateMachineActionsAutoConfiguration {
      * Provide a lazy {@link InitializeAction} bean.
      *
      * @param executionContext The job execution context to use
+     * @param agentJobService  The agent job service to use
+     * @param agentMetadata    The agent metadata to use
      * @return An {@link InitializeAction} instance
      */
     @Bean
     @Lazy
-    public InitializeAction initializeAction(final ExecutionContext executionContext) {
-        return new InitializeAction(executionContext);
+    public InitializeAction initializeAction(
+        final ExecutionContext executionContext,
+        final AgentJobService agentJobService,
+        final AgentMetadata agentMetadata
+    ) {
+        return new InitializeAction(executionContext, agentJobService, agentMetadata);
     }
 
     /**

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/exceptions/AgentExecutionExceptionsSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/exceptions/AgentExecutionExceptionsSpec.groovy
@@ -52,6 +52,7 @@ class AgentExecutionExceptionsSpec extends Specification {
         JobIdUnavailableException.class           | true
         JobReservationException.class             | true
         ChangeJobStatusException.class            | true
+        HandshakeException.class                  | true
         InvalidStateException.class               | false
     }
 }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/actions/InitializeActionSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/actions/InitializeActionSpec.groovy
@@ -18,9 +18,12 @@
 
 package com.netflix.genie.agent.execution.statemachine.actions
 
+import com.netflix.genie.agent.AgentMetadata
 import com.netflix.genie.agent.execution.ExecutionContext
-
+import com.netflix.genie.agent.execution.exceptions.HandshakeException
+import com.netflix.genie.agent.execution.services.AgentJobService
 import com.netflix.genie.agent.execution.statemachine.Events
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata
 import com.netflix.genie.test.categories.UnitTest
 import org.junit.experimental.categories.Category
 import spock.lang.Specification
@@ -28,11 +31,21 @@ import spock.lang.Specification
 @Category(UnitTest.class)
 class InitializeActionSpec extends Specification {
     ExecutionContext executionContext
+    AgentJobService agentJobService
+    AgentMetadata agentMetadata
     String agentId
+    String hostname = "123.123.123.123"
+    String version = "1.2.3"
+    int pid = 12345
 
     void setup() {
         this.executionContext = Mock(ExecutionContext)
+        this.agentJobService = Mock(AgentJobService)
+        this.agentMetadata = Mock(AgentMetadata)
         this.agentId = UUID.randomUUID().toString()
+        this.hostname = "123.123.123.123"
+        this.version = "1.2.3"
+        this.pid = 12345
     }
 
     void cleanup() {
@@ -40,10 +53,43 @@ class InitializeActionSpec extends Specification {
 
     def "Initialize"() {
         setup:
-        InitializeAction action = new InitializeAction(executionContext)
+        InitializeAction action = new InitializeAction(executionContext, agentJobService, agentMetadata)
+        AgentClientMetadata agentClientMetadataCapture
+
         when:
         def event = action.executeStateAction(executionContext)
+
         then:
+        1 * agentMetadata.getAgentHostName() >> hostname
+        1 * agentMetadata.getAgentVersion() >> version
+        1 * agentMetadata.getAgentPid() >> String.valueOf(pid)
+        1 * agentJobService.handshake(_ as AgentClientMetadata) >> {
+            args -> agentClientMetadataCapture = args[0]
+        }
+        agentClientMetadataCapture.getHostname().get() == hostname
+        agentClientMetadataCapture.getVersion().get() == version
+        agentClientMetadataCapture.getPid().get() == pid
+
         event == Events.INITIALIZE_COMPLETE
     }
+
+    def "Rejected via handshake"() {
+        setup:
+        InitializeAction action = new InitializeAction(executionContext, agentJobService, agentMetadata)
+        Exception exception = new HandshakeException("Client rejected")
+
+        when:
+        def e = action.executeStateAction(executionContext)
+
+        then:
+        1 * agentMetadata.getAgentHostName() >> hostname
+        1 * agentMetadata.getAgentVersion() >> version
+        1 * agentMetadata.getAgentPid() >> String.valueOf(pid)
+        1 * agentJobService.handshake(_ as AgentClientMetadata) >> {
+            throw exception
+        }
+        e = thrown(RuntimeException)
+        e.getCause() == exception
+    }
+
 }

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/converters/JobServiceProtoConverter.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/converters/JobServiceProtoConverter.java
@@ -40,6 +40,7 @@ import com.netflix.genie.proto.ChangeJobStatusRequest;
 import com.netflix.genie.proto.ClaimJobRequest;
 import com.netflix.genie.proto.DryRunJobSpecificationRequest;
 import com.netflix.genie.proto.ExecutionResource;
+import com.netflix.genie.proto.HandshakeRequest;
 import com.netflix.genie.proto.JobSpecificationRequest;
 import com.netflix.genie.proto.JobSpecificationResponse;
 import com.netflix.genie.proto.ReserveJobIdRequest;
@@ -240,6 +241,23 @@ public class JobServiceProtoConverter {
             .setCurrentStatus(currentJobStatus.name())
             .setNewStatus(newJobStatus.name())
             .setNewStatusMessage(message == null ? "" : message)
+            .build();
+    }
+
+    /**
+     * Convert parameters into HandshakeRequest for the server.
+     *
+     * @param agentClientMetadata agent client metadata
+     * @return a {@link HandshakeRequest}
+     * @throws GenieConversionException if the inputs are invalid
+     */
+    public HandshakeRequest toHandshakeRequest(
+        final AgentClientMetadata agentClientMetadata
+    ) throws GenieConversionException {
+        return HandshakeRequest.newBuilder()
+            .setAgentMetadata(
+                toProtoAgentMetadata(agentClientMetadata)
+            )
             .build();
     }
 

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/exceptions/unchecked/GenieAgentRejectedException.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/exceptions/unchecked/GenieAgentRejectedException.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.exceptions.unchecked;
+
+/**
+ * An exception to represent the case where an Agent was rejected by the server.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class GenieAgentRejectedException extends GenieRuntimeException {
+    /**
+     * Constructor.
+     */
+    public GenieAgentRejectedException() {
+        super();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message The detail message
+     */
+    public GenieAgentRejectedException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message The detail message
+     * @param cause   The root cause of this exception
+     */
+    public GenieAgentRejectedException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cause The root cause of this exception
+     */
+    public GenieAgentRejectedException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/converters/JobServiceProtoConverterSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/converters/JobServiceProtoConverterSpec.groovy
@@ -35,6 +35,7 @@ import com.netflix.genie.proto.AgentConfig
 import com.netflix.genie.proto.AgentMetadata
 import com.netflix.genie.proto.DryRunJobSpecificationRequest
 import com.netflix.genie.proto.ExecutionResource
+import com.netflix.genie.proto.HandshakeRequest
 import com.netflix.genie.proto.JobArchivalData
 import com.netflix.genie.proto.JobSpecificationResponse
 import com.netflix.genie.proto.ReserveJobIdRequest
@@ -395,6 +396,20 @@ class JobServiceProtoConverterSpec extends Specification {
         currentStatus == JobStatus.parse(changeJobStatusRequest.getCurrentStatus())
         newStatus == JobStatus.parse(changeJobStatusRequest.getNewStatus())
         message == changeJobStatusRequest.getNewStatusMessage()
+    }
+
+    def "Can convert AgentClientMetadata to HandshakeRequest"() {
+        AgentClientMetadata agentClientMetatada = createAgentClientMetadata()
+
+        when:
+        HandshakeRequest handshakeRequest = converter.toHandshakeRequest(agentClientMetatada)
+
+        then:
+        AgentMetadata agentMetadata = handshakeRequest.getAgentMetadata()
+        agentMetadata != null
+        agentMetadata.getAgentHostname() == agentHostname
+        agentMetadata.getAgentVersion() == agentVersion
+        agentMetadata.getAgentPid() == agentPid
     }
 
     AgentJobRequest createJobRequest(String id, String archiveLocationPrefix) {

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/exceptions/unchecked/GenieAgentRejectedExceptionSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/exceptions/unchecked/GenieAgentRejectedExceptionSpec.groovy
@@ -1,0 +1,63 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.exceptions.unchecked
+
+import spock.lang.Specification
+
+/**
+ * Specifications for the {@link GenieAgentRejectedException} class.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+class GenieAgentRejectedExceptionSpec extends Specification {
+
+    def "Can construct"() {
+        String message = UUID.randomUUID().toString()
+        Throwable cause = new Exception()
+        GenieAgentRejectedException exception
+
+        when:
+        exception = new GenieAgentRejectedException()
+
+        then:
+        exception.getMessage() == null
+        exception.getCause() == null
+
+        when:
+        exception = new GenieAgentRejectedException(message)
+
+        then:
+        exception.getMessage() == message
+        exception.getCause() == null
+
+        when:
+        exception = new GenieAgentRejectedException(message, cause)
+
+        then:
+        exception.getMessage() == message
+        exception.getCause() == cause
+
+        when:
+        exception = new GenieAgentRejectedException(cause)
+
+        then:
+        exception.getMessage() == cause.toString()
+        exception.getCause() == cause
+    }
+}

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -463,6 +463,12 @@ published within the local JVM and available on the Actuator `/metrics` endpoint
 |HealthCheckMetricsAspect
 |status, exceptionClass, healthIndicatorName
 
+|genie.services.agentJob.handshake.counter
+|Counter for calls to the 'handshake' protocol of the Genie Agent Job Service
+|count
+|AgentJobServiceImpl
+|status, exceptionClass, agentVersion, agentHost, handshakeDecision
+
 |===
 
 (*) Source may add additional tags on a case-by-case basis

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -23,6 +23,22 @@ that isn't listed in this map the default credentials configured will be used
 no value is specified the bucket is assumed to be in the same region as the Genie process.
 |
 
+|genie.agent.filter.enabled
+|If set to `true`, enables the built-in agent filter service. The filter behavior is controlled by other active `genie.agent.filter.*` properties.
+|
+
+|genie.agent.filter.version.minimum
+|(Dynamic) The minimum version an agent needs to be (e.g., `1.2.3`) in order to communicate with this server. The filter needs to be enabled for this to take effect.
+|
+
+|genie.agent.filter.version.blacklist
+|(Dynamic) A regex matched against agent version (e.g., `1\.2\..*`), matching agents are rejected. The filter needs to be enabled for this to take effect.
+|
+
+|genie.agent.filter.version.whitelist
+|(Dynamic) A regex matched against agent version (e.g., `1\.2\..*`), agents not matching are rejected. The filter needs to be enabled for this to take effect.
+|
+
 |genie.aws.credentials.role
 |The AWS role ARN to assume when connecting to S3. If this is set Genie will create a credentials provider that will
 attempt to assume this role on the host Genie is running on

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -10,336 +10,416 @@ The Spring properties described here are ones that we have overridden from Sprin
 
 ==== Genie Properties
 
+Properties marked 'dynamic' reflect change of property value in the environment happening at runtime.
+Whereas static properties values are bound during application startup and do not change after the application is up and running.
+
 |===
-|Property |Description| Default Value
+|Property |Description |Default Value |Dynamic
 
 |genie.aws.s3.buckets.[bucketName].roleARN
 |For the bucket with name `bucketName` the ARN of the role to assume to read/write to that bucket. If a bucket is used
 that isn't listed in this map the default credentials configured will be used
 |
+|no
 
 |genie.aws.s3.buckets.[bucketName].region
 |The AWS region the bucket with `bucketName` is in. Clients to talk to this bucket will be created in this region. If
 no value is specified the bucket is assumed to be in the same region as the Genie process.
 |
+|no
 
 |genie.agent.filter.enabled
 |If set to `true`, enables the built-in agent filter service. The filter behavior is controlled by other active `genie.agent.filter.*` properties.
 |
+|no
 
 |genie.agent.filter.version.minimum
-|(Dynamic) The minimum version an agent needs to be (e.g., `1.2.3`) in order to communicate with this server. The filter needs to be enabled for this to take effect.
+|The minimum version an agent needs to be (e.g., `1.2.3`) in order to communicate with this server. The filter needs to be enabled for this to take effect.
 |
+|yes
 
 |genie.agent.filter.version.blacklist
-|(Dynamic) A regex matched against agent version (e.g., `1\.2\..*`), matching agents are rejected. The filter needs to be enabled for this to take effect.
+|A regex matched against agent version (e.g., `1\.2\..*`), matching agents are rejected. The filter needs to be enabled for this to take effect.
 |
+|yes
 
 |genie.agent.filter.version.whitelist
-|(Dynamic) A regex matched against agent version (e.g., `1\.2\..*`), agents not matching are rejected. The filter needs to be enabled for this to take effect.
+|A regex matched against agent version (e.g., `1\.2\..*`), agents not matching are rejected. The filter needs to be enabled for this to take effect.
 |
+|yes
 
 |genie.aws.credentials.role
 |The AWS role ARN to assume when connecting to S3. If this is set Genie will create a credentials provider that will
 attempt to assume this role on the host Genie is running on
 |
+|no
 
 |genie.file.cache.location
 |Where to store cached files on local disk
 |file:///tmp/genie/cache
+|no
 
 |genie.grpc.server.enabled
 |Whether to start the gRPC server and services during server startup
 |true
+|no
 
 |genie.grpc.server.services.job-file-sync.ackIntervalMilliseconds
 |How many milliseconds to wait between checks whether some acknowledgement should be sent to the agent regardless of
 whether the `maxSyncMessages` threshold has been reached or not
 |30,000
+|no
 
 |genie.grpc.server.services.job-file-sync.maxSyncMessages
 |How many messages to receive from the agent before an acknowledgement message is sent back from the server
 |10
+|no
 
 |genie.health.maxCpuLoadConsecutiveOccurrences
 |Defines the threshold of consecutive occurrences of CPU load crossing the <maxCpuLoadPercent>.
 Health of the system is marked unhealthy if the CPU load of a system goes beyond the threshold 'maxCpuLoadPercent'
 for 'maxCpuLoadConsecutiveOccurrences' consecutive times.
 |3
+|no
 
 |genie.health.maxCpuLoadPercent
 |Defines the threshold for the maximum CPU load percentage to consider for an instance to be unhealthy.
 Health of the system is marked unhealthy if the CPU load of a system goes beyond this threshold for
 'maxCpuLoadConsecutiveOccurrences' consecutive times.
 |80
+|no
 
 |genie.http.connect.timeout
 |The number of milliseconds before HTTP calls between Genie nodes should time out on connection
 |2000
+|no
 
 |genie.http.read.timeout
 |The number of milliseconds before HTTP calls between Genie nodes should time out on attempting to read data
 |10000
+|no
 
 |genie.jobs.cleanup.deleteDependencies
 |Whether or not to delete the dependencies directories for applications, cluster, command to save disk space after job completion
 |true
+|no
 
 |genie.jobs.clusters.load-balancers.script.destination
 |The location on disk where the script source file should be stored after it is downloaded from
 `genie.jobs.clusters.load-balancers.script.source`. The file will be given the same name.
 |file:///tmp/genie/loadbalancers/script/destination/
+|no
 
 |genie.jobs.clusters.load-balancers.script.enabled
 |Whether the script based load balancer should be enabled for the system or not.
 See also: `genie.jobs.clusters.load-balancers.script.source`
 See also: `genie.jobs.clusters.load-balancers.script.destination`
 |false
+|no
 
 |genie.jobs.clusters.load-balancers.script.refreshRate
 |How frequently to refresh the load balancer script (in milliseconds)
 |300000
+|no
 
 |genie.jobs.clusters.load-balancers.script.source
 |The location of the script the load balancer should load to evaluate which cluster to use for a job request
 |file:///tmp/genie/loadBalancers/script/source/loadBalance.js
+|no
 
 |genie.jobs.clusters.load-balancers.script.timeout
 |The amount of time (in milliseconds) that the system will attempt to run the cluster load balancer script before it
 forces a timeout
 |5000
+|no
 
 |genie.jobs.forwarding.enabled
 |Whether or not to attempt to forward kill and get output requests for jobs
 |true
+|no
 
 |genie.jobs.forwarding.port
 |The port to forward requests to as it could be different than ELB port
 |8080
+|no
 
 |genie.jobs.forwarding.scheme
 |The connection protocol to use (http or https)
 |http
+|no
 
 |genie.jobs.locations.archives
 |The default root location where job archives should be stored. Scheme should be included. Created if doesn't exist.
 |file:///tmp/genie/archives/
+|no
 
 |genie.jobs.locations.attachments
 |The default root location where job attachments will be temporarily stored. Scheme should be included. Created if
 doesn't exist.
 |file:///tmp/genie/attachments/
+|no
 
 |genie.jobs.locations.jobs
 |The default root location where job working directories will be placed. Created by system if doesn't exist.
 |file:///tmp/genie/jobs/
+|no
 
 |genie.jobs.max.stdOutSize
 |The maximum number of bytes the job standard output file can grow to before Genie will kill the job
 |8589934592
+|no
 
 |genie.jobs.max.stdErrSize
 |The maximum number of bytes the job standard error file can grow to before Genie will kill the job
 |8589934592
+|no
 
 |genie.jobs.memory.maxSystemMemory
 |The total number of MB out of the system memory that Genie can use for running jobs
 |30720
+|no
 
 |genie.jobs.memory.defaultJobMemory
 |The total number of megabytes Genie will assume a job is allocated if not overridden by a command or user at runtime
 |1024
+|no
 
 |genie.jobs.memory.maxJobMemory
 |The maximum amount of memory, in megabytes, that a job client can be allocated
 |10240
+|no
 
 |genie.jobs.users.creationEnabled
 |Whether Genie should attempt to create a system user in order to run the job as or not. Genie user must have sudo
 rights for this to work.
 |false
+|no
 
 |genie.jobs.users.runAsUserEnabled
 |Whether Genie should run the jobs as the user who submitted the job or not. Genie user must have sudo rights for this
 to work.
 |false
+|no
 
 |genie.jobs.active-limit.enabled
 |Enables the per-user active job limit. The number of jobs is controlled by the `genie.jobs.users.active-limit.count` property.
 |false
+|no
 
 |genie.jobs.active-limit.count
 |The maximum number of active jobs a user is allowed to have. Once a user hits this limit, jobs submitted are rejected. This is property is ignored unless `genie.jobs.users.active-limit.enabled` is set to true. This limit applies to users that don't have an override set via `genie.jobs.users.active-limit.overrides.<user-name>`.
 |100
+|no
 
 |genie.jobs.active-limit.overrides.<user-name>
-|(Dynamic) The maximum number of active jobs that user 'user-name' is allowed to have. This is property is ignored unless `genie.jobs.users.active-limit.enabled` is set to true.
+|The maximum number of active jobs that user 'user-name' is allowed to have. This is property is ignored unless `genie.jobs.users.active-limit.enabled` is set to true.
 |-
+|yes
 
 |genie.jobs.completion-check-back-off.min-interval
 |The minimum time between checks for job completion in milliseconds. Must be greater than zero.
 |100
+|no
 
 |genie.jobs.completion-check-back-off.max-interval
 |The maximum time between checks for job completion in milliseconds. This is a fallback value, the value used in most cases is specified as part of the `Command` entity for a particular job.
 |10000
+|no
 
 |genie.jobs.completion-check-back-off.factor
 |Multiplication factor that grows the delay between checks for job completions. Must be greater than 1.
 |1.2
+|no
 
 |genie.leader.enabled
 |Whether this node should be the leader of the cluster or not. Should only be used if leadership is not being
 determined by Zookeeper or other mechanism via Spring
 |false
+|no
 
 |genie.mail.fromAddress
 |The e-mail address that should be used as the from address when alert emails are sent
 |no-reply-genie@geniehost.com
+|no
 
 |genie.mail.user
 |The user to log into the e-mail server with
 |
+|no
 
 |genie.mail.password
 |The password for the e-mail server
 |
+|no
 
 |genie.redis.enabled
 |Whether to enable storage of HTTP sessions inside Redis via http://projects.spring.io/spring-session/[Spring Session]
 |false
+|no
 
 |genie.retry.initialInterval
 |The amount of time to wait after initial failure before retrying the first time in milliseconds
 |10000
+|no
 
 |genie.retry.maxInterval
 |The maximum amount of time to wait between retries for the final retry in the back-off policy
 |60000
+|no
 
 |genie.retry.noOfRetries
 |The number of times to retry requests to before failure
 |5
+|no
 
 |genie.retry.s3.noOfRetries
 |The number of times to retry requests to S3 before failure
 |5
+|no
 
 |genie.security.oauth2.enabled
 |Whether to enable oauth2 based security or not for REST APIs
 |false
+|no
 
 |genie.security.oauth2.pingfederate.enabled
 |Whether Ping Federate is being used as the OAuth2 server and Genie should assume default configuration for its tokens
 |false
+|no
 
 |genie.security.oauth2.pingfederate.jwt.enabled
 |Whether to assume that the bearer tokens coming with API requests are https://jwt.io/[JWT] tokens or not
 |false
+|no
 
 |genie.security.oauth2.pingfederate.jwt.keyValue
 |The public key used to verify the JWT signature
 |
+|no
 
 |genie.security.saml.enabled
 |Whether SAML security should be turned on to protect access to the user interface
 |false
+|no
 
 |genie.security.saml.attributes.user
 |The key in the SAML assertion to get the user name from
 |
+|no
 
 |genie.security.saml.attributes.groups.name
 |The key in the SAML assertion to get group information for the user from
 |
+|no
 
 |genie.security.saml.attributes.groups.admin
 |The group a user needs to be a member of in order to be granted an admin role
 |
+|no
 
 |genie.security.saml.idp.serviceProviderMetadataUrl
 |The URL where metadata for Genie service SAML configuration can be pulled from
 |
+|no
 
 |genie.security.saml.keystore.name
 |The name of the keystore file on the classpath for SAML assertions
 |
+|no
 
 |genie.security.saml.keystore.password
 |The password for opening the keystore
 |
+|no
 
 |genie.security.saml.keystore.defaultKey.name
 |The name of the default key to use for signing the SAML request
 |
+|no
 
 |genie.security.saml.keystore.defaultKey.password
 |The password to open the default key
 |
+|no
 
 |genie.security.saml.loadBalancer.contextPath
 |The context path for Genie
 |/
+|no
 
 |genie.security.saml.loadBalancer.includeServerPortInRequestURL
 |Whether or not to include the port of the load balancer in the redirect request
 |false
+|no
 
 |genie.security.saml.loadBalancer.scheme
 |The scheme the load balancer Genie cluster is run behind uses (http or https). Used for SAML post back
 |
+|no
 
 |genie.security.saml.loadBalancer.serverName
 |Root context for the Genie load balancer e.g. genie.prod.com
 |
+|no
 
 |genie.security.saml.loadBalancer.serverPort
 |The port the load balancer is listening on. Used for SAML post back
 |
+|no
 
 |genie.security.saml.sp.entityId
 |The id that Genie is identified by in the identity provider
 |
+|no
 
 |genie.security.saml.sp.entityBaseURL
 |Where the SAML assertion should be posted back to. e.g. https://genie.prod.com
 |
+|no
 
 |genie.security.x509.enabled
 |Whether to enable x509 certificate security on the REST APIs
 |false
+|no
 
 |genie.swagger.enabled
 |Whether to enable http://swagger.io/[Swagger] to be bootstrapped into the Genie service so that the endpoint
 /swagger-ui.html shows API documentation generated by the swagger specification
 |false
+|no
 
 |genie.tasks.cluster-checker.healthIndicatorsToIgnore
 |The health indicator groups from the actuator /health endpoint to ignore when determining if a node is lost or not as
 a comma separated list
 |memory,genieMemory,discoveryComposite
+|no
 
 |genie.tasks.cluster-checker.lostThreshold
 |The number of times a Genie nodes need to fail health check in order for jobs running on that node to be marked as
 lost and failed by the Genie leader
 |3
+|no
 
 |genie.tasks.cluster-checker.port
 |The port to connect to other Genie nodes on
 |8080
+|no
 
 |genie.tasks.cluster-checker.rate
 |The number of milliseconds to wait between health checks to other Genie nodes
 |300000
+|no
 
 |genie.tasks.cluster-checker.scheme
 |The scheme (http or https) for connecting to other Genie nodes
 |http
+|no
 
 |genie.tasks.database-cleanup.enabled
 |Whether or not to delete old and unused records from the database at a scheduled interval.
 See: `genie.tasks.database-cleanup.expression`
 |true
+|no
 
 |genie.tasks.database-cleanup.maxDeletedPerTransaction
 |The number of job records (across multiple tables) to delete from the database
@@ -347,64 +427,79 @@ See: `genie.tasks.database-cleanup.expression`
  all jobs older than the retention time are deleted.
  This is a soft limit, it could be rounded up to the next multiple of page size.
 |1000
+|no
 
 |genie.tasks.database-cleanup.pageSize
 |The page size used within each cleanup transaction to iterate through the job records
 |1000
+|no
 
 |genie.tasks.database-cleanup.expression
 |The cron expression for how often to run the database cleanup task
 |0 0 0 * * *
+|no
 
 |genie.tasks.database-cleanup.retention
 |The number of days to retain jobs in the database
 |90
+|no
 
 |genie.tasks.database-cleanup.skipJobsCleanup
 |Skip the Jobs table when performing database cleanup
 |false
+|no
 
 |genie.tasks.database-cleanup.skipClustersCleanup
 |Skip the Clusters table when performing database cleanup
 |false
+|no
 
 |genie.tasks.database-cleanup.skipFilesCleanup
 |Skip the Files table when performing database cleanup
 |false
+|no
 
 |genie.tasks.database-cleanup.skipTagsCleanup
 |Skip the Tags table when performing database cleanup
 |false
+|no
 
 |genie.tasks.disk-cleanup.enabled
 |Whether or not to remove old job directories on the Genie node or not
 |true
+|no
 
 |genie.tasks.disk-cleanup.expression
 |How often to run the disk cleanup task as a cron expression
 |0 0 0 * * *
+|no
 
 |genie.tasks.disk-cleanup.retention
 |The number of days to leave old job directories on disk
 |3
+|no
 
 |genie.tasks.executor.pool.size
 |The number of executor threads available for tasks to be run on within the node in an adhoc manner. Best to set to the
 number of CPU cores x 2 + 1
 |1
+|no
 
 |genie.tasks.scheduler.pool.size
 |The number of available threads for the scheduler to use to run tasks on the node at scheduled intervals. Best to set
 to the number of CPU cores x 2 + 1
 |1
+|no
 
 |genie.zookeeper.leader.path
 |The namespace to use for Genie leadership election of a given cluster
 |/genie/leader/
+|no
 
 |genie.s3filetransfer.strictUrlCheckEnabled
 |Whether to strictly check an S3 URL for illegal characters before attempting to use it
 |false
+|no
 
 |===
 

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -173,6 +173,16 @@ the user wants at runtime via a Spring bean definition.
 
 Switched to http://micrometer.io/[Micrometer]
 
+==== Added
+
+|===
+|Name |Reason
+
+|genie.services.agentJob.handshake.counter
+|Count usages of 'handshake' protocol, record agent metadata and decision made
+
+|===
+
 ==== Renamed
 
 |===

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -84,6 +84,22 @@ whether the `maxSyncMessages` threshold has been reached or not
 |Whether Spring data repositories are enabled on top of redis as the backend store
 |false
 
+|genie.agent.filter.enabled
+|If set to `true`, enables the built-in agent filter service. The filter behavior is controlled by other active `genie.agent.filter.*` properties.
+|
+
+|genie.agent.filter.version.minimum
+|(Dynamic) The minimum version an agent needs to be (e.g., `1.2.3`) in order to communicate with this server. The filter needs to be enabled for this to take effect.
+|
+
+|genie.agent.filter.version.blacklist
+|(Dynamic) A regex matched against agent version (e.g., `1\.2\..*`), matching agents are rejected. The filter needs to be enabled for this to take effect.
+|
+
+|genie.agent.filter.version.whitelist
+|(Dynamic) A regex matched against agent version (e.g., `1\.2\..*`), agents not matching are rejected. The filter needs to be enabled for this to take effect.
+|
+
 |===
 
 ==== Renamed

--- a/genie-proto/src/main/proto/genie.proto
+++ b/genie-proto/src/main/proto/genie.proto
@@ -33,6 +33,7 @@ message PongResponse {
 
 // Job Service
 service JobService {
+    rpc handshake (HandshakeRequest) returns (HandshakeResponse);
     rpc reserveJobId (ReserveJobIdRequest) returns (ReserveJobIdResponse);
     rpc resolveJobSpecification (JobSpecificationRequest) returns (JobSpecificationResponse);
     rpc getJobSpecification (JobSpecificationRequest) returns (JobSpecificationResponse);
@@ -79,6 +80,22 @@ message AgentConfig {
 
 message JobArchivalData {
     string requested_archive_location_prefix = 1;
+}
+
+message HandshakeRequest {
+    AgentMetadata agent_metadata = 1;
+}
+
+message HandshakeResponse {
+    enum Type {
+      UNKNOWN = 0;
+      ALLOWED = 1;
+      REJECTED = 2;
+      SERVER_ERROR = 3;
+      INVALID_REQUEST = 4;
+    }
+    Type type = 1;
+    string message = 2;
 }
 
 message ReserveJobIdRequest {

--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     compile("org.springframework.cloud:spring-cloud-starter-zookeeper")
     compile("org.springframework.integration:spring-integration-zookeeper")
     compile("org.springframework.retry:spring-retry")
+    compile("org.apache.maven:maven-artifact") {
+      transitive = false
+    }
 
     /*******************************
      * Provided Dependencies

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/GenieAgentFilterAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/GenieAgentFilterAutoConfiguration.java
@@ -1,0 +1,115 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.configs;
+
+import com.netflix.genie.web.properties.AgentFilterProperties;
+import com.netflix.genie.web.services.AgentFilterService;
+import com.netflix.genie.web.services.impl.AgentFilterServiceImpl;
+import com.netflix.genie.web.util.AgentMetadataInspector;
+import com.netflix.genie.web.util.BlacklistedVersionAgentMetadataInspector;
+import com.netflix.genie.web.util.MinimumVersionAgentMetadataInspector;
+import com.netflix.genie.web.util.WhitelistedVersionAgentMetadataInspector;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * Auto-configuration for the {@link AgentFilterService} default implementation.
+ * This component is activated unless another bean is present AND if the corresponding property is set to true.
+ * <p>
+ * This configuration also creates a set of pre-configured {@link AgentMetadataInspector} that the
+ * service loads and uses:
+ * - Version whitelist: accept agent only if version matches a given pattern
+ * - Version blacklist: reject agent if version matches a given pattern
+ * - Minimum version: reject agent whose version is lower than a given version
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Configuration
+@ConditionalOnProperty(value = AgentFilterProperties.VERSION_FILTER_ENABLED_PROPERTY, havingValue = "true")
+@EnableConfigurationProperties(
+    {
+        AgentFilterProperties.class,
+    }
+)
+public class GenieAgentFilterAutoConfiguration {
+
+    /**
+     * A {@link AgentFilterService} implementation that federates the decision to a set of
+     * {@link AgentMetadataInspector}s.
+     *
+     * @param agentMetadataInspectorsList the list of inspectors.
+     * @return An {@link AgentFilterService} instance.
+     */
+    @Bean
+    public AgentFilterService agentFilterService(
+        final List<AgentMetadataInspector> agentMetadataInspectorsList
+    ) {
+        return new AgentFilterServiceImpl(agentMetadataInspectorsList);
+    }
+
+    /**
+     * A {@link AgentMetadataInspector} that only accepts agents whose version matches a given regex.
+     *
+     * @param agentFilterProperties the agent filter properties
+     * @return a {@link AgentMetadataInspector}
+     */
+    @Bean
+    public AgentMetadataInspector whitelistedVersionAgentMetadataInspector(
+        final AgentFilterProperties agentFilterProperties
+    ) {
+        return new WhitelistedVersionAgentMetadataInspector(
+            agentFilterProperties
+        );
+    }
+
+    /**
+     * A {@link AgentMetadataInspector} that rejects agents whose version matches a given regex.
+     *
+     * @param agentFilterProperties the agent filter properties
+     * @return a {@link AgentMetadataInspector}
+     */
+    @Bean
+    public AgentMetadataInspector blacklistedVersionAgentMetadataInspector(
+        final AgentFilterProperties agentFilterProperties
+    ) {
+        return new BlacklistedVersionAgentMetadataInspector(
+            agentFilterProperties
+        );
+    }
+
+    /**
+     * A {@link AgentMetadataInspector} that rejects agents whose version is lower than a given version.
+     *
+     * @param agentFilterProperties the agent filter properties
+     * @return a {@link AgentMetadataInspector}
+     */
+    @Bean
+    public AgentMetadataInspector minimumVersionAgentMetadataInspector(
+        final AgentFilterProperties agentFilterProperties
+    ) {
+        return new MinimumVersionAgentMetadataInspector(
+            agentFilterProperties
+        );
+    }
+
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/GenieServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/GenieServicesAutoConfiguration.java
@@ -36,6 +36,7 @@ import com.netflix.genie.web.properties.JobsMemoryProperties;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.properties.JobsUsersProperties;
 import com.netflix.genie.web.services.AgentConnectionPersistenceService;
+import com.netflix.genie.web.services.AgentFilterService;
 import com.netflix.genie.web.services.AgentJobService;
 import com.netflix.genie.web.services.AgentRoutingService;
 import com.netflix.genie.web.services.ApplicationPersistenceService;
@@ -67,6 +68,7 @@ import com.netflix.genie.web.services.impl.JobSpecificationServiceImpl;
 import com.netflix.genie.web.services.impl.LocalFileTransferImpl;
 import com.netflix.genie.web.services.impl.LocalJobRunner;
 import com.netflix.genie.web.tasks.job.JobCompletionService;
+import com.netflix.genie.web.util.InspectionReport;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.exec.Executor;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -343,6 +345,7 @@ public class GenieServicesAutoConfiguration {
      *
      * @param jobPersistenceService   The persistence service to use
      * @param jobSpecificationService The specification service to use
+     * @param agentFilterService      The agent filter service to use
      * @param meterRegistry           The metrics registry to use
      * @return An {@link AgentJobServiceImpl} instance.
      */
@@ -351,11 +354,13 @@ public class GenieServicesAutoConfiguration {
     public AgentJobService agentJobService(
         final JobPersistenceService jobPersistenceService,
         final JobSpecificationService jobSpecificationService,
+        final AgentFilterService agentFilterService,
         final MeterRegistry meterRegistry
     ) {
         return new AgentJobServiceImpl(
             jobPersistenceService,
             jobSpecificationService,
+            agentFilterService,
             meterRegistry
         );
     }
@@ -458,6 +463,21 @@ public class GenieServicesAutoConfiguration {
             registry,
             jobsProperties,
             retryTemplate
+        );
+    }
+
+    /**
+     * Get a NOOP/fallback {@link AgentFilterService} instance if there isn't already one.
+     *
+     * @see GenieAgentFilterAutoConfiguration
+     * @return An {@link AgentFilterService} instance.
+     */
+    @Bean
+    @ConditionalOnMissingBean(AgentFilterService.class)
+    public AgentFilterService agentFilterService() {
+        return agentClientMetadata -> new InspectionReport(
+            InspectionReport.Decision.ACCEPT,
+            "Accepted by default"
         );
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/AgentFilterProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/AgentFilterProperties.java
@@ -1,0 +1,98 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.validation.annotation.Validated;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Properties for the {@link com.netflix.genie.web.services.AgentFilterService}.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@ConfigurationProperties
+@Validated
+public class AgentFilterProperties implements EnvironmentAware {
+
+    private static final String PROPERTY_PREFIX = "genie.agent.filter";
+
+    /**
+     * Property that enables the default implementation of {@link com.netflix.genie.web.services.AgentFilterService}.
+     */
+    public static final String VERSION_FILTER_ENABLED_PROPERTY = PROPERTY_PREFIX + ".enabled";
+    private static final String MINIMUM_VERSION_PROPERTY = PROPERTY_PREFIX + ".version.minimum";
+    private static final String BLACKLISTED_VERSION_REGEX_PROPERTY = PROPERTY_PREFIX + ".version.blacklist";
+    private static final String WHITELISTED_VERSION_REGEX_PROPERTY = PROPERTY_PREFIX + ".version.whitelist";
+
+    private AtomicReference<Environment> environment = new AtomicReference<>();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setEnvironment(final Environment environment) {
+        this.environment.set(environment);
+    }
+
+    /**
+     * Get the (dynamic) property value representing the minimum agent version allowed to connect.
+     *
+     * @return a version string or null if a minimum is not active
+     */
+    @Nullable
+    public String getMinimumVersion() {
+        return getValueOrNull(MINIMUM_VERSION_PROPERTY);
+
+    }
+
+    /**
+     * Get the (dynamic) property value containing a regular expression used to blacklist agent versions.
+     *
+     * @return a string containing a regular expression pattern, or null if one is not set
+     */
+    @Nullable
+    public String getBlacklistedVersions() {
+        return getValueOrNull(BLACKLISTED_VERSION_REGEX_PROPERTY);
+    }
+
+    /**
+     * Get the (dynamic) property value containing a regular expression used to whitelist agent versions.
+     *
+     * @return a string containing a regular expression pattern, or null if one is not set
+     */
+    @Nullable
+    public String getWhitelistedVersions() {
+        return getValueOrNull(WHITELISTED_VERSION_REGEX_PROPERTY);
+    }
+
+    private String getValueOrNull(final String propertyKey) {
+        final Environment env = this.environment.get();
+        if (env != null) {
+            return env.getProperty(propertyKey);
+        }
+        return null;
+    }
+
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/AgentFilterService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/AgentFilterService.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.services;
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
+import com.netflix.genie.web.util.InspectionReport;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+
+/**
+ * Service to block agent/clients that the server wants to refuse service to.
+ * For example, blacklist clients running a deprecated or incompatible versions.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Validated
+public interface AgentFilterService {
+
+    /**
+     * Inspect the Agent metadata and decide whether to allow this client to proceed.
+     *
+     * @param agentClientMetadata the agent client metadata
+     * @return an inspection report
+     */
+    InspectionReport inspectAgentMetadata(@Valid AgentClientMetadata agentClientMetadata);
+
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/AgentJobService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/AgentJobService.java
@@ -21,6 +21,7 @@ import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
 import com.netflix.genie.common.internal.dto.v4.JobRequest;
 import com.netflix.genie.common.internal.dto.v4.JobSpecification;
+import com.netflix.genie.common.internal.exceptions.unchecked.GenieAgentRejectedException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieApplicationNotFoundException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieClusterNotFoundException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieCommandNotFoundException;
@@ -44,6 +45,15 @@ import javax.validation.constraints.NotBlank;
  */
 @Validated
 public interface AgentJobService {
+
+    /**
+     * Shake hands and allow a client or reject it based on the supplied {@link AgentClientMetadata}.
+     *
+     * @param agentMetadata The metadata about the agent starting to run a given job
+     * @throws GenieAgentRejectedException       If the server rejects the client based on its metadata
+     * @throws ConstraintViolationException If the arguments fail validation
+     */
+    void handshake(@Valid AgentClientMetadata agentMetadata);
 
     /**
      * Reserve a job id and persist job details in the database based on the supplied {@link JobRequest}.

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/AgentFilterServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/AgentFilterServiceImpl.java
@@ -1,0 +1,89 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.services.impl;
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
+import com.netflix.genie.web.services.AgentFilterService;
+import com.netflix.genie.web.util.AgentMetadataInspector;
+import com.netflix.genie.web.util.InspectionReport;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.validation.Valid;
+import java.util.List;
+
+/**
+ * Implementation of {@link AgentFilterService} which delegates iterates through an ordered list of
+ * {@link AgentMetadataInspector}. Giving them the chance to accept and reject agents based on their provided
+ * metadata. This filter accepts by default if none of the inspectors rejected.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public class AgentFilterServiceImpl implements AgentFilterService {
+
+    private final List<AgentMetadataInspector> agentMetadataInspectorList;
+
+    /**
+     * Constructor.
+     *
+     * @param agentMetadataInspectorList the list of inspectors to consult
+     */
+    public AgentFilterServiceImpl(
+        final List<AgentMetadataInspector> agentMetadataInspectorList
+    ) {
+        this.agentMetadataInspectorList = agentMetadataInspectorList;
+    }
+
+    /**
+     * Inspect agent metadata and decide to accept or reject it.
+     * This implementation iterates over the given set of {@link AgentMetadataInspector} and stops at the first one
+     * that rejects. If none rejects, then the client is accepted.
+     *
+     * @param agentClientMetadata the agent client metadata
+     * @return an inspection report
+     */
+    @Override
+    public InspectionReport inspectAgentMetadata(@Valid final AgentClientMetadata agentClientMetadata) {
+        for (final AgentMetadataInspector agentMetadataInspector : agentMetadataInspectorList) {
+            final InspectionReport inspectionReport = agentMetadataInspector.inspect(agentClientMetadata);
+            final InspectionReport.Decision decision = inspectionReport.getDecision();
+            final String message = inspectionReport.getMessage();
+
+            log.debug(
+                "Inspector: {} inspected: {}, decision: {} ({})",
+                agentMetadataInspector.getClass().getSimpleName(),
+                agentClientMetadata,
+                decision.name(),
+                message
+            );
+
+            if (decision == InspectionReport.Decision.REJECT) {
+                return InspectionReport.newRejection(
+                    "Rejected by: "
+                        + agentMetadataInspector.getClass().getSimpleName()
+                        + ": "
+                        + message
+                );
+            }
+        }
+
+        return InspectionReport.newAcceptance("All inspections passed");
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/util/AgentMetadataInspector.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/AgentMetadataInspector.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util;
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+
+/**
+ * Component that inspects an Agent client metadata and makes decision on whether it is allowed to proceed.
+ */
+@Validated
+public interface AgentMetadataInspector {
+    /**
+     * Perform inspection of an Agent client metadata.
+     *
+     * @param agentClientMetadata the agent client metadata
+     * @return the inspection outcome
+     */
+    InspectionReport inspect(@Valid AgentClientMetadata agentClientMetadata);
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/util/BaseRegexAgentMetadataInspector.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/BaseRegexAgentMetadataInspector.java
@@ -1,0 +1,91 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Abstract base class for {@link AgentMetadataInspector} based on regex matching.
+ * Can be configure to accept or reject in case of match and do the opposite in case of no match.
+ * If a valid regex is not provided, this inspector accepts.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+abstract class BaseRegexAgentMetadataInspector implements AgentMetadataInspector {
+
+    private final AtomicReference<Pattern> patternReference = new AtomicReference<>();
+    private final InspectionReport.Decision decisionIfMatch;
+    private String lastCompiledPattern;
+
+    BaseRegexAgentMetadataInspector(
+        final InspectionReport.Decision decisionIfMatch
+    ) {
+        this.decisionIfMatch = decisionIfMatch;
+    }
+
+    InspectionReport inspectWithPattern(
+        @Nullable final String currentPatternString,
+        @Nullable final String metadataAttribute
+    ) {
+        final Pattern currentPattern = maybeReloadPattern(currentPatternString);
+
+        if (currentPattern == null) {
+            return InspectionReport.newAcceptance("Pattern not not set");
+        } else if (StringUtils.isBlank(metadataAttribute)) {
+            return InspectionReport.newRejection("Metadata attribute not set");
+        } else if (currentPattern.matcher(metadataAttribute).matches()) {
+            return new InspectionReport(
+                decisionIfMatch,
+                "Attribute: " + metadataAttribute + " matches: " + currentPattern.pattern()
+            );
+        } else {
+            return new InspectionReport(
+                InspectionReport.Decision.flip(decisionIfMatch),
+                "Attribute: " + metadataAttribute + " does not match: " + currentPattern.pattern()
+            );
+        }
+    }
+
+    private Pattern maybeReloadPattern(@Nullable final String currentPatternString) {
+        synchronized (this) {
+            if (StringUtils.isBlank(currentPatternString)) {
+                patternReference.set(null);
+                lastCompiledPattern = null;
+            } else if (!currentPatternString.equals(lastCompiledPattern)) {
+                try {
+                    final Pattern newPattern = Pattern.compile(currentPatternString);
+                    patternReference.set(newPattern);
+                } catch (final PatternSyntaxException e) {
+                    patternReference.set(null);
+                    log.error("Failed to load pattern: {}", currentPatternString, e);
+                }
+                lastCompiledPattern = currentPatternString;
+            }
+        }
+        return patternReference.get();
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/util/BlacklistedVersionAgentMetadataInspector.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/BlacklistedVersionAgentMetadataInspector.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util;
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
+import com.netflix.genie.web.properties.AgentFilterProperties;
+
+import javax.validation.Valid;
+
+/**
+ * An {@link AgentMetadataInspector} that rejects agent whose version matches a regular expression
+ * (obtained via properties) and accepts everything else.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class BlacklistedVersionAgentMetadataInspector extends BaseRegexAgentMetadataInspector {
+
+    private final AgentFilterProperties agentFilterProperties;
+
+    /**
+     * Constructor.
+     * @param agentFilterProperties version filter properties
+     */
+    public BlacklistedVersionAgentMetadataInspector(final AgentFilterProperties agentFilterProperties) {
+        super(InspectionReport.Decision.REJECT);
+        this.agentFilterProperties = agentFilterProperties;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InspectionReport inspect(@Valid final AgentClientMetadata agentClientMetadata) {
+        return super.inspectWithPattern(
+            agentFilterProperties.getBlacklistedVersions(),
+            agentClientMetadata.getVersion().orElse(null)
+        );
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/util/InspectionReport.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/InspectionReport.java
@@ -1,0 +1,82 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Representation of the outcome of an inspection performed by an {@link AgentMetadataInspector}.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@AllArgsConstructor
+@Getter
+public class InspectionReport {
+    private final Decision decision;
+    private final String message;
+
+    /**
+     * Factory method for {@link InspectionReport}.
+     *
+     * @param message a message
+     * @return a new {@link InspectionReport}
+     */
+    public static InspectionReport newRejection(final String message) {
+        return new InspectionReport(Decision.REJECT, message);
+    }
+
+    /**
+     * Factory method for {@link InspectionReport}.
+     *
+     * @param message a message
+     * @return a new {@link InspectionReport}
+     */
+    public static InspectionReport newAcceptance(final String message) {
+        return new InspectionReport(Decision.ACCEPT, message);
+    }
+
+    /**
+     * The possible outcomes of an inspection.
+     */
+    public enum Decision {
+        /**
+         * Subject passed the inspection and is allowed to proceed.
+         */
+        ACCEPT,
+        /**
+         * Subject failed the inspection and is not allowed to proceed.
+         */
+        REJECT;
+
+        static Decision flip(final Decision decision) {
+            switch (decision) {
+                case REJECT:
+                    return ACCEPT;
+                case ACCEPT:
+                    return REJECT;
+
+                default:
+                    throw new RuntimeException("Unexpected: " + decision.name());
+            }
+        }
+    }
+
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/util/MetricsConstants.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/MetricsConstants.java
@@ -18,7 +18,7 @@
 package com.netflix.genie.web.util;
 
 /**
- * Used to store contants related to metric names.
+ * Used to store constants related to metric names.
  *
  * @author tgianos
  * @since 3.0.0

--- a/genie-web/src/main/java/com/netflix/genie/web/util/MinimumVersionAgentMetadataInspector.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/MinimumVersionAgentMetadataInspector.java
@@ -1,0 +1,80 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util;
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
+import com.netflix.genie.web.properties.AgentFilterProperties;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+
+import javax.validation.Valid;
+
+/**
+ * An {@link AgentMetadataInspector} that rejects agents whose version is older than a given version.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class MinimumVersionAgentMetadataInspector implements AgentMetadataInspector {
+
+    private final AgentFilterProperties agentFilterProperties;
+
+    /**
+     * Constructor.
+     *
+     * @param agentFilterProperties agent filter properties
+     */
+    public MinimumVersionAgentMetadataInspector(final AgentFilterProperties agentFilterProperties) {
+        this.agentFilterProperties = agentFilterProperties;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InspectionReport inspect(@Valid final AgentClientMetadata agentClientMetadata) {
+
+        final String minimumVersionString = this.agentFilterProperties.getMinimumVersion();
+        final String agentVersionString = agentClientMetadata.getVersion().orElse(null);
+
+        if (StringUtils.isBlank(minimumVersionString)) {
+            return InspectionReport.newAcceptance("Minimum version requirement not set");
+
+        } else if (StringUtils.isBlank(agentVersionString)) {
+            return InspectionReport.newRejection("Agent version not set");
+
+        } else {
+            final ArtifactVersion minimumVersion = new DefaultArtifactVersion(minimumVersionString);
+            final ArtifactVersion agentVersion = new DefaultArtifactVersion(agentVersionString);
+
+            final boolean deprecated = minimumVersion.compareTo(agentVersion) > 0;
+
+            return new InspectionReport(
+                deprecated ? InspectionReport.Decision.REJECT : InspectionReport.Decision.ACCEPT,
+                String.format(
+                    "Agent version: %s is %s than minimum: %s",
+                    agentVersionString,
+                    deprecated ? "older" : "newer or equal",
+                    minimumVersionString
+                )
+            );
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/util/WhitelistedVersionAgentMetadataInspector.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/WhitelistedVersionAgentMetadataInspector.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util;
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
+import com.netflix.genie.web.properties.AgentFilterProperties;
+
+import javax.validation.Valid;
+
+/**
+ * An {@link AgentMetadataInspector} that accepts agent whose version matches a regular expression
+ * (obtained via properties) and rejects everything else.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class WhitelistedVersionAgentMetadataInspector extends BaseRegexAgentMetadataInspector {
+
+    private final AgentFilterProperties agentFilterProperties;
+
+    /**
+     * Constructor.
+     * @param agentFilterProperties version filter properties
+     */
+    public WhitelistedVersionAgentMetadataInspector(final AgentFilterProperties agentFilterProperties) {
+        super(InspectionReport.Decision.ACCEPT);
+        this.agentFilterProperties = agentFilterProperties;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InspectionReport inspect(@Valid final AgentClientMetadata agentClientMetadata) {
+        return super.inspectWithPattern(
+            agentFilterProperties.getWhitelistedVersions(),
+            agentClientMetadata.getVersion().orElse(null)
+        );
+    }
+}

--- a/genie-web/src/main/resources/META-INF/spring.factories
+++ b/genie-web/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.netflix.genie.web.configs.GenieAgentFilterAutoConfiguration,\
   com.netflix.genie.web.configs.GenieApiAutoConfiguration,\
   com.netflix.genie.web.configs.GenieClusterLoadBalancerAutoConfiguration,\
   com.netflix.genie.web.configs.GenieEventBusAutoConfiguration,\

--- a/genie-web/src/test/groovy/com/netflix/genie/web/configs/GenieAgentFilterAutoConfigurationSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/configs/GenieAgentFilterAutoConfigurationSpec.groovy
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.configs
+
+import com.netflix.genie.web.properties.AgentFilterProperties
+import spock.lang.Specification
+
+class GenieAgentFilterAutoConfigurationSpec extends Specification {
+    GenieAgentFilterAutoConfiguration config
+    AgentFilterProperties agentFilterProperties
+
+    void setup() {
+        this.agentFilterProperties = Mock(AgentFilterProperties)
+        this.config = new GenieAgentFilterAutoConfiguration()
+    }
+
+    def "Get AgentFilterService"() {
+        when:
+        config.agentFilterService(
+            [
+                config.whitelistedVersionAgentMetadataInspector(agentFilterProperties),
+                config.blacklistedVersionAgentMetadataInspector(agentFilterProperties),
+                config.minimumVersionAgentMetadataInspector(agentFilterProperties)
+            ]
+        )
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentFilterPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentFilterPropertiesSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.properties
+
+import org.springframework.core.env.Environment
+import spock.lang.Specification
+
+class AgentFilterPropertiesSpec extends Specification {
+    AgentFilterProperties agentFilterProperties
+
+    void setup() {
+        this.agentFilterProperties = new AgentFilterProperties()
+    }
+
+    def "Return null if environment is not set"() {
+        String value
+
+        when:
+        value = agentFilterProperties.getMinimumVersion()
+
+        then:
+        value == null
+
+        when:
+        value = agentFilterProperties.getBlacklistedVersions()
+
+        then:
+        value == null
+
+        when:
+        value = agentFilterProperties.getWhitelistedVersions()
+
+        then:
+        value == null
+    }
+
+    def "Return environment value if environment is set"() {
+        String environmentValue = "some-value"
+        String value
+
+        Environment environment = Mock(Environment)
+        agentFilterProperties.setEnvironment(environment)
+
+        when:
+        value = agentFilterProperties.getMinimumVersion()
+
+        then:
+        1 * environment.getProperty(AgentFilterProperties.MINIMUM_VERSION_PROPERTY) >> environmentValue
+        value == environmentValue
+
+        when:
+        value = agentFilterProperties.getBlacklistedVersions()
+
+        then:
+        1 * environment.getProperty(AgentFilterProperties.BLACKLISTED_VERSION_REGEX_PROPERTY) >> environmentValue
+        value == environmentValue
+
+        when:
+        value = agentFilterProperties.getWhitelistedVersions()
+
+        then:
+        1 * environment.getProperty(AgentFilterProperties.WHITELISTED_VERSION_REGEX_PROPERTY) >> environmentValue
+        value == environmentValue
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/AgentFilterServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/AgentFilterServiceImplSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.services.impl
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata
+import com.netflix.genie.common.internal.exceptions.unchecked.GenieAgentRejectedException
+import com.netflix.genie.web.util.AgentMetadataInspector
+import com.netflix.genie.web.util.InspectionReport
+import spock.lang.Specification
+
+class AgentFilterServiceImplSpec extends Specification {
+
+    List<AgentMetadataInspector> inspectors
+    AgentFilterServiceImpl service
+    AgentClientMetadata agentClientMetadata
+
+    void setup() {
+        this.inspectors = [
+            Mock(AgentMetadataInspector),
+            Mock(AgentMetadataInspector),
+        ]
+        this.agentClientMetadata = Mock(AgentClientMetadata)
+        this.service = new AgentFilterServiceImpl(inspectors)
+    }
+
+    def "Default accept"() {
+        InspectionReport finalDecision
+        this.service = new AgentFilterServiceImpl([])
+
+        when:
+        finalDecision = service.inspectAgentMetadata(agentClientMetadata)
+
+        then:
+        finalDecision.getDecision() == InspectionReport.Decision.ACCEPT
+        !finalDecision.getMessage().isEmpty()
+    }
+
+    def "Inspect and accept"() {
+        InspectionReport finalDecision
+
+        when:
+        finalDecision = service.inspectAgentMetadata(agentClientMetadata)
+
+        then:
+        1 * inspectors[0].inspect(agentClientMetadata) >> InspectionReport.newAcceptance("Welcome")
+        1 * inspectors[1].inspect(agentClientMetadata) >> InspectionReport.newAcceptance("Welcome")
+        finalDecision.getDecision() == InspectionReport.Decision.ACCEPT
+        !finalDecision.getMessage().isEmpty()
+    }
+
+    def "Inspect and reject"() {
+        InspectionReport finalDecision
+
+        when:
+        finalDecision = service.inspectAgentMetadata(agentClientMetadata)
+
+        then:
+        1 * inspectors[0].inspect(agentClientMetadata) >> InspectionReport.newRejection("Thou shall not pass")
+        0 * inspectors[1].inspect(agentClientMetadata)
+        finalDecision.getDecision() == InspectionReport.Decision.REJECT
+        !finalDecision.getMessage().isEmpty()
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/util/BaseRegexAgentMetadataInspectorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/util/BaseRegexAgentMetadataInspectorSpec.groovy
@@ -1,0 +1,100 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata
+import org.apache.commons.lang3.NotImplementedException
+import com.netflix.genie.web.util.InspectionReport.Decision;
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BaseRegexAgentMetadataInspectorSpec extends Specification {
+
+    void setup() {
+    }
+
+    @Unroll
+    def "Decide #decisionIfMatch.name() if there is a match, handle corner cases and errors"() {
+
+        setup:
+        TestRegexInspector inspector = new TestRegexInspector(decisionIfMatch)
+        InspectionReport decision
+
+        when:
+        decision = inspector.inspectWithPattern("^foo\$", "")
+
+        then:
+        decision.getDecision() == Decision.REJECT
+        !decision.getMessage().isEmpty()
+
+        when:
+        decision = inspector.inspectWithPattern("^foo\$", "foo")
+
+        then:
+        decision.getDecision() == decisionIfMatch
+        !decision.getMessage().isEmpty()
+
+        when:
+        decision = inspector.inspectWithPattern("(", "foo")
+
+        then:
+        decision.getDecision() == Decision.ACCEPT
+        !decision.getMessage().isEmpty()
+
+        when:
+        decision = inspector.inspectWithPattern(null, "foo")
+
+        then:
+        decision.getDecision() == Decision.ACCEPT
+        !decision.getMessage().isEmpty()
+
+        when:
+        decision = inspector.inspectWithPattern(null, null)
+
+        then:
+        decision.getDecision() == Decision.ACCEPT
+        !decision.getMessage().isEmpty()
+
+        when:
+        decision = inspector.inspectWithPattern("^bar.*", "foo")
+
+        then:
+        decision.getDecision() != decisionIfMatch
+        !decision.getMessage().isEmpty()
+
+        where:
+        decisionIfMatch | _
+        Decision.ACCEPT | _
+        Decision.REJECT | _
+    }
+
+    class TestRegexInspector extends BaseRegexAgentMetadataInspector {
+
+        TestRegexInspector(
+            final Decision decisionIfMatch
+        ) {
+            super(decisionIfMatch)
+        }
+
+        @Override
+        InspectionReport inspect(final AgentClientMetadata agentClientMetadata) {
+            throw new NotImplementedException("Not implemented")
+        }
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/util/BlacklistedVersionAgentMetadataInspectorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/util/BlacklistedVersionAgentMetadataInspectorSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata
+import com.netflix.genie.web.properties.AgentFilterProperties
+import com.netflix.genie.web.util.InspectionReport.Decision
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BlacklistedVersionAgentMetadataInspectorSpec extends Specification {
+    AgentFilterProperties versionFilterProperties
+    AgentClientMetadata agentClientMetadata
+    AgentMetadataInspector inspector
+
+    void setup() {
+        versionFilterProperties = Mock(AgentFilterProperties)
+        agentClientMetadata = Mock(AgentClientMetadata)
+        inspector = new BlacklistedVersionAgentMetadataInspector(versionFilterProperties)
+    }
+
+    @Unroll
+    def "Match #agentVersion against #blacklistExpression and expect #expectedDecision"() {
+
+        InspectionReport decision
+
+        when:
+        decision = inspector.inspect(agentClientMetadata)
+
+        then:
+        1 * agentClientMetadata.getVersion() >> Optional.ofNullable(agentVersion)
+        1 * versionFilterProperties.getBlacklistedVersions() >> blacklistExpression
+        decision.getDecision() == expectedDecision
+        !decision.getMessage().isEmpty()
+
+        where:
+        agentVersion | blacklistExpression | expectedDecision
+        "1.2.3"      | "^(1\\.2\\.3|1\\.2\\.4)\$"  | Decision.REJECT
+        "1.2.3-RC.2" | "^(1\\.2\\.3|1\\.2\\.4)\$"  | Decision.ACCEPT
+        "1.2.0"      | "^(1\\.2\\.3|1\\.2\\.4)\$"  | Decision.ACCEPT
+        "1.2.0"      | "^(1\\.2\\.3|1\\.2\\.4)\$"  | Decision.ACCEPT
+        "1.2.0"      | "1\\.2\\..*"                | Decision.REJECT
+        "1.2.0-RC.2" | "1\\.2\\..*"                | Decision.REJECT
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/util/MinimumVersionAgentMetadataInspectorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/util/MinimumVersionAgentMetadataInspectorSpec.groovy
@@ -1,0 +1,116 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata
+import com.netflix.genie.web.properties.AgentFilterProperties
+import com.netflix.genie.web.util.InspectionReport.Decision
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class MinimumVersionAgentMetadataInspectorSpec extends Specification {
+    AgentClientMetadata agentClientMetadata
+    AgentFilterProperties versionFilterProperties
+    AgentMetadataInspector inspector
+
+    void setup() {
+        this.versionFilterProperties = Mock(AgentFilterProperties)
+        this.agentClientMetadata = Mock(AgentClientMetadata)
+        this.inspector = new MinimumVersionAgentMetadataInspector(versionFilterProperties)
+    }
+
+    @Unroll
+    def "No minimum set inspection returns ACCEPT"() {
+        when:
+        InspectionReport report = inspector.inspect(agentClientMetadata)
+
+        then:
+        1 * versionFilterProperties.getMinimumVersion() >> propertyValue
+        1 * agentClientMetadata.getVersion() >> Optional.of("1.2.3")
+        report.getDecision() == Decision.ACCEPT
+        !report.getMessage().isEmpty()
+
+        where:
+        propertyValue | _
+        null          | _
+        ""            | _
+
+    }
+
+    @Unroll
+    def "No agent version set inspection returns REJECT"() {
+        when:
+        InspectionReport report = inspector.inspect(agentClientMetadata)
+
+        then:
+        1 * versionFilterProperties.getMinimumVersion() >> "1.2.3"
+        1 * agentClientMetadata.getVersion() >> agentVersionValue
+        report.getDecision() == Decision.REJECT
+        !report.getMessage().isEmpty()
+
+        where:
+        agentVersionValue | _
+        Optional.of("")   | _
+        Optional.empty()  | _
+    }
+
+    @Unroll
+    def "No agent version and no minimum set inspection returns ACCEPT"() {
+        when:
+        InspectionReport report = inspector.inspect(agentClientMetadata)
+
+        then:
+        1 * versionFilterProperties.getMinimumVersion() >> propertyValue
+        1 * agentClientMetadata.getVersion() >> agentVersionValue
+        report.getDecision() == Decision.ACCEPT
+        !report.getMessage().isEmpty()
+
+        where:
+        agentVersionValue | propertyValue
+        Optional.of("")   | ""
+        Optional.empty()  | null
+    }
+
+    @Unroll
+    def "Version #agentVersion returns #decision if minimum is #minimumVersion"() {
+        when:
+        InspectionReport report = inspector.inspect(agentClientMetadata)
+
+        then:
+        1 * versionFilterProperties.getMinimumVersion() >> minimumVersion
+        1 * agentClientMetadata.getVersion() >> Optional.of(agentVersion)
+        report.getDecision() == decision
+        !report.getMessage().isEmpty()
+
+        where:
+        agentVersion     | minimumVersion   | decision
+        "1.0.0"          | "1.0.0"          | Decision.ACCEPT
+        "1.0.0"          | "1.0.1"          | Decision.REJECT
+        "1.0.1"          | "1.0.0"          | Decision.ACCEPT
+        "1.0.0-SNAPSHOT" | "1.0.0-SNAPSHOT" | Decision.ACCEPT
+        "1.0.0-SNAPSHOT" | "1.0.1-SNAPSHOT" | Decision.REJECT
+        "1.0.1-SNAPSHOT" | "1.0.0-SNAPSHOT" | Decision.ACCEPT
+        "1.0.0"          | "1.0.0-SNAPSHOT" | Decision.ACCEPT
+        "1.0.0-SNAPSHOT" | "1.0.0"          | Decision.REJECT
+        "1.0.0-RC.1"     | "1.0.0"          | Decision.REJECT
+        "1.0.0"          | "1.0.0-RC.1"     | Decision.ACCEPT
+        "1.0.0-RC.1"     | "1.0.0-SNAPSHOT" | Decision.REJECT //N.B.
+        "1.0.0-SNAPSHOT" | "1.0.0-RC.1"     | Decision.ACCEPT //N.B.
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/util/WhitelistedVersionAgentMetadataInspectorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/util/WhitelistedVersionAgentMetadataInspectorSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.web.util
+
+import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata
+import com.netflix.genie.web.properties.AgentFilterProperties
+import com.netflix.genie.web.util.InspectionReport.Decision
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class WhitelistedVersionAgentMetadataInspectorSpec extends Specification {
+    AgentFilterProperties versionFilterProperties
+    AgentClientMetadata agentClientMetadata
+    AgentMetadataInspector inspector
+
+    void setup() {
+        versionFilterProperties = Mock(AgentFilterProperties)
+        agentClientMetadata = Mock(AgentClientMetadata)
+        inspector = new WhitelistedVersionAgentMetadataInspector(versionFilterProperties)
+    }
+
+    @Unroll
+    def "Match #agentVersion against #blacklistExpression and expect #expectedDecision"() {
+
+        InspectionReport decision
+
+        when:
+        decision = inspector.inspect(agentClientMetadata)
+
+        then:
+        1 * agentClientMetadata.getVersion() >> Optional.ofNullable(agentVersion)
+        1 * versionFilterProperties.getWhitelistedVersions() >> whitelistExpression
+        decision.getDecision() == expectedDecision
+        !decision.getMessage().isEmpty()
+
+        where:
+        agentVersion | whitelistExpression | expectedDecision
+        "1.2.3"      | "^(1\\.2\\.3|1\\.2\\.4)\$"  | Decision.ACCEPT
+        "1.2.3-RC.2" | "^(1\\.2\\.3|1\\.2\\.4)\$"  | Decision.REJECT
+        "1.2.0"      | "^(1\\.2\\.3|1\\.2\\.4)\$"  | Decision.REJECT
+        "1.2.0"      | "^(1\\.2\\.3|1\\.2\\.4)\$"  | Decision.REJECT
+        "1.2.0"      | "1\\.2\\..*"                | Decision.ACCEPT
+        "1.2.0-RC.2" | "1\\.2\\..*"                | Decision.ACCEPT
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/GenieAgentFilterAutoConfigurationIntegrationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/GenieAgentFilterAutoConfigurationIntegrationTest.java
@@ -1,0 +1,109 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.configs;
+
+import com.netflix.genie.test.categories.IntegrationTest;
+import com.netflix.genie.web.services.AgentFilterService;
+import com.netflix.genie.web.util.AgentMetadataInspector;
+import com.netflix.genie.web.util.BlacklistedVersionAgentMetadataInspector;
+import com.netflix.genie.web.util.MinimumVersionAgentMetadataInspector;
+import com.netflix.genie.web.util.WhitelistedVersionAgentMetadataInspector;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Tests for behavior of {@link GenieAgentFilterAutoConfiguration}.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Category(IntegrationTest.class)
+public class GenieAgentFilterAutoConfigurationIntegrationTest {
+
+    /**
+     * Test expected context when configuration is enabled.
+     */
+    @Test
+    public void testContextIfEnabled() {
+        new ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    GenieAgentFilterAutoConfiguration.class
+                )
+            )
+            .withPropertyValues(
+                "genie.agent.filter.enabled=true"
+            )
+            .run(
+                (context) -> {
+                    Assertions.assertThat(context).hasSingleBean(AgentFilterService.class);
+                    Assertions.assertThat(context).getBeans(AgentMetadataInspector.class).hasSize(3);
+                    Assertions.assertThat(context).hasSingleBean(WhitelistedVersionAgentMetadataInspector.class);
+                    Assertions.assertThat(context).hasSingleBean(BlacklistedVersionAgentMetadataInspector.class);
+                    Assertions.assertThat(context).hasSingleBean(MinimumVersionAgentMetadataInspector.class);
+                }
+            );
+    }
+
+    /**
+     * Test expected context when configuration is disabled.
+     */
+    @Test
+    public void testContextIfDisabled() {
+        new ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    GenieAgentFilterAutoConfiguration.class
+                )
+            )
+            .withPropertyValues(
+                "genie.agent.filter.enabled=nope"
+            )
+            .run(
+                (context) -> {
+                    Assertions.assertThat(context).doesNotHaveBean(AgentFilterService.class);
+                    Assertions.assertThat(context).doesNotHaveBean(AgentMetadataInspector.class);
+                }
+            );
+    }
+
+    /**
+     * Test expected context when configuration is not explicitly enabled or disabled.
+     */
+    @Test
+    public void testContextIfUnspecified() {
+        new ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    GenieAgentFilterAutoConfiguration.class
+                )
+            )
+            .withPropertyValues(
+                "genie.some.other.property=true"
+            )
+            .run(
+                (context) -> {
+                    Assertions.assertThat(context).doesNotHaveBean(AgentFilterService.class);
+                    Assertions.assertThat(context).doesNotHaveBean(AgentMetadataInspector.class);
+                }
+            );
+    }
+}


### PR DESCRIPTION
Introduce `handshake` gRPC protocol between Agent and server.

Provides an opportunity to the server to turn away clients running a version that is known to be incompatible or deprecated.
The filtering is extensible via Spring injection and the built-in metadata inspectors are responsive to dynamic changes of property values, allowing changing of filters without application re-deployment.