### PR TITLE
Switch from 'ps' to 'kill -0' to check on children processes

### DIFF
--- a/genie-core/src/main/java/com/netflix/genie/core/util/ProcessChecker.java
+++ b/genie-core/src/main/java/com/netflix/genie/core/util/ProcessChecker.java
@@ -21,6 +21,7 @@ import com.netflix.genie.common.exceptions.GenieTimeoutException;
 import org.apache.commons.exec.ExecuteException;
 
 import java.io.IOException;
+import java.util.Date;
 
 /**
  * Interface for implementing process checking on various operating systems.
@@ -38,4 +39,19 @@ public interface ProcessChecker {
      * @throws IOException           For any other problem
      */
     void checkProcess() throws GenieTimeoutException, ExecuteException, IOException;
+
+    /**
+     * Interface for Factory of ProcessChecker.
+     */
+    interface Factory {
+
+        /**
+         * Get a new process checker to check on the given PID.
+         *
+         * @param pid     the process id to check on
+         * @param timeout the moment in time after which the check should produce a {@link GenieTimeoutException}
+         * @return a {@link ProcessChecker}
+         */
+        ProcessChecker get(int pid, final Date timeout);
+    }
 }

--- a/genie-core/src/test/java/com/netflix/genie/core/util/UnixProcessCheckerUnitTests.java
+++ b/genie-core/src/test/java/com/netflix/genie/core/util/UnixProcessCheckerUnitTests.java
@@ -46,7 +46,7 @@ public class UnixProcessCheckerUnitTests {
     private static final int PID = 18243;
 
     private Executor executor;
-    private UnixProcessChecker processChecker;
+    private Calendar tomorrow;
 
     /**
      * Setup for the tests.
@@ -55,10 +55,9 @@ public class UnixProcessCheckerUnitTests {
     public void setup() {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
         this.executor = Mockito.mock(Executor.class);
-        final Calendar tomorrow = Calendar.getInstance();
+        this.tomorrow = Calendar.getInstance();
         // For standard tests this will keep it from dying
         tomorrow.add(Calendar.DAY_OF_YEAR, 1);
-        this.processChecker = new UnixProcessChecker(PID, this.executor, tomorrow.getTime());
     }
 
     /**
@@ -70,13 +69,38 @@ public class UnixProcessCheckerUnitTests {
     @Test
     public void canCheckProcess() throws GenieTimeoutException, IOException {
         final ArgumentCaptor<CommandLine> argumentCaptor = ArgumentCaptor.forClass(CommandLine.class);
-        this.processChecker.checkProcess();
+        final UnixProcessChecker processChecker =
+            new UnixProcessChecker(PID, this.executor, tomorrow.getTime(), false);
+        processChecker.checkProcess();
         Mockito.verify(this.executor).execute(argumentCaptor.capture());
-        Assert.assertThat(argumentCaptor.getValue().getExecutable(), Matchers.is("ps"));
+        Assert.assertThat(argumentCaptor.getValue().getExecutable(), Matchers.is("kill"));
         Assert.assertThat(argumentCaptor.getValue().getArguments().length, Matchers.is(2));
-        Assert.assertThat(argumentCaptor.getValue().getArguments()[0], Matchers.is("-p"));
+        Assert.assertThat(argumentCaptor.getValue().getArguments()[0], Matchers.is("-0"));
         Assert.assertThat(
             argumentCaptor.getValue().getArguments()[1],
+            Matchers.is(Integer.toString(PID))
+        );
+    }
+
+    /**
+     * Make sure the correct process is invoked.
+     *
+     * @throws GenieTimeoutException on timeout
+     * @throws IOException           on error
+     */
+    @Test
+    public void canCheckProcessWithSudo() throws GenieTimeoutException, IOException {
+        final ArgumentCaptor<CommandLine> argumentCaptor = ArgumentCaptor.forClass(CommandLine.class);
+        final UnixProcessChecker processChecker =
+            new UnixProcessChecker(PID, this.executor, tomorrow.getTime(), true);
+        processChecker.checkProcess();
+        Mockito.verify(this.executor).execute(argumentCaptor.capture());
+        Assert.assertThat(argumentCaptor.getValue().getExecutable(), Matchers.is("sudo"));
+        Assert.assertThat(argumentCaptor.getValue().getArguments().length, Matchers.is(3));
+        Assert.assertThat(argumentCaptor.getValue().getArguments()[0], Matchers.is("kill"));
+        Assert.assertThat(argumentCaptor.getValue().getArguments()[1], Matchers.is("-0"));
+        Assert.assertThat(
+            argumentCaptor.getValue().getArguments()[2],
             Matchers.is(Integer.toString(PID))
         );
     }
@@ -91,7 +115,6 @@ public class UnixProcessCheckerUnitTests {
     public void canCheckProcessTimeout() throws GenieTimeoutException, IOException {
         final Calendar yesterday = Calendar.getInstance();
         yesterday.add(Calendar.DAY_OF_YEAR, -1);
-        this.processChecker = new UnixProcessChecker(PID, this.executor, yesterday.getTime());
-        this.processChecker.checkProcess();
+        new UnixProcessChecker.Factory(this.executor, false).get(PID, yesterday.getTime()).checkProcess();
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/JobConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/JobConfig.java
@@ -37,7 +37,6 @@ import com.netflix.spectator.api.Registry;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.lang3.SystemUtils;
 import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -161,7 +160,6 @@ public class JobConfig {
      */
     @Bean
     @Order(value = 5)
-    @Autowired
     public WorkflowTask jobProcessorTask(
         final AttachmentService attachmentService,
         final Registry registry,
@@ -182,7 +180,6 @@ public class JobConfig {
      */
     @Bean
     @Order(value = 6)
-    @Autowired
     public WorkflowTask jobKickoffTask(
         final JobsProperties jobsProperties,
         final Executor executor,
@@ -206,7 +203,6 @@ public class JobConfig {
      * @return a {@link ProcessChecker.Factory}
      */
     @Bean
-    @Autowired
     @ConditionalOnMissingBean(ProcessChecker.Factory.class)
     public ProcessChecker.Factory processCheckerFactory(
         final Executor executor,

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/ServicesConfig.java
@@ -60,6 +60,7 @@ import com.netflix.genie.core.services.impl.LocalJobKillServiceImpl;
 import com.netflix.genie.core.services.impl.LocalJobRunner;
 import com.netflix.genie.core.services.impl.MailServiceImpl;
 import com.netflix.genie.core.services.impl.RandomizedClusterLoadBalancerImpl;
+import com.netflix.genie.core.util.ProcessChecker;
 import com.netflix.spectator.api.Registry;
 import org.apache.commons.exec.Executor;
 import org.springframework.beans.factory.FactoryBean;
@@ -264,13 +265,14 @@ public class ServicesConfig {
     /**
      * Get an local implementation of the JobKillService.
      *
-     * @param hostName         The name of the host this Genie node is running on.
-     * @param jobSearchService The job search service to use to locate job information.
-     * @param executor         The executor to use to run system processes.
-     * @param jobsProperties   The jobs properties to use
-     * @param genieEventBus    The application event bus to use to publish system wide events
-     * @param genieWorkingDir  Working directory for genie where it creates jobs directories.
-     * @param objectMapper     The Jackson ObjectMapper used to serialize from/to JSON
+     * @param hostName              The name of the host this Genie node is running on.
+     * @param jobSearchService      The job search service to use to locate job information.
+     * @param executor              The executor to use to run system processes.
+     * @param jobsProperties        The jobs properties to use
+     * @param genieEventBus         The application event bus to use to publish system wide events
+     * @param genieWorkingDir       Working directory for genie where it creates jobs directories.
+     * @param objectMapper          The Jackson ObjectMapper used to serialize from/to JSON
+     * @param processCheckerFactory The factory of process checkers
      * @return A job kill service instance.
      */
     @Bean
@@ -281,7 +283,8 @@ public class ServicesConfig {
         final JobsProperties jobsProperties,
         final GenieEventBus genieEventBus,
         @Qualifier("jobsDir") final Resource genieWorkingDir,
-        final ObjectMapper objectMapper
+        final ObjectMapper objectMapper,
+        final ProcessChecker.Factory processCheckerFactory
     ) {
         return new LocalJobKillServiceImpl(
             hostName,
@@ -290,7 +293,8 @@ public class ServicesConfig {
             jobsProperties.getUsers().isRunAsUserEnabled(),
             genieEventBus,
             genieWorkingDir,
-            objectMapper
+            objectMapper,
+            processCheckerFactory
         );
     }
 

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/ServicesConfigUnitTests.java
@@ -38,6 +38,7 @@ import com.netflix.genie.core.services.JobPersistenceService;
 import com.netflix.genie.core.services.JobSearchService;
 import com.netflix.genie.core.services.JobStateService;
 import com.netflix.genie.core.services.TagService;
+import com.netflix.genie.core.util.ProcessChecker;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.spectator.api.Registry;
 import org.apache.commons.exec.Executor;
@@ -292,7 +293,8 @@ public class ServicesConfigUnitTests {
                 new JobsProperties(),
                 Mockito.mock(GenieEventBus.class),
                 Mockito.mock(FileSystemResource.class),
-                new ObjectMapper()
+                new ObjectMapper(),
+                Mockito.mock(ProcessChecker.Factory.class)
             )
         );
     }

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorUnitTests.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorUnitTests.java
@@ -31,9 +31,9 @@ import com.netflix.genie.core.jobs.JobConstants;
 import com.netflix.genie.core.properties.JobsProperties;
 import com.netflix.genie.core.services.JobSearchService;
 import com.netflix.genie.core.services.JobSubmitterService;
+import com.netflix.genie.core.util.ProcessChecker;
 import com.netflix.genie.test.categories.UnitTest;
 import com.netflix.spectator.api.DefaultRegistry;
-import org.apache.commons.exec.Executor;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -79,6 +79,7 @@ public class JobMonitoringCoordinatorUnitTests {
     private JobSearchService jobSearchService;
     private GenieEventBus genieEventBus;
     private Date tomorrow;
+    private ProcessChecker.Factory processCheckerFactory;
 
     /**
      * Setup for the tests.
@@ -92,9 +93,9 @@ public class JobMonitoringCoordinatorUnitTests {
         this.tomorrow = cal.getTime();
         this.jobSearchService = Mockito.mock(JobSearchService.class);
         final JobSubmitterService jobSubmitterService = Mockito.mock(JobSubmitterService.class);
-        final Executor executor = Mockito.mock(Executor.class);
         this.scheduler = Mockito.mock(TaskScheduler.class);
         this.genieEventBus = Mockito.mock(GenieEventBus.class);
+        this.processCheckerFactory = Mockito.mock(ProcessChecker.Factory.class);
 
         final File jobsFile = this.folder.newFolder();
         final Resource jobsDir = Mockito.mock(Resource.class);
@@ -105,11 +106,11 @@ public class JobMonitoringCoordinatorUnitTests {
             this.jobSearchService,
             this.genieEventBus,
             this.scheduler,
-            executor,
             new DefaultRegistry(),
             jobsDir,
             new JobsProperties(),
-            jobSubmitterService
+            jobSubmitterService,
+            this.processCheckerFactory
         );
     }
 


### PR DESCRIPTION
Using 'ps' to check for process termination can sometimes produce false-negatives.
I.e. returning with non-zero exit code when the process is actually still running.
This situation can lead Genie to mark a job as failed when it was actually still running.

Switch to using 'kill -0' as per POSIX recommendation.

I.e. returning with non-zero exit code when the process is actually still running.
This situation can lead Genie to mark a job as failed when it was actually still running.

Switch to using  as per POSIX recommendation.
(this can still produce false negatives, such as when permissions are lacking, or when kill fails to launch due to resource exhaustion)