### PR TITLE
Add missing indices for update and creation time to all core tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,18 @@ before_script:
   - sudo service mysql restart
   - mysql -u root -e 'create database genie;'
   - psql  -U postgres -c 'create database genie;'
-script: ./travis/buildViaTravis.sh
+script: "./travis/buildViaTravis.sh"
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-  - rm -f  $HOME/.gradle/caches/*/fileHashes/fileHashes.bin
-  - rm -f  $HOME/.gradle/caches/*/fileHashes/fileHashes.lock
+  - rm -f  "${HOME}/.gradle/caches/modules-2/modules-2.lock"
+  - rm -fr "${HOME}/.gradle/caches/*/plugin-resolution/"
+  - rm -f  "${HOME}/.gradle/caches/*/fileHashes/fileHashes.bin"
+  - rm -f  "${HOME}/.gradle/caches/*/fileHashes/fileHashes.lock"
 cache:
   directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
+    - "${HOME}/.gradle/caches/"
+    - "${HOME}/.gradle/wrapper/"
     - genie-ui/node_modules/
     - genie-ui/.gradle/nodejs
     - genie-ui/.gradle/npm
@@ -44,9 +44,9 @@ env:
     - secure: g8oRT4YUr2VyO6h8+Pm+MvSgPyfEtd+ndCxF70F0SUj5eNV9SFt7yYOn6V6Mxx9eEyZMQSdPed+70+94Nd8yD+cjIGHNnlvKt6V/Q4i09XxhT3/ZiM8B9qRd1eGON0mEaU5Bl+918CGEIVCVsfLPGLVpItaSz2Tda46EDOdRHO8=
     - secure: c0LFCj1KBTEIFSWlpRGgaei86bfrpnSr8qmMOu/S4dl2JRnCnW9AHmrmQzYhd5NlNPugOAncYk9lnkxA7xqtDlv/Ih4YKBaeP924hwLWO//0tKgxhF1dr0dHI+bRKURvcSyLXFDNFjuXUrw4SalBLbZCmiNFzJLMmy2Lvs9UTso=
     - secure: Nv1mMLy2XX+bYziq536KbNg/mAVDTaLw3q3bKP2Mil3JVicXxYVbkEo+DK2O4rsuT7JNbyroN6/3x7xT9qBo4X7vzCjU91QUAxq5t0SmG0FW+oAIApHWTum307b5XS2UyqV/88gg1O6g9or3bKmDLUsJ1A/+fsASozA207a7zls=
-    - secure: "GNQsJ9ylRN9UXWQ20+Ba7NrgmO9SykkLUzO30x0RpicH+uphSPXs785cQuDgPheRs0eTisco/31m7PeqfdS/4KuJ/BI2FwLuCt3uTKvhYgSr/rd7iVb4ldHChmfAjSF+cytLKQd2xPvOveTbX4+/mQfdH0f7WXyxA/zpu18nHPk="
-    - secure: "RWtT5UaOQsNaR4x74Lq3UYVaXfY+j+O5eYmPTHhQ6z+mG/cFxZF+2f4W/yHh8WRB+eMvjG0DWb48cEnHSzTC41wsg0fbEu1T7Iv0OglnZVbkzEG+JsyDsqRm4r/HsjXopNIcR+lQ5gpE85PLVTaOdzgH7W44nlo581bR0dkV88o="
-    - secure: "a5QmXCWR7wwEf/poWSj3PDAb6VICKqTTw3qbNjQwSvCzaCYtZZmxLbruQQlKOyR6W4j2VMrp2Ip5xrBjlCrOTvkFymPY3L+EwbPxsXbO4uhzs43BNFLhDon/Duv3TRhnedkqP0s8hN1ylxCbcID0UUPXQGrhnu8mb5QlDUx2mr8="
+    - secure: GNQsJ9ylRN9UXWQ20+Ba7NrgmO9SykkLUzO30x0RpicH+uphSPXs785cQuDgPheRs0eTisco/31m7PeqfdS/4KuJ/BI2FwLuCt3uTKvhYgSr/rd7iVb4ldHChmfAjSF+cytLKQd2xPvOveTbX4+/mQfdH0f7WXyxA/zpu18nHPk=
+    - secure: RWtT5UaOQsNaR4x74Lq3UYVaXfY+j+O5eYmPTHhQ6z+mG/cFxZF+2f4W/yHh8WRB+eMvjG0DWb48cEnHSzTC41wsg0fbEu1T7Iv0OglnZVbkzEG+JsyDsqRm4r/HsjXopNIcR+lQ5gpE85PLVTaOdzgH7W44nlo581bR0dkV88o=
+    - secure: a5QmXCWR7wwEf/poWSj3PDAb6VICKqTTw3qbNjQwSvCzaCYtZZmxLbruQQlKOyR6W4j2VMrp2Ip5xrBjlCrOTvkFymPY3L+EwbPxsXbO4uhzs43BNFLhDon/Duv3TRhnedkqP0s8hN1ylxCbcID0UUPXQGrhnu8mb5QlDUx2mr8=
 notifications:
   slack:
     secure: H5nS+GX6TYTU27ur6YFG5OgrQeUbzXLok5ub6+xcmyYEeVPpnQ1Gg/wKqTAGsP9j6tAkqPpxgYT9i9Do6eyTEplK6bTvQVyhilsEDtxGJbUO8XOE9TSo6jAe/lD3EB5l46gxFID+Hg9IkPii4LwEabP7PVehrB1JfNZ6QDgSRRM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
