### PR TITLE
Split command args on space but retain all tokens

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
@@ -18,15 +18,16 @@
 package com.netflix.genie.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.netflix.genie.common.util.CommandArgUtils;
 import com.netflix.genie.common.util.TimeUtils;
 import lombok.Getter;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
@@ -92,11 +93,23 @@ public class Job extends CommonDTO {
      * Get the arguments to be put on the command line along with the command executable.
      *
      * @return The command arguments
+     * @deprecated Use {@link #getCommandArgsAsList()} instead
      */
+    @Deprecated
     public Optional<String> getCommandArgs() {
         return this.commandArgs.isEmpty()
             ? Optional.empty()
-            : Optional.ofNullable(StringUtils.join(this.commandArgs, StringUtils.SPACE));
+            : Optional.ofNullable(CommandArgUtils.rebuildCommandArgString(this.commandArgs));
+    }
+
+    /**
+     * Get the arguments to be put on the command line along with the command executable as a list.
+     *
+     * @return The command arguments as an immutable list
+     */
+    @JsonIgnore
+    public List<String> getCommandArgsAsList() {
+        return this.commandArgs;
     }
 
     /**
@@ -231,7 +244,7 @@ public class Job extends CommonDTO {
             super(name, user, version);
             this.bCommandArgs = commandArgs == null
                 ? Lists.newArrayList()
-                : Lists.newArrayList(commandArgs);
+                : Lists.newArrayList(CommandArgUtils.splitCommandArgs(commandArgs));
         }
 
         /**
@@ -249,7 +262,7 @@ public class Job extends CommonDTO {
         public Builder withCommandArgs(@Nullable final String commandArgs) {
             this.bCommandArgs.clear();
             if (commandArgs != null) {
-                this.bCommandArgs.add(commandArgs);
+                this.bCommandArgs.addAll(CommandArgUtils.splitCommandArgs(commandArgs));
             }
             return this;
         }

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
@@ -18,11 +18,13 @@
 package com.netflix.genie.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.netflix.genie.common.util.CommandArgUtils;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
@@ -82,7 +84,6 @@ public class JobRequest extends ExecutionEnvironmentDTO {
      *
      * @param builder The builder to use
      */
-    @SuppressWarnings("unchecked")
     JobRequest(@Valid final Builder builder) {
         super(builder);
         this.commandArgs = ImmutableList.copyOf(builder.bCommandArgs);
@@ -103,11 +104,23 @@ public class JobRequest extends ExecutionEnvironmentDTO {
      * Get the arguments to be put on the command line along with the command executable.
      *
      * @return The command arguments
+     * @deprecated Use {@link #getCommandArgsAsList()} instead
      */
+    @Deprecated
     public Optional<String> getCommandArgs() {
         return this.commandArgs.isEmpty()
             ? Optional.empty()
-            : Optional.ofNullable(StringUtils.join(this.commandArgs, StringUtils.SPACE));
+            : Optional.ofNullable(CommandArgUtils.rebuildCommandArgString(this.commandArgs));
+    }
+
+    /**
+     * Get the arguments to be put on the command line as a list.
+     *
+     * @return The command arguments as an immutable list.
+     */
+    @JsonIgnore
+    public List<String> getCommandArgsAsList() {
+        return this.commandArgs;
     }
 
     /**
@@ -251,7 +264,7 @@ public class JobRequest extends ExecutionEnvironmentDTO {
             super(name, user, version);
             this.bCommandArgs = commandArgs == null
                 ? Lists.newArrayList()
-                : Lists.newArrayList(commandArgs);
+                : Lists.newArrayList(CommandArgUtils.splitCommandArgs(commandArgs));
             this.bClusterCriterias.addAll(clusterCriterias);
             commandCriteria.forEach(
                 criteria -> {
@@ -277,7 +290,7 @@ public class JobRequest extends ExecutionEnvironmentDTO {
         public Builder withCommandArgs(@Nullable final String commandArgs) {
             this.bCommandArgs.clear();
             if (commandArgs != null) {
-                this.bCommandArgs.add(commandArgs);
+                this.bCommandArgs.addAll(CommandArgUtils.splitCommandArgs(commandArgs));
             }
             return this;
         }

--- a/genie-common/src/main/java/com/netflix/genie/common/util/CommandArgUtils.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/util/CommandArgUtils.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utilities for working with command args.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public final class CommandArgUtils {
+
+    /**
+     * The maximum allowable size for a single command argument.
+     */
+    public static final int MAX_COMMAND_ARG_LENGTH = 10_000;
+
+    private CommandArgUtils() {
+    }
+
+    /**
+     * Given a string of command args for a job this method will split it (if necessary) into chunks
+     * that will fit into requirements within the system.
+     *
+     * @param commandArgs The command args to split
+     * @return The list of command args split into storable sizes
+     */
+    public static List<String> splitCommandArgs(final String commandArgs) {
+        return Arrays.asList(StringUtils.splitPreserveAllTokens(commandArgs, StringUtils.SPACE));
+    }
+
+    /**
+     * Utility method to standardize how we rebuild a single command arg strig from a list of command args.
+     *
+     * @param commandArgs the Command args to use as building blocks
+     * @return A string representation of the command args
+     */
+    public static String rebuildCommandArgString(final List<String> commandArgs) {
+        return StringUtils.join(commandArgs, StringUtils.SPACE);
+    }
+}

--- a/genie-common/src/main/java/com/netflix/genie/common/util/JsonUtils.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/util/JsonUtils.java
@@ -23,6 +23,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collection;
 
@@ -64,7 +65,7 @@ public final class JsonUtils {
      * @throws GenieException For any exception during unmarshalling
      */
     public static <T extends Collection> T unmarshall(
-        final String source,
+        @Nullable final String source,
         final TypeReference<T> typeReference
     ) throws GenieException {
         try {

--- a/genie-common/src/main/java/com/netflix/genie/common/util/package-info.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/util/package-info.java
@@ -21,4 +21,7 @@
  *
  * @author tgianos
  */
+@ParametersAreNonnullByDefault
 package com.netflix.genie.common.util;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-common/src/test/groovy/com/netflix/genie/common/util/CommandArgUtilsSpec.groovy
+++ b/genie-common/src/test/groovy/com/netflix/genie/common/util/CommandArgUtilsSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.util
+
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Specifications for {@link CommandArgUtils}
+ *
+ * @author tgianos
+ */
+class CommandArgUtilsSpec extends Specification {
+
+    @Unroll
+    def "Can split #commandArgs"() {
+
+        expect:
+        def split = CommandArgUtils.splitCommandArgs(commandArgs)
+        split == expectedSplit
+        CommandArgUtils.rebuildCommandArgString(split) == commandArgs
+
+        where:
+        commandArgs    | expectedSplit
+        " blah  blah " | ["", "blah", "", "blah", ""]
+        "blah    "     | ["blah", "", "", "", ""]
+        "   blah"      | ["", "", "", "blah"]
+    }
+}

--- a/genie-web/src/integTest/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/controllers/JobRestControllerIntegrationTest.java
@@ -65,6 +65,7 @@ import org.springframework.restdocs.request.RequestDocumentation;
 import org.springframework.restdocs.restassured3.RestAssuredRestDocumentation;
 import org.springframework.restdocs.restassured3.RestDocumentationFilter;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -341,7 +342,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     private String submitJob(
         final int documentationId,
         final JobRequest jobRequest,
-        final List<MockMultipartFile> attachments
+        @Nullable final List<MockMultipartFile> attachments
     ) throws Exception {
         if (attachments != null) {
             final RestDocumentationFilter createResultFilter = RestAssuredRestDocumentation.document(

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
@@ -397,9 +397,7 @@ public final class DtoConverters {
         return new JobRequest(
             v3JobRequest.getId().orElse(null),
             resources,
-            v3JobRequest.getCommandArgs().isPresent()
-                ? Lists.newArrayList(StringUtils.split(v3JobRequest.getCommandArgs().get(), ' '))
-                : null,
+            v3JobRequest.getCommandArgsAsList(),
             metadataBuilder.build(),
             criteria,
             agentEnvironmentBuilder.build(),

--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/JobRestController.java
@@ -306,9 +306,9 @@ public class JobRestController {
                 .withTags(jobRequest.getTags())
                 .withConfigs(jobRequest.getConfigs())
                 .withDependencies(jobRequest.getDependencies())
-                .withApplications(jobRequest.getApplications());
+                .withApplications(jobRequest.getApplications())
+                .withCommandArgs(jobRequest.getCommandArgsAsList());
 
-            jobRequest.getCommandArgs().ifPresent(builder::withCommandArgs);
             jobRequest.getCpu().ifPresent(builder::withCpu);
             jobRequest.getMemory().ifPresent(builder::withMemory);
             jobRequest.getGroup().ifPresent(builder::withGroup);

--- a/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/JobTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/JobTask.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.internal.jobs.JobConstants;
+import com.netflix.genie.common.util.CommandArgUtils;
 import com.netflix.genie.web.jobs.JobExecutionEnvironment;
 import com.netflix.genie.web.services.AttachmentService;
 import com.netflix.genie.web.services.impl.GenieFileTransferService;
@@ -49,7 +50,6 @@ import java.util.concurrent.TimeUnit;
 public class JobTask extends GenieBaseTask {
 
     private static final String JOB_TASK_TIMER_NAME = "genie.jobs.tasks.jobTask.timer";
-    private static final String EMPTY_STRING = "";
     private final AttachmentService attachmentService;
     private final GenieFileTransferService fts;
 
@@ -147,7 +147,7 @@ public class JobTask extends GenieBaseTask {
             writer.write(
                 StringUtils.join(jobExecEnv.getCommand().getExecutable(), ' ')
                     + JobConstants.WHITE_SPACE
-                    + jobExecEnv.getJobRequest().getCommandArgs().orElse(EMPTY_STRING)
+                    + CommandArgUtils.rebuildCommandArgString(jobExecEnv.getJobRequest().getCommandArgsAsList())
                     + JobConstants.STDOUT_REDIRECT
                     + "${" + JobConstants.GENIE_JOB_DIR_ENV_VAR + "}/" + JobConstants.STDOUT_LOG_FILE_NAME
                     + JobConstants.STDERR_REDIRECT

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/entities/JobEntity.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.jpa.entities;
 
 import com.google.common.collect.Maps;
 import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.common.util.CommandArgUtils;
 import com.netflix.genie.web.jpa.entities.projections.JobApplicationsProjection;
 import com.netflix.genie.web.jpa.entities.projections.JobArchiveLocationProjection;
 import com.netflix.genie.web.jpa.entities.projections.JobClusterProjection;
@@ -356,9 +357,9 @@ public class JobEntity extends BaseEntity implements
             @JoinColumn(name = "job_id", nullable = false, updatable = false)
         }
     )
-    @Column(name = "argument", length = 10_000, nullable = false, updatable = false)
+    @Column(name = "argument", length = CommandArgUtils.MAX_COMMAND_ARG_LENGTH, nullable = false, updatable = false)
     @OrderColumn(name = "argument_order", nullable = false, updatable = false)
-    private List<@NotBlank @Size(max = 10_000) String> commandArgs = new ArrayList<>();
+    private List<@Size(max = CommandArgUtils.MAX_COMMAND_ARG_LENGTH) String> commandArgs = new ArrayList<>();
 
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
@@ -66,7 +66,6 @@ import com.netflix.genie.web.jpa.repositories.JpaCommandRepository;
 import com.netflix.genie.web.jpa.repositories.JpaJobRepository;
 import com.netflix.genie.web.services.JobPersistenceService;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -670,10 +669,7 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
             .getMetadata()
             .ifPresent(metadata -> EntityDtoConverters.setJsonField(metadata, jobEntity::setMetadata));
         JpaServiceUtils.setEntityMetadata(GenieObjectMapper.getMapper(), jobRequest, jobEntity);
-        jobRequest.getCommandArgs().ifPresent(
-            commandArgs ->
-                jobEntity.setCommandArgs(Lists.newArrayList(StringUtils.split(commandArgs)))
-        );
+        jobEntity.setCommandArgs(jobRequest.getCommandArgsAsList());
         jobRequest.getGroup().ifPresent(jobEntity::setGenieUserGroup);
         final FileEntity setupFile = jobRequest.getSetupFile().isPresent()
             ? this.createAndGetFileEntity(jobRequest.getSetupFile().get())

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -160,9 +160,9 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
                 .withId(jobId)
                 .withTags(jobRequest.getTags())
                 .withStatus(JobStatus.INIT)
-                .withStatusMsg("Job Accepted and in initialization phase.");
+                .withStatusMsg("Job Accepted and in initialization phase.")
+                .withCommandArgs(jobRequest.getCommandArgsAsList());
 
-            jobRequest.getCommandArgs().ifPresent(jobBuilder::withCommandArgs);
             jobRequest.getDescription().ifPresent(jobBuilder::withDescription);
 
             // TODO: Disabling this check for now to force archival for all jobs during internal V4 migration.


### PR DESCRIPTION
Before this our database blocked entry of blank entries for command args in order to save space. However this introduced side effects with constructing
and deconstructing command arguments from the V3 JSON payload which is just one long string. The database is setup now for the future where the arguments
should come in as a List to make escaping easier. The models in the DTOs represent this too but at the API layer we need compatibility so they still
go over the wire as a long string. To try and match V3 behavior the strings are now split on space but all tokens are preserved. In this way when
the string is rebuilt and we join on space the resulting string should be exactly the same as the input.

I would view this entire solution as temporary to get us through the V3->V4 server migration and make sure we have no further regressions. Afterwards this can be
revisited either in a V4 API or a more proper solution that we can slowly break jobs while not conflating those issues with other server migration issues that may
exist.