### PR TITLE
URL-encoding in forwarding and ScriptLoadBalancer metrics

### DIFF
--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -287,7 +287,7 @@ published within the local JVM and available on the Actuator `/metrics` endpoint
 |Time taken by the loaded script to select a cluster among the one passed as input
 |nanoseconds
 |ScriptLoadBalancer
-|status, exceptionClass
+|status, exceptionClass, clusterName, clusterId
 
 |genie.jobs.clusters.loadBalancers.script.update.timer
 |Time taken to reload the script
@@ -443,7 +443,7 @@ published within the local JVM and available on the Actuator `/metrics` endpoint
 |Counter for cluster load balancer algorithms invocations
 |count
 |JobSpecificationServiceImpl
-|class, status
+|class, status, clusterName, clusterId, loadBalancerClass
 
 |genie.services.specification.selectApplications.timer
 |Time taken to retrieve applications information for this task

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
@@ -126,7 +126,7 @@ public class JobRestController {
     private static final String TRANSFER_ENCODING_HEADER = "Transfer-Encoding";
     private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
     private static final String NAME_HEADER_COOKIE = "cookie";
-    private static final String JOB_API_TEMPLATE = "/api/v3/jobs/{id}";
+    private static final String JOB_API_BASE_PATH = "/api/v3/jobs/";
     private static final String COMMA = ",";
 
     private final JobCoordinatorService jobCoordinatorService;
@@ -565,15 +565,14 @@ public class JobRestController {
                 try {
                     //Need to forward job
                     this.restTemplate.execute(
-                        forwardHost + JOB_API_TEMPLATE,
+                        forwardHost + JOB_API_BASE_PATH + id,
                         HttpMethod.DELETE,
                         forwardRequest -> copyRequestHeaders(request, forwardRequest),
                         (final ClientHttpResponse forwardResponse) -> {
                             response.setStatus(HttpStatus.ACCEPTED.value());
                             copyResponseHeaders(response, forwardResponse);
                             return null;
-                        },
-                        id
+                        }
                     );
                 } catch (HttpStatusCodeException e) {
                     log.error("Failed killing job on {}. Error: {}", forwardHost, e.getMessage());
@@ -736,7 +735,7 @@ public class JobRestController {
                 final String forwardHost = this.buildForwardHost(jobHostname);
                 try {
                     this.restTemplate.execute(
-                        forwardHost + JOB_API_TEMPLATE + "/output/{path}",
+                        forwardHost + JOB_API_BASE_PATH + id + "/output/" + path,
                         HttpMethod.GET,
                         forwardRequest -> copyRequestHeaders(request, forwardRequest),
                         (ResponseExtractor<Void>) forwardResponse -> {
@@ -746,9 +745,7 @@ public class JobRestController {
                             // the stream so this should resolve memory problems if the file returned is large
                             ByteStreams.copy(forwardResponse.getBody(), response.getOutputStream());
                             return null;
-                        },
-                        id,
-                        path
+                        }
                     );
                 } catch (final HttpStatusCodeException e) {
                     log.error("Failed getting the remote job output from {}. Error: {}", forwardHost, e.getMessage());

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobSpecificationServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobSpecificationServiceImpl.java
@@ -375,7 +375,14 @@ public class JobSpecificationServiceImpl implements JobSpecificationService {
                             selectedCluster.getId(),
                             loadBalancerClass
                         );
-                        counterTags.add(Tag.of(MetricsConstants.TagKeys.STATUS, LOAD_BALANCER_STATUS_SUCCESS));
+                        counterTags.addAll(
+                            Lists.newArrayList(
+                                Tag.of(MetricsConstants.TagKeys.STATUS, LOAD_BALANCER_STATUS_SUCCESS),
+                                Tag.of(MetricsConstants.TagKeys.CLUSTER_ID, selectedCluster.getId()),
+                                Tag.of(MetricsConstants.TagKeys.CLUSTER_NAME, selectedCluster.getMetadata().getName()),
+                                Tag.of(MetricsConstants.TagKeys.LOAD_BALANCER_CLASS, loadBalancerClass)
+                            )
+                        );
                         this.registry.counter(SELECT_LOAD_BALANCER_COUNTER_NAME, counterTags).increment();
                         cluster = selectedCluster;
                         break;

--- a/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancer.java
@@ -177,6 +177,8 @@ public class ScriptLoadBalancer implements ClusterLoadBalancer {
             for (final Cluster cluster : clusters) {
                 if (clusterId.equals(cluster.getId())) {
                     tags.add(Tag.of(MetricsConstants.TagKeys.STATUS, STATUS_TAG_FOUND));
+                    tags.add(Tag.of(MetricsConstants.TagKeys.CLUSTER_NAME, cluster.getMetadata().getName()));
+                    tags.add(Tag.of(MetricsConstants.TagKeys.CLUSTER_ID, cluster.getId()));
                     return cluster;
                 }
             }

--- a/genie-web/src/main/java/com/netflix/genie/web/util/MetricsConstants.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/MetricsConstants.java
@@ -108,6 +108,11 @@ public final class MetricsConstants {
         public static final String JOBS_USER_LIMIT = "jobsUserLimit";
 
         /**
+         * Key to tag the load balancer class used.
+         */
+        public static final String LOAD_BALANCER_CLASS = "loadBalancerClass";
+
+        /**
          * Utility class private constructor.
          */
         private TagKeys() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/loadbalancers/script/ScriptLoadBalancerSpec.groovy
@@ -241,9 +241,14 @@ class ScriptLoadBalancerSpec extends Specification {
         then: "Can successfully find a cluster"
         cluster != null
         cluster.getId() == "1"
+        cluster.getMetadata().getName() == "g"
         1 * registry.timer(
             ScriptLoadBalancer.SELECT_TIMER_NAME,
-            ImmutableSet.of(Tag.of(MetricsConstants.TagKeys.STATUS, ScriptLoadBalancer.STATUS_TAG_FOUND))
+            ImmutableSet.of(
+                Tag.of(MetricsConstants.TagKeys.STATUS, ScriptLoadBalancer.STATUS_TAG_FOUND),
+                Tag.of(MetricsConstants.TagKeys.CLUSTER_NAME, "g"),
+                Tag.of(MetricsConstants.TagKeys.CLUSTER_ID, "1")
+            )
         ) >> selectTimer
         1 * selectTimer.record(_ as Long, TimeUnit.NANOSECONDS)
 
@@ -329,8 +334,10 @@ class ScriptLoadBalancerSpec extends Specification {
         }
         1 * timer.record(_, TimeUnit.NANOSECONDS)
         tags != null
-        tags.size() == 1
+        tags.size() == 3
         tags.contains(Tag.of(MetricsConstants.TagKeys.STATUS, ScriptLoadBalancer.STATUS_TAG_FOUND))
+        tags.contains(Tag.of(MetricsConstants.TagKeys.CLUSTER_NAME, cluster.getMetadata().getName()))
+        tags.contains(Tag.of(MetricsConstants.TagKeys.CLUSTER_ID, cluster.getId()))
         clustersGood.contains(cluster)
         cluster.getId() == "2"
 

--- a/genie-web/src/test/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerTest.java
@@ -51,6 +51,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequest;
@@ -214,13 +215,14 @@ public class JobRestControllerTest {
     public void canRespondToV3KillRequestForwardError() throws IOException, ServletException, GenieException {
         this.jobsProperties.getForwarding().setEnabled(true);
         final String jobId = UUID.randomUUID().toString();
+        final String host = UUID.randomUUID().toString();
         final String forwardedFrom = null;
         final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
         Mockito.when(request.getRequestURL()).thenReturn(new StringBuffer(UUID.randomUUID().toString()));
         Mockito.when(this.jobPersistenceService.isV4(jobId)).thenReturn(false);
-        Mockito.when(this.jobSearchService.getJobHost(jobId)).thenReturn(UUID.randomUUID().toString());
+        Mockito.when(this.jobSearchService.getJobHost(jobId)).thenReturn(host);
 
         final StatusLine statusLine = Mockito.mock(StatusLine.class);
         Mockito.when(statusLine.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND.value());
@@ -231,8 +233,7 @@ public class JobRestControllerTest {
                 Mockito.anyString(),
                 Mockito.any(),
                 Mockito.any(),
-                Mockito.any(),
-                Mockito.anyString()
+                Mockito.any()
             )
         )
             .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
@@ -248,11 +249,10 @@ public class JobRestControllerTest {
         Mockito
             .verify(this.restTemplate, Mockito.times(1))
             .execute(
-                Mockito.anyString(),
+                Mockito.eq("http://" + host + ":8080/api/v3/jobs/" + jobId),
+                Mockito.eq(HttpMethod.DELETE),
                 Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.anyString()
+                Mockito.any()
             );
     }
 
@@ -267,13 +267,14 @@ public class JobRestControllerTest {
     public void canForwardV3JobKillRequest() throws IOException, ServletException, GenieException {
         this.jobsProperties.getForwarding().setEnabled(true);
         final String jobId = UUID.randomUUID().toString();
+        final String host = UUID.randomUUID().toString();
         final String forwardedFrom = null;
         final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
         Mockito.when(request.getRequestURL()).thenReturn(new StringBuffer(UUID.randomUUID().toString()));
         Mockito.when(this.jobPersistenceService.isV4(jobId)).thenReturn(false);
-        Mockito.when(this.jobSearchService.getJobHost(jobId)).thenReturn(UUID.randomUUID().toString());
+        Mockito.when(this.jobSearchService.getJobHost(jobId)).thenReturn(host);
 
         final StatusLine statusLine = Mockito.mock(StatusLine.class);
         Mockito.when(statusLine.getStatusCode()).thenReturn(HttpStatus.ACCEPTED.value());
@@ -286,8 +287,7 @@ public class JobRestControllerTest {
                     Mockito.anyString(),
                     Mockito.any(),
                     Mockito.any(),
-                    Mockito.any(),
-                    Mockito.anyString()
+                    Mockito.any()
                 )
             )
             .thenReturn(null);
@@ -299,7 +299,12 @@ public class JobRestControllerTest {
         Mockito.verify(this.jobSearchService, Mockito.times(1)).getJobHost(jobId);
         Mockito.verify(this.agentRoutingService, Mockito.never()).getHostnameForAgentConnection(Mockito.eq(jobId));
         Mockito.verify(this.restTemplate, Mockito.times(1))
-            .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
+            .execute(
+                Mockito.eq("http://" + host + ":8080/api/v3/jobs/" + jobId),
+                Mockito.eq(HttpMethod.DELETE),
+                Mockito.any(),
+                Mockito.any()
+            );
     }
 
     /**
@@ -329,7 +334,7 @@ public class JobRestControllerTest {
             .getHostnameForAgentConnection(Mockito.eq(jobId));
         Mockito
             .verify(this.restTemplate, Mockito.never())
-            .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
+            .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any());
     }
 
     /**
@@ -342,6 +347,7 @@ public class JobRestControllerTest {
     public void canRespondToV4KillRequestForwardError() throws IOException, GenieException {
         this.jobsProperties.getForwarding().setEnabled(true);
         final String jobId = UUID.randomUUID().toString();
+        final String host = UUID.randomUUID().toString();
         final String forwardedFrom = null;
         final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
@@ -349,7 +355,7 @@ public class JobRestControllerTest {
         Mockito.when(request.getRequestURL()).thenReturn(new StringBuffer(UUID.randomUUID().toString()));
         Mockito.when(this.jobPersistenceService.isV4(jobId)).thenReturn(true);
         Mockito.when(this.agentRoutingService.getHostnameForAgentConnection(jobId))
-            .thenReturn(Optional.of(UUID.randomUUID().toString()));
+            .thenReturn(Optional.of(host));
 
         final StatusLine statusLine = Mockito.mock(StatusLine.class);
         Mockito.when(statusLine.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND.value());
@@ -360,8 +366,7 @@ public class JobRestControllerTest {
                 Mockito.anyString(),
                 Mockito.any(),
                 Mockito.any(),
-                Mockito.any(),
-                Mockito.anyString()
+                Mockito.any()
             )
         )
             .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
@@ -377,11 +382,10 @@ public class JobRestControllerTest {
         Mockito
             .verify(this.restTemplate, Mockito.times(1))
             .execute(
-                Mockito.anyString(),
+                Mockito.eq("http://" + host + ":8080/api/v3/jobs/" + jobId),
+                Mockito.eq(HttpMethod.DELETE),
                 Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.anyString()
+                Mockito.any()
             );
     }
 
@@ -395,6 +399,7 @@ public class JobRestControllerTest {
     public void canForwardV4JobKillRequest() throws IOException, GenieException {
         this.jobsProperties.getForwarding().setEnabled(true);
         final String jobId = UUID.randomUUID().toString();
+        final String host = UUID.randomUUID().toString();
         final String forwardedFrom = null;
         final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
@@ -402,7 +407,7 @@ public class JobRestControllerTest {
         Mockito.when(request.getRequestURL()).thenReturn(new StringBuffer(UUID.randomUUID().toString()));
         Mockito.when(this.jobPersistenceService.isV4(jobId)).thenReturn(true);
         Mockito.when(this.agentRoutingService.getHostnameForAgentConnection(jobId))
-            .thenReturn(Optional.of(UUID.randomUUID().toString()));
+            .thenReturn(Optional.of(host));
 
         final StatusLine statusLine = Mockito.mock(StatusLine.class);
         Mockito.when(statusLine.getStatusCode()).thenReturn(HttpStatus.ACCEPTED.value());
@@ -415,8 +420,7 @@ public class JobRestControllerTest {
                     Mockito.anyString(),
                     Mockito.any(),
                     Mockito.any(),
-                    Mockito.any(),
-                    Mockito.anyString()
+                    Mockito.any()
                 )
             )
             .thenReturn(null);
@@ -428,7 +432,12 @@ public class JobRestControllerTest {
         Mockito.verify(this.jobSearchService, Mockito.never()).getJobHost(jobId);
         Mockito.verify(this.agentRoutingService, Mockito.times(1)).getHostnameForAgentConnection(Mockito.eq(jobId));
         Mockito.verify(this.restTemplate, Mockito.times(1))
-            .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
+            .execute(
+                Mockito.eq("http://" + host + ":8080/api/v3/jobs/" + jobId),
+                Mockito.eq(HttpMethod.DELETE),
+                Mockito.any(),
+                Mockito.any()
+            );
     }
 
     /**
@@ -454,7 +463,12 @@ public class JobRestControllerTest {
         Mockito.verify(this.agentRoutingService, Mockito.never()).getHostnameForAgentConnection(Mockito.eq(jobId));
         Mockito
             .verify(this.restTemplate, Mockito.never())
-            .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
+            .execute(
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()
+            );
     }
 
     /**
@@ -482,7 +496,12 @@ public class JobRestControllerTest {
         Mockito.verify(this.agentRoutingService, Mockito.never()).getHostnameForAgentConnection(Mockito.eq(jobId));
         Mockito
             .verify(this.restTemplate, Mockito.never())
-            .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
+            .execute(
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()
+            );
     }
 
     /**
@@ -510,7 +529,12 @@ public class JobRestControllerTest {
         Mockito.verify(this.agentRoutingService, Mockito.times(1)).getHostnameForAgentConnection(Mockito.eq(jobId));
         Mockito
             .verify(this.restTemplate, Mockito.never())
-            .execute(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString());
+            .execute(
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()
+            );
     }
 
     /**
@@ -703,9 +727,7 @@ public class JobRestControllerTest {
                 Mockito.anyString(),
                 Mockito.any(),
                 Mockito.any(),
-                Mockito.any(),
-                Mockito.anyString(),
-                Mockito.anyString()
+                Mockito.any()
             )
         )
             .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
@@ -715,12 +737,10 @@ public class JobRestControllerTest {
         Mockito.verify(this.jobSearchService, Mockito.times(1)).getJobHost(Mockito.eq(jobId));
         Mockito.verify(this.restTemplate, Mockito.times(1))
             .execute(
-                Mockito.anyString(),
+                Mockito.eq("http://" + jobHostName + ":8080/api/v3/jobs/" + jobId + "/output/"),
+                Mockito.eq(HttpMethod.GET),
                 Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.anyString(),
-                Mockito.anyString()
+                Mockito.any()
             );
         Mockito.verify(response, Mockito.times(1)).sendError(Mockito.eq(errorCode), Mockito.anyString());
         Mockito


### PR DESCRIPTION
 - Avoid URL-encoding when forwarding from one node to another.
 - Fix incorrect ScriptLoadBalancer metrics