### PR TITLE
Add grouping and groupingInstance fields to job search page

### DIFF
--- a/genie-web/src/main/resources/static/scripts/Job.js
+++ b/genie-web/src/main/resources/static/scripts/Job.js
@@ -87,7 +87,9 @@ export default class Job extends Page {
       { label: "Cluster Name", name: "clusterName", value: "", type: "input" },
       { label: "Cluster ID", name: "clusterId", value: "", type: "input" },
       { label: "Command Name", name: "commandName", value: "", type: "input" },
-      { label: "Command ID", name: "commandId", value: "", type: "input" }
+      { label: "Command ID", name: "commandId", value: "", type: "input" },
+      { label: "Grouping", name: "grouping", value: "", type: "input" },
+      { label: "Grouping Instance", name: "groupingInstance", value: "", type: "input" },
     ];
   }
 


### PR DESCRIPTION
* This PR adds two new fields to the Job search page
    * Grouping
    * GroupingInstance
* Genie search API already supports those two fields. So this is a UI change
