### PR TITLE
Revert command arg functionality to a variation of V3 for API

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/JobTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/JobTask.java
@@ -145,7 +145,7 @@ public class JobTask extends GenieBaseTask {
                 + System.lineSeparator());
 
             writer.write(
-                StringUtils.join(jobExecEnv.getCommand().getExecutable(), ' ')
+                StringUtils.join(jobExecEnv.getCommand().getExecutable(), StringUtils.SPACE)
                     + JobConstants.WHITE_SPACE
                     + jobExecEnv.getJobRequest().getCommandArgs().orElse(EMPTY_STRING)
                     + JobConstants.STDOUT_REDIRECT

--- a/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jpa/services/JpaJobPersistenceServiceImpl.java
@@ -66,7 +66,6 @@ import com.netflix.genie.web.jpa.repositories.JpaCommandRepository;
 import com.netflix.genie.web.jpa.repositories.JpaJobRepository;
 import com.netflix.genie.web.services.JobPersistenceService;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -670,10 +669,7 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
             .getMetadata()
             .ifPresent(metadata -> EntityDtoConverters.setJsonField(metadata, jobEntity::setMetadata));
         JpaServiceUtils.setEntityMetadata(GenieObjectMapper.getMapper(), jobRequest, jobEntity);
-        jobRequest.getCommandArgs().ifPresent(
-            commandArgs ->
-                jobEntity.setCommandArgs(Lists.newArrayList(StringUtils.split(commandArgs)))
-        );
+        jobRequest.getCommandArgs().ifPresent(commandArgs -> jobEntity.setCommandArgs(Lists.newArrayList(commandArgs)));
         jobRequest.getGroup().ifPresent(jobEntity::setGenieUserGroup);
         final FileEntity setupFile = jobRequest.getSetupFile().isPresent()
             ? this.createAndGetFileEntity(jobRequest.getSetupFile().get())


### PR DESCRIPTION
This change makes the job request and job objects behave pretty much as they did in V3 with the caveat that they limit the
number of characters total in the command arguments to 10,000 and throws a precondition exception if that is exceeded.