### PR TITLE
Job state notifications

### DIFF
--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -541,6 +541,12 @@ published within the local JVM and available on the Actuator `/metrics` endpoint
 |UserMetricsTask
 |-
 
+|genie.notifications.sns.publish.counter
+|Count the number of notification published to SNS
+|count
+|SNSNotificationsPublisher
+|status
+
 |===
 
 (*) Source may add additional tags on a case-by-case basis

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -127,6 +127,18 @@ published within the local JVM and available on the Actuator `/metrics` endpoint
 |JobStateServiceImpl
 |-
 
+|genie.jobs.notifications.final-state.counter
+|Count the number of completed job notifications
+|count
+|JobNotificationMetricPublisher
+|jobFinalState
+
+|genie.jobs.notifications.state-transition.counter
+|Count the number of job transitions notifications
+|count
+|JobNotificationMetricPublisher
+|fromState, toState
+
 |genie.jobs.submit.localRunner.overall.timer
 |Time takend to submit a new job (create workspace and scripts, register in database and kick off)
 |nanoseconds

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -184,6 +184,21 @@ doesn't exist.
 |10240
 |no
 
+|genie.notifications.sns.enabled
+|Wether to enable SNS publishing of events
+|-
+|no
+
+|genie.notifications.sns.topicARN
+|The SNS topic to publish to
+|-
+|no
+
+|genie.notifications.sns.additionalEventKeys.<KEY>
+|Map of KEYs and corresponding values to be added to the SNS messages published
+|-
+|no
+
 |genie.jobs.users.creationEnabled
 |Whether Genie should attempt to create a system user in order to run the job as or not. Genie user must have sudo
 rights for this to work.

--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-tomcat")
     compile("org.springframework.boot:spring-boot-starter-web")
     compile("org.springframework.cloud:spring-cloud-starter-aws")
+    compile("org.springframework.cloud:spring-cloud-starter-aws-messaging")
     compile("org.springframework.cloud:spring-cloud-starter-zookeeper")
     compile("org.springframework.integration:spring-integration-zookeeper")
     compile("org.springframework.retry:spring-retry")

--- a/genie-web/src/main/java/com/netflix/genie/web/data/entities/JobEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/entities/JobEntity.java
@@ -56,6 +56,7 @@ import javax.persistence.MapKeyColumn;
 import javax.persistence.OrderColumn;
 import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -460,6 +461,9 @@ public class JobEntity extends BaseEntity implements
         }
     )
     private Set<TagEntity> tags = new HashSet<>();
