### PR TITLE
Change command args string argument to not split on whitespace

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.netflix.genie.common.util.TimeUtils;
 import lombok.Getter;
@@ -62,9 +63,9 @@ public class Job extends CommonDTO {
     @NotNull
     @JsonSerialize(using = ToStringSerializer.class)
     private final Duration runtime;
-    private String commandArgs;
-    private String grouping;
-    private String groupingInstance;
+    private final List<String> commandArgs;
+    private final String grouping;
+    private final String groupingInstance;
 
     /**
      * Constructor used by the builder.
@@ -73,9 +74,7 @@ public class Job extends CommonDTO {
      */
     protected Job(@Valid final Builder builder) {
         super(builder);
-        this.commandArgs = builder.bCommandArgs.isEmpty()
-            ? null
-            : StringUtils.join(builder.bCommandArgs, StringUtils.SPACE);
+        this.commandArgs = ImmutableList.copyOf(builder.bCommandArgs);
         this.status = builder.bStatus;
         this.statusMsg = builder.bStatusMsg;
         this.started = builder.bStarted;
@@ -95,7 +94,9 @@ public class Job extends CommonDTO {
      * @return The command arguments
      */
     public Optional<String> getCommandArgs() {
-        return Optional.ofNullable(this.commandArgs);
+        return this.commandArgs.isEmpty()
+            ? Optional.empty()
+            : Optional.ofNullable(StringUtils.join(this.commandArgs, StringUtils.SPACE));
     }
 
     /**
@@ -230,7 +231,7 @@ public class Job extends CommonDTO {
             super(name, user, version);
             this.bCommandArgs = commandArgs == null
                 ? Lists.newArrayList()
-                : Lists.newArrayList(StringUtils.splitByWholeSeparator(commandArgs, StringUtils.SPACE));
+                : Lists.newArrayList(commandArgs);
         }
 
         /**
@@ -248,9 +249,7 @@ public class Job extends CommonDTO {
         public Builder withCommandArgs(@Nullable final String commandArgs) {
             this.bCommandArgs.clear();
             if (commandArgs != null) {
-                this.bCommandArgs.addAll(
-                    Lists.newArrayList(StringUtils.splitByWholeSeparator(commandArgs, StringUtils.SPACE))
-                );
+                this.bCommandArgs.add(commandArgs);
             }
             return this;
         }

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
@@ -55,7 +55,7 @@ public class JobRequest extends ExecutionEnvironmentDTO {
 
     private static final long serialVersionUID = 3163971970144435277L;
 
-    private final String commandArgs;
+    private final List<String> commandArgs;
     @Valid
     @NotEmpty(message = "At least one cluster criteria is required")
     private final List<ClusterCriteria> clusterCriterias;
@@ -74,8 +74,8 @@ public class JobRequest extends ExecutionEnvironmentDTO {
     @Min(value = 1, message = "The timeout must be at least 1 second, preferably much more.")
     private final Integer timeout;
     private final List<String> applications;
-    private String grouping;
-    private String groupingInstance;
+    private final String grouping;
+    private final String groupingInstance;
 
     /**
      * Constructor used by the builder build() method.
@@ -85,9 +85,7 @@ public class JobRequest extends ExecutionEnvironmentDTO {
     @SuppressWarnings("unchecked")
     JobRequest(@Valid final Builder builder) {
         super(builder);
-        this.commandArgs = builder.bCommandArgs.isEmpty()
-            ? null
-            : StringUtils.join(builder.bCommandArgs, StringUtils.SPACE);
+        this.commandArgs = ImmutableList.copyOf(builder.bCommandArgs);
         this.clusterCriterias = ImmutableList.copyOf(builder.bClusterCriterias);
         this.commandCriteria = ImmutableSet.copyOf(builder.bCommandCriteria);
         this.group = builder.bGroup;
@@ -107,7 +105,9 @@ public class JobRequest extends ExecutionEnvironmentDTO {
      * @return The command arguments
      */
     public Optional<String> getCommandArgs() {
-        return Optional.ofNullable(this.commandArgs);
+        return this.commandArgs.isEmpty()
+            ? Optional.empty()
+            : Optional.ofNullable(StringUtils.join(this.commandArgs, StringUtils.SPACE));
     }
 
     /**
@@ -251,7 +251,7 @@ public class JobRequest extends ExecutionEnvironmentDTO {
             super(name, user, version);
             this.bCommandArgs = commandArgs == null
                 ? Lists.newArrayList()
-                : Lists.newArrayList(StringUtils.splitByWholeSeparator(commandArgs, StringUtils.SPACE));
+                : Lists.newArrayList(commandArgs);
             this.bClusterCriterias.addAll(clusterCriterias);
             commandCriteria.forEach(
                 criteria -> {
@@ -277,9 +277,7 @@ public class JobRequest extends ExecutionEnvironmentDTO {
         public Builder withCommandArgs(@Nullable final String commandArgs) {
             this.bCommandArgs.clear();
             if (commandArgs != null) {
-                this.bCommandArgs.addAll(
-                    Lists.newArrayList(StringUtils.splitByWholeSeparator(commandArgs, StringUtils.SPACE))
-                );
+                this.bCommandArgs.add(commandArgs);
             }
             return this;
         }

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/JobRequestTest.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/JobRequestTest.java
@@ -456,4 +456,37 @@ public class JobRequestTest {
         Assert.assertEquals(jobRequest1.hashCode(), jobRequest2.hashCode());
         Assert.assertNotEquals(jobRequest1.hashCode(), jobRequest3.hashCode());
     }
+
+    /**
+     * Test to prove a bug with command args splitting with trailing whitespace was corrected.
+     */
+    @Test
+    public void testCommandArgsEdgeCases() {
+        final JobRequest.Builder builder
+            = new JobRequest.Builder(NAME, USER, VERSION, Lists.newArrayList(), Sets.newHashSet());
+
+        String commandArgs = " blah ";
+        builder.withCommandArgs(commandArgs);
+        Assert.assertThat(
+            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(" blah ")
+        );
+        commandArgs = " blah    ";
+        builder.withCommandArgs(commandArgs);
+        Assert.assertThat(
+            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(" blah    ")
+        );
+        commandArgs = "  blah blah     blah\nblah\tblah \"blah\" blah  ";
+        builder.withCommandArgs(commandArgs);
+        Assert.assertThat(
+            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is("  blah blah     blah\nblah\tblah \"blah\" blah  ")
+        );
+        builder.withCommandArgs(Lists.newArrayList("blah", "blah", "  blah", "\nblah", "\"blah\""));
+        Assert.assertThat(
+            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is("blah blah   blah \nblah \"blah\"")
+        );
+    }
 }

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/JobTest.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/JobTest.java
@@ -375,4 +375,36 @@ public class JobTest {
         Assert.assertEquals(job1.hashCode(), job2.hashCode());
         Assert.assertNotEquals(job1.hashCode(), job3.hashCode());
     }
+
+    /**
+     * Test to prove a bug with command args splitting with trailing whitespace was corrected.
+     */
+    @Test
+    public void testCommandArgsEdgeCases() {
+        final Job.Builder builder = new Job.Builder(NAME, USER, VERSION);
+
+        String commandArgs = " blah ";
+        builder.withCommandArgs(commandArgs);
+        Assert.assertThat(
+            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(" blah ")
+        );
+        commandArgs = " blah    ";
+        builder.withCommandArgs(commandArgs);
+        Assert.assertThat(
+            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(" blah    ")
+        );
+        commandArgs = "  blah blah     blah\nblah\tblah \"blah\" blah  ";
+        builder.withCommandArgs(commandArgs);
+        Assert.assertThat(
+            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is("  blah blah     blah\nblah\tblah \"blah\" blah  ")
+        );
+        builder.withCommandArgs(Lists.newArrayList("blah", "blah", "  blah", "\nblah", "\"blah\""));
+        Assert.assertThat(
+            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
+            Matchers.is("blah blah   blah \nblah \"blah\"")
+        );
+    }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/aspect/HealthCheckMetricsAspect.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/aspect/HealthCheckMetricsAspect.java
@@ -31,6 +31,7 @@ import org.aspectj.lang.annotation.Before;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -45,7 +46,7 @@ import java.util.concurrent.TimeUnit;
  * @since 3.2.4
  */
 @Aspect
-//@Component
+@Component
 @Slf4j
 public class HealthCheckMetricsAspect {
 

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -19,7 +19,6 @@ package com.netflix.genie.web.controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
@@ -309,13 +308,7 @@ public class JobRestController {
                 .withDependencies(jobRequest.getDependencies())
                 .withApplications(jobRequest.getApplications());
 
-            jobRequest.getCommandArgs().ifPresent(
-                commandArgs ->
-                    builder
-                        .withCommandArgs(
-                            Lists.newArrayList(StringUtils.splitByWholeSeparator(commandArgs, StringUtils.SPACE))
-                        )
-            );
+            jobRequest.getCommandArgs().ifPresent(builder::withCommandArgs);
             jobRequest.getCpu().ifPresent(builder::withCpu);
             jobRequest.getMemory().ifPresent(builder::withMemory);
             jobRequest.getGroup().ifPresent(builder::withGroup);

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
@@ -672,11 +672,7 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
         JpaServiceUtils.setEntityMetadata(GenieObjectMapper.getMapper(), jobRequest, jobEntity);
         jobRequest.getCommandArgs().ifPresent(
             commandArgs ->
-                jobEntity.setCommandArgs(
-                    Lists.newArrayList(
-                        StringUtils.splitByWholeSeparator(commandArgs, StringUtils.SPACE)
-                    )
-                )
+                jobEntity.setCommandArgs(Lists.newArrayList(StringUtils.split(commandArgs)))
         );
         jobRequest.getGroup().ifPresent(jobEntity::setGenieUserGroup);
         final FileEntity setupFile = jobRequest.getSetupFile().isPresent()

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -18,7 +18,6 @@
 package com.netflix.genie.web.services.impl;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
@@ -52,7 +51,6 @@ import com.netflix.genie.web.util.MetricsUtils;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -164,13 +162,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
                 .withStatus(JobStatus.INIT)
                 .withStatusMsg("Job Accepted and in initialization phase.");
 
-            jobRequest.getCommandArgs().ifPresent(
-                commandArgs ->
-                    jobBuilder
-                        .withCommandArgs(
-                            Lists.newArrayList(StringUtils.splitByWholeSeparator(commandArgs, StringUtils.SPACE))
-                        )
-            );
+            jobRequest.getCommandArgs().ifPresent(jobBuilder::withCommandArgs);
             jobRequest.getDescription().ifPresent(jobBuilder::withDescription);
 
             // TODO: Disabling this check for now to force archival for all jobs during internal V4 migration.


### PR DESCRIPTION
The command args field was modified to be a List<String> in the data model and in the database in order to better support escaping and other issues with bash we've had in the past. However to enable this we were splitting naively on whitespace which could have unintended consequences. This commit reverts that behavior to treat anyone calling the deprecated "string" builder API for the JobRequest to just treat that as a single argument blob. The List<String> builder method still will treat it correctly and join it with a space on a call to get. This should behave as it has in the past with 3 until we have a V4 API. The agent will continue to behave the right way as it only supports List<String> command arguments.