### PR TITLE
Switch to FileSystemUtils.deleteRecursively for job folder cleanup

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/actions/SetUpJobAction.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/actions/SetUpJobAction.java
@@ -576,7 +576,7 @@ class SetUpJobAction extends BaseStateAction implements StateAction.SetUpJob {
                     .forEach(path -> {
                         try {
                             log.debug("Deleting {}", path);
-                            Files.deleteIfExists(path);
+                            FileSystemUtils.deleteRecursively(path);
                         } catch (final IOException e) {
                             log.warn("Failed to delete: {}", path.toAbsolutePath().toString(), e);
                         }


### PR DESCRIPTION
Using 'Files.deleteIfExists(path)' may fail depending on traversal order, as it may delete a non-empty directory.