### PR TITLE
Job manifest caching

### DIFF
--- a/genie-agent/src/integTest/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfigurationIntegrationTest.java
+++ b/genie-agent/src/integTest/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfigurationIntegrationTest.java
@@ -24,6 +24,7 @@ import com.netflix.genie.agent.execution.services.AgentJobKillService;
 import com.netflix.genie.agent.execution.services.AgentJobService;
 import com.netflix.genie.agent.execution.services.KillService;
 import com.netflix.genie.agent.rpc.GRpcAutoConfiguration;
+import com.netflix.genie.common.internal.configs.CommonServicesAutoConfiguration;
 import com.netflix.genie.common.internal.dto.v4.converters.JobDirectoryManifestProtoConverter;
 import com.netflix.genie.common.internal.dto.v4.converters.JobServiceProtoConverter;
 import org.junit.Assert;
@@ -46,6 +47,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(
     classes = {
+        CommonServicesAutoConfiguration.class,
         GRpcAutoConfiguration.class,
         GRpcServicesAutoConfiguration.class,
         GRpcServicesAutoConfigurationIntegrationTest.MockConfig.class

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
@@ -20,7 +20,7 @@ package com.netflix.genie.agent.execution.services.impl.grpc;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
 import com.netflix.genie.agent.execution.services.AgentFileStreamService;
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest;
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.dto.v4.converters.JobDirectoryManifestProtoConverter;
 import com.netflix.genie.common.internal.exceptions.GenieConversionException;
 import com.netflix.genie.common.internal.util.ExponentialBackOffTrigger;
@@ -140,7 +140,7 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
             try {
                 jobFileManifest = manifestProtoConverter.manifestToProtoMessage(
                     this.jobId,
-                    new JobDirectoryManifest(this.jobDirectoryPath, false)
+                    new DirectoryManifest(this.jobDirectoryPath, false)
                 );
             } catch (final IOException e) {
                 log.error("Failed to construct manifest", e);

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
@@ -24,6 +24,7 @@ import com.netflix.genie.agent.execution.services.AgentJobService;
 import com.netflix.genie.agent.execution.services.KillService;
 import com.netflix.genie.common.internal.dto.v4.converters.JobDirectoryManifestProtoConverter;
 import com.netflix.genie.common.internal.dto.v4.converters.JobServiceProtoConverter;
+import com.netflix.genie.common.internal.services.JobDirectoryManifestService;
 import com.netflix.genie.proto.FileStreamServiceGrpc;
 import com.netflix.genie.proto.HeartBeatServiceGrpc;
 import com.netflix.genie.proto.JobKillServiceGrpc;
@@ -104,6 +105,7 @@ public class GRpcServicesAutoConfiguration {
      * @param fileStreamServiceStub              The stub to use for communications with the server
      * @param taskScheduler                      The task scheduler to use
      * @param jobDirectoryManifestProtoConverter The converter to serialize manifests into messages
+     * @param jobDirectoryManifestService        The job directory manifest service
      * @return A {@link AgentFileStreamService} instance
      */
     @Bean
@@ -112,12 +114,14 @@ public class GRpcServicesAutoConfiguration {
     public AgentFileStreamService agentFileStreamService(
         final FileStreamServiceGrpc.FileStreamServiceStub fileStreamServiceStub,
         @Qualifier("heartBeatServiceTaskExecutor") final TaskScheduler taskScheduler,
-        final JobDirectoryManifestProtoConverter jobDirectoryManifestProtoConverter
+        final JobDirectoryManifestProtoConverter jobDirectoryManifestProtoConverter,
+        final JobDirectoryManifestService jobDirectoryManifestService
     ) {
         return new GRpcAgentFileStreamServiceImpl(
             fileStreamServiceStub,
             taskScheduler,
-            jobDirectoryManifestProtoConverter
+            jobDirectoryManifestProtoConverter,
+            jobDirectoryManifestService
         );
     }
 }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImplSpec.groovy
@@ -20,7 +20,7 @@ package com.netflix.genie.agent.execution.services.impl.grpc
 
 import com.google.common.collect.Maps
 import com.netflix.genie.agent.execution.services.AgentFileStreamService
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest
+import com.netflix.genie.common.internal.dto.DirectoryManifest
 import com.netflix.genie.common.internal.dto.v4.converters.JobDirectoryManifestProtoConverter
 import com.netflix.genie.common.internal.exceptions.GenieConversionException
 import com.netflix.genie.proto.*
@@ -127,7 +127,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
         runnableCapture.run()
 
         then: "A sync channel is open and a manifest is transmitted"
-        1 * converter.manifestToProtoMessage(jobId, _ as JobDirectoryManifest) >> manifestMessage
+        1 * converter.manifestToProtoMessage(jobId, _ as DirectoryManifest) >> manifestMessage
         1 == remoteService.activeSyncStreams.size()
         1 == remoteService.manifestMessageReceived.size()
         manifestMessage == remoteService.manifestMessageReceived.get(0)
@@ -136,14 +136,14 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
         runnableCapture.run()
 
         then: "Handle manifest creation exception"
-        1 * converter.manifestToProtoMessage(jobId, _ as JobDirectoryManifest) >> { throw new IOException("...") }
+        1 * converter.manifestToProtoMessage(jobId, _ as DirectoryManifest) >> { throw new IOException("...") }
         1 == remoteService.activeSyncStreams.size()
 
         when:
         runnableCapture.run()
 
         then: "Handle manifest message conversion exception"
-        1 * converter.manifestToProtoMessage(jobId, _ as JobDirectoryManifest) >> {
+        1 * converter.manifestToProtoMessage(jobId, _ as DirectoryManifest) >> {
             throw new GenieConversionException("...")
         }
         1 == remoteService.activeSyncStreams.size()
@@ -152,7 +152,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
         runnableCapture.run()
 
         then: "Another manifest is transmitted over the existing sync channel"
-        1 * converter.manifestToProtoMessage(jobId, _ as JobDirectoryManifest) >> manifestMessage
+        1 * converter.manifestToProtoMessage(jobId, _ as DirectoryManifest) >> manifestMessage
         1 == remoteService.activeSyncStreams.size()
         2 == remoteService.manifestMessageReceived.size()
         manifestMessage == remoteService.manifestMessageReceived.get(1)
@@ -162,7 +162,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
         runnableCapture.run()
 
         then:
-        1 * converter.manifestToProtoMessage(jobId, _ as JobDirectoryManifest) >> manifestMessage
+        1 * converter.manifestToProtoMessage(jobId, _ as DirectoryManifest) >> manifestMessage
 
         when:
         agentFileStreamService.stop()
@@ -195,7 +195,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
         runnableCapture.run()
 
         then: "A sync channel is open and a manifest is transmitted"
-        1 * converter.manifestToProtoMessage(jobId, _ as JobDirectoryManifest) >> manifestMessage
+        1 * converter.manifestToProtoMessage(jobId, _ as DirectoryManifest) >> manifestMessage
         1 == remoteService.activeSyncStreams.size()
         1 == remoteService.manifestMessageReceived.size()
         manifestMessage == remoteService.manifestMessageReceived.get(0)
@@ -243,7 +243,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
         runnableCapture.run()
 
         then: "A sync channel is open and a manifest is transmitted"
-        1 * converter.manifestToProtoMessage(jobId, _ as JobDirectoryManifest) >> manifestMessage
+        1 * converter.manifestToProtoMessage(jobId, _ as DirectoryManifest) >> manifestMessage
         1 == remoteService.activeSyncStreams.size()
         1 == remoteService.manifestMessageReceived.size()
         manifestMessage == remoteService.manifestMessageReceived.get(0)

--- a/genie-common-internal/build.gradle
+++ b/genie-common-internal/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.apache.commons:commons-lang3")
     implementation("org.apache.tika:tika-core")
     implementation("org.springframework:spring-context")
+    implementation("com.github.ben-manes.caffeine:caffeine")
 
     /*******************************
      * Provided Dependencies

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfiguration.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfiguration.java
@@ -87,7 +87,7 @@ public class CommonServicesAutoConfiguration {
      * Provide a {@link JobDirectoryManifestService} if no override is defined.
      * The manifest produced by this service include checksum for each entry.
      *
-     * @param directoryManifestFilter the filter to apply when constructing the manifest
+     * @param directoryManifestFactory the factory to produce the manifest if needed
      * @return a {@link JobDirectoryManifestService}
      */
     @Bean(name = JOB_DIRECTORY_MANIFEST_SERVICE_CS_BEAN)
@@ -95,16 +95,16 @@ public class CommonServicesAutoConfiguration {
         name = JOB_DIRECTORY_MANIFEST_SERVICE_CS_BEAN
     )
     public JobDirectoryManifestService checksummingJobDirectoryManifestService(
-        final DirectoryManifest.Filter directoryManifestFilter
+        final DirectoryManifest.Factory directoryManifestFactory
     ) {
-        return jobDirectoryPath -> new DirectoryManifest(jobDirectoryPath, true, directoryManifestFilter);
+        return jobDirectoryPath -> directoryManifestFactory.getDirectoryManifest(jobDirectoryPath, true);
     }
 
     /**
      * Provide a {@link JobDirectoryManifestService} if no override is defined.
      * The manifest produced by this service do not include checksum for each entry.
      *
-     * @param directoryManifestFilter the filter to apply when constructing the manifest
+     * @param directoryManifestFactory the factory to produce the manifest if needed
      * @return a {@link JobDirectoryManifestService}
      */
     @Bean(name = JOB_DIRECTORY_MANIFEST_SERVICE_BEAN)
@@ -113,9 +113,23 @@ public class CommonServicesAutoConfiguration {
         name = JOB_DIRECTORY_MANIFEST_SERVICE_BEAN
     )
     public JobDirectoryManifestService jobDirectoryManifestService(
+        final DirectoryManifest.Factory directoryManifestFactory
+    ) {
+        return jobDirectoryPath -> directoryManifestFactory.getDirectoryManifest(jobDirectoryPath, false);
+    }
+
+    /**
+     * Provide a {@link DirectoryManifest.Factory} if no override is defined.
+     *
+     * @param directoryManifestFilter the filter used during manifest creation
+     * @return a directory manifest factory
+     */
+    @Bean
+    @ConditionalOnMissingBean(DirectoryManifest.Factory.class)
+    public DirectoryManifest.Factory directoryManifestFactory(
         final DirectoryManifest.Filter directoryManifestFilter
     ) {
-        return jobDirectoryPath -> new DirectoryManifest(jobDirectoryPath, false, directoryManifestFilter);
+        return new DirectoryManifest.Factory(directoryManifestFilter);
     }
 
     /**

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfiguration.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfiguration.java
@@ -91,7 +91,7 @@ public class CommonServicesAutoConfiguration {
         name = JOB_DIRECTORY_MANIFEST_SERVICE_CS_BEAN
     )
     public JobDirectoryManifestService checksummingJobDirectoryManifestService() {
-        return jobDirectoryPath -> new DirectoryManifest(jobDirectoryPath, true);
+        return jobDirectoryPath -> new DirectoryManifest(jobDirectoryPath, true, new DirectoryManifest.Filter() { });
     }
 
     /**
@@ -106,6 +106,6 @@ public class CommonServicesAutoConfiguration {
         name = JOB_DIRECTORY_MANIFEST_SERVICE_BEAN
     )
     public JobDirectoryManifestService jobDirectoryManifestService() {
-        return jobDirectoryPath -> new DirectoryManifest(jobDirectoryPath, false);
+        return jobDirectoryPath -> new DirectoryManifest(jobDirectoryPath, false, new DirectoryManifest.Filter() { });
     }
 }

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfiguration.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfiguration.java
@@ -17,13 +17,17 @@
  */
 package com.netflix.genie.common.internal.configs;
 
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import com.netflix.genie.common.internal.services.JobArchiver;
+import com.netflix.genie.common.internal.services.JobDirectoryManifestService;
 import com.netflix.genie.common.internal.services.impl.FileSystemJobArchiverImpl;
 import com.netflix.genie.common.internal.services.impl.JobArchiveServiceImpl;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
@@ -45,6 +49,9 @@ public class CommonServicesAutoConfiguration {
      */
     public static final int FILE_SYSTEM_JOB_ARCHIVER_PRECEDENCE = Ordered.LOWEST_PRECEDENCE - 20;
 
+    private static final String JOB_DIRECTORY_MANIFEST_SERVICE_CS_BEAN = "checksummingJobDirectoryManifestService";
+    private static final String JOB_DIRECTORY_MANIFEST_SERVICE_BEAN = "jobDirectoryManifestService";
+
     /**
      * Provide a {@link JobArchiver} implementation that will copy from one place on the filesystem to another.
      *
@@ -59,12 +66,46 @@ public class CommonServicesAutoConfiguration {
     /**
      * Provide a default {@link JobArchiveService} if no override is defined.
      *
-     * @param jobArchivers The ordered available {@link JobArchiver} implementations in the system
+     * @param jobArchivers                The ordered available {@link JobArchiver} implementations in the system
+     * @param jobDirectoryManifestService the job directory manifest service
      * @return A {@link JobArchiveServiceImpl} instance
      */
     @Bean
     @ConditionalOnMissingBean(JobArchiveService.class)
-    public JobArchiveService jobArchiveService(final List<JobArchiver> jobArchivers) {
-        return new JobArchiveServiceImpl(jobArchivers);
+    public JobArchiveService jobArchiveService(
+        final List<JobArchiver> jobArchivers,
+        @Qualifier(JOB_DIRECTORY_MANIFEST_SERVICE_CS_BEAN)
+        final JobDirectoryManifestService jobDirectoryManifestService
+    ) {
+        return new JobArchiveServiceImpl(jobArchivers, jobDirectoryManifestService);
+    }
+
+    /**
+     * Provide a {@link JobDirectoryManifestService} if no override is defined.
+     * The manifest produced by this service include checksum for each entry.
+     *
+     * @return a {@link JobDirectoryManifestService}
+     */
+    @Bean(name = JOB_DIRECTORY_MANIFEST_SERVICE_CS_BEAN)
+    @ConditionalOnMissingBean(
+        name = JOB_DIRECTORY_MANIFEST_SERVICE_CS_BEAN
+    )
+    public JobDirectoryManifestService checksummingJobDirectoryManifestService() {
+        return jobDirectoryPath -> new DirectoryManifest(jobDirectoryPath, true);
+    }
+
+    /**
+     * Provide a {@link JobDirectoryManifestService} if no override is defined.
+     * The manifest produced by this service do not include checksum for each entry.
+     *
+     * @return a {@link JobDirectoryManifestService}
+     */
+    @Bean(name = JOB_DIRECTORY_MANIFEST_SERVICE_BEAN)
+    @Primary
+    @ConditionalOnMissingBean(
+        name = JOB_DIRECTORY_MANIFEST_SERVICE_BEAN
+    )
+    public JobDirectoryManifestService jobDirectoryManifestService() {
+        return jobDirectoryPath -> new DirectoryManifest(jobDirectoryPath, false);
     }
 }

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/DirectoryManifest.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/DirectoryManifest.java
@@ -75,15 +75,7 @@ public class DirectoryManifest {
     private final int numDirectories;
     private final long totalSizeOfFiles;
 
-    /**
-     * Create a manifest from the given job directory.
-     *
-     * @param directory              The job directory to create a manifest from
-     * @param calculateFileChecksums Whether or not to calculate checksums for each file added to the manifest
-     * @param filter                 The filter applied to directories and files included in the manifest
-     * @throws IOException If there is an error reading the directory
-     */
-    public DirectoryManifest(
+    private DirectoryManifest(
         final Path directory,
         final boolean calculateFileChecksums,
         final Filter filter
@@ -275,6 +267,46 @@ public class DirectoryManifest {
          */
         default boolean walkDirectory(final Path dirPath, BasicFileAttributes attrs) {
             return true;
+        }
+    }
+
+    /**
+     * Factory that encapsulates directory manifest creation.
+     */
+    public static class Factory {
+
+        private static final Filter ACCEPT_ALL_FILTER = new DirectoryManifest.Filter() { };
+        private final Filter filter;
+
+        /**
+         * Constructor with no filters.
+         */
+        public Factory() {
+            this(ACCEPT_ALL_FILTER);
+        }
+
+        /**
+         * Constructor with filter.
+         *
+         * @param filter the manifest filter
+         */
+        public Factory(final Filter filter) {
+            this.filter = filter;
+        }
+
+        /**
+         * Create a manifest from the given job directory.
+         *
+         * @param directory       The job directory to create a manifest from
+         * @param includeChecksum Whether or not to calculate checksums for each file added to the manifest
+         * @return a directory manifest
+         * @throws IOException If there is an error reading the directory
+         */
+        public DirectoryManifest getDirectoryManifest(
+            final Path directory,
+            final boolean includeChecksum
+        ) throws IOException {
+            return new DirectoryManifest(directory, includeChecksum, this.filter);
         }
     }
 

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/DirectoryManifest.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/DirectoryManifest.java
@@ -58,14 +58,14 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * A manifest of all the files and subdirectories in a Genie job working directory.
+ * A manifest of all the files and subdirectories in a directory.
  *
  * @author tgianos
  * @since 4.0.0
  */
 @ToString(doNotUseGetters = true)
 @EqualsAndHashCode(doNotUseGetters = true)
-public class JobDirectoryManifest {
+public class DirectoryManifest {
     private static final String ENTRIES_KEY = "entries";
     private static final String EMPTY_STRING = "";
 
@@ -79,21 +79,11 @@ public class JobDirectoryManifest {
     /**
      * Create a manifest from the given job directory.
      *
-     * @param directory The job directory to create a manifest from
-     * @throws IOException If there is an error reading the directory
-     */
-    public JobDirectoryManifest(final Path directory) throws IOException {
-        this(directory, true);
-    }
-
-    /**
-     * Create a manifest from the given job directory.
-     *
      * @param directory              The job directory to create a manifest from
      * @param calculateFileChecksums Whether or not to calculate checksums for each file added to the manifest
      * @throws IOException If there is an error reading the directory
      */
-    public JobDirectoryManifest(final Path directory, final boolean calculateFileChecksums) throws IOException {
+    public DirectoryManifest(final Path directory, final boolean calculateFileChecksums) throws IOException {
         // Walk the directory
         final ImmutableMap.Builder<String, ManifestEntry> builder = ImmutableMap.builder();
         final ManifestVisitor manifestVisitor = new ManifestVisitor(directory, builder, calculateFileChecksums);
@@ -128,7 +118,7 @@ public class JobDirectoryManifest {
      * @param entries The entries in this manifest
      */
     @JsonCreator
-    public JobDirectoryManifest(
+    public DirectoryManifest(
         @JsonProperty(value = ENTRIES_KEY, required = true) final Set<ManifestEntry> entries
     ) {
         final ImmutableMap.Builder<String, ManifestEntry> builder = ImmutableMap.builder();

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/converters/JobDirectoryManifestProtoConverter.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/converters/JobDirectoryManifestProtoConverter.java
@@ -20,7 +20,7 @@ package com.netflix.genie.common.internal.dto.v4.converters;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest;
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.exceptions.GenieConversionException;
 import com.netflix.genie.proto.AgentManifestMessage;
 import org.springframework.validation.annotation.Validated;
@@ -29,7 +29,7 @@ import javax.validation.constraints.NotBlank;
 import java.io.IOException;
 
 /**
- * Converts {@link JobDirectoryManifest} from/to {@link AgentManifestMessage} in order to transport manifests
+ * Converts {@link DirectoryManifest} from/to {@link AgentManifestMessage} in order to transport manifests
  * over gRPC.
  *
  * @author mprimi
@@ -50,7 +50,7 @@ public class JobDirectoryManifestProtoConverter {
     }
 
     /**
-     * Construct a {@link AgentManifestMessage} from the given {@link JobDirectoryManifest}.
+     * Construct a {@link AgentManifestMessage} from the given {@link DirectoryManifest}.
      *
      * @param claimedJobId the id of the job this file manifest belongs to
      * @param manifest     the manifest
@@ -59,7 +59,7 @@ public class JobDirectoryManifestProtoConverter {
      */
     public AgentManifestMessage manifestToProtoMessage(
         @NotBlank final String claimedJobId,
-        final JobDirectoryManifest manifest
+        final DirectoryManifest manifest
     ) throws GenieConversionException {
         final String manifestJsonString;
         try {
@@ -76,15 +76,15 @@ public class JobDirectoryManifestProtoConverter {
     }
 
     /**
-     * Load a {@link JobDirectoryManifest} from a {@link AgentManifestMessage}.
+     * Load a {@link DirectoryManifest} from a {@link AgentManifestMessage}.
      *
      * @param message the message
-     * @return a {@link JobDirectoryManifest}
+     * @return a {@link DirectoryManifest}
      * @throws GenieConversionException if loading fails
      */
-    public JobDirectoryManifest toManifest(final AgentManifestMessage message) throws GenieConversionException {
+    public DirectoryManifest toManifest(final AgentManifestMessage message) throws GenieConversionException {
         try {
-            return objectMapper.readValue(message.getManifestJson(), JobDirectoryManifest.class);
+            return objectMapper.readValue(message.getManifestJson(), DirectoryManifest.class);
         } catch (final IOException e) {
             throw new GenieConversionException("Failed to load manifest", e);
         }

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/JobDirectoryManifestService.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/JobDirectoryManifestService.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.services;
+
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Factory-like service that produces {@link DirectoryManifest} for Genie jobs directories.
+ * Implementations can have behaviors such as remotely fetching, or caching.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public interface JobDirectoryManifestService {
+
+    /**
+     * Produces a {@link DirectoryManifest} for the given job.
+     *
+     * @param jobDirectoryPath the job id
+     * @return a {@link DirectoryManifest}
+     * @throws IOException if the manifest cannot be created.
+     */
+    DirectoryManifest getDirectoryManifest(
+        Path jobDirectoryPath
+    ) throws IOException;
+
+}

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImpl.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImpl.java
@@ -18,7 +18,7 @@
 package com.netflix.genie.common.internal.services.impl;
 
 import com.google.common.collect.ImmutableList;
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest;
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.exceptions.JobArchiveException;
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import com.netflix.genie.common.internal.services.JobArchiver;
@@ -60,7 +60,7 @@ public class JobArchiveServiceImpl implements JobArchiveService {
         // TODO: This relies highly on convention. Might be nicer to better abstract with database
         //       record that points directly to where the manifest is or other solution?
         try {
-            final JobDirectoryManifest manifest = new JobDirectoryManifest(directory);
+            final DirectoryManifest manifest = new DirectoryManifest(directory, true);
             final Path manifestDirectoryPath = StringUtils.isBlank(JobArchiveService.MANIFEST_DIRECTORY)
                 ? directory
                 : directory.resolve(JobArchiveService.MANIFEST_DIRECTORY);

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImpl.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImpl.java
@@ -22,7 +22,6 @@ import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.exceptions.JobArchiveException;
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import com.netflix.genie.common.internal.services.JobArchiver;
-import com.netflix.genie.common.internal.services.JobDirectoryManifestService;
 import com.netflix.genie.common.util.GenieObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -43,20 +42,20 @@ import java.util.List;
 public class JobArchiveServiceImpl implements JobArchiveService {
 
     private final ImmutableList<JobArchiver> jobArchivers;
-    private final JobDirectoryManifestService jobDirectoryManifestService;
+    private final DirectoryManifest.Factory directoryManifestFactory;
 
     /**
      * Constructor.
      *
-     * @param jobArchivers                The ordered list of {@link JobArchiver} implementations to use. Not empty.
-     * @param jobDirectoryManifestService The job directory manifest service
+     * @param jobArchivers             The ordered list of {@link JobArchiver} implementations to use. Not empty.
+     * @param directoryManifestFactory The job directory manifest factory
      */
     public JobArchiveServiceImpl(
         final List<JobArchiver> jobArchivers,
-        final JobDirectoryManifestService jobDirectoryManifestService
+        final DirectoryManifest.Factory directoryManifestFactory
     ) {
         this.jobArchivers = ImmutableList.copyOf(jobArchivers);
-        this.jobDirectoryManifestService = jobDirectoryManifestService;
+        this.directoryManifestFactory = directoryManifestFactory;
     }
 
     /**
@@ -67,7 +66,7 @@ public class JobArchiveServiceImpl implements JobArchiveService {
         // TODO: This relies highly on convention. Might be nicer to better abstract with database
         //       record that points directly to where the manifest is or other solution?
         try {
-            final DirectoryManifest manifest = jobDirectoryManifestService.getDirectoryManifest(directory);
+            final DirectoryManifest manifest = directoryManifestFactory.getDirectoryManifest(directory, true);
             final Path manifestDirectoryPath = StringUtils.isBlank(JobArchiveService.MANIFEST_DIRECTORY)
                 ? directory
                 : directory.resolve(JobArchiveService.MANIFEST_DIRECTORY);

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImpl.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImpl.java
@@ -22,6 +22,7 @@ import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.exceptions.JobArchiveException;
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import com.netflix.genie.common.internal.services.JobArchiver;
+import com.netflix.genie.common.internal.services.JobDirectoryManifestService;
 import com.netflix.genie.common.util.GenieObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -42,14 +43,20 @@ import java.util.List;
 public class JobArchiveServiceImpl implements JobArchiveService {
 
     private final ImmutableList<JobArchiver> jobArchivers;
+    private final JobDirectoryManifestService jobDirectoryManifestService;
 
     /**
      * Constructor.
      *
-     * @param jobArchivers The ordered list of {@link JobArchiver} implementations to use. Not empty.
+     * @param jobArchivers                The ordered list of {@link JobArchiver} implementations to use. Not empty.
+     * @param jobDirectoryManifestService The job directory manifest service
      */
-    public JobArchiveServiceImpl(final List<JobArchiver> jobArchivers) {
+    public JobArchiveServiceImpl(
+        final List<JobArchiver> jobArchivers,
+        final JobDirectoryManifestService jobDirectoryManifestService
+    ) {
         this.jobArchivers = ImmutableList.copyOf(jobArchivers);
+        this.jobDirectoryManifestService = jobDirectoryManifestService;
     }
 
     /**
@@ -60,7 +67,7 @@ public class JobArchiveServiceImpl implements JobArchiveService {
         // TODO: This relies highly on convention. Might be nicer to better abstract with database
         //       record that points directly to where the manifest is or other solution?
         try {
-            final DirectoryManifest manifest = new DirectoryManifest(directory, true);
+            final DirectoryManifest manifest = jobDirectoryManifestService.getDirectoryManifest(directory);
             final Path manifestDirectoryPath = StringUtils.isBlank(JobArchiveService.MANIFEST_DIRECTORY)
                 ? directory
                 : directory.resolve(JobArchiveService.MANIFEST_DIRECTORY);

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobDirectoryManifestServiceImpl.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobDirectoryManifestServiceImpl.java
@@ -1,0 +1,83 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.services.impl;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
+import com.netflix.genie.common.internal.services.JobDirectoryManifestService;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Implementation of {@link JobDirectoryManifestService} that caches manifests produced by the factory for a few
+ * seconds, thus avoiding re-calculating the same for subsequent requests (e.g. a user navigating a tree true the UI).
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public class JobDirectoryManifestServiceImpl implements JobDirectoryManifestService {
+
+    private final Cache<Path, DirectoryManifest> cache;
+    private final DirectoryManifest.Factory factory;
+    private final boolean includeChecksum;
+
+    /**
+     * Constructor.
+     *
+     * @param factory         the directory manifest factory
+     * @param cache           the loading cache to use
+     * @param includeChecksum whether to produce manifests that include checksums
+     */
+    public JobDirectoryManifestServiceImpl(
+        final DirectoryManifest.Factory factory,
+        final Cache<Path, DirectoryManifest> cache,
+        final boolean includeChecksum
+    ) {
+        this.factory = factory;
+        this.cache = cache;
+        this.includeChecksum = includeChecksum;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DirectoryManifest getDirectoryManifest(final Path jobDirectoryPath) throws IOException {
+        try {
+            return cache.get(
+                jobDirectoryPath.normalize().toAbsolutePath(),
+                path -> {
+                    try {
+                        return this.factory.getDirectoryManifest(path, this.includeChecksum);
+                    } catch (IOException e) {
+                        throw new RuntimeException("Failed to create manifest", e);
+                    }
+                }
+            );
+        } catch (RuntimeException e) {
+            if (e.getCause() != null && e.getCause() instanceof IOException) {
+                // Unwrap and throw the original IOException
+                throw (IOException) e.getCause();
+            }
+            throw e;
+        }
+    }
+}

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.configs
+
+import com.netflix.genie.common.internal.dto.DirectoryManifest
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.attribute.BasicFileAttributes
+
+class CommonServicesAutoConfigurationSpec extends Specification {
+
+    DirectoryManifest.Filter filter = new CommonServicesAutoConfiguration().directoryManifestFilter()
+    BasicFileAttributes attributes = Mock(BasicFileAttributes)
+
+    @Unroll
+    def "DirectoryManifestFilter for #pathString"() {
+        setup:
+        Path path = Paths.get(pathString)
+
+        when:
+        boolean fileIncluded = filter.includeFile(path, attributes)
+        boolean dirIncluded = filter.includeDirectory(path, attributes)
+        boolean treeIncluded = filter.walkDirectory(path, attributes)
+
+        then:
+        fileIncluded == expectFileIncluded
+        dirIncluded == expectDirIncluded
+        treeIncluded == expectTreeIncluded
+
+        where:
+        expectFileIncluded | expectDirIncluded | expectTreeIncluded | pathString
+        true               | true              | false              | "/foo/genie/application/hadoop/dependencies"
+        true               | true              | false              | "/foo/genie/application/hadoop/dependencies/"
+        true               | true              | true               | "/foo/hadoop/dependencies"
+        true               | true              | true               | "/foo/genie/application/hadoop/xdependencies"
+        true               | true              | true               | "/foo/dependencies"
+        true               | true              | true               | "/dependencies"
+    }
+}

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/DirectoryManifestSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/DirectoryManifestSpec.groovy
@@ -30,11 +30,11 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 /**
- * Specifications for {@link JobDirectoryManifest}.
+ * Specifications for {@link DirectoryManifest}.
  *
  * @author tgianos
  */
-class JobDirectoryManifestSpec extends Specification {
+class DirectoryManifestSpec extends Specification {
 
     @Rule
     TemporaryFolder temporaryFolder = new TemporaryFolder()
@@ -134,9 +134,9 @@ class JobDirectoryManifestSpec extends Specification {
     @Unroll
     def "can create a manifest, serialize it, deserialize it and verify correctness (md5: #includeMd5)"() {
         when:
-        def manifest = new JobDirectoryManifest(this.rootPath, includeMd5)
+        def manifest = new DirectoryManifest(this.rootPath, includeMd5)
         def json = GenieObjectMapper.getMapper().writeValueAsString(manifest)
-        def manifest2 = GenieObjectMapper.getMapper().readValue(json, JobDirectoryManifest.class)
+        def manifest2 = GenieObjectMapper.getMapper().readValue(json, DirectoryManifest.class)
 
         then:
         manifest == manifest2
@@ -149,18 +149,7 @@ class JobDirectoryManifestSpec extends Specification {
         false      | _
     }
 
-    def "default constructor includes md5"() {
-        when:
-        def manifestDefault = new JobDirectoryManifest(this.rootPath)
-
-        then:
-        manifestDefault.getEntries()
-            .stream()
-            .filter({ e -> !e.isDirectory() })
-            .forEach({ e -> assert e.getMd5().isPresent() })
-    }
-
-    void verifyManifest(JobDirectoryManifest manifest, boolean expectMd5Present) {
+    void verifyManifest(DirectoryManifest manifest, boolean expectMd5Present) {
         assert manifest.getEntries().size() == 11
         assert manifest.getFiles().size() == 7
         assert manifest.getNumFiles() == 7
@@ -309,7 +298,7 @@ class JobDirectoryManifestSpec extends Specification {
     }
 
     def verifyEntry(
-        JobDirectoryManifest.ManifestEntry entry,
+        DirectoryManifest.ManifestEntry entry,
         String expectedRelativePath,
         Path expectedFile,
         boolean isDirectory,

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/DirectoryManifestSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/DirectoryManifestSpec.groovy
@@ -149,7 +149,7 @@ class DirectoryManifestSpec extends Specification {
     @Unroll
     def "can create a manifest, serialize it, deserialize it and verify correctness (md5: #includeMd5)"() {
         when:
-        def manifest = new DirectoryManifest(this.rootPath, includeMd5, new DirectoryManifest.Filter() { })
+        def manifest = new DirectoryManifest.Factory().getDirectoryManifest(this.rootPath, includeMd5)
         def json = GenieObjectMapper.getMapper().writeValueAsString(manifest)
         def manifest2 = GenieObjectMapper.getMapper().readValue(json, DirectoryManifest.class)
 
@@ -166,7 +166,7 @@ class DirectoryManifestSpec extends Specification {
 
     def "can create a manifest with filter"() {
         when:
-        def manifest = new DirectoryManifest(this.rootPath, false, new DirectoryManifest.Filter() {
+        def manifest = new DirectoryManifest.Factory(new DirectoryManifest.Filter() {
             @Override
             boolean includeFile(final Path filePath, final BasicFileAttributes attrs) {
                 return filePath.getFileName().toString() != "env.sh"
@@ -181,7 +181,7 @@ class DirectoryManifestSpec extends Specification {
             boolean walkDirectory(final Path dirPath, final BasicFileAttributes attrs) {
                 return dirPath.getFileName().toString() != "application"
             }
-        })
+        }).getDirectoryManifest(this.rootPath, false)
 
         then:
         manifest.getEntries().size() == 9

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/converters/DirectoryManifestProtoConverterSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/converters/DirectoryManifestProtoConverterSpec.groovy
@@ -20,12 +20,12 @@ package com.netflix.genie.common.internal.dto.v4.converters
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest
+import com.netflix.genie.common.internal.dto.DirectoryManifest
 import com.netflix.genie.common.internal.exceptions.GenieConversionException
 import com.netflix.genie.proto.AgentManifestMessage
 import spock.lang.Specification
 
-class JobDirectoryManifestProtoConverterSpec extends Specification {
+class DirectoryManifestProtoConverterSpec extends Specification {
     ObjectMapper objectMapper
     JobDirectoryManifestProtoConverter converter
     static final String JSON_MANIFEST = "{ fake json serialization of manifest }"
@@ -38,7 +38,7 @@ class JobDirectoryManifestProtoConverterSpec extends Specification {
     def "Manifest to message to manifest"() {
         setup:
         String jobId = "123456"
-        JobDirectoryManifest manifest = Mock(JobDirectoryManifest)
+        DirectoryManifest manifest = Mock(DirectoryManifest)
 
         when:
         AgentManifestMessage message = this.converter.manifestToProtoMessage(jobId, manifest)
@@ -49,16 +49,16 @@ class JobDirectoryManifestProtoConverterSpec extends Specification {
         message.getManifestJson() == JSON_MANIFEST
 
         when:
-        JobDirectoryManifest loadedManifest = converter.toManifest(message)
+        DirectoryManifest loadedManifest = converter.toManifest(message)
 
         then:
-        1 * objectMapper.readValue(JSON_MANIFEST, JobDirectoryManifest.class) >> manifest
+        1 * objectMapper.readValue(JSON_MANIFEST, DirectoryManifest.class) >> manifest
         loadedManifest == manifest
     }
 
     def "Manifest JSON serialization error"() {
         setup:
-        JobDirectoryManifest manifest = Mock(JobDirectoryManifest)
+        DirectoryManifest manifest = Mock(DirectoryManifest)
         Exception exception = new JsonProcessingException("...")
 
         when:
@@ -78,7 +78,7 @@ class JobDirectoryManifestProtoConverterSpec extends Specification {
         this.converter.toManifest(AgentManifestMessage.getDefaultInstance())
 
         then:
-        1 * objectMapper.readValue(_, JobDirectoryManifest.class) >> {throw exception}
+        1 * objectMapper.readValue(_, DirectoryManifest.class) >> {throw exception}
         Exception e = thrown(GenieConversionException)
         e.getCause() == exception
     }

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImplSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImplSpec.groovy
@@ -17,7 +17,7 @@
  */
 package com.netflix.genie.common.internal.services.impl
 
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest
+import com.netflix.genie.common.internal.dto.DirectoryManifest
 import com.netflix.genie.common.internal.exceptions.JobArchiveException
 import com.netflix.genie.common.internal.services.JobArchiveService
 import com.netflix.genie.common.internal.services.JobArchiver
@@ -65,7 +65,7 @@ class JobArchiveServiceImplSpec extends Specification {
         Files.exists(manifestPath)
 
         when:
-        def manifest = GenieObjectMapper.getMapper().readValue(manifestPath.toFile(), JobDirectoryManifest)
+        def manifest = GenieObjectMapper.getMapper().readValue(manifestPath.toFile(), DirectoryManifest)
 
         then:
         manifest.getNumDirectories() == 2

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImplSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImplSpec.groovy
@@ -21,7 +21,6 @@ import com.netflix.genie.common.internal.dto.DirectoryManifest
 import com.netflix.genie.common.internal.exceptions.JobArchiveException
 import com.netflix.genie.common.internal.services.JobArchiveService
 import com.netflix.genie.common.internal.services.JobArchiver
-import com.netflix.genie.common.internal.services.JobDirectoryManifestService
 import com.netflix.genie.common.util.GenieObjectMapper
 import org.apache.commons.lang3.StringUtils
 import org.junit.Rule
@@ -49,8 +48,8 @@ class JobArchiveServiceImplSpec extends Specification {
                 return false
             }
         }
-        JobDirectoryManifestService jobDirectoryManifestService = Mock(JobDirectoryManifestService)
-        def service = new JobArchiveServiceImpl([archiver], jobDirectoryManifestService)
+        DirectoryManifest.Factory directoryManifestFactory = Mock(DirectoryManifest.Factory)
+        def service = new JobArchiveServiceImpl([archiver], directoryManifestFactory)
         def jobDirectory = this.temporaryFolder.newFolder().toPath()
         Files.write(jobDirectory.resolve("someFile"), UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8))
         Files.createDirectory(jobDirectory.resolve("subDir"))
@@ -66,7 +65,7 @@ class JobArchiveServiceImplSpec extends Specification {
 
 
         then:
-        1 * jobDirectoryManifestService.getDirectoryManifest(jobDirectory) >> originalManifest
+        1 * directoryManifestFactory.getDirectoryManifest(jobDirectory, true) >> originalManifest
         Files.exists(manifestPath)
 
         when:

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImplSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImplSpec.groovy
@@ -59,7 +59,7 @@ class JobArchiveServiceImplSpec extends Specification {
             ? jobDirectory
             : jobDirectory.resolve(JobArchiveService.MANIFEST_DIRECTORY)
         def manifestPath = manifestDirectoryPath.resolve(JobArchiveService.MANIFEST_NAME)
-        def originalManifest = new DirectoryManifest(jobDirectory, true)
+        def originalManifest = new DirectoryManifest(jobDirectory, true, new DirectoryManifest.Filter() {})
 
         when:
         service.archiveDirectory(jobDirectory, target)

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImplSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImplSpec.groovy
@@ -59,7 +59,7 @@ class JobArchiveServiceImplSpec extends Specification {
             ? jobDirectory
             : jobDirectory.resolve(JobArchiveService.MANIFEST_DIRECTORY)
         def manifestPath = manifestDirectoryPath.resolve(JobArchiveService.MANIFEST_NAME)
-        def originalManifest = new DirectoryManifest(jobDirectory, true, new DirectoryManifest.Filter() {})
+        def originalManifest = new DirectoryManifest.Factory().getDirectoryManifest(jobDirectory, true)
 
         when:
         service.archiveDirectory(jobDirectory, target)

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobDirectoryManifestServiceImplSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/JobDirectoryManifestServiceImplSpec.groovy
@@ -1,0 +1,126 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.services.impl
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.Ticker
+import com.netflix.genie.common.internal.dto.DirectoryManifest
+import com.netflix.genie.common.internal.services.JobDirectoryManifestService
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+
+/**
+ * Unit test for JobDirectoryManifestServiceImplSpec
+ */
+class JobDirectoryManifestServiceImplSpec extends Specification {
+    DirectoryManifest.Factory factory
+    Cache<Path, DirectoryManifest> cache
+
+    static IOException ioe = new IOException("...")
+    static RuntimeException re = new RuntimeException("...")
+    static IllegalStateException ise = new IllegalStateException("...")
+    static InterruptedException ie = new InterruptedException("...")
+
+    void setup() {
+        this.factory = Mock(DirectoryManifest.Factory)
+        this.cache = Caffeine.newBuilder()
+            .maximumSize(100)
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .build()
+    }
+
+    @Unroll
+    def "GetDirectoryManifest cache (checksum: #includeChecksum)"() {
+        setup:
+        JobDirectoryManifestService service = new JobDirectoryManifestServiceImpl(factory, cache, includeChecksum)
+
+        when:
+        for (int i = 0; i < 10; i++) {
+            service.getDirectoryManifest(Paths.get("/temp/foo"))
+        }
+
+        then:
+        1 * factory.getDirectoryManifest(Paths.get("/temp/foo"), includeChecksum) >> Mock(DirectoryManifest)
+
+        where:
+        includeChecksum | _
+        true            | _
+        false           | _
+    }
+
+    @Unroll
+    def "GetDirectoryManifest loading exception: #factoryException"(
+        Exception factoryException,
+        Exception expectedException,
+        Class<? extends Exception> expectedExceptionType
+    ) {
+        setup:
+        boolean includeChecksum = false
+        JobDirectoryManifestService service = new JobDirectoryManifestServiceImpl(factory, cache, includeChecksum)
+
+        when:
+        service.getDirectoryManifest(Paths.get("/temp/foo"))
+
+        then:
+        1 * factory.getDirectoryManifest(Paths.get("/temp/foo"), includeChecksum) >> { throw factoryException }
+        def t = thrown(Exception)
+        expectedExceptionType.isInstance(t)
+        if (expectedException != null) {
+            t == expectedException
+        }
+
+        where:
+        factoryException | expectedException | expectedExceptionType
+        ioe              | ioe               | IOException
+        re               | re                | RuntimeException
+        ise              | null              | RuntimeException
+        ie               | null              | InterruptedException
+    }
+
+    def "GetDirectoryManifest cache time-based eviction"() {
+        setup:
+        def ticker = Mock(Ticker)
+        def cache = Caffeine.newBuilder()
+            .maximumSize(100)
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .ticker(ticker)
+            .build()
+        JobDirectoryManifestService service = new JobDirectoryManifestServiceImpl(factory, cache, false)
+
+        when:
+        for (int i = 0; i < 10; i++) {
+            service.getDirectoryManifest(Paths.get("/temp/foo"))
+        }
+
+        then:
+        1 * factory.getDirectoryManifest(Paths.get("/temp/foo"), false) >> Mock(DirectoryManifest)
+        _ * ticker.read() >> 0
+
+        when:
+        service.getDirectoryManifest(Paths.get("/temp/foo"))
+
+        then:
+        _ * ticker.read() >> TimeUnit.HOURS.toNanos(1) + 1
+        1 * factory.getDirectoryManifest(Paths.get("/temp/foo"), false) >> Mock(DirectoryManifest)
+    }
+}

--- a/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
+++ b/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.common.internal.configs;
 
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import com.netflix.genie.common.internal.services.JobArchiver;
 import com.netflix.genie.common.internal.services.JobDirectoryManifestService;
@@ -120,6 +121,18 @@ public class CommonServicesAutoConfigurationTest {
                 Assertions.assertThat(context).getBean(
                     JobDirectoryManifestService.class
                 ).isEqualTo(context.getBean("jobDirectoryManifestService"));
+            }
+        );
+    }
+
+    /**
+     * Make JobDirectoryManifestService beans are configured as expected.
+     */
+    @Test
+    public void testDirectoryManifestFilter() {
+        this.contextRunner.run(
+            context -> {
+                Assertions.assertThat(context).hasSingleBean(DirectoryManifest.Filter.class);
             }
         );
     }

--- a/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
+++ b/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
@@ -100,27 +100,13 @@ public class CommonServicesAutoConfigurationTest {
     }
 
     /**
-     * Make JobDirectoryManifestService beans are configured as expected.
+     * Make JobDirectoryManifestService beans is configured as expected.
      */
     @Test
-    public void testJobDirectoryManifestServices() {
+    public void testJobDirectoryManifestService() {
         this.contextRunner.run(
             context -> {
-                // 2 Beans of this type
-                Assertions.assertThat(context).getBeans(JobDirectoryManifestService.class).size().isEqualTo(2);
-                // Get by name
-                Assertions.assertThat(context).getBean(
-                    "checksummingJobDirectoryManifestService",
-                    JobDirectoryManifestService.class
-                ).isNotNull();
-                Assertions.assertThat(context).getBean(
-                    "jobDirectoryManifestService",
-                    JobDirectoryManifestService.class
-                ).isNotNull();
-                // Default is non-checksumming
-                Assertions.assertThat(context).getBean(
-                    JobDirectoryManifestService.class
-                ).isEqualTo(context.getBean("jobDirectoryManifestService"));
+                Assertions.assertThat(context).hasSingleBean(JobDirectoryManifestService.class);
             }
         );
     }
@@ -132,11 +118,10 @@ public class CommonServicesAutoConfigurationTest {
     public void testDirectoryManifestFactory() {
         this.contextRunner.run(
             context -> {
-                Assertions.assertThat(context).getBeans(DirectoryManifest.Factory.class).size().isEqualTo(1);
+                Assertions.assertThat(context).hasSingleBean(DirectoryManifest.Factory.class);
             }
         );
     }
-
 
     /**
      * Make JobDirectoryManifestService beans are configured as expected.

--- a/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
+++ b/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
@@ -126,6 +126,19 @@ public class CommonServicesAutoConfigurationTest {
     }
 
     /**
+     * Make sure DirectoryManifest.Factory bean is configured as expected.
+     */
+    @Test
+    public void testDirectoryManifestFactory() {
+        this.contextRunner.run(
+            context -> {
+                Assertions.assertThat(context).getBeans(DirectoryManifest.Factory.class).size().isEqualTo(1);
+            }
+        );
+    }
+
+
+    /**
      * Make JobDirectoryManifestService beans are configured as expected.
      */
     @Test

--- a/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
+++ b/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package com.netflix.genie.common.internal.configs;
 
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import com.netflix.genie.common.internal.services.JobArchiver;
+import com.netflix.genie.common.internal.services.JobDirectoryManifestService;
 import com.netflix.genie.common.internal.services.impl.FileSystemJobArchiverImpl;
 import com.netflix.genie.common.internal.services.impl.S3JobArchiverImpl;
 import org.assertj.core.api.Assertions;
@@ -95,5 +96,31 @@ public class CommonServicesAutoConfigurationTest {
                         .isEqualTo(2);
                 }
             );
+    }
+
+    /**
+     * Make JobDirectoryManifestService beans are configured as expected.
+     */
+    @Test
+    public void testJobDirectoryManifestServices() {
+        this.contextRunner.run(
+            context -> {
+                // 2 Beans of this type
+                Assertions.assertThat(context).getBeans(JobDirectoryManifestService.class).size().isEqualTo(2);
+                // Get by name
+                Assertions.assertThat(context).getBean(
+                    "checksummingJobDirectoryManifestService",
+                    JobDirectoryManifestService.class
+                ).isNotNull();
+                Assertions.assertThat(context).getBean(
+                    "jobDirectoryManifestService",
+                    JobDirectoryManifestService.class
+                ).isNotNull();
+                // Default is non-checksumming
+                Assertions.assertThat(context).getBean(
+                    JobDirectoryManifestService.class
+                ).isEqualTo(context.getBean("jobDirectoryManifestService"));
+            }
+        );
     }
 }

--- a/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
+++ b/genie-common-internal/src/test/java/com/netflix/genie/common/internal/configs/CommonServicesAutoConfigurationTest.java
@@ -112,6 +112,18 @@ public class CommonServicesAutoConfigurationTest {
     }
 
     /**
+     * Make JobDirectoryManifest cache bean is configured as expected.
+     */
+    @Test
+    public void testJobDirectoryManifestCache() {
+        this.contextRunner.run(
+            context -> {
+                Assertions.assertThat(context).getBean("jobDirectoryManifestCache").isNotNull();
+            }
+        );
+    }
+
+    /**
      * Make sure DirectoryManifest.Factory bean is configured as expected.
      */
     @Test

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/GenieServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/GenieServicesAutoConfiguration.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.services.JobArchiveService;
+import com.netflix.genie.common.internal.services.JobDirectoryManifestService;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.jobs.workflow.WorkflowTask;
@@ -520,11 +521,13 @@ public class GenieServicesAutoConfiguration {
     /**
      * Provide the default implementation of {@link JobDirectoryServerService} for serving job directory resources.
      *
-     * @param resourceLoader         The application resource loader used to get references to resources
-     * @param jobPersistenceService  The job persistence service used to get information about a job
-     * @param jobFileService         The service responsible for managing the job working directory on disk for V3 Jobs
-     * @param agentFileStreamService The service to request a file from an agent running a job
-     * @param meterRegistry          The meter registry used to keep track of metrics
+     * @param resourceLoader              The application resource loader used to get references to resources
+     * @param jobPersistenceService       The job persistence service used to get information about a job
+     * @param jobFileService              The service responsible for managing the job working directory on disk for
+     *                                    V3 Jobs
+     * @param agentFileStreamService      The service to request a file from an agent running a job
+     * @param meterRegistry               The meter registry used to keep track of metrics
+     * @param jobDirectoryManifestService The job directory manifest service
      * @return An instance of {@link JobDirectoryServerServiceImpl}
      */
     @Bean
@@ -534,14 +537,16 @@ public class GenieServicesAutoConfiguration {
         final JobPersistenceService jobPersistenceService,
         final JobFileService jobFileService,
         final AgentFileStreamService agentFileStreamService,
-        final MeterRegistry meterRegistry
+        final MeterRegistry meterRegistry,
+        final JobDirectoryManifestService jobDirectoryManifestService
     ) {
         return new JobDirectoryServerServiceImpl(
             resourceLoader,
             jobPersistenceService,
             jobFileService,
             agentFileStreamService,
-            meterRegistry
+            meterRegistry,
+            jobDirectoryManifestService
         );
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/GenieServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/GenieServicesAutoConfiguration.java
@@ -19,7 +19,7 @@ package com.netflix.genie.web.configs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.genie.common.exceptions.GenieException;
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest;
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.web.events.GenieEventBus;
@@ -564,7 +564,7 @@ public class GenieServicesAutoConfiguration {
             }
 
             @Override
-            public Optional<JobDirectoryManifest> getManifest(final String jobId) {
+            public Optional<DirectoryManifest> getManifest(final String jobId) {
                 throw new NotImplementedException("Not supported when using fallback service");
             }
         };

--- a/genie-web/src/main/java/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcAgentFileStreamServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcAgentFileStreamServiceImpl.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
 import com.netflix.genie.common.exceptions.GenieTimeoutException;
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest;
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.dto.v4.converters.JobDirectoryManifestProtoConverter;
 import com.netflix.genie.common.internal.exceptions.GenieConversionException;
 import com.netflix.genie.proto.AgentFileMessage;
@@ -105,7 +105,7 @@ class GRpcAgentFileStreamServiceImpl
      * {@inheritDoc}
      */
     @Override
-    public Optional<JobDirectoryManifest> getManifest(final String jobId) {
+    public Optional<DirectoryManifest> getManifest(final String jobId) {
         final ControlStreamObserver streamObserver = this.jobIdControlStreamMap.get(jobId);
         if (streamObserver != null) {
             return Optional.ofNullable(streamObserver.manifestRef.get());
@@ -126,13 +126,13 @@ class GRpcAgentFileStreamServiceImpl
             return Optional.empty();
         }
 
-        final JobDirectoryManifest manifest = streamObserver.manifestRef.get();
+        final DirectoryManifest manifest = streamObserver.manifestRef.get();
         if (manifest == null) {
             log.warn("Stream record for job id: {} does not have a manifest", jobId);
             return Optional.empty();
         }
 
-        final JobDirectoryManifest.ManifestEntry manifestEntry =
+        final DirectoryManifest.ManifestEntry manifestEntry =
             manifest.getEntry(relativePath.toString()).orElse(null);
 
         if (manifestEntry == null) {
@@ -322,7 +322,7 @@ class GRpcAgentFileStreamServiceImpl
     private static class ControlStreamObserver implements StreamObserver<AgentManifestMessage> {
         private final GRpcAgentFileStreamServiceImpl gRpcAgentFileStreamService;
         private final StreamObserver<ServerControlMessage> responseObserver;
-        private final AtomicReference<JobDirectoryManifest> manifestRef = new AtomicReference<>();
+        private final AtomicReference<DirectoryManifest> manifestRef = new AtomicReference<>();
         private final AtomicReference<String> jobIdRef = new AtomicReference<>();
 
         ControlStreamObserver(

--- a/genie-web/src/main/java/com/netflix/genie/web/services/AgentFileStreamService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/AgentFileStreamService.java
@@ -18,7 +18,7 @@
 
 package com.netflix.genie.web.services;
 
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest;
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import org.springframework.core.io.Resource;
 
 import javax.validation.constraints.NotBlank;
@@ -55,9 +55,9 @@ public interface AgentFileStreamService {
      * completed, or because the agent is connected to a different node).
      *
      * @param jobId the job id
-     * @return an optional {@link JobDirectoryManifest}
+     * @return an optional {@link DirectoryManifest}
      */
-    Optional<JobDirectoryManifest> getManifest(String jobId);
+    Optional<DirectoryManifest> getManifest(String jobId);
 
     /**
      * A {@link Resource} for files local to a remote agent.

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
@@ -24,7 +24,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Lists;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest;
+import com.netflix.genie.common.internal.dto.DirectoryManifest;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import com.netflix.genie.common.util.GenieObjectMapper;
@@ -161,9 +161,9 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
                         if (!manifestResource.exists()) {
                             throw new GenieNotFoundException("No job manifest exists at " + manifestLocation);
                         }
-                        final JobDirectoryManifest manifest = GenieObjectMapper
+                        final DirectoryManifest manifest = GenieObjectMapper
                             .getMapper()
-                            .readValue(manifestResource.getInputStream(), JobDirectoryManifest.class);
+                            .readValue(manifestResource.getInputStream(), DirectoryManifest.class);
 
                         return new ManifestCacheValue(manifest, jobDirectoryRoot);
                     }
@@ -221,7 +221,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
 
         if (jobStatus.isActive() && isV4) {
 
-            final Optional<JobDirectoryManifest> manifest = this.agentFileStreamService.getManifest(jobId);
+            final Optional<DirectoryManifest> manifest = this.agentFileStreamService.getManifest(jobId);
             if (!manifest.isPresent()) {
                 log.error("Manifest not found for active job: {}", jobId);
                 response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value(), "Could not load manifest for job: " + jobId);
@@ -261,11 +261,11 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
             }
             final Path jobDirPath = Paths.get(jobDirRoot);
 
-            final JobDirectoryManifest manifest = new JobDirectoryManifest(jobDirPath, false);
+            final DirectoryManifest manifest = new DirectoryManifest(jobDirPath, false);
             this.handleRequest(baseUri, relativePath, request, response, manifest, jobDirRoot);
         } else {
             // Archived job
-            final JobDirectoryManifest manifest;
+            final DirectoryManifest manifest;
             final URI jobDirRoot;
             try {
                 final ManifestCacheValue cacheValue = this.manifestCache.get(jobId);
@@ -292,7 +292,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
         final String relativePath,
         final HttpServletRequest request,
         final HttpServletResponse response,
-        final JobDirectoryManifest manifest,
+        final DirectoryManifest manifest,
         final URI jobDirectoryRoot
     ) throws IOException, ServletException {
         log.debug(
@@ -301,8 +301,8 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
             relativePath,
             jobDirectoryRoot
         );
-        final JobDirectoryManifest.ManifestEntry entry;
-        final Optional<JobDirectoryManifest.ManifestEntry> entryOptional = manifest.getEntry(relativePath);
+        final DirectoryManifest.ManifestEntry entry;
+        final Optional<DirectoryManifest.ManifestEntry> entryOptional = manifest.getEntry(relativePath);
         if (entryOptional.isPresent()) {
             entry = entryOptional.get();
         } else {
@@ -321,7 +321,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
             try {
                 entry.getParent().ifPresent(
                     parentPath -> {
-                        final JobDirectoryManifest.ManifestEntry parentEntry = manifest
+                        final DirectoryManifest.ManifestEntry parentEntry = manifest
                             .getEntry(parentPath)
                             .orElseThrow(IllegalArgumentException::new);
                         directory.setParent(createEntry(parentEntry, baseUri));
@@ -329,7 +329,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
                 );
 
                 for (final String childPath : entry.getChildren()) {
-                    final JobDirectoryManifest.ManifestEntry childEntry = manifest
+                    final DirectoryManifest.ManifestEntry childEntry = manifest
                         .getEntry(childPath)
                         .orElseThrow(IllegalArgumentException::new);
 
@@ -377,7 +377,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
     }
 
     private DefaultDirectoryWriter.Entry createEntry(
-        final JobDirectoryManifest.ManifestEntry manifestEntry,
+        final DirectoryManifest.ManifestEntry manifestEntry,
         final URI baseUri
     ) {
         final DefaultDirectoryWriter.Entry entry = new DefaultDirectoryWriter.Entry();
@@ -462,7 +462,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
     @EqualsAndHashCode(doNotUseGetters = true)
     @ToString(doNotUseGetters = true)
     private static class ManifestCacheValue {
-        private final JobDirectoryManifest manifest;
+        private final DirectoryManifest manifest;
         private final URI jobDirectoryRoot;
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcAgentFileStreamServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcAgentFileStreamServiceImplSpec.groovy
@@ -71,7 +71,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
 
         this.jobId = UUID.randomUUID().toString()
         this.manifestMessage = AgentManifestMessage.newBuilder().setJobId(jobId).build()
-        this.manifest = Spy(new DirectoryManifest(this.temporaryFolder.getRoot().toPath(), true, new DirectoryManifest.Filter() {}))
+        this.manifest = Spy(new DirectoryManifest.Factory().getDirectoryManifest(this.temporaryFolder.getRoot().toPath(), true))
     }
 
     void cleanup() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcAgentFileStreamServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcAgentFileStreamServiceImplSpec.groovy
@@ -71,7 +71,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
 
         this.jobId = UUID.randomUUID().toString()
         this.manifestMessage = AgentManifestMessage.newBuilder().setJobId(jobId).build()
-        this.manifest = Spy(new DirectoryManifest(this.temporaryFolder.getRoot().toPath(), true))
+        this.manifest = Spy(new DirectoryManifest(this.temporaryFolder.getRoot().toPath(), true, new DirectoryManifest.Filter() {}))
     }
 
     void cleanup() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcAgentFileStreamServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/services/impl/v4/GRpcAgentFileStreamServiceImplSpec.groovy
@@ -20,7 +20,7 @@ package com.netflix.genie.web.rpc.grpc.services.impl.v4
 
 import com.google.protobuf.ByteString
 import com.netflix.genie.common.exceptions.GenieTimeoutException
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest
+import com.netflix.genie.common.internal.dto.DirectoryManifest
 import com.netflix.genie.common.internal.dto.v4.converters.JobDirectoryManifestProtoConverter
 import com.netflix.genie.common.internal.exceptions.GenieConversionException
 import com.netflix.genie.proto.AgentFileMessage
@@ -50,7 +50,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
     StreamObserver<ServerAckMessage> serverTransmitObserver
     AgentManifestMessage manifestMessage
     String jobId
-    JobDirectoryManifest manifest
+    DirectoryManifest manifest
     ByteString data
 
     void setup() {
@@ -71,7 +71,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
 
         this.jobId = UUID.randomUUID().toString()
         this.manifestMessage = AgentManifestMessage.newBuilder().setJobId(jobId).build()
-        this.manifest = Spy(new JobDirectoryManifest(this.temporaryFolder.getRoot().toPath()))
+        this.manifest = Spy(new DirectoryManifest(this.temporaryFolder.getRoot().toPath(), true))
     }
 
     void cleanup() {
@@ -79,7 +79,7 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
 
     def "Control stream"() {
         setup:
-        Optional<JobDirectoryManifest> m
+        Optional<DirectoryManifest> m
         StreamObserver<AgentManifestMessage> o
 
         when: "Fetch manifest before any agent connected"

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.genie.common.dto.JobStatus
 import com.netflix.genie.common.exceptions.GenieNotFoundException
 import com.netflix.genie.common.internal.dto.DirectoryManifest
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException
+import com.netflix.genie.common.internal.services.JobDirectoryManifestService
 import com.netflix.genie.web.resources.agent.AgentFileProtocolResolver
 import com.netflix.genie.web.services.AgentFileStreamService
 import com.netflix.genie.web.services.JobDirectoryServerService
@@ -56,6 +57,7 @@ class JobDirectoryServerServiceImplSpec extends Specification {
     Resource resource
     JobDirectoryServerServiceImpl.GenieResourceHandler.Factory handlerFactory
     JobDirectoryServerServiceImpl.GenieResourceHandler handler
+    JobDirectoryManifestService jobDirectoryManifestService
 
     void setup() {
         this.resourceLoader = Mock(ResourceLoader)
@@ -65,7 +67,8 @@ class JobDirectoryServerServiceImplSpec extends Specification {
         this.meterRegistry = Mock(MeterRegistry)
         this.handlerFactory = Mock(JobDirectoryServerServiceImpl.GenieResourceHandler.Factory)
         this.handler = Mock(JobDirectoryServerServiceImpl.GenieResourceHandler)
-        this.service = new JobDirectoryServerServiceImpl(resourceLoader, jobPersistenceService, jobFileService, agentFileStreamService, meterRegistry, handlerFactory)
+        this.jobDirectoryManifestService = Mock(JobDirectoryManifestService)
+        this.service = new JobDirectoryServerServiceImpl(resourceLoader, jobPersistenceService, jobFileService, agentFileStreamService, meterRegistry, handlerFactory, jobDirectoryManifestService)
 
         this.request = Mock(HttpServletRequest)
         this.response = Mock(HttpServletResponse)

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
@@ -20,7 +20,7 @@ package com.netflix.genie.web.services.impl
 
 import com.netflix.genie.common.dto.JobStatus
 import com.netflix.genie.common.exceptions.GenieNotFoundException
-import com.netflix.genie.common.internal.dto.JobDirectoryManifest
+import com.netflix.genie.common.internal.dto.DirectoryManifest
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException
 import com.netflix.genie.web.resources.agent.AgentFileProtocolResolver
 import com.netflix.genie.web.services.AgentFileStreamService
@@ -51,8 +51,8 @@ class JobDirectoryServerServiceImplSpec extends Specification {
     JobDirectoryServerService service
     HttpServletRequest request
     HttpServletResponse response
-    JobDirectoryManifest manifest
-    JobDirectoryManifest.ManifestEntry manifestEntry
+    DirectoryManifest manifest
+    DirectoryManifest.ManifestEntry manifestEntry
     Resource resource
     JobDirectoryServerServiceImpl.GenieResourceHandler.Factory handlerFactory
     JobDirectoryServerServiceImpl.GenieResourceHandler handler
@@ -69,8 +69,8 @@ class JobDirectoryServerServiceImplSpec extends Specification {
 
         this.request = Mock(HttpServletRequest)
         this.response = Mock(HttpServletResponse)
-        this.manifest = Mock(JobDirectoryManifest)
-        this.manifestEntry = Mock(JobDirectoryManifest.ManifestEntry)
+        this.manifest = Mock(DirectoryManifest)
+        this.manifestEntry = Mock(DirectoryManifest.ManifestEntry)
         this.resource = Mock(Resource)
     }
 


### PR DESCRIPTION
Refactoring around the DirectoryManifest used in various places.
* Rename from JobDirectoryManifest
* Encapsulate creation inside a service
* Allow filtering
* Configure to filter `dependencies` subtrees
* Cache manifests