+
+    @Transient
+    private JobStatus notifiedJobStatus;
 
     /**
      * Default Constructor.

--- a/genie-web/src/main/java/com/netflix/genie/web/data/entities/JobEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/entities/JobEntity.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.data.entities;
 
 import com.google.common.collect.Maps;
 import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.web.data.entities.listeners.JobEntityListener;
 import com.netflix.genie.web.data.entities.projections.JobApplicationsProjection;
 import com.netflix.genie.web.data.entities.projections.JobArchiveLocationProjection;
 import com.netflix.genie.web.data.entities.projections.JobClusterProjection;
@@ -44,6 +45,7 @@ import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -123,6 +125,12 @@ import java.util.Set;
     doNotUseGetters = true
 )
 @Entity
+@EntityListeners(
+    {
+        // Can't decouple through interface or abstract class or configuration, only concrete classes work.
+        JobEntityListener.class
+    }
+)
 @Table(name = "jobs")
 public class JobEntity extends BaseEntity implements
     JobProjection,

--- a/genie-web/src/main/java/com/netflix/genie/web/data/entities/listeners/JobEntityListener.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/entities/listeners/JobEntityListener.java
@@ -1,0 +1,98 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.data.entities.listeners;
+
+import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.web.data.entities.JobEntity;
+import com.netflix.genie.web.data.observers.PersistedJobStatusObserver;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.persistence.PostLoad;
+import javax.persistence.PostUpdate;
+
+/**
+ * Listener for Job JPA entity ({@link JobEntity}).
+ * Currently tracks persistent changes to the status of a job and notifies an observer.
+ * Could be extended to do proxy more persist changes.
+ * <p>
+ * N.B. Spring configuration.
+ * - This class does not appear in any AutoConfiguration as bean.
+ * It is referenced as {@link java.util.EventListener} by {@link JobEntity}.
+ * EntityManager creates it even if a bean of the same type exists already.
+ * - The constructor parameter {@code persistedJobStatusObserver} is marked {@code Nullable} so that an instance can be
+ * created even if no bean of that type is configured.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public class JobEntityListener {
+
+    private final PersistedJobStatusObserver persistedJobStatusObserver;
+
+    /**
+     * Constructor.
+     *
+     * @param persistedJobStatusObserver the observer to notify of persisted job status changes
+     */
+    public JobEntityListener(
+        final PersistedJobStatusObserver persistedJobStatusObserver
+    ) {
+        this.persistedJobStatusObserver = persistedJobStatusObserver;
+    }
+
+    /**
+     * Persistence callback invoked after a job entity has been committed/flushed into persistent storage.
+     * If the persisted status of the job is different from the last one notified, then a notification is emitted.
+     *
+     * @param jobEntity the job that was just persisted
+     */
+    @PostUpdate
+    public void jobUpdate(final JobEntity jobEntity) {
+
+        final JobStatus currentState = jobEntity.getStatus();
+        final JobStatus previouslyNotifiedState = jobEntity.getNotifiedJobStatus();
+        final String jobId = jobEntity.getUniqueId();
+        if (currentState != previouslyNotifiedState) {
+            log.info(
+                "Detected state change for job: {} from: {} to: {}",
+                jobId,
+                previouslyNotifiedState,
+                currentState
+            );
+
+            // Notify observer
+            this.persistedJobStatusObserver.notify(jobId, previouslyNotifiedState, currentState);
+
+            // Save this as the latest published state
+            jobEntity.setNotifiedJobStatus(currentState);
+        }
+    }
+
+    /**
+     * Persistence callback invoked after a job entity is loaded or refreshed.
+     * The job status loaded from persistent storage is also the last state that was notified.
+     *
+     * @param jobEntity the job that was just loaded
+     */
+    @PostLoad
+    public void jobLoad(final JobEntity jobEntity) {
+        // The persisted status is also the most recently notified state.
+        jobEntity.setNotifiedJobStatus(jobEntity.getStatus());
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/data/entities/listeners/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/entities/listeners/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Entity listeners classes that listen to changes applied in persistent storage.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.web.data.entities.listeners;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/java/com/netflix/genie/web/data/observers/PersistedJobStatusObserver.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/observers/PersistedJobStatusObserver.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.data.observers;
+
+import com.netflix.genie.common.dto.JobStatus;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface for an observer that gets notified of job 'status' change after the latter is persisted.
+ * This observer is invoked as callback during data/persistence methods.
+ * It should NOT spend significant time processing.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public interface PersistedJobStatusObserver {
+
+    /**
+     * Handle a notification of job status change after the latter was successfully committed to persistent storage.
+     *
+     * @param jobId          the job unique id
+     * @param previousStatus the previous job status, or null if this job was just created and persisted
+     * @param currentStatus  the job status that was just persisted. Guaranteed to be different than the previous.
+     */
+    void notify(
+        String jobId,
+        @Nullable JobStatus previousStatus,
+        JobStatus currentStatus
+    );
+
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/data/observers/PersistedJobStatusObserverImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/observers/PersistedJobStatusObserverImpl.java
@@ -1,0 +1,63 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.data.observers;
+
+import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.web.events.GenieEventBus;
+import com.netflix.genie.web.events.JobStateChangeEvent;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+
+/**
+ * Observer of persisted entities modifications that publishes events on the event bus to be consumed asynchronously by
+ * interested consumers.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public class PersistedJobStatusObserverImpl implements PersistedJobStatusObserver {
+    private final GenieEventBus genieEventBus;
+
+    /**
+     * Constructor.
+     *
+     * @param genieEventBus the genie event bus
+     */
+    public PersistedJobStatusObserverImpl(
+        final GenieEventBus genieEventBus
+    ) {
+        this.genieEventBus = genieEventBus;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void notify(
+        final String jobId,
+        @Nullable final JobStatus previousStatus,
+        final JobStatus currentStatus
+    ) {
+        final JobStateChangeEvent event = new JobStateChangeEvent(jobId, previousStatus, currentStatus, this);
+        log.warn("Publishing event: {}", event);
+        this.genieEventBus.publishAsynchronousEvent(event);
+    }
+
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/data/observers/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/observers/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Entity classes that represent the Genie data model/internal state.
+ *
+ * @author tgianos
+ * @since 3.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.web.data.observers;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/java/com/netflix/genie/web/data/observers/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/observers/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2015 Netflix, Inc.
+ *  Copyright 2019 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  */
 
 /**
- * Entity classes that represent the Genie data model/internal state.
+ * Entity observer classes that get notified about transformations applied to entities.
  *
  * @author tgianos
  * @since 3.0.0

--- a/genie-web/src/main/java/com/netflix/genie/web/events/JobNotificationMetricPublisher.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/events/JobNotificationMetricPublisher.java
@@ -1,0 +1,84 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.events;
+
+import com.google.common.collect.Sets;
+import com.netflix.genie.web.util.MetricsConstants;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+
+/**
+ * Listens to job status changes and publishes metrics.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public class JobNotificationMetricPublisher implements ApplicationListener<JobStateChangeEvent> {
+    private static final String STATE_TRANSITION_METRIC_NAME = "genie.jobs.notifications.state-transition.counter";
+    private static final String FINAL_STATE_METRIC_NAME = "genie.jobs.notifications.final-state.counter";
+    private final MeterRegistry registry;
+
+    /**
+     * Constructor.
+     *
+     * @param registry metrics registry
+     */
+    public JobNotificationMetricPublisher(final MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onApplicationEvent(final JobStateChangeEvent event) {
+
+        final String fromStateString = event.getPreviousStatus() == null ? "null" : event.getPreviousStatus().name();
+        final String toStateString = event.getNewStatus().name();
+        final boolean isFinalState = event.getNewStatus().isFinished();
+
+        log.info(
+            "Job '{}' changed state from {} to {} {}",
+            event.getJobId(),
+            fromStateString,
+            toStateString,
+            isFinalState ? "(final state)" : ""
+        );
+
+        // Increment counter for this particular from/to transition
+        this.registry.counter(
+            STATE_TRANSITION_METRIC_NAME,
+            Sets.newHashSet(
+                Tag.of(MetricsConstants.TagKeys.FROM_STATE, fromStateString),
+                Tag.of(MetricsConstants.TagKeys.TO_STATE, toStateString)
+            )
+        ).increment();
+
+        // Increment counter for final state
+        if (isFinalState) {
+            this.registry.counter(
+                FINAL_STATE_METRIC_NAME,
+                MetricsConstants.TagKeys.TO_STATE,
+                toStateString
+            ).increment();
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/events/JobStateChangeEvent.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/events/JobStateChangeEvent.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.events;
+
+import com.netflix.genie.common.dto.JobStatus;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.context.ApplicationEvent;
+
+import javax.annotation.Nullable;
+
+/**
+ * Event representing a job status change.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Getter
+@ToString
+public class JobStateChangeEvent extends ApplicationEvent {
+    private final String jobId;
+    private final JobStatus previousStatus;
+    private final JobStatus newStatus;
+
+    /**
+     * Constructor.
+     *
+     * @param jobId          the job id
+     * @param previousStatus the previous status, or null if the job was just created
+     * @param newStatus      the status the job just transitioned to
+     * @param source         the event source
+     */
+    public JobStateChangeEvent(
+        final String jobId,
+        @Nullable final JobStatus previousStatus,
+        final JobStatus newStatus,
+        final Object source
+    ) {
+        super(source);
+        this.jobId = jobId;
+        this.previousStatus = previousStatus;
+        this.newStatus = newStatus;
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/events/SNSNotificationsPublisher.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/events/SNSNotificationsPublisher.java
@@ -1,0 +1,154 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.events;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.web.properties.SNSNotificationsProperties;
+import com.netflix.genie.web.util.MetricsUtils;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.ApplicationListener;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Publishes Amazon SNS notifications.
+ * Currently, only job status changes trigger a notification.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public class SNSNotificationsPublisher implements ApplicationListener<JobStateChangeEvent> {
+
+    private static final String PUBLISH_METRIC_COUNTER_NAME = "genie.notifications.sns.publish.counter";
+
+    // Top level keys
+    private static final String EVENT_TYPE_KEY_NAME = "event-type";
+    private static final String EVENT_ID_KEY_NAME = "event-id";
+    private static final String EVENT_TIMESTAMP_KEY_NAME = "event-timestamp";
+    private static final String EVENT_DETAILS_KEY_NAME = "event-details";
+
+    // Keys for JOB_STATUS_CHANGE
+    private static final String JOB_ID_KEY_NAME = "job-id";
+    private static final String FROM_STATE_KEY_NAME = "from-state";
+    private static final String TO_STATE_KEY_NAME = "to-state";
+
+    private final AmazonSNS snsClient;
+    private final SNSNotificationsProperties properties;
+    private final MeterRegistry registry;
+    private final ObjectMapper mapper;
+
+    /**
+     * Constructor.
+     *
+     * @param snsClient  Amazon SNS client
+     * @param properties configuration properties
+     * @param registry   metrics registry
+     * @param mapper     object mapper
+     */
+    public SNSNotificationsPublisher(
+        final AmazonSNS snsClient,
+        final SNSNotificationsProperties properties,
+        final MeterRegistry registry,
+        final ObjectMapper mapper
+    ) {
+        this.snsClient = snsClient;
+        this.properties = properties;
+        this.registry = registry;
+        this.mapper = mapper;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onApplicationEvent(final JobStateChangeEvent event) {
+        final String jobId = event.getJobId();
+        final JobStatus fromState = event.getPreviousStatus();
+        final JobStatus toState = event.getNewStatus();
+
+        final HashMap<String, String> eventDetailsMap = Maps.newHashMap();
+
+        eventDetailsMap.put(JOB_ID_KEY_NAME, jobId);
+        eventDetailsMap.put(FROM_STATE_KEY_NAME, fromState != null ? fromState.name() : "null");
+        eventDetailsMap.put(TO_STATE_KEY_NAME, toState.name());
+
+        this.publishEvent(EventType.JOB_STATUS_CHANGE, eventDetailsMap);
+    }
+
+    private void publishEvent(final EventType eventType, final HashMap<String, String> eventDetailsMap) {
+        if (!this.properties.isEnabled()) {
+            // Publishing is disabled
+            return;
+        }
+
+        final String topic = this.properties.getTopicARN();
+
+        if (StringUtils.isBlank(topic)) {
+            // Likely a misconfiguration. Emit a warning.
+            log.warn("SNS Notifications enabled, but no topic specified");
+            return;
+        }
+
+        final Map<String, Object> eventMap = Maps.newHashMap();
+
+        // Add static keys defined in configuration
+        eventMap.putAll(this.properties.getAdditionalEventKeys());
+
+        // Add event type, timestamp, event id
+        eventMap.put(EVENT_TYPE_KEY_NAME, eventType.name());
+        eventMap.put(EVENT_ID_KEY_NAME, UUID.randomUUID().toString());
+        eventMap.put(EVENT_TIMESTAMP_KEY_NAME, Instant.now());
+
+        // Add event details
+        eventMap.put(EVENT_DETAILS_KEY_NAME, eventDetailsMap);
+
+        Set<Tag> metricTags = MetricsUtils.newSuccessTagsSet();
+
+        try {
+            // Serialize message
+            final String serializedMessage = this.mapper.writeValueAsString(eventMap);
+            // Send message
+            this.snsClient.publish(topic, serializedMessage);
+            log.debug("Published SNS notification)");
+        } catch (JsonProcessingException | RuntimeException e) {
+            metricTags = MetricsUtils.newFailureTagsSetForException(e);
+            log.error("Failed to publish SNS notification", e);
+        } finally {
+            registry.counter(PUBLISH_METRIC_COUNTER_NAME, metricTags).increment();
+        }
+    }
+
+    /**
+     * Types of event.
+     */
+    private enum EventType {
+        JOB_STATUS_CHANGE,
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/SNSNotificationsProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/SNSNotificationsProperties.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import com.google.common.collect.Maps;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Map;
+
+/**
+ * Properties to configure notification delivered via SNS.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@ConfigurationProperties(prefix = SNSNotificationsProperties.PROPERTY_PREFIX)
+@Getter
+@Setter
+@Validated
+public class SNSNotificationsProperties {
+
+    /**
+     * The property prefix for all properties in this group.
+     */
+    public static final String PROPERTY_PREFIX = "genie.notifications.sns";
+
+    /**
+     * The property that determines if the SNS publishing is enabled.
+     */
+    public static final String ENABLED_PROPERTY = PROPERTY_PREFIX + ".enabled";
+
+    private boolean enabled;
+
+    private String topicARN;
+
+    private Map<String, String> additionalEventKeys = Maps.newHashMap();
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.spring.autoconfigure.events;
+
+
+import com.netflix.genie.web.data.observers.PersistedJobStatusObserver;
+import com.netflix.genie.web.data.observers.PersistedJobStatusObserverImpl;
+import com.netflix.genie.web.events.GenieEventBus;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Beans related to external notifications.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Configuration
+public class NotificationsAutoConfiguration {
+
+    /**
+     * Create {@link PersistedJobStatusObserver} if one does not exist.
+     *
+     * @param genieEventBus the genie event bus
+     * @return a {@link PersistedJobStatusObserver}
+     */
+    @Bean
+    @ConditionalOnMissingBean(PersistedJobStatusObserver.class)
+    public PersistedJobStatusObserver persistedJobStatusObserver(
+        final GenieEventBus genieEventBus
+    ) {
+        return new PersistedJobStatusObserverImpl(genieEventBus);
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfiguration.java
@@ -17,10 +17,11 @@
  */
 package com.netflix.genie.web.spring.autoconfigure.events;
 
-
 import com.netflix.genie.web.data.observers.PersistedJobStatusObserver;
 import com.netflix.genie.web.data.observers.PersistedJobStatusObserverImpl;
 import com.netflix.genie.web.events.GenieEventBus;
+import com.netflix.genie.web.events.JobNotificationMetricPublisher;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,5 +47,20 @@ public class NotificationsAutoConfiguration {
         final GenieEventBus genieEventBus
     ) {
         return new PersistedJobStatusObserverImpl(genieEventBus);
+    }
+
+    /**
+     * Create a {@link JobNotificationMetricPublisher} which publishes metrics related to to job state changes
+     * notifications.
+     *
+     * @param registry the metrics registry
+     * @return a {@link JobNotificationMetricPublisher}
+     */
+    @Bean
+    @ConditionalOnMissingBean(JobNotificationMetricPublisher.class)
+    public JobNotificationMetricPublisher jobNotificationMetricPublisher(
+        final MeterRegistry registry
+    ) {
+        return new JobNotificationMetricPublisher(registry);
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/util/MetricsConstants.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/MetricsConstants.java
@@ -113,6 +113,16 @@ public final class MetricsConstants {
         public static final String LOAD_BALANCER_CLASS = "loadBalancerClass";
 
         /**
+         * Key to tag the origin/source state of a state transition.
+         */
+        public static final String FROM_STATE = "fromState";
+
+        /**
+         * Key to tag the destination/target state of a state transition.
+         */
+        public static final String TO_STATE = "toState";
+
+        /**
          * Utility class private constructor.
          */
         private TagKeys() {

--- a/genie-web/src/main/resources/META-INF/spring.factories
+++ b/genie-web/src/main/resources/META-INF/spring.factories
@@ -10,6 +10,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   com.netflix.genie.web.spring.autoconfigure.aspects.AspectsAutoConfiguration,\
   com.netflix.genie.web.spring.autoconfigure.data.DataAutoConfiguration,\
   com.netflix.genie.web.spring.autoconfigure.events.EventsAutoConfiguration,\
+  com.netflix.genie.web.spring.autoconfigure.events.NotificationsAutoConfiguration,\
   com.netflix.genie.web.spring.autoconfigure.health.HealthAutoConfiguration,\
   com.netflix.genie.web.spring.autoconfigure.jobs.JobsAutoConfiguration,\
   com.netflix.genie.web.spring.autoconfigure.services.ServicesAutoConfiguration,\

--- a/genie-web/src/test/groovy/com/netflix/genie/web/data/entities/listeners/JobEntityListenerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/data/entities/listeners/JobEntityListenerSpec.groovy
@@ -1,0 +1,78 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.data.entities.listeners
+
+import com.netflix.genie.common.dto.JobStatus
+import com.netflix.genie.web.data.entities.JobEntity
+import com.netflix.genie.web.data.observers.PersistedJobStatusObserver
+import spock.lang.Specification
+
+class JobEntityListenerSpec extends Specification {
+    String jobId
+    PersistedJobStatusObserver observer
+    JobEntity jobEntity
+
+    void setup() {
+
+        this.jobId = UUID.randomUUID().toString()
+        this.observer = Mock(PersistedJobStatusObserver)
+        this.jobEntity = Mock(JobEntity)
+    }
+
+    def "Can track job status and notify the observer"() {
+        setup:
+        JobEntityListener listener = new JobEntityListener(observer)
+
+        when:
+        listener.jobUpdate(jobEntity)
+
+        then:
+        1 * jobEntity.getStatus() >> JobStatus.RESERVED
+        1 * jobEntity.getNotifiedJobStatus() >> null
+        1 * jobEntity.getUniqueId() >> jobId
+        1 * observer.notify(jobId, null, JobStatus.RESERVED)
+        1 * jobEntity.setNotifiedJobStatus(JobStatus.RESERVED)
+
+        when:
+        listener.jobLoad(jobEntity)
+
+        then:
+        1 * jobEntity.getStatus() >> JobStatus.RESERVED
+        1 * jobEntity.setNotifiedJobStatus(JobStatus.RESERVED)
+
+        when:
+        listener.jobUpdate(jobEntity)
+
+        then:
+        1 * jobEntity.getStatus() >> JobStatus.RESOLVED
+        1 * jobEntity.getNotifiedJobStatus() >> JobStatus.RESERVED
+        1 * jobEntity.getUniqueId() >> jobId
+        1 * observer.notify(jobId, JobStatus.RESERVED, JobStatus.RESOLVED)
+        1 * jobEntity.setNotifiedJobStatus(JobStatus.RESOLVED)
+
+        when:
+        listener.jobUpdate(jobEntity)
+
+        then:
+        1 * jobEntity.getStatus() >> JobStatus.RUNNING
+        1 * jobEntity.getNotifiedJobStatus() >> JobStatus.RUNNING
+        1 * jobEntity.getUniqueId() >> jobId
+        0 * observer.notify(_, _, _)
+        0 * jobEntity.setNotifiedJobStatus(_)
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/data/observers/PersistedJobStatusObserverImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/data/observers/PersistedJobStatusObserverImplSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.data.observers
+
+import com.netflix.genie.common.dto.JobStatus
+import com.netflix.genie.web.events.GenieEventBus
+import com.netflix.genie.web.events.JobStateChangeEvent
+import org.springframework.context.ApplicationEvent
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PersistedJobStatusObserverImplSpec extends Specification {
+
+    GenieEventBus genieEventbus
+    String jobId
+
+    void setup() {
+        this.genieEventbus = Mock(GenieEventBus)
+        this.jobId = UUID.randomUUID().toString()
+    }
+
+    @Unroll
+    def "Notify #prevStatus -> #currStatus"() {
+        setup:
+        PersistedJobStatusObserver observer = new PersistedJobStatusObserverImpl(genieEventbus)
+        JobStateChangeEvent event
+
+        when:
+        observer.notify(jobId, prevStatus, currStatus)
+
+        then:
+        1 * genieEventbus.publishAsynchronousEvent(_ as ApplicationEvent) >> {
+            args ->
+                event = args[0] as JobStateChangeEvent
+        }
+        event != null
+        event.getSource() == observer
+        event.getPreviousStatus() == prevStatus
+        event.getNewStatus() == currStatus
+        event.getJobId() == jobId
+
+        where:
+        prevStatus         | currStatus
+        null               | JobStatus.RESERVED
+        JobStatus.RESERVED | JobStatus.RESOLVED
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/events/JobNotificationMetricPublisherSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/events/JobNotificationMetricPublisherSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.events
+
+import com.google.common.collect.Sets
+import com.netflix.genie.common.dto.JobStatus
+import com.netflix.genie.web.util.MetricsConstants
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class JobNotificationMetricPublisherSpec extends Specification {
+    String jobId = UUID.randomUUID().toString()
+
+    @Unroll
+    def "State change notification from: #fromState to: #toState"() {
+        setup:
+        boolean isFinalState = toState.isFinished()
+        MeterRegistry registry = Mock(MeterRegistry)
+        JobNotificationMetricPublisher publisher = new JobNotificationMetricPublisher(registry)
+        Counter counter = Mock(Counter)
+        Set<Tag> transitionTags = Sets.newHashSet(
+            Tag.of(MetricsConstants.TagKeys.FROM_STATE, fromState == null ? "null" : fromState.name()),
+            Tag.of(MetricsConstants.TagKeys.TO_STATE, toState.name()),
+        )
+
+        when:
+        publisher.onApplicationEvent(
+            new JobStateChangeEvent(jobId, fromState, toState, this)
+        )
+
+        then:
+        1 * registry.counter(
+            JobNotificationMetricPublisher.STATE_TRANSITION_METRIC_NAME,
+            transitionTags
+        ) >> counter
+        1 * counter.increment()
+
+        if (!isFinalState) {
+            0 * registry.counter(JobNotificationMetricPublisher.FINAL_STATE_METRIC_NAME, _)
+        } else {
+            1 * registry.counter(
+                JobNotificationMetricPublisher.FINAL_STATE_METRIC_NAME,
+                MetricsConstants.TagKeys.TO_STATE,
+                toState.name()
+            ) >> counter
+            1 * counter.increment()
+        }
+
+        where:
+        fromState          | toState
+        null               | JobStatus.RESERVED
+        JobStatus.RESERVED | JobStatus.RESOLVED
+        JobStatus.INIT     | JobStatus.KILLED
+        JobStatus.RESERVED | JobStatus.FAILED
+        JobStatus.RUNNING  | JobStatus.SUCCEEDED
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/events/JobStateChangeEventSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/events/JobStateChangeEventSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.events
+
+import com.netflix.genie.common.dto.JobStatus
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class JobStateChangeEventSpec extends Specification {
+
+    String jobId = UUID.randomUUID().toString()
+
+    @Unroll
+    def "Construct with #prevStatus, #nextStatus"() {
+        JobStateChangeEvent event = new JobStateChangeEvent(jobId, prevStatus, nextStatus, this)
+
+        expect:
+        event.getJobId() == jobId
+        event.getNewStatus() == nextStatus
+        event.getPreviousStatus() == prevStatus
+        event.getSource() == this
+
+        where:
+        prevStatus         | nextStatus
+        null               | JobStatus.RESERVED
+        JobStatus.RESERVED | JobStatus.ACCEPTED
+
+    }
+
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/events/SNSNotificationsPublisherSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/events/SNSNotificationsPublisherSpec.groovy
@@ -1,0 +1,170 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.events
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sns.model.AuthorizationErrorException
+import com.amazonaws.services.sns.model.PublishResult
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.collect.Maps
+import com.netflix.genie.common.dto.JobStatus
+import com.netflix.genie.common.util.GenieObjectMapper
+import com.netflix.genie.web.properties.SNSNotificationsProperties
+import com.netflix.genie.web.util.MetricsUtils
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class SNSNotificationsPublisherSpec extends Specification {
+    SNSNotificationsPublisher publisher
+    AmazonSNS snsClient
+    SNSNotificationsProperties snsProperties
+    MeterRegistry registry
+    ObjectMapper mapper
+    JobStateChangeEvent event
+    Map<String, String> extraKeysMap
+    String jobId
+    String topicARN
+    Counter counter
+
+    void setup() {
+        this.snsClient = Mock(AmazonSNS)
+        this.snsProperties = Mock(SNSNotificationsProperties)
+        this.registry = Mock(MeterRegistry)
+        this.mapper = GenieObjectMapper.getMapper()
+        this.publisher = new SNSNotificationsPublisher(snsClient, snsProperties, registry, mapper)
+        this.event = Mock(JobStateChangeEvent)
+        this.extraKeysMap = Maps.newHashMap()
+        this.jobId = UUID.randomUUID().toString()
+        this.topicARN = UUID.randomUUID().toString()
+        this.counter = Mock(Counter)
+    }
+
+    def "Skip publishing if disabled"() {
+        setup:
+        JobStateChangeEvent event = Mock(JobStateChangeEvent)
+
+        when:
+        this.publisher.onApplicationEvent(event)
+
+        then:
+        1 * event.getJobId() >> jobId
+        1 * event.getPreviousStatus() >> JobStatus.RUNNING
+        1 * event.getNewStatus() >> JobStatus.SUCCEEDED
+        1 * snsProperties.isEnabled() >> false
+        0 * snsClient.publish(_, _)
+        0 * registry.counter(_, _)
+    }
+
+    def "Skip publishing if no topic"() {
+        setup:
+        JobStateChangeEvent event = Mock(JobStateChangeEvent)
+
+        when:
+        this.publisher.onApplicationEvent(event)
+
+        then:
+        1 * event.getJobId() >> jobId
+        1 * event.getPreviousStatus() >> JobStatus.RUNNING
+        1 * event.getNewStatus() >> JobStatus.SUCCEEDED
+        1 * snsProperties.isEnabled() >> true
+        1 * snsProperties.getTopicARN() >> ""
+        0 * snsClient.publish(_, _)
+        0 * registry.counter(_, _)
+    }
+
+    @Unroll
+    def "Publish event (when previous state is #prevState)"() {
+        setup:
+        this.extraKeysMap.putAll([foo: "bar", bar: "foo"])
+        String message = null
+
+        when:
+        this.publisher.onApplicationEvent(event)
+
+        then:
+        1 * event.getJobId() >> jobId
+        1 * event.getPreviousStatus() >> prevState
+        1 * event.getNewStatus() >> JobStatus.SUCCEEDED
+        1 * snsProperties.isEnabled() >> true
+        1 * snsProperties.getTopicARN() >> topicARN
+        1 * snsProperties.getAdditionalEventKeys() >> extraKeysMap
+        1 * snsClient.publish(topicARN, _ as String) >> {
+            args ->
+                message = args[1] as String
+                return Mock(PublishResult)
+        }
+        1 * registry.counter(
+            SNSNotificationsPublisher.PUBLISH_METRIC_COUNTER_NAME,
+            MetricsUtils.newSuccessTagsSet()
+        ) >> counter
+        1 * counter.increment()
+
+        expect:
+        message != null
+        Map<String, Object> parsedMessage = GenieObjectMapper.getMapper().readValue(
+            message,
+            Map.class
+        )
+
+        parsedMessage.size() == 6
+        parsedMessage.get("foo") as String == "bar"
+        parsedMessage.get("bar") as String == "foo"
+        parsedMessage.get("event-type") as String ==  "JOB_STATUS_CHANGE"
+        parsedMessage.get("event-id") != null
+        parsedMessage.get("event-timestamp") != null
+        Map<String, String> eventDetails = parsedMessage.get("event-details") as Map<String, String>
+        eventDetails != null
+        eventDetails.get("job-id") == jobId
+        eventDetails.get("from-state") == String.valueOf(prevState)
+        eventDetails.get("to-state") == JobStatus.SUCCEEDED.name()
+
+        where:
+        prevState      | _
+        null           | _
+        JobStatus.INIT | _
+    }
+
+    def "Publish event exception"() {
+        setup:
+        Exception e = new AuthorizationErrorException("...")
+
+        when:
+        this.publisher.onApplicationEvent(event)
+        print(MetricsUtils.newFailureTagsSetForException(e))
+
+        then:
+        1 * snsProperties.isEnabled() >> true
+        1 * event.getJobId() >> jobId
+        1 * event.getPreviousStatus() >> JobStatus.INIT
+        1 * event.getNewStatus() >> JobStatus.SUCCEEDED
+        1 * snsProperties.getAdditionalEventKeys() >> extraKeysMap
+        1 * snsProperties.getTopicARN() >> topicARN
+        1 * snsClient.publish(topicARN, _ as String) >> {
+            throw e
+        }
+        1 * registry.counter(
+            SNSNotificationsPublisher.PUBLISH_METRIC_COUNTER_NAME,
+            MetricsUtils.newFailureTagsSetForException(e)
+        ) >> counter
+        1 * counter.increment()
+
+    }
+
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/SNSNotificationsPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/SNSNotificationsPropertiesSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties
+
+import spock.lang.Specification
+
+class SNSNotificationsPropertiesSpec extends Specification {
+    SNSNotificationsProperties properties
+
+    void setup() {
+        this.properties = new SNSNotificationsProperties()
+    }
+
+    def "Defaults"() {
+        expect:
+        !this.properties.isEnabled()
+        this.properties.getTopicARN() == null
+        this.properties.getAdditionalEventKeys().isEmpty()
+    }
+
+    def "Set and Get"() {
+        when:
+        this.properties.setEnabled(true)
+        this.properties.setTopicARN("foo")
+        this.properties.getAdditionalEventKeys().put("foo", "bar")
+        this.properties.getAdditionalEventKeys().put("null", null)
+
+        then:
+        this.properties.isEnabled()
+        this.properties.getTopicARN() == "foo"
+        this.properties.getAdditionalEventKeys().get("foo") == "bar"
+        this.properties.getAdditionalEventKeys().get("null") == null
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfigurationSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfigurationSpec.groovy
@@ -17,9 +17,12 @@
  */
 package com.netflix.genie.web.spring.autoconfigure.events
 
+import com.amazonaws.services.sns.AmazonSNS
 import com.netflix.genie.web.data.observers.PersistedJobStatusObserver
 import com.netflix.genie.web.events.GenieEventBus
 import com.netflix.genie.web.events.JobNotificationMetricPublisher
+import com.netflix.genie.web.events.SNSNotificationsPublisher
+import com.netflix.genie.web.properties.SNSNotificationsProperties
 import io.micrometer.core.instrument.MeterRegistry
 import spock.lang.Specification
 
@@ -47,6 +50,20 @@ class NotificationsAutoConfigurationSpec extends Specification {
     def "jobNotificationMetricPublisher"() {
         when:
         JobNotificationMetricPublisher publisher = this.config.jobNotificationMetricPublisher(registry)
+
+        then:
+        publisher != null
+    }
+
+    def "jobNotificationsSNSPublisher"() {
+        AmazonSNS snsClient = Mock(AmazonSNS)
+        SNSNotificationsProperties snsProperties = Mock(SNSNotificationsProperties)
+        when:
+        SNSNotificationsPublisher publisher = this.config.jobNotificationsSNSPublisher(
+            snsProperties,
+            registry,
+            snsClient
+        )
 
         then:
         publisher != null

--- a/genie-web/src/test/groovy/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfigurationSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfigurationSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.genie.web.spring.autoconfigure.events
 
 import com.netflix.genie.web.data.observers.PersistedJobStatusObserver
 import com.netflix.genie.web.events.GenieEventBus
+import com.netflix.genie.web.events.JobNotificationMetricPublisher
 import io.micrometer.core.instrument.MeterRegistry
 import spock.lang.Specification
 
@@ -41,5 +42,13 @@ class NotificationsAutoConfigurationSpec extends Specification {
 
         then:
         observer != null
+    }
+
+    def "jobNotificationMetricPublisher"() {
+        when:
+        JobNotificationMetricPublisher publisher = this.config.jobNotificationMetricPublisher(registry)
+
+        then:
+        publisher != null
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfigurationSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfigurationSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.spring.autoconfigure.events
+
+import com.netflix.genie.web.data.observers.PersistedJobStatusObserver
+import com.netflix.genie.web.events.GenieEventBus
+import io.micrometer.core.instrument.MeterRegistry
+import spock.lang.Specification
+
+class NotificationsAutoConfigurationSpec extends Specification {
+    GenieEventBus genieEventBus
+    NotificationsAutoConfiguration config
+    MeterRegistry registry
+
+    void setup() {
+        this.genieEventBus = Mock(GenieEventBus)
+        this.registry = Mock(MeterRegistry)
+        this.config = new NotificationsAutoConfiguration()
+    }
+
+    def "persistedJobStatusObserver"() {
+        PersistedJobStatusObserver observer
+
+        when:
+        observer = this.config.persistedJobStatusObserver(genieEventBus)
+
+        then:
+        observer != null
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/data/entities/JobEntityTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/data/entities/JobEntityTest.java
@@ -252,8 +252,19 @@ public class JobEntityTest extends EntityTestBase {
     }
 
     /**
-     * Test the setter and the getter for tags.
+     * Tests setting and getting the (transient) notifiedJobStatus field.
      */
+    @Test
+    public void testSetNotifiedJobStatus() {
+        final JobEntity localJobEntity = new JobEntity();
+        Assert.assertNull(localJobEntity.getNotifiedJobStatus());
+        localJobEntity.setNotifiedJobStatus(JobStatus.RUNNING);
+        Assert.assertEquals(JobStatus.RUNNING, localJobEntity.getNotifiedJobStatus());
+    }
+
+        /**
+         * Test the setter and the getter for tags.
+         */
     @Test
     public void testSetGetTags() {
         Assert.assertNotNull(this.jobEntity.getTags());

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,35 @@
+💡 Spring Data REST Events (@RepositoryEventHandler)
+
+https://www.baeldung.com/spring-data-rest-events
+
+@HandleAfterCreate and @HandleAfterSave could intercept.
+
+However save() can generate false positives.
+To avoid notifying an event twice, some state must be maintained.
+
+(❓) Entity could save state right after creation and notify if different?
+(❓) Entity could provide custom setter that tracks 'dirty' status?
+
+❌ Dead end -- only works with REST-Enabled repositories and on REST calls.
+
+----
+
+💡 Repository events (@AbstractRepositoryEventListener)
+
+Same as Data REST.
+
+----
+
+
+💡 Spring JPA audit hoops
+
+💡
+
+💡
+
+
+---
+Tests:
+
+ - JobRestControllerIntegrationTest
+ - JpaJobPersistenceServiceImplIntegrationTest


### PR DESCRIPTION
 - Refactor JobPersistence to intercept state changes** and notify a pluggable observer
 - Multicast state changes on Genie event bus for listeners to process asynchronously
 - Implement listener that publishes metrics 
 - Implement listener that publishes SNS notifications

** N.B.: The job state transition graph for V3 execution is different than V4 (a.k.a Agent execution).
Namely, `INIT` is the first state for a V3 job, while `RESERVED`, `RESOLVED`, `CLAIMED` are exposed only for agent jobs.