### PR TITLE
Disable JCommander argument splitting for repeated arguments

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/cli/JobRequestArgumentsImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/cli/JobRequestArgumentsImpl.java
@@ -80,7 +80,8 @@ class JobRequestArgumentsImpl implements ArgumentDelegates.JobRequestArguments {
     @Parameter(
         names = {"--clusterCriterion"},
         description = "Criterion for cluster selection, can be repeated (see CRITERION SYNTAX)",
-        converter = ArgumentConverters.CriterionConverter.class
+        converter = ArgumentConverters.CriterionConverter.class,
+        splitter = NoopParameterSplitter.class
     )
     private List<Criterion> clusterCriteria = Lists.newArrayList();
 
@@ -136,7 +137,8 @@ class JobRequestArgumentsImpl implements ArgumentDelegates.JobRequestArguments {
 
     @Parameter(
         names = {"--jobTag"},
-        description = "Job tag, can be repeated"
+        description = "Job tag, can be repeated",
+        splitter = NoopParameterSplitter.class
     )
     private Set<String> jobTags = Sets.newHashSet();
 

--- a/genie-agent/src/main/java/com/netflix/genie/agent/cli/NoopParameterSplitter.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/cli/NoopParameterSplitter.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.cli;
+
+import com.beust.jcommander.converters.IParameterSplitter;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * Argument splitter that does not split arguments.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+class NoopParameterSplitter implements IParameterSplitter {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> split(final String value) {
+        return Lists.newArrayList(value);
+    }
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/NoopParameterSplitterSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/NoopParameterSplitterSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.genie.agent.cli
+
+import spock.lang.Specification
+
+class NoopParameterSplitterSpec extends Specification {
+    def "Split"(String inputString) {
+        setup:
+        NoopParameterSplitter splitter = new NoopParameterSplitter()
+
+        expect:
+        splitter.split(inputString) == [inputString]
+
+        where:
+        _ | inputString
+        _ | ""
+        _ | "foo"
+        _ | "foo, bar"
+        _ | "foo,bar"
+    }
+}


### PR DESCRIPTION
Repeatable arguments are treated specially during JCommander parsing.
The default behavior is to split values containing a comma into multiple values for that option.

i.e. `--foo a,b,c` becomes (logically) equivalent to `--foo a --foo b --foo c`.
This is problematic for the `--clusterCriterion` option which is repeatable and can contain commas.

This commit overrides the default comma string splitter with one that performs no splitting.