### PR TITLE
Tweak log levels

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ApplicationRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ApplicationRestController.java
@@ -112,7 +112,7 @@ public class ApplicationRestController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> createApplication(@RequestBody final Application app) throws GenieException {
-        log.debug("Called to create new application");
+        log.info("Called to create new application: {}", app);
         final String id = this.applicationPersistenceService.createApplication(
             DtoConverters.toV4ApplicationRequest(app)
         );
@@ -135,7 +135,7 @@ public class ApplicationRestController {
     @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteAllApplications() throws GenieException {
-        log.debug("Delete all Applications");
+        log.warn("Called to delete all Applications");
         this.applicationPersistenceService.deleteAllApplications();
     }
 
@@ -163,8 +163,15 @@ public class ApplicationRestController {
         @PageableDefault(sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<Application> assembler
     ) throws GenieException {
-        log.debug("Called [name | user | status | tags | type | pageable]");
-        log.debug("{} | {} | {} | {} | | {} | {}", name, user, statuses, tags, type, page);
+        log.info(
+            "Finding applications [name | user | status | tags | type | pageable]\n{} | {} | {} | {} | | {} | {}",
+            name,
+            user,
+            statuses,
+            tags,
+            type,
+            page
+        );
 
         Set<ApplicationStatus> enumStatuses = null;
         if (statuses != null) {
@@ -245,7 +252,7 @@ public class ApplicationRestController {
     @GetMapping(value = "/{id}", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public ApplicationResource getApplication(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called to get Application for id {}", id);
+        log.info("Called to get Application for id {}", id);
         return this.applicationResourceAssembler.toResource(
             DtoConverters.toV3Application(this.applicationPersistenceService.getApplication(id))
         );
@@ -264,7 +271,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @RequestBody final Application updateApp
     ) throws GenieException {
-        log.debug("called to update application {} with info {}", id, updateApp);
+        log.info("called to update application {} with info {}", id, updateApp);
         this.applicationPersistenceService.updateApplication(id, DtoConverters.toV4Application(updateApp));
     }
 
@@ -281,7 +288,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @RequestBody final JsonPatch patch
     ) throws GenieException {
-        log.debug("Called to patch application {} with patch {}", id, patch);
+        log.info("Called to patch application {} with patch {}", id, patch);
         final Application currentApp = DtoConverters.toV3Application(
             this.applicationPersistenceService.getApplication(id)
         );
@@ -308,7 +315,7 @@ public class ApplicationRestController {
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteApplication(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Delete an application with id {}", id);
+        log.info("Delete an application with id {}", id);
         this.applicationPersistenceService.deleteApplication(id);
     }
 
@@ -326,7 +333,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> configs
     ) throws GenieException {
-        log.debug("Called with id {} and config {}", id, configs);
+        log.info("Called with id {} and config {}", id, configs);
         this.applicationPersistenceService.addConfigsToApplication(id, configs);
     }
 
@@ -341,7 +348,7 @@ public class ApplicationRestController {
     @GetMapping(value = "/{id}/configs", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getConfigsForApplication(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return this.applicationPersistenceService.getConfigsForApplication(id);
     }
 
@@ -360,7 +367,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> configs
     ) throws GenieException {
-        log.debug("Called with id {} and configs {}", id, configs);
+        log.info("Called with id {} and configs {}", id, configs);
         this.applicationPersistenceService.updateConfigsForApplication(id, configs);
     }
 
@@ -374,7 +381,7 @@ public class ApplicationRestController {
     @DeleteMapping(value = "/{id}/configs")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllConfigsForApplication(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.applicationPersistenceService.removeAllConfigsForApplication(id);
     }
 
@@ -392,7 +399,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> dependencies
     ) throws GenieException {
-        log.debug("Called with id {} and dependencies {}", id, dependencies);
+        log.info("Called with id {} and dependencies {}", id, dependencies);
         this.applicationPersistenceService.addDependenciesForApplication(id, dependencies);
     }
 
@@ -407,7 +414,7 @@ public class ApplicationRestController {
     @GetMapping(value = "/{id}/dependencies", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getDependenciesForApplication(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return this.applicationPersistenceService.getDependenciesForApplication(id);
     }
 
@@ -426,7 +433,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> dependencies
     ) throws GenieException {
-        log.debug("Called with id {} and dependencies {}", id, dependencies);
+        log.info("Called with id {} and dependencies {}", id, dependencies);
         this.applicationPersistenceService.updateDependenciesForApplication(id, dependencies);
     }
 
@@ -440,7 +447,7 @@ public class ApplicationRestController {
     @DeleteMapping(value = "/{id}/dependencies")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllDependenciesForApplication(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.applicationPersistenceService.removeAllDependenciesForApplication(id);
     }
 
@@ -458,7 +465,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> tags
     ) throws GenieException {
-        log.debug("Called with id {} and config {}", id, tags);
+        log.info("Called with id {} and config {}", id, tags);
         this.applicationPersistenceService.addTagsForApplication(id, tags);
     }
 
@@ -473,7 +480,7 @@ public class ApplicationRestController {
     @GetMapping(value = "/{id}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getTagsForApplication(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return DtoConverters.toV3Application(this.applicationPersistenceService.getApplication(id)).getTags();
     }
 
@@ -492,7 +499,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> tags
     ) throws GenieException {
-        log.debug("Called with id {} and tags {}", id, tags);
+        log.info("Called with id {} and tags {}", id, tags);
         this.applicationPersistenceService.updateTagsForApplication(id, tags);
     }
 
@@ -506,7 +513,7 @@ public class ApplicationRestController {
     @DeleteMapping(value = "/{id}/tags")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllTagsForApplication(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.applicationPersistenceService.removeAllTagsForApplication(id);
     }
 
@@ -524,7 +531,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @PathVariable("tag") final String tag
     ) throws GenieException {
-        log.debug("Called with id {} and tag {}", id, tag);
+        log.info("Called with id {} and tag {}", id, tag);
         this.applicationPersistenceService.removeTagForApplication(id, tag);
     }
 
@@ -542,7 +549,7 @@ public class ApplicationRestController {
         @PathVariable("id") final String id,
         @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses
     ) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {} and statuses {}", id, statuses);
 
         Set<CommandStatus> enumStatuses = null;
         if (statuses != null) {

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ApplicationRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ApplicationRestController.java
@@ -61,6 +61,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
@@ -154,11 +155,11 @@ public class ApplicationRestController {
     @GetMapping(produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public PagedResources<ApplicationResource> getApplications(
-        @RequestParam(value = "name", required = false) final String name,
-        @RequestParam(value = "user", required = false) final String user,
-        @RequestParam(value = "status", required = false) final Set<String> statuses,
-        @RequestParam(value = "tag", required = false) final Set<String> tags,
-        @RequestParam(value = "type", required = false) final String type,
+        @RequestParam(value = "name", required = false) @Nullable final String name,
+        @RequestParam(value = "user", required = false) @Nullable final String user,
+        @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses,
+        @RequestParam(value = "tag", required = false) @Nullable final Set<String> tags,
+        @RequestParam(value = "type", required = false) @Nullable final String type,
         @PageableDefault(sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<Application> assembler
     ) throws GenieException {
@@ -539,7 +540,7 @@ public class ApplicationRestController {
     @GetMapping(value = "/{id}/commands", produces = MediaTypes.HAL_JSON_VALUE)
     public Set<CommandResource> getCommandsForApplication(
         @PathVariable("id") final String id,
-        @RequestParam(value = "status", required = false) final Set<String> statuses
+        @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses
     ) throws GenieException {
         log.debug("Called with id {}", id);
 

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
@@ -61,6 +61,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import java.io.IOException;
 import java.time.Instant;
@@ -160,11 +161,11 @@ ClusterRestController {
     @GetMapping(produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public PagedResources<ClusterResource> getClusters(
-        @RequestParam(value = "name", required = false) final String name,
-        @RequestParam(value = "status", required = false) final Set<String> statuses,
-        @RequestParam(value = "tag", required = false) final Set<String> tags,
-        @RequestParam(value = "minUpdateTime", required = false) final Long minUpdateTime,
-        @RequestParam(value = "maxUpdateTime", required = false) final Long maxUpdateTime,
+        @RequestParam(value = "name", required = false) @Nullable final String name,
+        @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses,
+        @RequestParam(value = "tag", required = false) @Nullable final Set<String> tags,
+        @RequestParam(value = "minUpdateTime", required = false) @Nullable final Long minUpdateTime,
+        @RequestParam(value = "maxUpdateTime", required = false) @Nullable final Long maxUpdateTime,
         @PageableDefault(size = 64, sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<Cluster> assembler
     ) throws GenieException {
@@ -588,7 +589,7 @@ ClusterRestController {
     @ResponseStatus(HttpStatus.OK)
     public List<CommandResource> getCommandsForCluster(
         @PathVariable("id") final String id,
-        @RequestParam(value = "status", required = false) final Set<String> statuses
+        @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses
     ) throws GenieException {
         log.debug("Called with id {} status {}", id, statuses);
 

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/ClusterRestController.java
@@ -115,7 +115,7 @@ ClusterRestController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> createCluster(@RequestBody @Valid final Cluster cluster) throws GenieException {
-        log.debug("Called to create new cluster {}", cluster);
+        log.info("Called to create new cluster {}", cluster);
         final String id = this.clusterPersistenceService.createCluster(DtoConverters.toV4ClusterRequest(cluster));
         final HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setLocation(
@@ -138,7 +138,7 @@ ClusterRestController {
     @GetMapping(value = "/{id}", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public ClusterResource getCluster(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id: {}", id);
+        log.info("Called with id: {}", id);
         return this.clusterResourceAssembler.toResource(
             DtoConverters.toV3Cluster(this.clusterPersistenceService.getCluster(id))
         );
@@ -169,8 +169,16 @@ ClusterRestController {
         @PageableDefault(size = 64, sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<Cluster> assembler
     ) throws GenieException {
-        log.debug("Called [name | statuses | tags | minUpdateTime | maxUpdateTime | page]");
-        log.debug("{} | {} | {} | {} | {} | {}", name, statuses, tags, minUpdateTime, maxUpdateTime, page);
+        log.info(
+            "Called to find clusters [name | statuses | tags | minUpdateTime | maxUpdateTime | page]\n"
+                + "{} | {} | {} | {} | {} | {}",
+            name,
+            statuses,
+            tags,
+            minUpdateTime,
+            maxUpdateTime,
+            page
+        );
         //Create this conversion internal in case someone uses lower case by accident?
         Set<ClusterStatus> enumStatuses = null;
         if (statuses != null) {
@@ -283,7 +291,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final Cluster updateCluster
     ) throws GenieException {
-        log.debug("Called to update cluster with id {} update fields {}", id, updateCluster);
+        log.info("Called to update cluster with id {} update fields {}", id, updateCluster);
         this.clusterPersistenceService.updateCluster(id, DtoConverters.toV4Cluster(updateCluster));
     }
 
@@ -300,7 +308,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final JsonPatch patch
     ) throws GenieException {
-        log.debug("Called to patch cluster {} with patch {}", id, patch);
+        log.info("Called to patch cluster {} with patch {}", id, patch);
 
         final Cluster currentCluster = DtoConverters.toV3Cluster(this.clusterPersistenceService.getCluster(id));
 
@@ -326,7 +334,7 @@ ClusterRestController {
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteCluster(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Delete called for id: {}", id);
+        log.info("Delete cluster called for id: {}", id);
         this.clusterPersistenceService.deleteCluster(id);
     }
 
@@ -338,7 +346,7 @@ ClusterRestController {
     @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteAllClusters() throws GenieException {
-        log.debug("called");
+        log.warn("Delete all clusters called");
         this.clusterPersistenceService.deleteAllClusters();
     }
 
@@ -356,7 +364,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> configs
     ) throws GenieException {
-        log.debug("Called with id {} and config {}", id, configs);
+        log.info("Called with id {} and config {}", id, configs);
         this.clusterPersistenceService.addConfigsForCluster(id, configs);
     }
 
@@ -371,7 +379,7 @@ ClusterRestController {
     @GetMapping(value = "/{id}/configs", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getConfigsForCluster(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return this.clusterPersistenceService.getConfigsForCluster(id);
     }
 
@@ -390,7 +398,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> configs
     ) throws GenieException {
-        log.debug("Called with id {} and configs {}", id, configs);
+        log.info("Called with id {} and configs {}", id, configs);
         this.clusterPersistenceService.updateConfigsForCluster(id, configs);
     }
 
@@ -404,7 +412,7 @@ ClusterRestController {
     @DeleteMapping(value = "/{id}/configs")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllConfigsForCluster(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.clusterPersistenceService.removeAllConfigsForCluster(id);
     }
 
@@ -422,7 +430,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> dependencies
     ) throws GenieException {
-        log.debug("Called with id {} and dependencies {}", id, dependencies);
+        log.info("Called with id {} and dependencies {}", id, dependencies);
         this.clusterPersistenceService.addDependenciesForCluster(id, dependencies);
     }
 
@@ -437,7 +445,7 @@ ClusterRestController {
     @GetMapping(value = "/{id}/dependencies", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getDependenciesForCluster(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return this.clusterPersistenceService.getDependenciesForCluster(id);
     }
 
@@ -456,7 +464,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> dependencies
     ) throws GenieException {
-        log.debug("Called with id {} and dependencies {}", id, dependencies);
+        log.info("Called with id {} and dependencies {}", id, dependencies);
         this.clusterPersistenceService.updateDependenciesForCluster(id, dependencies);
     }
 
@@ -470,7 +478,7 @@ ClusterRestController {
     @DeleteMapping(value = "/{id}/dependencies")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllDependenciesForCluster(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.clusterPersistenceService.removeAllDependenciesForCluster(id);
     }
 
@@ -488,7 +496,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> tags
     ) throws GenieException {
-        log.debug("Called with id {} and tags {}", id, tags);
+        log.info("Called with id {} and tags {}", id, tags);
         this.clusterPersistenceService.addTagsForCluster(id, tags);
     }
 
@@ -503,7 +511,7 @@ ClusterRestController {
     @GetMapping(value = "/{id}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getTagsForCluster(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return DtoConverters.toV3Cluster(this.clusterPersistenceService.getCluster(id)).getTags();
     }
 
@@ -522,7 +530,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> tags
     ) throws GenieException {
-        log.debug("Called with id {} and tags {}", id, tags);
+        log.info("Called with id {} and tags {}", id, tags);
         this.clusterPersistenceService.updateTagsForCluster(id, tags);
     }
 
@@ -536,7 +544,7 @@ ClusterRestController {
     @DeleteMapping(value = "/{id}/tags")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllTagsForCluster(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.clusterPersistenceService.removeAllTagsForCluster(id);
     }
 
@@ -554,7 +562,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @PathVariable("tag") final String tag
     ) throws GenieException {
-        log.debug("Called with id {} and tag {}", id, tag);
+        log.info("Called with id {} and tag {}", id, tag);
         this.clusterPersistenceService.removeTagForCluster(id, tag);
     }
 
@@ -572,7 +580,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final List<String> commandIds
     ) throws GenieException {
-        log.debug("Called with id {} and commandIds {}", id, commandIds);
+        log.info("Called with id {} and commandIds {}", id, commandIds);
         this.clusterPersistenceService.addCommandsForCluster(id, commandIds);
     }
 
@@ -591,7 +599,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses
     ) throws GenieException {
-        log.debug("Called with id {} status {}", id, statuses);
+        log.info("Called with id {} status {}", id, statuses);
 
         Set<CommandStatus> enumStatuses = null;
         if (statuses != null) {
@@ -623,7 +631,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @RequestBody final List<String> commandIds
     ) throws GenieException {
-        log.debug("Called with id {} and commandIds {}", id, commandIds);
+        log.info("Called with id {} and commandIds {}", id, commandIds);
         this.clusterPersistenceService.setCommandsForCluster(id, commandIds);
     }
 
@@ -637,7 +645,7 @@ ClusterRestController {
     @DeleteMapping(value = "/{id}/commands")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllCommandsForCluster(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.clusterPersistenceService.removeAllCommandsForCluster(id);
     }
 
@@ -655,7 +663,7 @@ ClusterRestController {
         @PathVariable("id") final String id,
         @PathVariable("commandId") final String commandId
     ) throws GenieException {
-        log.debug("Called with id {} and command id {}", id, commandId);
+        log.info("Called with id {} and command id {}", id, commandId);
         this.clusterPersistenceService.removeCommandForCluster(id, commandId);
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/CommandRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/CommandRestController.java
@@ -120,7 +120,7 @@ public class CommandRestController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Void> createCommand(@RequestBody @Valid final Command command) throws GenieException {
-        log.debug("called to create new command configuration {}", command);
+        log.info("Called to create new command {}", command);
         final String id = this.commandPersistenceService.createCommand(DtoConverters.toV4CommandRequest(command));
         final HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setLocation(
@@ -143,7 +143,7 @@ public class CommandRestController {
     @GetMapping(value = "/{id}", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public CommandResource getCommand(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called to get command with id {}", id);
+        log.info("Called to get command with id {}", id);
         return this.commandResourceAssembler.toResource(
             DtoConverters.toV3Command(this.commandPersistenceService.getCommand(id))
         );
@@ -171,8 +171,14 @@ public class CommandRestController {
         @PageableDefault(size = 64, sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<Command> assembler
     ) throws GenieException {
-        log.debug("Called [name | user | status | tags | page]");
-        log.debug("{} | {} | {} | {} | {}", name, user, statuses, tags, page);
+        log.info(
+            "Called [name | user | status | tags | page]\n{} | {} | {} | {} | {}",
+            name,
+            user,
+            statuses,
+            tags,
+            page
+        );
 
         Set<CommandStatus> enumStatuses = null;
         if (statuses != null) {
@@ -298,7 +304,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestBody final JsonPatch patch
     ) throws GenieException {
-        log.debug("Called to patch command {} with patch {}", id, patch);
+        log.info("Called to patch command {} with patch {}", id, patch);
 
         final Command currentCommand = DtoConverters.toV3Command(this.commandPersistenceService.getCommand(id));
 
@@ -323,7 +329,7 @@ public class CommandRestController {
     @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteAllCommands() throws GenieException {
-        log.debug("called to delete all commands.");
+        log.warn("Called to delete all commands.");
         this.commandPersistenceService.deleteAllCommands();
     }
 
@@ -336,7 +342,7 @@ public class CommandRestController {
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteCommand(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called to delete command with id {}", id);
+        log.info("Called to delete command with id {}", id);
         this.commandPersistenceService.deleteCommand(id);
     }
 
@@ -354,7 +360,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> configs
     ) throws GenieException {
-        log.debug("Called with id {} and config {}", id, configs);
+        log.info("Called with id {} and config {}", id, configs);
         this.commandPersistenceService.addConfigsForCommand(id, configs);
     }
 
@@ -369,7 +375,7 @@ public class CommandRestController {
     @GetMapping(value = "/{id}/configs", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getConfigsForCommand(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return this.commandPersistenceService.getConfigsForCommand(id);
     }
 
@@ -388,7 +394,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> configs
     ) throws GenieException {
-        log.debug("Called with id {} and configs {}", id, configs);
+        log.info("Called with id {} and configs {}", id, configs);
         this.commandPersistenceService.updateConfigsForCommand(id, configs);
     }
 
@@ -402,7 +408,7 @@ public class CommandRestController {
     @DeleteMapping(value = "/{id}/configs")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllConfigsForCommand(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.commandPersistenceService.removeAllConfigsForCommand(id);
     }
 
@@ -420,7 +426,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> dependencies
     ) throws GenieException {
-        log.debug("Called with id {} and dependencies {}", id, dependencies);
+        log.info("Called with id {} and dependencies {}", id, dependencies);
         this.commandPersistenceService.addDependenciesForCommand(id, dependencies);
     }
 
@@ -435,7 +441,7 @@ public class CommandRestController {
     @GetMapping(value = "/{id}/dependencies", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getDependenciesForCommand(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return this.commandPersistenceService.getDependenciesForCommand(id);
     }
 
@@ -454,7 +460,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> dependencies
     ) throws GenieException {
-        log.debug("Called with id {} and dependencies {}", id, dependencies);
+        log.info("Called with id {} and dependencies {}", id, dependencies);
         this.commandPersistenceService.updateDependenciesForCommand(id, dependencies);
     }
 
@@ -468,7 +474,7 @@ public class CommandRestController {
     @DeleteMapping(value = "/{id}/dependencies")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllDependenciesForCommand(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.commandPersistenceService.removeAllDependenciesForCommand(id);
     }
 
@@ -486,7 +492,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> tags
     ) throws GenieException {
-        log.debug("Called with id {} and tags {}", id, tags);
+        log.info("Called with id {} and tags {}", id, tags);
         this.commandPersistenceService.addTagsForCommand(id, tags);
     }
 
@@ -501,7 +507,7 @@ public class CommandRestController {
     @GetMapping(value = "/{id}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public Set<String> getTagsForCommand(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return DtoConverters.toV3Command(this.commandPersistenceService.getCommand(id)).getTags();
     }
 
@@ -520,7 +526,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestBody final Set<String> tags
     ) throws GenieException {
-        log.debug("Called with id {} and tags {}", id, tags);
+        log.info("Called with id {} and tags {}", id, tags);
         this.commandPersistenceService.updateTagsForCommand(id, tags);
     }
 
@@ -534,7 +540,7 @@ public class CommandRestController {
     @DeleteMapping(value = "/{id}/tags")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllTagsForCommand(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         this.commandPersistenceService.removeAllTagsForCommand(id);
     }
 
@@ -552,7 +558,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @PathVariable("tag") final String tag
     ) throws GenieException {
-        log.debug("Called with id {} and tag {}", id, tag);
+        log.info("Called with id {} and tag {}", id, tag);
         this.commandPersistenceService.removeTagForCommand(id, tag);
     }
 
@@ -570,7 +576,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestBody final List<String> applicationIds
     ) throws GenieException {
-        log.debug("Called with id {} and application {}", id, applicationIds);
+        log.info("Called with id {} and application {}", id, applicationIds);
         this.commandPersistenceService.addApplicationsForCommand(id, applicationIds);
     }
 
@@ -587,7 +593,7 @@ public class CommandRestController {
     public List<ApplicationResource> getApplicationsForCommand(
         @PathVariable("id") final String id
     ) throws GenieException {
-        log.debug("Called with id {}", id);
+        log.info("Called with id {}", id);
         return this.commandPersistenceService.getApplicationsForCommand(id)
             .stream()
             .map(DtoConverters::toV3Application)
@@ -609,7 +615,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestBody final List<String> applicationIds
     ) throws GenieException {
-        log.debug("Called with id {} and application {}", id, applicationIds);
+        log.info("Called with id {} and application {}", id, applicationIds);
         this.commandPersistenceService.setApplicationsForCommand(id, applicationIds);
     }
 
@@ -623,7 +629,7 @@ public class CommandRestController {
     @DeleteMapping(value = "/{id}/applications")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAllApplicationsForCommand(@PathVariable("id") final String id) throws GenieException {
-        log.debug("Called with id '{}'.", id);
+        log.info("Called with id '{}'", id);
         this.commandPersistenceService.removeApplicationsForCommand(id);
     }
 
@@ -641,7 +647,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @PathVariable("appId") final String appId
     ) throws GenieException {
-        log.debug("Called with id '{}' and app id {}", id, appId);
+        log.info("Called with id '{}' and app id {}", id, appId);
         this.commandPersistenceService.removeApplicationForCommand(id, appId);
     }
 
@@ -660,7 +666,7 @@ public class CommandRestController {
         @PathVariable("id") final String id,
         @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses
     ) throws GenieException {
-        log.debug("Called with id {} and statuses {}", id, statuses);
+        log.info("Called with id {} and statuses {}", id, statuses);
 
         Set<ClusterStatus> enumStatuses = null;
         if (statuses != null) {

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/CommandRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/CommandRestController.java
@@ -63,6 +63,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import java.io.IOException;
 import java.util.EnumSet;
@@ -163,10 +164,10 @@ public class CommandRestController {
     @GetMapping(produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public PagedResources<CommandResource> getCommands(
-        @RequestParam(value = "name", required = false) final String name,
-        @RequestParam(value = "user", required = false) final String user,
-        @RequestParam(value = "status", required = false) final Set<String> statuses,
-        @RequestParam(value = "tag", required = false) final Set<String> tags,
+        @RequestParam(value = "name", required = false) @Nullable final String name,
+        @RequestParam(value = "user", required = false) @Nullable final String user,
+        @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses,
+        @RequestParam(value = "tag", required = false) @Nullable final Set<String> tags,
         @PageableDefault(size = 64, sort = {"updated"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<Command> assembler
     ) throws GenieException {
@@ -657,7 +658,7 @@ public class CommandRestController {
     @ResponseStatus(HttpStatus.OK)
     public Set<ClusterResource> getClustersForCommand(
         @PathVariable("id") final String id,
-        @RequestParam(value = "status", required = false) final Set<String> statuses
+        @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses
     ) throws GenieException {
         log.debug("Called with id {} and statuses {}", id, statuses);
 

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -377,8 +377,7 @@ public class JobRestController {
      * @throws GenieException For any error
      */
     @GetMapping(value = "/{id}", produces = MediaTypes.HAL_JSON_VALUE)
-    public JobResource getJob(
-        @PathVariable("id") final String id) throws GenieException {
+    public JobResource getJob(@PathVariable("id") final String id) throws GenieException {
         log.info("[getJob] Called for job with id: {}", id);
         return this.jobResourceAssembler.toResource(this.jobSearchService.getJob(id));
     }
@@ -391,9 +390,7 @@ public class JobRestController {
      * @throws GenieException on error
      */
     @GetMapping(value = "/{id}/status", produces = MediaType.APPLICATION_JSON_VALUE)
-    public JsonNode getJobStatus(
-        @PathVariable("id") final String id) throws GenieException {
-        log.debug("[getJobStatus] Called for job with id: {}", id);
+    public JsonNode getJobStatus(@PathVariable("id") final String id) throws GenieException {
         final JsonNodeFactory factory = JsonNodeFactory.instance;
         return factory
             .objectNode()
@@ -651,9 +648,7 @@ public class JobRestController {
      */
     @GetMapping(value = "/{id}/cluster", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public ClusterResource getJobCluster(
-        @PathVariable("id") final String id
-    ) throws GenieException {
+    public ClusterResource getJobCluster(@PathVariable("id") final String id) throws GenieException {
         log.info("[getJobCluster] Called for job with id {}", id);
         return this.clusterResourceAssembler.toResource(this.jobSearchService.getJobCluster(id));
     }
@@ -667,8 +662,7 @@ public class JobRestController {
      */
     @GetMapping(value = "/{id}/command", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public CommandResource getJobCommand(
-        @PathVariable("id") final String id) throws GenieException {
+    public CommandResource getJobCommand(@PathVariable("id") final String id) throws GenieException {
         log.info("[getJobCommand] Called for job with id {}", id);
         return this.commandResourceAssembler.toResource(this.jobSearchService.getJobCommand(id));
     }
@@ -682,8 +676,7 @@ public class JobRestController {
      */
     @GetMapping(value = "/{id}/applications", produces = MediaTypes.HAL_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public List<ApplicationResource> getJobApplications(
-        @PathVariable("id") final String id) throws GenieException {
+    public List<ApplicationResource> getJobApplications(@PathVariable("id") final String id) throws GenieException {
         log.info("[getJobApplications] Called for job with id {}", id);
 
         return this.jobSearchService

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -394,7 +394,7 @@ public class JobRestController {
         final JsonNodeFactory factory = JsonNodeFactory.instance;
         return factory
             .objectNode()
-            .set("status", factory.textNode(this.jobSearchService.getJobStatus(id).toString()));
+            .set("status", factory.textNode(this.jobPersistenceService.getJobStatus(id).toString()));
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -94,6 +94,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -233,8 +234,8 @@ public class JobRestController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResponseEntity<Void> submitJob(
         @Valid @RequestBody final JobRequest jobRequest,
-        @RequestHeader(value = FORWARDED_FOR_HEADER, required = false) final String clientHost,
-        @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) final String userAgent,
+        @RequestHeader(value = FORWARDED_FOR_HEADER, required = false) @Nullable final String clientHost,
+        @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) @Nullable final String userAgent,
         final HttpServletRequest httpServletRequest
     ) throws GenieException {
         log.info("[submitJob] Called json method type to submit job: {}", jobRequest);
@@ -258,8 +259,8 @@ public class JobRestController {
     public ResponseEntity<Void> submitJob(
         @Valid @RequestPart("request") final JobRequest jobRequest,
         @RequestPart("attachment") final MultipartFile[] attachments,
-        @RequestHeader(value = FORWARDED_FOR_HEADER, required = false) final String clientHost,
-        @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) final String userAgent,
+        @RequestHeader(value = FORWARDED_FOR_HEADER, required = false) @Nullable final String clientHost,
+        @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) @Nullable final String userAgent,
         final HttpServletRequest httpServletRequest
     ) throws GenieException {
         log.info("[submitJob] Called multipart method to submit job: {}", jobRequest);
@@ -269,9 +270,9 @@ public class JobRestController {
 
     private ResponseEntity<Void> handleSubmitJob(
         final JobRequest jobRequest,
-        final MultipartFile[] attachments,
-        final String clientHost,
-        final String userAgent,
+        @Nullable final MultipartFile[] attachments,
+        @Nullable final String clientHost,
+        @Nullable final String userAgent,
         final HttpServletRequest httpServletRequest
     ) throws GenieException {
         if (jobRequest == null) {
@@ -431,21 +432,21 @@ public class JobRestController {
     @ResponseStatus(HttpStatus.OK)
     @SuppressWarnings("checkstyle:parameternumber")
     public PagedResources<JobSearchResultResource> findJobs(
-        @RequestParam(value = "id", required = false) final String id,
-        @RequestParam(value = "name", required = false) final String name,
-        @RequestParam(value = "user", required = false) final String user,
-        @RequestParam(value = "status", required = false) final Set<String> statuses,
-        @RequestParam(value = "tag", required = false) final Set<String> tags,
-        @RequestParam(value = "clusterName", required = false) final String clusterName,
-        @RequestParam(value = "clusterId", required = false) final String clusterId,
-        @RequestParam(value = "commandName", required = false) final String commandName,
-        @RequestParam(value = "commandId", required = false) final String commandId,
-        @RequestParam(value = "minStarted", required = false) final Long minStarted,
-        @RequestParam(value = "maxStarted", required = false) final Long maxStarted,
-        @RequestParam(value = "minFinished", required = false) final Long minFinished,
-        @RequestParam(value = "maxFinished", required = false) final Long maxFinished,
-        @RequestParam(value = "grouping", required = false) final String grouping,
-        @RequestParam(value = "groupingInstance", required = false) final String groupingInstance,
+        @RequestParam(value = "id", required = false) @Nullable final String id,
+        @RequestParam(value = "name", required = false) @Nullable final String name,
+        @RequestParam(value = "user", required = false) @Nullable final String user,
+        @RequestParam(value = "status", required = false) @Nullable final Set<String> statuses,
+        @RequestParam(value = "tag", required = false) @Nullable final Set<String> tags,
+        @RequestParam(value = "clusterName", required = false) @Nullable final String clusterName,
+        @RequestParam(value = "clusterId", required = false) @Nullable final String clusterId,
+        @RequestParam(value = "commandName", required = false) @Nullable final String commandName,
+        @RequestParam(value = "commandId", required = false) @Nullable final String commandId,
+        @RequestParam(value = "minStarted", required = false) @Nullable final Long minStarted,
+        @RequestParam(value = "maxStarted", required = false) @Nullable final Long maxStarted,
+        @RequestParam(value = "minFinished", required = false) @Nullable final Long minFinished,
+        @RequestParam(value = "maxFinished", required = false) @Nullable final Long maxFinished,
+        @RequestParam(value = "grouping", required = false) @Nullable final String grouping,
+        @RequestParam(value = "groupingInstance", required = false) @Nullable final String groupingInstance,
         @PageableDefault(sort = {"created"}, direction = Sort.Direction.DESC) final Pageable page,
         final PagedResourcesAssembler<JobSearchResult> assembler
     ) throws GenieException {
@@ -549,7 +550,8 @@ public class JobRestController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void killJob(
         @PathVariable("id") final String id,
-        @RequestHeader(name = JobConstants.GENIE_FORWARDED_FROM_HEADER, required = false) final String forwardedFrom,
+        @RequestHeader(name = JobConstants.GENIE_FORWARDED_FROM_HEADER, required = false)
+        @Nullable final String forwardedFrom,
         final HttpServletRequest request,
         final HttpServletResponse response
     ) throws GenieException, IOException {
@@ -717,7 +719,8 @@ public class JobRestController {
     )
     public void getJobOutput(
         @PathVariable("id") final String id,
-        @RequestHeader(name = JobConstants.GENIE_FORWARDED_FROM_HEADER, required = false) final String forwardedFrom,
+        @RequestHeader(name = JobConstants.GENIE_FORWARDED_FROM_HEADER, required = false)
+        @Nullable final String forwardedFrom,
         final HttpServletRequest request,
         final HttpServletResponse response
     ) throws IOException, ServletException, GenieException {

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -28,7 +28,6 @@ import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.common.dto.search.JobSearchResult;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
-import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
 import com.netflix.genie.common.internal.jobs.JobConstants;
@@ -275,10 +274,6 @@ public class JobRestController {
         @Nullable final String userAgent,
         final HttpServletRequest httpServletRequest
     ) throws GenieException {
-        if (jobRequest == null) {
-            throw new GeniePreconditionException("No job request entered. Unable to submit.");
-        }
-
         // get client's host from the context
         final String localClientHost;
         if (StringUtils.isNotBlank(clientHost)) {

--- a/genie-web/src/main/java/com/netflix/genie/web/events/GenieEventBusImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/events/GenieEventBusImpl.java
@@ -156,6 +156,9 @@ public class GenieEventBusImpl implements
         this.asyncMulticaster.setBeanClassLoader(classLoader);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setBeanFactory(final BeanFactory beanFactory) {
         this.syncMulticaster.setBeanFactory(beanFactory);


### PR DESCRIPTION
In order to still get relevant entry point information but not switch the overall logs to debug this PR primarily changes all the controller top level logs to be level `info`