### PR TITLE
Switch to using 'kill -0' on UNIX to check on job children processes

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/configs/GenieJobWorkflowAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/GenieJobWorkflowAutoConfiguration.java
@@ -31,9 +31,14 @@ import com.netflix.genie.web.services.AttachmentService;
 import com.netflix.genie.web.services.impl.GenieFileTransferService;
 import com.netflix.genie.web.services.impl.HttpFileTransferImpl;
 import com.netflix.genie.web.services.impl.LocalFileTransferImpl;
+import com.netflix.genie.web.util.ProcessChecker;
+import com.netflix.genie.web.util.UnixProcessChecker;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.exec.Executor;
+import org.apache.commons.lang3.SystemUtils;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -187,5 +192,28 @@ public class GenieJobWorkflowAutoConfiguration {
             genieHostInfo.getHostname(),
             registry
         );
+    }
+
+    /**
+     * Create a {@link ProcessChecker.Factory} suitable for UNIX systems.
+     *
+     * @param executor       The executor where checks are executed
+     * @param jobsProperties The jobs properties
+     * @return a {@link ProcessChecker.Factory}
+     */
+    @Bean
+    @ConditionalOnMissingBean(ProcessChecker.Factory.class)
+    public ProcessChecker.Factory processCheckerFactory(
+        final Executor executor,
+        final JobsProperties jobsProperties
+    ) {
+        if (SystemUtils.IS_OS_UNIX) {
+            return new UnixProcessChecker.Factory(
+                executor,
+                jobsProperties.getUsers().isRunAsUserEnabled()
+            );
+        } else {
+            throw new BeanCreationException("No implementation available for non-UNIX systems");
+        }
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/GenieServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/GenieServicesAutoConfiguration.java
@@ -75,6 +75,7 @@ import com.netflix.genie.web.services.impl.LocalFileTransferImpl;
 import com.netflix.genie.web.services.impl.LocalJobRunner;
 import com.netflix.genie.web.tasks.job.JobCompletionService;
 import com.netflix.genie.web.util.InspectionReport;
+import com.netflix.genie.web.util.ProcessChecker;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.lang3.NotImplementedException;
@@ -159,13 +160,14 @@ public class GenieServicesAutoConfiguration {
     /**
      * Get an local implementation of the JobKillService.
      *
-     * @param genieHostInfo    Information about the host the Genie process is running on
-     * @param jobSearchService The job search service to use to locate job information.
-     * @param executor         The executor to use to run system processes.
-     * @param jobsProperties   The jobs properties to use
-     * @param genieEventBus    The application event bus to use to publish system wide events
-     * @param genieWorkingDir  Working directory for genie where it creates jobs directories.
-     * @param objectMapper     The Jackson ObjectMapper used to serialize from/to JSON
+     * @param genieHostInfo         Information about the host the Genie process is running on
+     * @param jobSearchService      The job search service to use to locate job information.
+     * @param executor              The executor to use to run system processes.
+     * @param jobsProperties        The jobs properties to use
+     * @param genieEventBus         The application event bus to use to publish system wide events
+     * @param genieWorkingDir       Working directory for genie where it creates jobs directories.
+     * @param objectMapper          The Jackson ObjectMapper used to serialize from/to JSON
+     * @param processCheckerFactory The process checker factory
      * @return A job kill service instance.
      */
     @Bean
@@ -177,7 +179,8 @@ public class GenieServicesAutoConfiguration {
         final JobsProperties jobsProperties,
         final GenieEventBus genieEventBus,
         @Qualifier("jobsDir") final Resource genieWorkingDir,
-        final ObjectMapper objectMapper
+        final ObjectMapper objectMapper,
+        final ProcessChecker.Factory processCheckerFactory
     ) {
         return new JobKillServiceV3(
             genieHostInfo.getHostname(),
@@ -186,7 +189,8 @@ public class GenieServicesAutoConfiguration {
             jobsProperties.getUsers().isRunAsUserEnabled(),
             genieEventBus,
             genieWorkingDir,
-            objectMapper
+            objectMapper,
+            processCheckerFactory
         );
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitor.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitor.java
@@ -29,13 +29,11 @@ import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.tasks.GenieTaskScheduleType;
 import com.netflix.genie.web.tasks.node.NodeTask;
 import com.netflix.genie.web.util.ProcessChecker;
-import com.netflix.genie.web.util.UnixProcessChecker;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.exec.ExecuteException;
-import org.apache.commons.exec.Executor;
 import org.apache.commons.lang3.SystemUtils;
 import org.springframework.scheduling.Trigger;
 
@@ -43,7 +41,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.io.IOException;
-import java.time.Instant;
 
 /**
  * Given a process id this class will check if the job client process is running or not.
@@ -82,19 +79,19 @@ public class JobMonitor extends NodeTask {
      * @param execution      The job execution object including the pid
      * @param stdOut         The std out output file
      * @param stdErr         The std err output file
-     * @param executor       The process executor to use
      * @param genieEventBus  The event bus implementation to use
      * @param registry       The metrics event registry
      * @param jobsProperties The properties for jobs
+     * @param processChecker The process checker
      */
     JobMonitor(
         @Valid final JobExecution execution,
         @NotNull final File stdOut,
         @NotNull final File stdErr,
-        @NotNull final Executor executor,
         @NonNull final GenieEventBus genieEventBus,
         @NotNull final MeterRegistry registry,
-        @NotNull final JobsProperties jobsProperties
+        @NotNull final JobsProperties jobsProperties,
+        @NotNull final ProcessChecker processChecker
     ) {
         if (!SystemUtils.IS_OS_UNIX) {
             throw new UnsupportedOperationException("Genie doesn't currently support " + SystemUtils.OS_NAME);
@@ -104,10 +101,7 @@ public class JobMonitor extends NodeTask {
         this.id = execution.getId().orElseThrow(IllegalArgumentException::new);
         this.execution = execution;
         this.genieEventBus = genieEventBus;
-
-        final int processId = execution.getProcessId().orElseThrow(IllegalArgumentException::new);
-        final Instant timeout = execution.getTimeout().orElseThrow(IllegalArgumentException::new);
-        this.processChecker = new UnixProcessChecker(processId, executor, timeout);
+        this.processChecker = processChecker;
 
         this.stdOut = stdOut;
         this.stdErr = stdErr;

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
@@ -33,10 +33,10 @@ import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.JobSearchService;
 import com.netflix.genie.web.services.JobSubmitterService;
 import com.netflix.genie.web.services.impl.JobStateServiceImpl;
+import com.netflix.genie.web.util.ProcessChecker;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.exec.Executor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEvent;
@@ -49,6 +49,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
@@ -65,9 +66,9 @@ import java.util.concurrent.ScheduledFuture;
 public class JobMonitoringCoordinator extends JobStateServiceImpl {
     private final String hostname;
     private final JobSearchService jobSearchService;
-    private final Executor executor;
     private final File jobsDir;
     private final JobsProperties jobsProperties;
+    private final ProcessChecker.Factory processCheckerFactory;
 
     private final Counter unableToReAttach;
 
@@ -78,11 +79,11 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
      * @param jobSearchService    The search service to use to find jobs
      * @param genieEventBus       The Genie event bus to use for publishing events
      * @param scheduler           The task scheduler to use to register scheduling of job checkers
-     * @param executor            The executor to use to launch processes
      * @param registry            The metrics registry
      * @param jobsDir             The directory where job output is stored
      * @param jobsProperties      The properties pertaining to jobs
      * @param jobSubmitterService implementation of the job submitter service
+     * @param processCheckerFactory The factory of process checkers
      * @throws IOException on error with the filesystem
      */
     @Autowired
@@ -91,18 +92,18 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
         final JobSearchService jobSearchService,
         final GenieEventBus genieEventBus,
         @Qualifier("genieTaskScheduler") final TaskScheduler scheduler,
-        final Executor executor,
         final MeterRegistry registry,
         final Resource jobsDir,
         final JobsProperties jobsProperties,
-        final JobSubmitterService jobSubmitterService
+        final JobSubmitterService jobSubmitterService,
+        final ProcessChecker.Factory processCheckerFactory
     ) throws IOException {
         super(jobSubmitterService, scheduler, genieEventBus, registry);
         this.hostname = genieHostInfo.getHostname();
         this.jobSearchService = jobSearchService;
-        this.executor = executor;
         this.jobsDir = jobsDir.getFile();
         this.jobsProperties = jobsProperties;
+        this.processCheckerFactory = processCheckerFactory;
 
         // Automatically track the number of jobs running on this node
         this.unableToReAttach = registry.counter("genie.jobs.unableToReAttach.rate");
@@ -188,15 +189,18 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
         final String jobId = jobExecution.getId().orElseThrow(IllegalArgumentException::new);
         final File stdOut = new File(this.jobsDir, jobId + "/" + JobConstants.STDOUT_LOG_FILE_NAME);
         final File stdErr = new File(this.jobsDir, jobId + "/" + JobConstants.STDERR_LOG_FILE_NAME);
+        final int processId = jobExecution.getProcessId().orElseThrow(IllegalArgumentException::new);
+        final Instant timeout = jobExecution.getTimeout().orElseThrow(IllegalArgumentException::new);
+        final ProcessChecker processChecker = this.processCheckerFactory.get(processId, timeout);
 
         final JobMonitor monitor = new JobMonitor(
             jobExecution,
             stdOut,
             stdErr,
-            this.executor,
             this.genieEventBus,
             this.registry,
-            this.jobsProperties
+            this.jobsProperties,
+            processChecker
         );
         final ScheduledFuture<?> future;
         switch (monitor.getScheduleType()) {

--- a/genie-web/src/main/java/com/netflix/genie/web/util/ProcessChecker.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/ProcessChecker.java
@@ -21,6 +21,7 @@ import com.netflix.genie.common.exceptions.GenieTimeoutException;
 import org.apache.commons.exec.ExecuteException;
 
 import java.io.IOException;
+import java.time.Instant;
 
 /**
  * Interface for implementing process checking on various operating systems.
@@ -38,4 +39,19 @@ public interface ProcessChecker {
      * @throws IOException           For any other problem
      */
     void checkProcess() throws GenieTimeoutException, ExecuteException, IOException;
+
+    /**
+     * Interface for Factory of ProcessChecker.
+     */
+    interface Factory {
+
+        /**
+         * Get a new process checker to check on the given PID.
+         *
+         * @param pid     the process id to check on
+         * @param timeout the moment in time after which the check should produce a {@link GenieTimeoutException}
+         * @return a {@link ProcessChecker}
+         */
+        ProcessChecker get(int pid, Instant timeout);
+    }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/util/UnixProcessChecker.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/UnixProcessChecker.java
@@ -43,22 +43,34 @@ public class UnixProcessChecker implements ProcessChecker {
     /**
      * Constructor.
      *
-     * @param pid      The process id to check.
-     * @param executor The executor to use for generating system commands.
-     * @param timeout  The time which after this job should be killed due to timeout
+     * @param pid           The process id to check.
+     * @param executor      The executor to use for generating system commands.
+     * @param timeout       The time which after this job should be killed due to timeout
+     * @param checkWithSudo Whether the checker requires sudo
      */
-    public UnixProcessChecker(@Min(1) final int pid, @NotNull final Executor executor, @NotNull final Instant timeout) {
+    UnixProcessChecker(
+        @Min(1) final int pid,
+        @NotNull final Executor executor,
+        @NotNull final Instant timeout,
+        final boolean checkWithSudo
+    ) {
         if (!SystemUtils.IS_OS_UNIX) {
             throw new IllegalArgumentException("Not running on a Unix system.");
         }
 
         this.executor = executor;
 
-        // Using PS for now but could instead check for existence of done file if this proves to have bad performance
-        // send output to /dev/null so it doesn't print to the logs
-        this.commandLine = new CommandLine("ps");
-        this.commandLine.addArgument("-p");
-        this.commandLine.addArgument(Integer.toString(pid));
+        // Use POSIX compliant 'kill -0 <PID>' to check if process is still running.
+        if (checkWithSudo) {
+            this.commandLine = new CommandLine("sudo");
+            this.commandLine.addArgument("kill");
+            this.commandLine.addArgument("-0");
+            this.commandLine.addArgument(Integer.toString(pid));
+        } else {
+            this.commandLine = new CommandLine("kill");
+            this.commandLine.addArgument("-0");
+            this.commandLine.addArgument(Integer.toString(pid));
+        }
 
         this.timeout = timeout;
     }
@@ -75,6 +87,34 @@ public class UnixProcessChecker implements ProcessChecker {
             throw new GenieTimeoutException(
                 "Job has exceeded its timeout time of " + this.timeout
             );
+        }
+    }
+
+    /**
+     * Factory for {@link ProcessChecker} for UNIX systems.
+     */
+    public static class Factory implements ProcessChecker.Factory {
+
+        private final Executor executor;
+        private final boolean checkWithSudo;
+
+        /**
+         * Constructor.
+         *
+         * @param executor      The executor used by process checkers
+         * @param checkWithSudo Whether the check requires sudo
+         */
+        public Factory(final Executor executor, final boolean checkWithSudo) {
+            this.executor = executor;
+            this.checkWithSudo = checkWithSudo;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public ProcessChecker get(final int pid, final Instant timeout) {
+            return new UnixProcessChecker(pid, this.executor, timeout, this.checkWithSudo);
         }
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/GenieServicesAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/GenieServicesAutoConfigurationTest.java
@@ -44,6 +44,7 @@ import com.netflix.genie.web.services.JobSpecificationService;
 import com.netflix.genie.web.services.JobStateService;
 import com.netflix.genie.web.services.impl.JobKillServiceV3;
 import com.netflix.genie.web.services.impl.LocalFileTransferImpl;
+import com.netflix.genie.web.util.ProcessChecker;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.lang3.NotImplementedException;
@@ -109,7 +110,8 @@ public class GenieServicesAutoConfigurationTest {
                 JobsProperties.getJobsPropertiesDefaults(),
                 Mockito.mock(GenieEventBus.class),
                 Mockito.mock(FileSystemResource.class),
-                GenieObjectMapper.getMapper()
+                GenieObjectMapper.getMapper(),
+                Mockito.mock(ProcessChecker.Factory.class)
             )
         );
     }

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorTest.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.tasks.job;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
@@ -35,9 +36,8 @@ import com.netflix.genie.web.events.JobStartedEvent;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.JobSearchService;
 import com.netflix.genie.web.services.JobSubmitterService;
+import com.netflix.genie.web.util.ProcessChecker;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.apache.commons.exec.Executor;
-import org.assertj.core.util.Lists;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -89,6 +89,7 @@ public class JobMonitoringCoordinatorTest {
     private Cluster cluster = Mockito.mock(Cluster.class);
     private Command command = Mockito.mock(Command.class);
     private List<Application> applications = Lists.newArrayList();
+    private ProcessChecker.Factory processCheckerFactory = Mockito.mock(ProcessChecker.Factory.class);
 
     /**
      * Setup for the tests.
@@ -100,7 +101,6 @@ public class JobMonitoringCoordinatorTest {
         this.tomorrow = Instant.now().plus(1, ChronoUnit.DAYS);
         this.jobSearchService = Mockito.mock(JobSearchService.class);
         final JobSubmitterService jobSubmitterService = Mockito.mock(JobSubmitterService.class);
-        final Executor executor = Mockito.mock(Executor.class);
         this.scheduler = Mockito.mock(TaskScheduler.class);
         this.genieEventBus = Mockito.mock(GenieEventBus.class);
 
@@ -113,11 +113,11 @@ public class JobMonitoringCoordinatorTest {
             this.jobSearchService,
             this.genieEventBus,
             this.scheduler,
-            executor,
             new SimpleMeterRegistry(),
             jobsDir,
             JobsProperties.getJobsPropertiesDefaults(),
-            jobSubmitterService
+            jobSubmitterService,
+            this.processCheckerFactory
         );
     }
 


### PR DESCRIPTION
Using 'ps' to check for process termination can sometimes produce false-negatives.
I.e. returning with non-zero exit code when the process is actually still running.
This situation can lead Genie to mark a job as failed when it was actually still running.
Switch to using 'kill -0' as per POSIX recommendation.

Also refactor and create a new ProcessChecker.Factory bean, rather than having users of ProcessChecker instantiate one directly.