### PR TITLE
Changes to set groundwork for local agent launch

### DIFF
--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/util/GenieHostInfo.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/util/GenieHostInfo.java
@@ -29,7 +29,7 @@ import lombok.ToString;
  */
 @Getter
 @EqualsAndHashCode(doNotUseGetters = true)
-@ToString
+@ToString(doNotUseGetters = true)
 public class GenieHostInfo {
     private final String hostname;
 

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -59,11 +59,6 @@ attempt to assume this role on the host Genie is running on
 |file:///tmp/genie/cache
 |no
 
-|genie.grpc.server.enabled
-|Whether to start the gRPC server and services during server startup
-|true
-|no
-
 |genie.grpc.server.services.job-file-sync.ackIntervalMilliseconds
 |How many milliseconds to wait between checks whether some acknowledgement should be sent to the agent regardless of
 whether the `maxSyncMessages` threshold has been reached or not

--- a/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
+++ b/genie-docs/src/docs/asciidoc/_releaseNotes.adoc
@@ -67,10 +67,6 @@ that isn't listed in this map the default credentials configured will be used
 no value is specified the bucket is assumed to be in the same region as the Genie process.
 |
 
-|genie.grpc.server.enabled
-|Whether to start the gRPC server and services during server startup
-|true
-
 |genie.grpc.server.services.job-file-sync.ackIntervalMilliseconds
 |How many milliseconds to wait between checks whether some acknowledgement should be sent to the agent regardless of
 whether the `maxSyncMessages` threshold has been reached or not

--- a/genie-security/src/integTest/resources/application-integration.yml
+++ b/genie-security/src/integTest/resources/application-integration.yml
@@ -34,8 +34,12 @@ genie:
       archives: /archive/location
       jobs: file:///tmp/genie/jobs/
 
+grpc:
+  server:
+    port: 0
+
 spring:
   autoconfigure:
     exclude:
-    - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
 

--- a/genie-ui/src/integTest/resources/application-integration.yml
+++ b/genie-ui/src/integTest/resources/application-integration.yml
@@ -1,4 +1,8 @@
+grpc:
+  server:
+    port: 0
+
 spring:
   autoconfigure:
     exclude:
-    - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration

--- a/genie-web/src/integTest/resources/application-grpc.yml
+++ b/genie-web/src/integTest/resources/application-grpc.yml
@@ -1,11 +1,5 @@
-genie:
-  grpc:
-    server:
-      enabled: true
-
 # Start gRPC on a random available port to avoid port binding conflicts during
 # integration tests shutting down less than gracefully
 grpc:
   server:
     port: 0
-    address: 127.0.0.1

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/grpc/GenieGRpcInterceptorsAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/grpc/GenieGRpcInterceptorsAutoConfiguration.java
@@ -17,10 +17,8 @@
  */
 package com.netflix.genie.web.configs.grpc;
 
-import com.netflix.genie.web.properties.GRpcServerProperties;
 import com.netflix.genie.web.rpc.grpc.interceptors.SimpleLoggingInterceptor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -32,7 +30,6 @@ import org.springframework.core.annotation.Order;
  * @since 4.0.0
  */
 @Configuration
-@ConditionalOnProperty(value = GRpcServerProperties.ENABLED_PROPERTY, havingValue = "true")
 public class GenieGRpcInterceptorsAutoConfiguration {
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/grpc/GenieGRpcServerAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/grpc/GenieGRpcServerAutoConfiguration.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -44,7 +43,6 @@ import java.util.Set;
  * @since 4.0.0
  */
 @Configuration
-@ConditionalOnProperty(value = GRpcServerProperties.ENABLED_PROPERTY, havingValue = "true")
 @EnableConfigurationProperties(
     {
         GRpcServerProperties.class,

--- a/genie-web/src/main/java/com/netflix/genie/web/configs/grpc/GenieGRpcServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/configs/grpc/GenieGRpcServicesAutoConfiguration.java
@@ -25,7 +25,6 @@ import com.netflix.genie.proto.HeartBeatServiceGrpc;
 import com.netflix.genie.proto.JobKillServiceGrpc;
 import com.netflix.genie.proto.JobServiceGrpc;
 import com.netflix.genie.proto.PingServiceGrpc;
-import com.netflix.genie.web.properties.GRpcServerProperties;
 import com.netflix.genie.web.rpc.grpc.services.impl.v4.GRpcAgentFileStreamServiceImpl;
 import com.netflix.genie.web.rpc.grpc.services.impl.v4.GRpcHeartBeatServiceImpl;
 import com.netflix.genie.web.rpc.grpc.services.impl.v4.GRpcJobKillServiceImpl;
@@ -38,7 +37,6 @@ import com.netflix.genie.web.services.JobSearchService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
@@ -51,7 +49,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  * @since 4.0.0
  */
 @Configuration
-@ConditionalOnProperty(value = GRpcServerProperties.ENABLED_PROPERTY, havingValue = "true")
 @Slf4j
 public class GenieGRpcServicesAutoConfiguration {
 

--- a/genie-web/src/main/java/com/netflix/genie/web/exceptions/checked/AgentLaunchException.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/exceptions/checked/AgentLaunchException.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.exceptions.checked;
+
+/**
+ * An exception for when the server can't launch an agent for whatever reason.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public class AgentLaunchException extends Exception {
+
+    /**
+     * Constructor.
+     *
+     * @param message The error message to associate with this exception
+     */
+    public AgentLaunchException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cause The root cause of this exception
+     */
+    public AgentLaunchException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message The error message to associate with this exception
+     * @param cause   The root cause of this exception
+     */
+    public AgentLaunchException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/exceptions/checked/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/exceptions/checked/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * All checked exceptions specific to the web server.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.web.exceptions.checked;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/java/com/netflix/genie/web/rpc/grpc/servers/GRpcServerManager.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/rpc/grpc/servers/GRpcServerManager.java
@@ -72,4 +72,16 @@ public class GRpcServerManager implements AutoCloseable {
             log.error("Unable to shutdown gRPC server due to being interrupted", ie);
         }
     }
+
+    /**
+     * Get the port the gRPC {@link Server} is listening on.
+     *
+     * @return The port or -1 if the server isn't currently listening on any port.
+     */
+    public int getServerPort() {
+        // Note: Since you can't construct one of these managers without it starting the server the
+        //       IllegalStateException defined in getPort() of the server shouldn't be possible here so it's not
+        //       documented as being thrown
+        return this.server.getPort();
+    }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/AttachmentService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/AttachmentService.java
@@ -21,10 +21,13 @@ import com.netflix.genie.common.exceptions.GenieException;
 import org.springframework.validation.annotation.Validated;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Map;
 
 /**
- * APIs for dealing with attachments sent in with Genie jobs. Implementations will handle where to store them and
+ * APIs for dealing with attachments sent in with Genie requests. Implementations will handle where to store them and
  * how to retrieve them when requested.
  *
  * @author tgianos
@@ -40,7 +43,9 @@ public interface AttachmentService {
      * @param filename The name of the attachment
      * @param content  A stream to access the contents of the attachment
      * @throws GenieException For any error during the save process
+     * @deprecated Use {@link #saveAll(Map)} instead
      */
+    @Deprecated
     void save(String jobId, String filename, InputStream content) throws GenieException;
 
     /**
@@ -49,7 +54,9 @@ public interface AttachmentService {
      * @param jobId       The id of the job to get the attachments for.
      * @param destination The directory to copy the attachments into
      * @throws GenieException For any error during the copy process
+     * @deprecated Use {@link #copyAll(String, Path)} instead
      */
+    @Deprecated
     void copy(String jobId, File destination) throws GenieException;
 
     /**
@@ -57,6 +64,36 @@ public interface AttachmentService {
      *
      * @param jobId The id of the job to delete the attachments for
      * @throws GenieException For any error during the delete process
+     * @deprecated Use {@link #deleteAll(String)} instead
      */
+    @Deprecated
     void delete(String jobId) throws GenieException;
+
+    /**
+     * Save all attachments for a given request.
+     *
+     * @param attachments The map of filename to contents for all attachments. All input streams will be closed after
+     *                    this method returns
+     * @return A unique identifier that can be used to reference the attachments later
+     * @throws IOException If unable to save any of the attachments
+     */
+    String saveAll(Map<String, InputStream> attachments) throws IOException;
+
+    /**
+     * Copy all attachments associated with the given id into the provided {@literal destination}.
+     *
+     * @param id          The id that was returned from the original call to {@link #saveAll(Map)}
+     * @param destination The destination where the attachments should be copied. Must be a directory if it already
+     *                    exists. If it doesn't exist it will be created.
+     * @throws IOException If the copy fails for any reason
+     */
+    void copyAll(String id, Path destination) throws IOException;
+
+    /**
+     * Delete all the attachments that were associated with the given {@literal id}.
+     *
+     * @param id The id that was returned from the original call to {@link #saveAll(Map)}
+     * @throws IOException On error during deletion
+     */
+    void deleteAll(String id) throws IOException;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/util/ExecutorFactory.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/ExecutorFactory.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.util;
+
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.Executor;
+import org.apache.commons.exec.PumpStreamHandler;
+
+/**
+ * A factory for {@link org.apache.commons.exec.Executor} instances.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public class ExecutorFactory {
+
+    /**
+     * Create a new {@link Executor} implementation instance.
+     *
+     * @param detached Whether the streams for processes run on this executor should be detached (ignored) or not
+     * @return A {@link Executor} instance
+     */
+    public Executor newInstance(final boolean detached) {
+        final Executor executor = new DefaultExecutor();
+        if (detached) {
+            executor.setStreamHandler(new PumpStreamHandler(null, null));
+        }
+        return executor;
+    }
+}

--- a/genie-web/src/main/resources/genie-web-defaults.yml
+++ b/genie-web/src/main/resources/genie-web-defaults.yml
@@ -106,7 +106,7 @@ genie:
 
 info:
   genie:
-    version: 1.2.3
+    version: @genie.version@
 
 management:
   endpoints:

--- a/genie-web/src/main/resources/genie-web-defaults.yml
+++ b/genie-web/src/main/resources/genie-web-defaults.yml
@@ -30,9 +30,6 @@ genie:
   file:
     cache:
       location: file:///tmp/genie/cache
-  grpc:
-    server:
-      enabled: true
   health:
     maxCpuLoadPercent: 80
   jobs:

--- a/genie-web/src/test/groovy/com/netflix/genie/web/exceptions/checked/AgentLaunchExceptionSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/exceptions/checked/AgentLaunchExceptionSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.exceptions.checked
+
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link AgentLaunchException}.
+ *
+ * @author tgianos
+ */
+class AgentLaunchExceptionSpec extends Specification {
+
+    def "can construct with message"() {
+        def message = "Launch failed"
+
+        when:
+        def exception = new AgentLaunchException(message)
+
+        then:
+        exception.getMessage() == message
+        exception.getCause() == null
+    }
+
+    def "can construct with cause"() {
+        def cause = new IllegalStateException("some bad state")
+
+        when:
+        def exception = new AgentLaunchException(cause)
+
+        then:
+        exception.getMessage() != null
+        exception.getCause() == cause
+    }
+
+    def "can construct with message and cause"() {
+        def message = "launch failed"
+        def cause = new IllegalStateException("no process")
+
+        when:
+        def exception = new AgentLaunchException(message, cause)
+
+        then:
+        exception.getMessage() == message
+        exception.getCause() == cause
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/servers/GRpcServerManagerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/rpc/grpc/servers/GRpcServerManagerSpec.groovy
@@ -98,4 +98,23 @@ class GRpcServerManagerSpec extends Specification {
         }
         noExceptionThrown()
     }
+
+    def "can get port"() {
+        def port = 38_323
+        def server = Mock(Server) {
+            getPort() >> port
+        }
+
+        when:
+        def manager = new GRpcServerManager(server)
+
+        then:
+        1 * server.start()
+
+        when:
+        def runningPort = manager.getServerPort()
+
+        then:
+        runningPort == port
+    }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/util/ExecutorFactorySpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/util/ExecutorFactorySpec.groovy
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.util
+
+import org.apache.commons.exec.PumpStreamHandler
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link ExecutorFactory}.
+ *
+ * @author tgianos
+ */
+class ExecutorFactorySpec extends Specification {
+
+    def "can create"() {
+        def factory = new ExecutorFactory()
+
+        when:
+        def executor = factory.newInstance(false)
+        def streamHandler = executor.getStreamHandler()
+
+        then:
+        streamHandler instanceof PumpStreamHandler
+        ((PumpStreamHandler) streamHandler).getErr() != null
+        ((PumpStreamHandler) streamHandler).getOut() != null
+
+        when:
+        def executor2 = factory.newInstance(true)
+        def streamHandler2 = executor2.getStreamHandler()
+
+        then:
+        streamHandler2 instanceof PumpStreamHandler
+        ((PumpStreamHandler) streamHandler2).getErr() == null
+        ((PumpStreamHandler) streamHandler2).getOut() == null
+        streamHandler != streamHandler2
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/GenieServicesAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/GenieServicesAutoConfigurationTest.java
@@ -47,7 +47,6 @@ import com.netflix.genie.web.services.impl.LocalFileTransferImpl;
 import com.netflix.genie.web.util.ProcessChecker;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.exec.Executor;
-import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -130,20 +129,6 @@ public class GenieServicesAutoConfigurationTest {
         );
     }
 
-    /**
-     * Can get the fallback V4 Kill service.
-     *
-     * @throws GenieException in case of error
-     */
-    @Test(expected = NotImplementedException.class)
-    public void canGetFallbackJobKillServiceV4Bean() throws GenieException {
-        final JobKillServiceV4 service = this.genieServicesAutoConfiguration.fallbackJobKillServiceV4();
-        Assert.assertNotNull(service);
-
-        service.killJob(UUID.randomUUID().toString(), "test");
-        Assert.fail("Expected exception");
-    }
-
 
     /**
      * Confirm we can get a GenieFileTransfer instance.
@@ -216,16 +201,4 @@ public class GenieServicesAutoConfigurationTest {
             )
         );
     }
-
-    /**
-     * Can get a bean for fallback Agent File Stream service.
-     */
-    @Test
-    public void canGetFallbackAgentFileStreamService() {
-        Assert.assertNotNull(
-            this.genieServicesAutoConfiguration.fallbackAgentFileStreamService()
-        );
-    }
-
-
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/grpc/GenieGRpcInterceptorsAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/grpc/GenieGRpcInterceptorsAutoConfigurationTest.java
@@ -43,22 +43,11 @@ public class GenieGRpcInterceptorsAutoConfigurationTest {
             );
 
     /**
-     * No beans created.
-     */
-    @Test
-    public void configurationNotAppliedIfNotEnabled() {
-        this.contextRunner
-            .withPropertyValues("genie.grpc.server.enabled=false")
-            .run(context -> Assertions.assertThat(context).doesNotHaveBean(SimpleLoggingInterceptor.class));
-    }
-
-    /**
      * Default beans created.
      */
     @Test
     public void expectedBeansExistIfGrpcEnabledAndNoUserBeans() {
         this.contextRunner
-            .withPropertyValues("genie.grpc.server.enabled=true")
             .run(context -> Assertions.assertThat(context).hasSingleBean(SimpleLoggingInterceptor.class));
     }
 
@@ -68,7 +57,6 @@ public class GenieGRpcInterceptorsAutoConfigurationTest {
     @Test
     public void expectedBeansExistWhenUserOverrides() {
         this.contextRunner
-            .withPropertyValues("genie.grpc.server.enabled=true")
             .withUserConfiguration(UserConfig.class)
             .run(
                 context -> {

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/grpc/GenieGRpcServerAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/grpc/GenieGRpcServerAutoConfigurationTest.java
@@ -45,28 +45,11 @@ public class GenieGRpcServerAutoConfigurationTest {
             );
 
     /**
-     * No beans should be created.
-     */
-    @Test
-    public void configurationNotAppliedIfNotEnabled() {
-        this.contextRunner
-            .withPropertyValues("genie.grpc.server.enabled=false")
-            .run(
-                context -> {
-                    Assertions.assertThat(context).doesNotHaveBean(GRpcServerProperties.class);
-                    Assertions.assertThat(context).doesNotHaveBean(Server.class);
-                    Assertions.assertThat(context).doesNotHaveBean(GRpcServerManager.class);
-                }
-            );
-    }
-
-    /**
      * Default beans should be created.
      */
     @Test
     public void expectedBeansExistIfGrpcEnabledAndNoUserBeans() {
         this.contextRunner
-            .withPropertyValues("genie.grpc.server.enabled=true")
             .run(
                 context -> {
                     Assertions.assertThat(context).hasSingleBean(GRpcServerProperties.class);
@@ -82,7 +65,6 @@ public class GenieGRpcServerAutoConfigurationTest {
     @Test
     public void expectedBeansExistWhenUserOverrides() {
         this.contextRunner
-            .withPropertyValues("genie.grpc.server.enabled=true")
             .withUserConfiguration(UserConfig.class)
             .run(
                 context -> {

--- a/genie-web/src/test/java/com/netflix/genie/web/configs/grpc/GenieGRpcServicesAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/configs/grpc/GenieGRpcServicesAutoConfigurationTest.java
@@ -60,42 +60,11 @@ public class GenieGRpcServicesAutoConfigurationTest {
             .withUserConfiguration(RequiredBeans.class);
 
     /**
-     * No beans created.
-     */
-    @Test
-    public void configurationNotAppliedIfNotEnabled() {
-        this.contextRunner
-            .withPropertyValues("genie.grpc.server.enabled=false")
-            .run(
-                context -> {
-                    Assertions.assertThat(context.containsBean("heartBeatServiceTaskScheduler")).isFalse();
-                    Assertions.assertThat(context).doesNotHaveBean(JobServiceProtoErrorComposer.class);
-                    Assertions
-                        .assertThat(context)
-                        .doesNotHaveBean(FileStreamServiceGrpc.FileStreamServiceImplBase.class);
-                    Assertions
-                        .assertThat(context)
-                        .doesNotHaveBean(HeartBeatServiceGrpc.HeartBeatServiceImplBase.class);
-                    Assertions
-                        .assertThat(context)
-                        .doesNotHaveBean(JobKillServiceGrpc.JobKillServiceImplBase.class);
-                    Assertions
-                        .assertThat(context)
-                        .doesNotHaveBean(JobServiceGrpc.JobServiceImplBase.class);
-                    Assertions
-                        .assertThat(context)
-                        .doesNotHaveBean(PingServiceGrpc.PingServiceImplBase.class);
-                }
-            );
-    }
-
-    /**
      * Default beans created.
      */
     @Test
     public void expectedBeansExistIfGrpcEnabledAndNoUserBeans() {
         this.contextRunner
-            .withPropertyValues("genie.grpc.server.enabled=true")
             .run(
                 context -> {
                     Assertions.assertThat(context.containsBean("heartBeatServiceTaskScheduler")).isTrue();
@@ -140,7 +109,6 @@ public class GenieGRpcServicesAutoConfigurationTest {
     @Test
     public void expectedBeansExistWhenUserOverrides() {
         this.contextRunner
-            .withPropertyValues("genie.grpc.server.enabled=true")
             .withUserConfiguration(UserConfig.class)
             .run(
                 context -> {


### PR DESCRIPTION
A few commits which set some of the groundwork to enable launching API jobs using the Genie agent instead of the 3.x job execution code