### PR TITLE
Fix bug where cluster and command criterion weren't backported to V3

### DIFF
--- a/genie-web/src/integTest/java/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImplIntegrationTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.Application;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobMetadata;
+import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.dto.search.JobSearchResult;
 import com.netflix.genie.common.exceptions.GenieException;
@@ -324,9 +325,37 @@ public class JpaJobSearchServiceImplIntegrationTest extends DBIntegrationTestBas
      */
     @Test
     public void canGetJobRequest() throws GenieException {
+        final JobRequest job1Request = this.service.getJobRequest(JOB_1_ID);
         Assert.assertThat(
-            this.service.getJobRequest(JOB_1_ID).getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            job1Request.getCommandArgs().orElseThrow(IllegalArgumentException::new),
             Matchers.is("-f query.q")
+        );
+        Assert.assertThat(
+            job1Request.getClusterCriterias().size(),
+            Matchers.is(2)
+        );
+        final Set<String> clusterCriterion0Tags = job1Request.getClusterCriterias().get(0).getTags();
+        Assert.assertThat(
+            clusterCriterion0Tags.size(),
+            Matchers.is(4)
+        );
+        Assert.assertThat(
+            clusterCriterion0Tags,
+            Matchers.is(Sets.newHashSet("genie.id:cluster1", "genie.name:h2query", "sla", "yarn"))
+        );
+        final Set<String> clusterCriterion1Tags = job1Request.getClusterCriterias().get(1).getTags();
+        Assert.assertThat(
+            clusterCriterion1Tags.size(),
+            Matchers.is(2)
+        );
+        Assert.assertThat(
+            clusterCriterion1Tags,
+            Matchers.is(Sets.newHashSet("sla", "adhoc"))
+        );
+        final Set<String> commandCriterionTags = job1Request.getCommandCriteria();
+        Assert.assertThat(
+            commandCriterionTags,
+            Matchers.is(Sets.newHashSet("type:spark", "ver:1.6.0", "genie.name:spark"))
         );
         Assert.assertThat(
             this.service.getJobRequest(JOB_2_ID).getCommandArgs().orElseThrow(IllegalArgumentException::new),

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImplIntegrationTest/init.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImplIntegrationTest/init.xml
@@ -383,6 +383,7 @@
 
     <criteria
         id="0"
+        name="spark"
     />
     <criteria_tags
         criterion_id="0"
@@ -444,6 +445,8 @@
     />
     <criteria
         id="1"
+        unique_id="cluster1"
+        name="h2query"
     />
     <criteria_tags
         criterion_id="1"
@@ -529,11 +532,11 @@
         id="4"
     />
     <criteria_tags
-        criterion_id="3"
+        criterion_id="4"
         tag_id="17"
     />
     <criteria_tags
-        criterion_id="3"
+        criterion_id="4"
         tag_id="12"
     />
     <jobs_cluster_criteria

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
@@ -476,7 +476,13 @@ public final class DtoConverters {
             .collect(Collectors.toSet());
     }
 
-    static ImmutableSet<String> toV3CriterionTags(final Criterion criterion) {
+    /**
+     * Convert a given V4 {@code criterion} to the equivalent representation in V3 set of tags.
+     *
+     * @param criterion The {@link Criterion} to convert
+     * @return A set of String's representing the criterion tags as they would have looked in V3
+     */
+    public static ImmutableSet<String> toV3CriterionTags(final Criterion criterion) {
         final ImmutableSet.Builder<String> tags = ImmutableSet.builder();
         criterion.getId().ifPresent(id -> tags.add(GENIE_ID_PREFIX + id));
         criterion.getName().ifPresent(name -> tags.add(GENIE_NAME_PREFIX + name));
@@ -484,7 +490,13 @@ public final class DtoConverters {
         return tags.build();
     }
 
-    private static ClusterCriteria toClusterCriteria(final Criterion criterion) {
+    /**
+     * Convert the given {@code criterion} to a V3 {@link ClusterCriteria} object.
+     *
+     * @param criterion The {@link Criterion} to convert
+     * @return The V3 criteria object
+     */
+    public static ClusterCriteria toClusterCriteria(final Criterion criterion) {
         return new ClusterCriteria(toV3CriterionTags(criterion));
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/EntityDtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/v4/EntityDtoConverters.java
@@ -233,10 +233,7 @@ public final class EntityDtoConverters {
         final JobArchivalDataRequest.Builder jobArchivalDataRequestBuilder = new JobArchivalDataRequest.Builder();
         jobRequestProjection
             .getRequestedArchiveLocationPrefix()
-            .ifPresent(
-                requestedArchiveLocationPrefix -> jobArchivalDataRequestBuilder
-                    .withRequestedArchiveLocationPrefix(requestedArchiveLocationPrefix)
-            );
+            .ifPresent(jobArchivalDataRequestBuilder::withRequestedArchiveLocationPrefix);
 
         // Rebuild the Agent Environment Request
         final AgentEnvironmentRequest.Builder agentEnvironmentRequestBuilder = new AgentEnvironmentRequest.Builder();
@@ -260,7 +257,13 @@ public final class EntityDtoConverters {
         );
     }
 
-    private static Criterion toCriterionDto(final CriterionEntity criterionEntity) {
+    /**
+     * Convert a given {@link CriterionEntity} to the equivalent {@link Criterion} DTO representation.
+     *
+     * @param criterionEntity The entity to convert
+     * @return The DTO representation
+     */
+    public static Criterion toCriterionDto(final CriterionEntity criterionEntity) {
         final Criterion.Builder builder = new Criterion.Builder();
         criterionEntity.getUniqueId().ifPresent(builder::withId);
         criterionEntity.getName().ifPresent(builder::withName);

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobSearchServiceImpl.java
@@ -254,6 +254,7 @@ public class JpaJobSearchServiceImpl implements JobSearchService {
      * {@inheritDoc}
      */
     @Override
+    @Deprecated
     public JobStatus getJobStatus(@NotBlank final String id) throws GenieException {
         log.debug("Called with id {}", id);
         return this.jobRepository

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaServiceUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaServiceUtils.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.genie.common.dto.Application;
 import com.netflix.genie.common.dto.Cluster;
-import com.netflix.genie.common.dto.ClusterCriteria;
 import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.CommonDTO;
 import com.netflix.genie.common.dto.Job;
@@ -30,11 +29,11 @@ import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
+import com.netflix.genie.web.controllers.DtoConverters;
 import com.netflix.genie.web.jpa.entities.ApplicationEntity;
 import com.netflix.genie.web.jpa.entities.BaseEntity;
 import com.netflix.genie.web.jpa.entities.ClusterEntity;
 import com.netflix.genie.web.jpa.entities.CommandEntity;
-import com.netflix.genie.web.jpa.entities.CriterionEntity;
 import com.netflix.genie.web.jpa.entities.FileEntity;
 import com.netflix.genie.web.jpa.entities.TagEntity;
 import com.netflix.genie.web.jpa.entities.projections.BaseProjection;
@@ -42,6 +41,7 @@ import com.netflix.genie.web.jpa.entities.projections.JobExecutionProjection;
 import com.netflix.genie.web.jpa.entities.projections.JobMetadataProjection;
 import com.netflix.genie.web.jpa.entities.projections.JobProjection;
 import com.netflix.genie.web.jpa.entities.projections.JobRequestProjection;
+import com.netflix.genie.web.jpa.entities.v4.EntityDtoConverters;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
@@ -191,14 +191,12 @@ public final class JpaServiceUtils {
             jobRequestProjection
                 .getClusterCriteria()
                 .stream()
-                .map(JpaServiceUtils::toClusterCriteriaDto)
+                .map(EntityDtoConverters::toCriterionDto)
+                .map(DtoConverters::toClusterCriteria)
                 .collect(Collectors.toList()),
-            jobRequestProjection
-                .getCommandCriterion()
-                .getTags()
-                .stream()
-                .map(TagEntity::getTag)
-                .collect(Collectors.toSet())
+            DtoConverters.toV3CriterionTags(
+                EntityDtoConverters.toCriterionDto(jobRequestProjection.getCommandCriterion())
+            )
         )
             .withCreated(jobRequestProjection.getCreated())
             .withId(jobRequestProjection.getUniqueId())
@@ -236,16 +234,6 @@ public final class JpaServiceUtils {
         setDtoMetadata(builder, jobRequestProjection);
 
         return builder.build();
-    }
-
-    private static ClusterCriteria toClusterCriteriaDto(final CriterionEntity clusterCriterionEntity) {
-        return new ClusterCriteria(
-            clusterCriterionEntity
-                .getTags()
-                .stream()
-                .map(TagEntity::getTag)
-                .collect(Collectors.toSet())
-        );
     }
 
     static JobExecution toJobExecutionDto(final JobExecutionProjection jobExecutionProjection) {

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobSearchService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobSearchService.java
@@ -119,7 +119,9 @@ public interface JobSearchService {
      * @param id The id of the job to get status for
      * @return The job status
      * @throws GenieException When any error, including not found, is encountered
+     * @deprecated Use {@link JobPersistenceService#getJobStatus(String)} instead
      */
+    @Deprecated
     JobStatus getJobStatus(@NotBlank String id) throws GenieException;
 
     /**


### PR DESCRIPTION
Job Requests representations properly

Id and Name parameters were being lost. This seems to have been a miss in conversion from the database record to the V3 representation.

Added a test to the JobSearchService integration tests which should cover the case. It was broken when I started this work and now it passes.