### PR TITLE
Add spring-boot-autoconfigure-processor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.0.0"
         classpath "com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1"
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
-        classpath "io.franzbecker:gradle-lombok:1.14"
+        classpath "io.franzbecker:gradle-lombok:2.1"
         classpath "com.moowork.gradle:gradle-node-plugin:1.2.0"
         classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.9"
     }
@@ -346,7 +346,7 @@ configure(javaProjects) {
     }
 
     lombok {
-        version = "1.18.2"
+        version = "1.18.4"
     }
 }
 

--- a/genie-agent/build.gradle
+++ b/genie-agent/build.gradle
@@ -13,6 +13,7 @@ dependencies {
      * Annotation Processors
      *******************************/
 
+    annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     /*******************************

--- a/genie-client/build.gradle
+++ b/genie-client/build.gradle
@@ -11,13 +11,13 @@ dependencies {
     api("com.github.fge:json-patch")
     api("com.squareup.okhttp3:okhttp")
     api("com.squareup.retrofit2:retrofit")
+    api("com.squareup.retrofit2:converter-jackson")
 
     /*******************************
      * Implementation Dependencies
      *******************************/
 
     implementation("commons-beanutils:commons-beanutils")
-    implementation("com.squareup.retrofit2:converter-jackson")
     implementation("org.apache.commons:commons-configuration2")
     implementation("org.slf4j:slf4j-api")
 

--- a/genie-common-internal/build.gradle
+++ b/genie-common-internal/build.gradle
@@ -1,6 +1,14 @@
 apply plugin: "java-library"
 
 dependencies {
+
+    /*******************************
+     * Annotation Processors
+     *******************************/
+    
+    annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
     /*******************************
      * API Dependencies
      *******************************/

--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -13,6 +13,7 @@ dependencies {
      *******************************/
 
     annotationProcessor("org.hibernate:hibernate-jpamodelgen")
+    annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     /*******************************


### PR DESCRIPTION
Per the [docs](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-developing-auto-configuration.html#boot-features-custom-starter-module-autoconfigure) this annotation processor speeds up startup time by creating a metadata file of the conditions on auto configuration classes at startup time. Might help agent startup time so no harm in adding it.