-sudo: required
-dist: trusty
+dist: xenial
 addons:
   postgresql: "9.6"
-  apt:
-    packages:
-      - mysql-server-5.6
-      - mysql-client-core-5.6
-      - mysql-client-5.6
 language: java
 jdk:
   - openjdk8

--- a/genie-web/src/main/resources/db/migration/h2/V4_0_0_1__Add_Missing_Time_Indices.sql
+++ b/genie-web/src/main/resources/db/migration/h2/V4_0_0_1__Add_Missing_Time_Indices.sql
@@ -1,0 +1,37 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+CREATE INDEX IF NOT EXISTS `APPLICATIONS_CREATED_INDEX`
+  ON `applications` (`created`);
+CREATE INDEX IF NOT EXISTS `APPLICATIONS_UPDATED_INDEX`
+  ON `applications` (`updated`);
+
+CREATE INDEX IF NOT EXISTS `CLUSTERS_CREATED_INDEX`
+  ON `clusters` (`created`);
+CREATE INDEX IF NOT EXISTS `CLUSTERS_UPDATED_INDEX`
+  ON `clusters` (`updated`);
+
+CREATE INDEX IF NOT EXISTS `COMMANDS_CREATED_INDEX`
+  ON `commands` (`created`);
+CREATE INDEX IF NOT EXISTS `COMMANDS_UPDATED_INDEX`
+  ON `commands` (`updated`);
+
+CREATE INDEX IF NOT EXISTS `JOBS_CREATED_INDEX`
+  ON `jobs` (`created`);
+CREATE INDEX IF NOT EXISTS `JOBS_UPDATED_INDEX`
+  ON `jobs` (`updated`);

--- a/genie-web/src/main/resources/db/migration/mysql/V4_0_0_1__Add_Missing_Time_Indices.sql
+++ b/genie-web/src/main/resources/db/migration/mysql/V4_0_0_1__Add_Missing_Time_Indices.sql
@@ -1,0 +1,32 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+ALTER TABLE `applications`
+  ADD KEY `APPLICATIONS_CREATED_INDEX` (`created`),
+  ADD KEY `APPLICATIONS_UPDATED_INDEX` (`updated`);
+
+ALTER TABLE `clusters`
+  ADD KEY `CLUSTERS_CREATED_INDEX` (`created`),
+  ADD KEY `CLUSTERS_UPDATED_INDEX` (`updated`);
+
+ALTER TABLE `commands`
+  ADD KEY `COMMANDS_CREATED_INDEX` (`created`),
+  ADD KEY `COMMANDS_UPDATED_INDEX` (`updated`);
+
+ALTER TABLE `jobs`
+  ADD KEY `JOBS_UPDATED_INDEX` (`updated`);

--- a/genie-web/src/main/resources/db/migration/postgresql/V4_0_0_1__Add_Missing_Time_Indices.sql
+++ b/genie-web/src/main/resources/db/migration/postgresql/V4_0_0_1__Add_Missing_Time_Indices.sql
@@ -1,0 +1,37 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+CREATE INDEX IF NOT EXISTS applications_created_index
+  ON applications (created);
+CREATE INDEX IF NOT EXISTS applications_updated_index
+  ON applications (updated);
+
+CREATE INDEX IF NOT EXISTS clusters_created_index
+  ON clusters (created);
+CREATE INDEX IF NOT EXISTS clusters_updated_index
+  ON clusters (updated);
+
+CREATE INDEX IF NOT EXISTS commands_created_index
+  ON commands (created);
+CREATE INDEX IF NOT EXISTS commands_updated_index
+  ON commands (updated);
+
+CREATE INDEX IF NOT EXISTS jobs_created_index
+  ON jobs (created);
+CREATE INDEX IF NOT EXISTS jobs_updated_index
+  ON jobs (updated);


### PR DESCRIPTION
Default ordering in 'find' APIs is by the 'updated' field so this will help performance. Also lets us prune off objects by these fields quicker if needed.