### PR TITLE
Ensure all leadership tasks are activated if requested

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/configs/GenieLeadershipAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/GenieLeadershipAutoConfiguration.java
@@ -51,6 +51,7 @@ import java.util.Collection;
 )
 @AutoConfigureAfter(
     {
+        GenieTasksAutoConfiguration.class,
         ZookeeperAutoConfiguration.class
     }
 )

--- a/genie-web/src/main/resources/genie-web-defaults.yml
+++ b/genie-web/src/main/resources/genie-web-defaults.yml
@@ -82,6 +82,8 @@ genie:
   swagger:
     enabled: false
   tasks:
+    agent-cleanup:
+      enabled: true
     cluster-checker:
       scheme: http
       port: 8080
@@ -102,6 +104,8 @@ genie:
     scheduler:
       pool:
         size: 5
+    user-metrics:
+      enabled: true
 
 info:
   genie:


### PR DESCRIPTION
Merged in PR #859 two new leadership tasks were added that accounted for user metrics and cleaning up dangling agent connections.

Unfortunately the properties were set to true only in the ConfigurationProperties class which is bound after evaluation of conditions so before then the properties
have no values and thus weren't enabled by default as expected. This commit fixes this in two ways:

1. Ensure that the GenieTasksAutoConfiguration is applied before the GenieLeadershipAutoConfiguration
2. Ensure that the default set of properties for the two leadership tasks are set to true in the files that are loaded into the environment before conditionals are evaluated on auto configs