### PR TITLE
Make java client more extensible

### DIFF
--- a/genie-client/build.gradle
+++ b/genie-client/build.gradle
@@ -1,29 +1,28 @@
+apply plugin: "java-library"
+
 dependencies {
     /*******************************
-     * Compile Dependencies
+     * API Dependencies
      *******************************/
 
-    compile project(":genie-common")
-    compile project(":genie-common-external")
+    api project(":genie-common")
+    api project(":genie-common-external")
 
-    compile("commons-beanutils:commons-beanutils")
-    compile("com.squareup.okhttp3:okhttp")
-    compile("com.squareup.retrofit2:retrofit")
-    compile("com.squareup.retrofit2:converter-jackson")
-    compile("org.apache.commons:commons-configuration2")
+    api("com.github.fge:json-patch")
+    api("com.squareup.okhttp3:okhttp")
+    api("com.squareup.retrofit2:retrofit")
 
-    // Logging
-    compile("org.slf4j:slf4j-api")
+    /*******************************
+     * Implementation Dependencies
+     *******************************/
 
-    // JSON Patch Support
-    compile("com.github.fge:json-patch")
+    implementation("commons-beanutils:commons-beanutils")
+    implementation("com.squareup.retrofit2:converter-jackson")
+    implementation("org.apache.commons:commons-configuration2")
+    implementation("org.slf4j:slf4j-api")
 
     /*******************************
      * Provided Dependencies
-     *******************************/
-
-    /*******************************
-     * Runtime Dependencies
      *******************************/
 
     /*******************************

--- a/genie-client/src/main/java/com/netflix/genie/client/CommandClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/CommandClient.java
@@ -28,9 +28,11 @@ import com.netflix.genie.common.dto.Command;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Interceptor;
 import org.apache.commons.lang3.StringUtils;
+import retrofit2.Retrofit;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,9 +45,18 @@ import java.util.Set;
  * @since 3.0.0
  */
 @Slf4j
-public class CommandClient extends BaseGenieClient {
+public class CommandClient {
 
     private CommandService commandService;
+
+    /**
+     * Constructor.
+     *
+     * @param retrofit The configured {@link Retrofit} client to a Genie server
+     */
+    public CommandClient(@NotNull final Retrofit retrofit) {
+        this.commandService = retrofit.create(CommandService.class);
+    }
 
     /**
      * Constructor.
@@ -54,14 +65,15 @@ public class CommandClient extends BaseGenieClient {
      * @param interceptors              Any interceptors to configure the client with, can include security ones
      * @param genieNetworkConfiguration The network configuration parameters. Could be null
      * @throws GenieClientException On error
+     * @deprecated Use {@link #CommandClient(Retrofit)}
      */
+    @Deprecated
     public CommandClient(
         @NotEmpty final String url,
         @Nullable final List<Interceptor> interceptors,
         @Nullable final GenieNetworkConfiguration genieNetworkConfiguration
     ) throws GenieClientException {
-        super(url, interceptors, genieNetworkConfiguration);
-        this.commandService = this.getService(CommandService.class);
+        this(GenieClientUtils.createRetrofitInstance(url, interceptors, genieNetworkConfiguration));
     }
 
     /* CRUD Methods */
@@ -80,7 +92,16 @@ public class CommandClient extends BaseGenieClient {
         if (command == null) {
             throw new IllegalArgumentException("Command cannot be null.");
         }
-        return getIdFromLocation(commandService.createCommand(command).execute().headers().get("location"));
+        final String locationHeader = this.commandService
+            .createCommand(command)
+            .execute()
+            .headers()
+            .get(GenieClientUtils.LOCATION_HEADER);
+
+        if (StringUtils.isBlank(locationHeader)) {
+            throw new GenieClientException("No location header. Unable to get ID");
+        }
+        return GenieClientUtils.getIdFromLocation(locationHeader);
     }
 
     /**
@@ -121,7 +142,7 @@ public class CommandClient extends BaseGenieClient {
             .get("_embedded");
         if (jNode != null) {
             for (final JsonNode objNode : jNode.get("commandList")) {
-                final Command command = this.treeToValue(objNode, Command.class);
+                final Command command = GenieClientUtils.treeToValue(objNode, Command.class);
                 commandList.add(command);
             }
         }

--- a/genie-client/src/main/java/com/netflix/genie/client/GenieClientUtils.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/GenieClientUtils.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Netflix, Inc.
+ *  Copyright 2019 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -29,35 +29,42 @@ import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Base class for the clients for Genie Services.
+ * Utility methods for the Genie client.
  *
- * @author amsharma
- * @since 3.0.0
+ * @author tgianos
+ * @since 4.0.0
  */
-abstract class BaseGenieClient {
+final class GenieClientUtils {
 
-    private Retrofit retrofit;
+    static final String LOCATION_HEADER = "location";
+    private static final String SLASH = "/";
 
     /**
-     * Constructor that takes the service url and a security interceptor implementation.
+     * Utility class doesn't need a public constructor.
+     */
+    private GenieClientUtils() {
+    }
+
+    /**
+     * Get a {@link Retrofit} instance given the parameters.
      *
      * @param url                       The url of the Genie Service.
      * @param interceptors              All desired interceptors for the client to be created
      * @param genieNetworkConfiguration A configuration object that provides network settings for HTTP calls.
-     * @throws GenieClientException If there is any problem creating the constructor.
+     * @return A {@link Retrofit} instance configured with the given information
+     * @throws GenieClientException If there is any problem creating the constructor
      */
-    BaseGenieClient(
-        @NotEmpty final String url,
+    static Retrofit createRetrofitInstance(
+        @NotBlank final String url,
         @Nullable final List<Interceptor> interceptors,
         @Nullable final GenieNetworkConfiguration genieNetworkConfiguration
     ) throws GenieClientException {
-
         if (StringUtils.isBlank(url)) {
             throw new GenieClientException("Service URL cannot be empty or null");
         }
@@ -65,7 +72,19 @@ abstract class BaseGenieClient {
         final OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
         if (genieNetworkConfiguration != null) {
-            this.addConfigParamsFromConfig(builder, genieNetworkConfiguration);
+            if (genieNetworkConfiguration.getConnectTimeout() != GenieNetworkConfiguration.DEFAULT_TIMEOUT) {
+                builder.connectTimeout(genieNetworkConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS);
+            }
+
+            if (genieNetworkConfiguration.getReadTimeout() != GenieNetworkConfiguration.DEFAULT_TIMEOUT) {
+                builder.readTimeout(genieNetworkConfiguration.getReadTimeout(), TimeUnit.MILLISECONDS);
+            }
+
+            if (genieNetworkConfiguration.getWriteTimeout() != GenieNetworkConfiguration.DEFAULT_TIMEOUT) {
+                builder.writeTimeout(genieNetworkConfiguration.getWriteTimeout(), TimeUnit.MILLISECONDS);
+            }
+
+            builder.retryOnConnectionFailure(genieNetworkConfiguration.isRetryOnConnectionFailure());
         }
 
         // Add the interceptor to map the retrofit response code to corresponding Genie Exceptions in case of
@@ -74,33 +93,26 @@ abstract class BaseGenieClient {
         if (interceptors != null) {
             interceptors.forEach(builder::addInterceptor);
         }
-        final OkHttpClient client = builder.build();
 
-        this.retrofit = new Retrofit.Builder()
+        return new Retrofit
+            .Builder()
             .baseUrl(url)
             .addConverterFactory(JacksonConverterFactory.create(GenieObjectMapper.getMapper()))
-            .client(client)
+            .client(builder.build())
             .build();
     }
 
-    // Private helper method to add network configurations to okhttp builder
-    private void addConfigParamsFromConfig(
-        final OkHttpClient.Builder builder,
-        final GenieNetworkConfiguration genieNetworkConfiguration
-    ) {
-        if (genieNetworkConfiguration.getConnectTimeout() != GenieNetworkConfiguration.DEFAULT_TIMEOUT) {
-            builder.connectTimeout(genieNetworkConfiguration.getConnectTimeout(), TimeUnit.MILLISECONDS);
-        }
-
-        if (genieNetworkConfiguration.getReadTimeout() != GenieNetworkConfiguration.DEFAULT_TIMEOUT) {
-            builder.readTimeout(genieNetworkConfiguration.getReadTimeout(), TimeUnit.MILLISECONDS);
-        }
-
-        if (genieNetworkConfiguration.getWriteTimeout() != GenieNetworkConfiguration.DEFAULT_TIMEOUT) {
-            builder.writeTimeout(genieNetworkConfiguration.getWriteTimeout(), TimeUnit.MILLISECONDS);
-        }
-
-        builder.retryOnConnectionFailure(genieNetworkConfiguration.isRetryOnConnectionFailure());
+    /**
+     * Bind JSON to a Java POJO.
+     *
+     * @param node  The JSON to convert
+     * @param clazz The clazz to bind to
+     * @param <T>   The type of the POJO returned
+     * @return An instance of {@code T}
+     * @throws IOException If the JSON can't bind
+     */
+    static <T> T treeToValue(final JsonNode node, final Class<T> clazz) throws IOException {
+        return GenieObjectMapper.getMapper().treeToValue(node, clazz);
     }
 
     /**
@@ -109,15 +121,7 @@ abstract class BaseGenieClient {
      * @param location The location string in the header.
      * @return The id of the entity embedded in the location.
      */
-    String getIdFromLocation(final String location) {
-        return location.substring(location.lastIndexOf("/") + 1);
-    }
-
-    <T> T getService(final Class<T> clazz) {
-        return this.retrofit.create(clazz);
-    }
-
-    <T> T treeToValue(final JsonNode node, final Class<T> clazz) throws IOException {
-        return GenieObjectMapper.getMapper().treeToValue(node, clazz);
+    static String getIdFromLocation(final String location) {
+        return location.substring(location.lastIndexOf(SLASH) + 1);
     }
 }

--- a/genie-client/src/main/java/com/netflix/genie/client/apis/TokenService.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/apis/TokenService.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public interface TokenService {
 
     /**
-     * A method to retrive oauth tokens from the server.
+     * A method to retrieve oauth tokens from the server.
      *
      * @param params A map of all the fields needed to fetch credentials.
      * @param url    The URL of the IDP from where to get the credentials.

--- a/genie-client/src/main/java/com/netflix/genie/client/package-info.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2016 Netflix, Inc.
+ *  Copyright 2019 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.

--- a/genie-client/src/test/java/com/netflix/genie/client/ApplicationClientIntegrationTests.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/ApplicationClientIntegrationTests.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-
 /**
  * Integration Tests for Application Client.
  *
@@ -93,8 +92,8 @@ public class ApplicationClientIntegrationTests extends GenieClientsIntegrationTe
         Assert.assertEquals(application.getDescription(), cmd.getDescription());
         Assert.assertEquals(application.getConfigs(), cmd.getConfigs());
         Assert.assertEquals(application.getSetupFile(), cmd.getSetupFile());
-        Assert.assertEquals(cmd.getTags().contains("foo"), true);
-        Assert.assertEquals(cmd.getTags().contains("bar"), true);
+        Assert.assertTrue(cmd.getTags().contains("foo"));
+        Assert.assertTrue(cmd.getTags().contains("bar"));
         Assert.assertEquals(application.getStatus(), cmd.getStatus());
     }
 
@@ -277,7 +276,7 @@ public class ApplicationClientIntegrationTests extends GenieClientsIntegrationTe
         Assert.assertFalse(application4.getSetupFile().isPresent());
         Assert.assertFalse(application4.getDescription().isPresent());
         Assert.assertEquals(Collections.emptySet(), application4.getConfigs());
-        Assert.assertEquals(application4.getTags().contains("foo"), false);
+        Assert.assertFalse(application4.getTags().contains("foo"));
     }
 
     /**
@@ -304,8 +303,8 @@ public class ApplicationClientIntegrationTests extends GenieClientsIntegrationTe
         // Test getTags for application
         Set<String> tags = applicationClient.getTagsForApplication("application1");
         Assert.assertEquals(4, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("bar"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("bar"));
 
         // Test adding a tag for application
         final Set<String> moreTags = Sets.newHashSet("pi");
@@ -313,23 +312,23 @@ public class ApplicationClientIntegrationTests extends GenieClientsIntegrationTe
         applicationClient.addTagsToApplication("application1", moreTags);
         tags = applicationClient.getTagsForApplication("application1");
         Assert.assertEquals(5, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("bar"), true);
-        Assert.assertEquals(tags.contains("pi"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("bar"));
+        Assert.assertTrue(tags.contains("pi"));
 
         // Test removing a tag for application
         applicationClient.removeTagFromApplication("application1", "bar");
         tags = applicationClient.getTagsForApplication("application1");
         Assert.assertEquals(4, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("pi"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("pi"));
 
         // Test update tags for a application
         applicationClient.updateTagsForApplication("application1", initialTags);
         tags = applicationClient.getTagsForApplication("application1");
         Assert.assertEquals(4, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("bar"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("bar"));
 
         // Test delete all tags in a application
         applicationClient.removeAllTagsForApplication("application1");
@@ -359,8 +358,8 @@ public class ApplicationClientIntegrationTests extends GenieClientsIntegrationTe
         // Test getConfigs for application
         Set<String> configs = applicationClient.getConfigsForApplication("application1");
         Assert.assertEquals(2, configs.size());
-        Assert.assertEquals(configs.contains("foo"), true);
-        Assert.assertEquals(configs.contains("bar"), true);
+        Assert.assertTrue(configs.contains("foo"));
+        Assert.assertTrue(configs.contains("bar"));
 
         // Test adding a config for application
         final Set<String> moreConfigs = Sets.newHashSet("pi");
@@ -368,16 +367,16 @@ public class ApplicationClientIntegrationTests extends GenieClientsIntegrationTe
         applicationClient.addConfigsToApplication("application1", moreConfigs);
         configs = applicationClient.getConfigsForApplication("application1");
         Assert.assertEquals(3, configs.size());
-        Assert.assertEquals(configs.contains("foo"), true);
-        Assert.assertEquals(configs.contains("bar"), true);
-        Assert.assertEquals(configs.contains("pi"), true);
+        Assert.assertTrue(configs.contains("foo"));
+        Assert.assertTrue(configs.contains("bar"));
+        Assert.assertTrue(configs.contains("pi"));
 
         // Test update configs for a application
         applicationClient.updateConfigsForApplication("application1", initialConfigs);
         configs = applicationClient.getConfigsForApplication("application1");
         Assert.assertEquals(2, configs.size());
-        Assert.assertEquals(configs.contains("foo"), true);
-        Assert.assertEquals(configs.contains("bar"), true);
+        Assert.assertTrue(configs.contains("foo"));
+        Assert.assertTrue(configs.contains("bar"));
 
         // Test delete all configs in a application
         applicationClient.removeAllConfigsForApplication("application1");
@@ -407,8 +406,8 @@ public class ApplicationClientIntegrationTests extends GenieClientsIntegrationTe
         // Test getDependencies for application
         Set<String> dependencies = applicationClient.getDependenciesForApplication("application1");
         Assert.assertEquals(2, dependencies.size());
-        Assert.assertEquals(dependencies.contains("foo"), true);
-        Assert.assertEquals(dependencies.contains("bar"), true);
+        Assert.assertTrue(dependencies.contains("foo"));
+        Assert.assertTrue(dependencies.contains("bar"));
 
         // Test adding a dependency for application
         final Set<String> moreDependencies = Sets.newHashSet("pi");
@@ -416,16 +415,16 @@ public class ApplicationClientIntegrationTests extends GenieClientsIntegrationTe
         applicationClient.addDependenciesToApplication("application1", moreDependencies);
         dependencies = applicationClient.getDependenciesForApplication("application1");
         Assert.assertEquals(3, dependencies.size());
-        Assert.assertEquals(dependencies.contains("foo"), true);
-        Assert.assertEquals(dependencies.contains("bar"), true);
-        Assert.assertEquals(dependencies.contains("pi"), true);
+        Assert.assertTrue(dependencies.contains("foo"));
+        Assert.assertTrue(dependencies.contains("bar"));
+        Assert.assertTrue(dependencies.contains("pi"));
 
         // Test update dependencies for a application
         applicationClient.updateDependenciesForApplication("application1", initialDependencies);
         dependencies = applicationClient.getDependenciesForApplication("application1");
         Assert.assertEquals(2, dependencies.size());
-        Assert.assertEquals(dependencies.contains("foo"), true);
-        Assert.assertEquals(dependencies.contains("bar"), true);
+        Assert.assertTrue(dependencies.contains("foo"));
+        Assert.assertTrue(dependencies.contains("bar"));
 
         // Test delete all dependencies in a application
         applicationClient.removeAllDependenciesForApplication("application1");

--- a/genie-client/src/test/java/com/netflix/genie/client/ClusterClientIntegrationTests.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/ClusterClientIntegrationTests.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-
 /**
  * Integration Tests for Cluster Client.
  *
@@ -95,8 +94,8 @@ public class ClusterClientIntegrationTests extends GenieClientsIntegrationTestsB
         Assert.assertEquals(cluster.getDescription(), cstr.getDescription());
         Assert.assertEquals(cluster.getConfigs(), cstr.getConfigs());
         Assert.assertEquals(cluster.getSetupFile(), cstr.getSetupFile());
-        Assert.assertEquals(cstr.getTags().contains("foo"), true);
-        Assert.assertEquals(cstr.getTags().contains("bar"), true);
+        Assert.assertTrue(cstr.getTags().contains("foo"));
+        Assert.assertTrue(cstr.getTags().contains("bar"));
         Assert.assertEquals(cluster.getStatus(), cstr.getStatus());
     }
 
@@ -267,7 +266,7 @@ public class ClusterClientIntegrationTests extends GenieClientsIntegrationTestsB
         Assert.assertFalse(cluster4.getSetupFile().isPresent());
         Assert.assertFalse(cluster4.getDescription().isPresent());
         Assert.assertEquals(Collections.emptySet(), cluster4.getConfigs());
-        Assert.assertEquals(cluster4.getTags().contains("foo"), false);
+        Assert.assertFalse(cluster4.getTags().contains("foo"));
     }
 
     /**
@@ -294,8 +293,8 @@ public class ClusterClientIntegrationTests extends GenieClientsIntegrationTestsB
         // Test getTags for cluster
         Set<String> tags = clusterClient.getTagsForCluster("cluster1");
         Assert.assertEquals(4, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("bar"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("bar"));
 
         // Test adding a tag for cluster
         final Set<String> moreTags = Sets.newHashSet("pi");
@@ -303,23 +302,23 @@ public class ClusterClientIntegrationTests extends GenieClientsIntegrationTestsB
         clusterClient.addTagsToCluster("cluster1", moreTags);
         tags = clusterClient.getTagsForCluster("cluster1");
         Assert.assertEquals(5, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("bar"), true);
-        Assert.assertEquals(tags.contains("pi"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("bar"));
+        Assert.assertTrue(tags.contains("pi"));
 
         // Test removing a tag for cluster
         clusterClient.removeTagFromCluster("cluster1", "bar");
         tags = clusterClient.getTagsForCluster("cluster1");
         Assert.assertEquals(4, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("pi"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("pi"));
 
         // Test update tags for a cluster
         clusterClient.updateTagsForCluster("cluster1", initialTags);
         tags = clusterClient.getTagsForCluster("cluster1");
         Assert.assertEquals(4, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("bar"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("bar"));
 
         // Test delete all tags in a cluster
         clusterClient.removeAllTagsForCluster("cluster1");
@@ -349,8 +348,8 @@ public class ClusterClientIntegrationTests extends GenieClientsIntegrationTestsB
         // Test getConfigs for cluster
         Set<String> configs = clusterClient.getConfigsForCluster("cluster1");
         Assert.assertEquals(2, configs.size());
-        Assert.assertEquals(configs.contains("foo"), true);
-        Assert.assertEquals(configs.contains("bar"), true);
+        Assert.assertTrue(configs.contains("foo"));
+        Assert.assertTrue(configs.contains("bar"));
 
         // Test adding a config for cluster
         final Set<String> moreConfigs = Sets.newHashSet("pi");
@@ -358,16 +357,16 @@ public class ClusterClientIntegrationTests extends GenieClientsIntegrationTestsB
         clusterClient.addConfigsToCluster("cluster1", moreConfigs);
         configs = clusterClient.getConfigsForCluster("cluster1");
         Assert.assertEquals(3, configs.size());
-        Assert.assertEquals(configs.contains("foo"), true);
-        Assert.assertEquals(configs.contains("bar"), true);
-        Assert.assertEquals(configs.contains("pi"), true);
+        Assert.assertTrue(configs.contains("foo"));
+        Assert.assertTrue(configs.contains("bar"));
+        Assert.assertTrue(configs.contains("pi"));
 
         // Test update configs for a cluster
         clusterClient.updateConfigsForCluster("cluster1", initialConfigs);
         configs = clusterClient.getConfigsForCluster("cluster1");
         Assert.assertEquals(2, configs.size());
-        Assert.assertEquals(configs.contains("foo"), true);
-        Assert.assertEquals(configs.contains("bar"), true);
+        Assert.assertTrue(configs.contains("foo"));
+        Assert.assertTrue(configs.contains("bar"));
 
         // Test delete all configs in a cluster
         clusterClient.removeAllConfigsForCluster("cluster1");
@@ -397,8 +396,8 @@ public class ClusterClientIntegrationTests extends GenieClientsIntegrationTestsB
         // Test getDependencies for cluster
         Set<String> dependencies = clusterClient.getDependenciesForCluster("cluster1");
         Assert.assertEquals(2, dependencies.size());
-        Assert.assertEquals(dependencies.contains("foo"), true);
-        Assert.assertEquals(dependencies.contains("bar"), true);
+        Assert.assertTrue(dependencies.contains("foo"));
+        Assert.assertTrue(dependencies.contains("bar"));
 
         // Test adding a dependency for cluster
         final Set<String> moreDependencies = Sets.newHashSet("pi");
@@ -406,16 +405,16 @@ public class ClusterClientIntegrationTests extends GenieClientsIntegrationTestsB
         clusterClient.addDependenciesToCluster("cluster1", moreDependencies);
         dependencies = clusterClient.getDependenciesForCluster("cluster1");
         Assert.assertEquals(3, dependencies.size());
-        Assert.assertEquals(dependencies.contains("foo"), true);
-        Assert.assertEquals(dependencies.contains("bar"), true);
-        Assert.assertEquals(dependencies.contains("pi"), true);
+        Assert.assertTrue(dependencies.contains("foo"));
+        Assert.assertTrue(dependencies.contains("bar"));
+        Assert.assertTrue(dependencies.contains("pi"));
 
         // Test update dependencies for a cluster
         clusterClient.updateDependenciesForCluster("cluster1", initialDependencies);
         dependencies = clusterClient.getDependenciesForCluster("cluster1");
         Assert.assertEquals(2, dependencies.size());
-        Assert.assertEquals(dependencies.contains("foo"), true);
-        Assert.assertEquals(dependencies.contains("bar"), true);
+        Assert.assertTrue(dependencies.contains("foo"));
+        Assert.assertTrue(dependencies.contains("bar"));
 
         // Test delete all dependencies in a cluster
         clusterClient.removeAllDependenciesForCluster("cluster1");

--- a/genie-client/src/test/java/com/netflix/genie/client/CommandClientIntegrationTests.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/CommandClientIntegrationTests.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-
 /**
  * Integration Tests for Command Client.
  *
@@ -99,8 +98,8 @@ public class CommandClientIntegrationTests extends GenieClientsIntegrationTestsB
         Assert.assertEquals(command.getDescription(), cmd.getDescription());
         Assert.assertEquals(command.getConfigs(), cmd.getConfigs());
         Assert.assertEquals(command.getSetupFile(), cmd.getSetupFile());
-        Assert.assertEquals(cmd.getTags().contains("foo"), true);
-        Assert.assertEquals(cmd.getTags().contains("bar"), true);
+        Assert.assertTrue(cmd.getTags().contains("foo"));
+        Assert.assertTrue(cmd.getTags().contains("bar"));
         Assert.assertEquals(command.getStatus(), cmd.getStatus());
     }
 
@@ -278,7 +277,7 @@ public class CommandClientIntegrationTests extends GenieClientsIntegrationTestsB
         Assert.assertFalse(command4.getSetupFile().isPresent());
         Assert.assertFalse(command4.getDescription().isPresent());
         Assert.assertEquals(Collections.emptySet(), command4.getConfigs());
-        Assert.assertEquals(command4.getTags().contains("foo"), false);
+        Assert.assertFalse(command4.getTags().contains("foo"));
     }
 
     /**
@@ -305,8 +304,8 @@ public class CommandClientIntegrationTests extends GenieClientsIntegrationTestsB
         // Test getTags for command
         Set<String> tags = commandClient.getTagsForCommand("command1");
         Assert.assertEquals(4, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("bar"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("bar"));
 
         // Test adding a tag for command
         final Set<String> moreTags = Sets.newHashSet("pi");
@@ -314,23 +313,23 @@ public class CommandClientIntegrationTests extends GenieClientsIntegrationTestsB
         commandClient.addTagsToCommand("command1", moreTags);
         tags = commandClient.getTagsForCommand("command1");
         Assert.assertEquals(5, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("bar"), true);
-        Assert.assertEquals(tags.contains("pi"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("bar"));
+        Assert.assertTrue(tags.contains("pi"));
 
         // Test removing a tag for command
         commandClient.removeTagFromCommand("command1", "bar");
         tags = commandClient.getTagsForCommand("command1");
         Assert.assertEquals(4, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("pi"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("pi"));
 
         // Test update tags for a command
         commandClient.updateTagsForCommand("command1", initialTags);
         tags = commandClient.getTagsForCommand("command1");
         Assert.assertEquals(4, tags.size());
-        Assert.assertEquals(tags.contains("foo"), true);
-        Assert.assertEquals(tags.contains("bar"), true);
+        Assert.assertTrue(tags.contains("foo"));
+        Assert.assertTrue(tags.contains("bar"));
 
         // Test delete all tags in a command
         commandClient.removeAllTagsForCommand("command1");
@@ -360,8 +359,8 @@ public class CommandClientIntegrationTests extends GenieClientsIntegrationTestsB
         // Test getConfigs for command
         Set<String> configs = commandClient.getConfigsForCommand("command1");
         Assert.assertEquals(2, configs.size());
-        Assert.assertEquals(configs.contains("foo"), true);
-        Assert.assertEquals(configs.contains("bar"), true);
+        Assert.assertTrue(configs.contains("foo"));
+        Assert.assertTrue(configs.contains("bar"));
 
         // Test adding a config for command
         final Set<String> moreConfigs = Sets.newHashSet("pi");
@@ -369,16 +368,16 @@ public class CommandClientIntegrationTests extends GenieClientsIntegrationTestsB
         commandClient.addConfigsToCommand("command1", moreConfigs);
         configs = commandClient.getConfigsForCommand("command1");
         Assert.assertEquals(3, configs.size());
-        Assert.assertEquals(configs.contains("foo"), true);
-        Assert.assertEquals(configs.contains("bar"), true);
-        Assert.assertEquals(configs.contains("pi"), true);
+        Assert.assertTrue(configs.contains("foo"));
+        Assert.assertTrue(configs.contains("bar"));
+        Assert.assertTrue(configs.contains("pi"));
 
         // Test update configs for a command
         commandClient.updateConfigsForCommand("command1", initialConfigs);
         configs = commandClient.getConfigsForCommand("command1");
         Assert.assertEquals(2, configs.size());
-        Assert.assertEquals(configs.contains("foo"), true);
-        Assert.assertEquals(configs.contains("bar"), true);
+        Assert.assertTrue(configs.contains("foo"));
+        Assert.assertTrue(configs.contains("bar"));
 
         // Test delete all configs in a command
         commandClient.removeAllConfigsForCommand("command1");
@@ -408,8 +407,8 @@ public class CommandClientIntegrationTests extends GenieClientsIntegrationTestsB
         // Test getDependencies for command
         Set<String> dependencies = commandClient.getDependenciesForCommand("command1");
         Assert.assertEquals(2, dependencies.size());
-        Assert.assertEquals(dependencies.contains("foo"), true);
-        Assert.assertEquals(dependencies.contains("bar"), true);
+        Assert.assertTrue(dependencies.contains("foo"));
+        Assert.assertTrue(dependencies.contains("bar"));
 
         // Test adding a dependency for command
         final Set<String> moreDependencies = Sets.newHashSet("pi");
@@ -417,16 +416,16 @@ public class CommandClientIntegrationTests extends GenieClientsIntegrationTestsB
         commandClient.addDependenciesToCommand("command1", moreDependencies);
         dependencies = commandClient.getDependenciesForCommand("command1");
         Assert.assertEquals(3, dependencies.size());
-        Assert.assertEquals(dependencies.contains("foo"), true);
-        Assert.assertEquals(dependencies.contains("bar"), true);
-        Assert.assertEquals(dependencies.contains("pi"), true);
+        Assert.assertTrue(dependencies.contains("foo"));
+        Assert.assertTrue(dependencies.contains("bar"));
+        Assert.assertTrue(dependencies.contains("pi"));
 
         // Test update dependencies for a command
         commandClient.updateDependenciesForCommand("command1", initialDependencies);
         dependencies = commandClient.getDependenciesForCommand("command1");
         Assert.assertEquals(2, dependencies.size());
-        Assert.assertEquals(dependencies.contains("foo"), true);
-        Assert.assertEquals(dependencies.contains("bar"), true);
+        Assert.assertTrue(dependencies.contains("foo"));
+        Assert.assertTrue(dependencies.contains("bar"));
 
         // Test delete all dependencies in a command
         commandClient.removeAllDependenciesForCommand("command1");

--- a/genie-client/src/test/java/com/netflix/genie/client/JobClientIntegrationTests.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/JobClientIntegrationTests.java
@@ -40,6 +40,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
+import retrofit2.Retrofit;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -90,8 +91,9 @@ public class JobClientIntegrationTests extends GenieClientsIntegrationTestsBase 
     @Before
     public void setup() throws Exception {
         this.resourceLoader = new DefaultResourceLoader();
-        clusterClient = new ClusterClient(getBaseUrl(), null, null);
-        commandClient = new CommandClient(getBaseUrl(), null, null);
+        final Retrofit retrofit = GenieClientUtils.createRetrofitInstance(getBaseUrl(), null, null);
+        clusterClient = new ClusterClient(retrofit);
+        commandClient = new CommandClient(retrofit);
         //applicationClient = new ApplicationClient(getBaseUrl());
         final GenieNetworkConfiguration genieNetworkConfiguration = new GenieNetworkConfiguration();
         genieNetworkConfiguration.setReadTimeout(20000);


### PR DESCRIPTION
A lot of the details of the Java client configuration were buried in a shared constructor. The primary focus of this change is to expose new constructors that allow passing in a shared Retrofit instance that can be configured outside the Genie controlled code. This will allow users to modify the behavior of the Http client easier.