### PR TITLE
Change V3 to V4 Job Request logic to ensure no splitting of command args

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/controllers/DtoConverters.java
@@ -390,16 +390,14 @@ public final class DtoConverters {
             .withInteractive(false);
         v3JobRequest.getTimeout().ifPresent(agentConfigBuilder::withTimeoutRequested);
 
-        final JobArchivalDataRequest.Builder jobArchivalDataRequestBuilder =
-            new JobArchivalDataRequest
-                .Builder();
+        final JobArchivalDataRequest.Builder jobArchivalDataRequestBuilder = new JobArchivalDataRequest.Builder();
 
+        final List<String> commandArgs = Lists.newArrayList();
+        v3JobRequest.getCommandArgs().ifPresent(commandArgs::add);
         return new JobRequest(
             v3JobRequest.getId().orElse(null),
             resources,
-            v3JobRequest.getCommandArgs().isPresent()
-                ? Lists.newArrayList(StringUtils.split(v3JobRequest.getCommandArgs().get(), ' '))
-                : null,
+            commandArgs,
             metadataBuilder.build(),
             criteria,
             agentEnvironmentBuilder.build(),

--- a/genie-web/src/test/groovy/com/netflix/genie/web/controllers/DtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/controllers/DtoConvertersSpec.groovy
@@ -982,7 +982,7 @@ class DtoConvertersSpec extends Specification {
         v4JobRequest.getMetadata().getVersion() == version
         v4JobRequest.getMetadata().getTags() == tags
         v4JobRequest.getCriteria().getApplicationIds() == applicationIds
-        v4JobRequest.getCommandArgs() == commandArgs
+        v4JobRequest.getCommandArgs() == [StringUtils.join(commandArgs, StringUtils.SPACE)] as List
         v4JobRequest.getRequestedAgentEnvironment().getRequestedJobMemory().orElse(null) == memory
         v4JobRequest.getRequestedAgentConfig().getTimeoutRequested().orElse(-1) == timeout
         v4JobRequest.getMetadata().getMetadata().orElse(null) == metadata


### PR DESCRIPTION
For backwards compatibility with how V3 job requests behave this will lump all the v3 command args into a single element in a list without splitting them to avoid errors