### PR TITLE
Make custom HealthIndicators return DOWN rathe than OUT_OF_SERVICE

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/health/GenieCpuHealthIndicator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/health/GenieCpuHealthIndicator.java
@@ -97,7 +97,7 @@ public class GenieCpuHealthIndicator implements HealthIndicator {
         if (cpuLoadConsecutiveOccurrences >= maxCpuLoadConsecutiveOccurrences) {
             log.warn("CPU usage {} crossed the threshold of {}", currentCpuLoadPercent, maxCpuLoadPercent);
             return Health
-                .outOfService()
+                .down()
                 .withDetail(CPU_LOAD, currentCpuLoadPercent)
                 .build();
         } else {

--- a/genie-web/src/main/java/com/netflix/genie/web/health/GenieMemoryHealthIndicator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/health/GenieMemoryHealthIndicator.java
@@ -73,7 +73,7 @@ public class GenieMemoryHealthIndicator implements HealthIndicator {
         if (availableMemory >= maxJobMemory) {
             builder = Health.up();
         } else {
-            builder = Health.outOfService();
+            builder = Health.down();
         }
 
         return builder

--- a/genie-web/src/test/groovy/com/netflix/genie/web/health/GenieCpuHealthIndicatorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/health/GenieCpuHealthIndicatorSpec.groovy
@@ -58,9 +58,9 @@ class GenieCpuHealthIndicatorSpec extends Specification {
         cpuHealthIndicator.health().getStatus() == status
         where:
         cpuLoad | count | status
-        90      | 1     | Status.OUT_OF_SERVICE
-        171     | 2     | Status.OUT_OF_SERVICE
-        81.1    | 1     | Status.OUT_OF_SERVICE
+        90      | 1     | Status.DOWN
+        171     | 2     | Status.DOWN
+        81.1    | 1     | Status.DOWN
         80.1    | 0     | Status.UP
         80      | 5     | Status.UP
         20.2    | 1     | Status.UP
@@ -92,6 +92,6 @@ class GenieCpuHealthIndicatorSpec extends Specification {
             new DefaultManagedTaskScheduler()
         )
         then:
-        indicator.health().getStatus() == Status.OUT_OF_SERVICE
+        indicator.health().getStatus() == Status.DOWN
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/health/GenieMemoryHealthIndicatorTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/health/GenieMemoryHealthIndicatorTest.java
@@ -68,7 +68,7 @@ public class GenieMemoryHealthIndicatorTest {
             .thenReturn(1024, 2048, MAX_SYSTEM_MEMORY - MAX_JOB_MEMORY + 1);
         Assert.assertThat(this.genieMemoryHealthIndicator.health().getStatus(), Matchers.is(Status.UP));
         Assert.assertThat(this.genieMemoryHealthIndicator.health().getStatus(), Matchers.is(Status.UP));
-        Assert.assertThat(this.genieMemoryHealthIndicator.health().getStatus(), Matchers.is(Status.OUT_OF_SERVICE));
+        Assert.assertThat(this.genieMemoryHealthIndicator.health().getStatus(), Matchers.is(Status.DOWN));
     }
 
     /**


### PR DESCRIPTION
OOS is not a state recognized by the internal discovery client. DOWN is the more appropriate state for this situations