### PR TITLE
Continuing work towards agent only job execution

### DIFF
--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/AgentConfigRequest.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/AgentConfigRequest.java
@@ -43,6 +43,7 @@ public class AgentConfigRequest {
     @Min(value = 1, message = "The timeout must be at least 1 second, preferably much more.")
     private final Integer timeoutRequested;
     private final boolean interactive;
+    // TODO: Switch to Path
     private final File requestedJobDirectoryLocation;
     private final JsonNode ext;
 

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/ApiJobRequest.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/ApiJobRequest.java
@@ -63,7 +63,7 @@ public interface ApiJobRequest extends CommonRequest {
      *
      * @return The requested agent environment
      */
-    AgentEnvironmentRequest getRequestedAgentEnvironment();
+    JobEnvironmentRequest getRequestedJobEnvironment();
 
     /**
      * Get the requested agent configuration.
@@ -91,7 +91,7 @@ public interface ApiJobRequest extends CommonRequest {
         private final JobMetadata bMetadata;
         private final ExecutionResourceCriteria bCriteria;
         private final List<String> bCommandArgs = Lists.newArrayList();
-        private AgentEnvironmentRequest bRequestedAgentEnvironment;
+        private JobEnvironmentRequest bRequestedJobEnvironment;
         private AgentConfigRequest bRequestedAgentConfig;
         private JobArchivalDataRequest bRequestedJobArchivalData;
 
@@ -129,13 +129,13 @@ public interface ApiJobRequest extends CommonRequest {
         /**
          * Set the information provided by a user for the Agent execution environment.
          *
-         * @param requestedAgentEnvironment the requested Genie Agent environment parameters
+         * @param requestedJobEnvironment the requested Genie job environment parameters
          * @return The builder
          */
         public Builder withRequestedAgentEnvironment(
-            @Nullable final AgentEnvironmentRequest requestedAgentEnvironment
+            @Nullable final JobEnvironmentRequest requestedJobEnvironment
         ) {
-            this.bRequestedAgentEnvironment = requestedAgentEnvironment;
+            this.bRequestedJobEnvironment = requestedJobEnvironment;
             return this;
         }
 

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/JobEnvironment.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/JobEnvironment.java
@@ -1,0 +1,164 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.dto.v4;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Final values for settings of the Genie job execution environment.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Getter
+@EqualsAndHashCode(doNotUseGetters = true)
+@ToString(doNotUseGetters = true)
+@JsonDeserialize(builder = JobEnvironment.Builder.class)
+@SuppressWarnings("checkstyle:finalclass")
+public class JobEnvironment {
+    private static final int DEFAULT_NUM_CPU = 1;
+    @Min(value = 1, message = "Number of CPU's can't be less than 1")
+    private final int cpu;
+    @Min(value = 1, message = "Amount of memory has to be greater than 1 MB and preferably much more")
+    private final int memory;
+    private final ImmutableMap<
+        @NotBlank(message = "Environment variable key can't be blank")
+        @Size(max = 255, message = "Max environment variable name length is 255 characters") String,
+        @NotNull(message = "Environment variable value can't be null")
+        @Size(max = 1024, message = "Max environment variable value length is 1024 characters") String>
+        environmentVariables;
+    private final JsonNode ext;
+
+    private JobEnvironment(final Builder builder) {
+        this.cpu = builder.bCpu == null ? DEFAULT_NUM_CPU : builder.bCpu;
+        this.memory = builder.bMemory;
+        this.environmentVariables = ImmutableMap.copyOf(builder.bEnvironmentVariables);
+        this.ext = builder.bExt;
+    }
+
+    /**
+     * Get the environment variables requested by the user to be added to the job runtime.
+     *
+     * @return The environment variables backed by an immutable map. Any attempt to modify with throw exception
+     */
+    public Map<String, String> getEnvironmentVariables() {
+        return this.environmentVariables;
+    }
+
+    /**
+     * Get the extension variables to the agent configuration as a JSON blob.
+     *
+     * @return The extension variables wrapped in an {@link Optional}
+     */
+    public Optional<JsonNode> getExt() {
+        return Optional.ofNullable(this.ext);
+    }
+
+    /**
+     * Builder to create an immutable {@link JobEnvironment} instance.
+     *
+     * @author tgianos
+     * @since 4.0.0
+     */
+    public static class Builder {
+        private final Map<String, String> bEnvironmentVariables = Maps.newHashMap();
+        private Integer bCpu;
+        private int bMemory;
+        private JsonNode bExt;
+
+        /**
+         * Constructor.
+         *
+         * @param memory The amount of memory (in MB) to allocate for the job
+         */
+        public Builder(final int memory) {
+            this.bMemory = memory;
+        }
+
+        /**
+         * Set the number of CPU cores that should be allocated to run the associated job.
+         *
+         * @param cpu The number of CPU's. Must be greater than or equal to 1.
+         * @return The builder
+         */
+        public Builder withCpu(@Nullable final Integer cpu) {
+            this.bCpu = cpu;
+            return this;
+        }
+
+        /**
+         * Set the amount of memory (in MB) that should be allocated for the job processes.
+         *
+         * @param memory The memory. Must be greater than or equal to 1 but preferably much more
+         * @return The builder
+         */
+        public Builder withMemory(final int memory) {
+            this.bMemory = memory;
+            return this;
+        }
+
+        /**
+         * Set any environment variables that the agent should add to the job runtime.
+         *
+         * @param environmentVariables Additional environment variables
+         * @return The builder
+         */
+        public Builder withEnvironmentVariables(@Nullable final Map<String, String> environmentVariables) {
+            this.bEnvironmentVariables.clear();
+            if (environmentVariables != null) {
+                this.bEnvironmentVariables.putAll(environmentVariables);
+            }
+            return this;
+        }
+
+        /**
+         * Set the extension configuration for the agent. This is generally used for specific implementations of the
+         * job launcher e.g. on Titus or local docker etc.
+         *
+         * @param ext The extension configuration which is effectively a DSL per job launch implementation
+         * @return The builder
+         */
+        public Builder withExt(@Nullable final JsonNode ext) {
+            this.bExt = ext;
+            return this;
+        }
+
+        /**
+         * Build a new immutable instance of an {@link JobEnvironment}.
+         *
+         * @return An instance containing the fields set in this builder
+         */
+        public JobEnvironment build() {
+            return new JobEnvironment(this);
+        }
+    }
+}

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/JobEnvironmentRequest.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/JobEnvironmentRequest.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Fields that allow manipulation of the Genie Agent execution container environment.
+ * Fields that allow manipulation of the Genie job execution container environment.
  *
  * @author tgianos
  * @since 4.0.0
@@ -42,9 +42,9 @@ import java.util.Optional;
 @Getter
 @EqualsAndHashCode(doNotUseGetters = true)
 @ToString(doNotUseGetters = true)
-@JsonDeserialize(builder = AgentEnvironmentRequest.Builder.class)
+@JsonDeserialize(builder = JobEnvironmentRequest.Builder.class)
 @SuppressWarnings("checkstyle:finalclass")
-public class AgentEnvironmentRequest {
+public class JobEnvironmentRequest {
     @Min(value = 1, message = "Number of CPU's requested can't be less than 1")
     private final Integer requestedJobCpu;
     @Min(value = 1, message = "Amount of memory requested has to be greater than 1 MB and preferably much more")
@@ -57,7 +57,7 @@ public class AgentEnvironmentRequest {
         requestedEnvironmentVariables;
     private final JsonNode ext;
 
-    private AgentEnvironmentRequest(final Builder builder) {
+    private JobEnvironmentRequest(final Builder builder) {
         this.requestedJobCpu = builder.bRequestedJobCpu;
         this.requestedJobMemory = builder.bRequestedJobMemory;
         this.requestedEnvironmentVariables = ImmutableMap.copyOf(builder.bRequestedEnvironmentVariables);
@@ -101,7 +101,7 @@ public class AgentEnvironmentRequest {
     }
 
     /**
-     * Builder to create an immutable {@link AgentEnvironmentRequest} instance.
+     * Builder to create an immutable {@link JobEnvironmentRequest} instance.
      *
      * @author tgianos
      * @since 4.0.0
@@ -163,12 +163,12 @@ public class AgentEnvironmentRequest {
         }
 
         /**
-         * Build a new immutable instance of an {@link AgentEnvironmentRequest}.
+         * Build a new immutable instance of an {@link JobEnvironmentRequest}.
          *
          * @return An instance containing the fields set in this builder
          */
-        public AgentEnvironmentRequest build() {
-            return new AgentEnvironmentRequest(this);
+        public JobEnvironmentRequest build() {
+            return new JobEnvironmentRequest(this);
         }
     }
 }

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/JobRequest.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/JobRequest.java
@@ -53,7 +53,7 @@ public class JobRequest extends CommonRequestImpl implements AgentJobRequest, Ap
     @Valid
     private final ExecutionResourceCriteria criteria;
     @Valid
-    private final AgentEnvironmentRequest requestedAgentEnvironment;
+    private final JobEnvironmentRequest requestedJobEnvironment;
     @Valid
     private final AgentConfigRequest requestedAgentConfig;
     @Valid
@@ -79,7 +79,7 @@ public class JobRequest extends CommonRequestImpl implements AgentJobRequest, Ap
             builder.getBCommandArgs(),
             builder.getBMetadata(),
             builder.getBCriteria(),
-            builder.getBRequestedAgentEnvironment(),
+            builder.getBRequestedJobEnvironment(),
             builder.getBRequestedAgentConfig(),
             builder.getBRequestedJobArchivalData()
         );
@@ -88,15 +88,15 @@ public class JobRequest extends CommonRequestImpl implements AgentJobRequest, Ap
     /**
      * Constructor.
      *
-     * @param requestedId               The requested id of the job if one was provided by the user
-     * @param resources                 The execution resources (if any) provided by the user
-     * @param commandArgs               Any command args provided by the user
-     * @param metadata                  Any metadata related to the job provided by the user
-     * @param criteria                  The criteria used by the server to determine execution resources
-     *                                  (cluster, command, etc)
-     * @param requestedAgentEnvironment The optional agent environment request parameters
-     * @param requestedAgentConfig      The optional configuration options for the Genie Agent
-     * @param requestedJobArchivalData  The optional configuration options for archiving the job folder by the agent
+     * @param requestedId              The requested id of the job if one was provided by the user
+     * @param resources                The execution resources (if any) provided by the user
+     * @param commandArgs              Any command args provided by the user
+     * @param metadata                 Any metadata related to the job provided by the user
+     * @param criteria                 The criteria used by the server to determine execution resources
+     *                                 (cluster, command, etc)
+     * @param requestedJobEnvironment  The optional job environment request parameters
+     * @param requestedAgentConfig     The optional configuration options for the Genie Agent
+     * @param requestedJobArchivalData The optional configuration options for archiving the job folder by the agent
      */
     public JobRequest(
         @Nullable final String requestedId,
@@ -104,7 +104,7 @@ public class JobRequest extends CommonRequestImpl implements AgentJobRequest, Ap
         @Nullable final List<String> commandArgs,
         final JobMetadata metadata,
         final ExecutionResourceCriteria criteria,
-        @Nullable final AgentEnvironmentRequest requestedAgentEnvironment,
+        @Nullable final JobEnvironmentRequest requestedJobEnvironment,
         @Nullable final AgentConfigRequest requestedAgentConfig,
         @Nullable final JobArchivalDataRequest requestedJobArchivalData
     ) {
@@ -117,9 +117,9 @@ public class JobRequest extends CommonRequestImpl implements AgentJobRequest, Ap
         );
         this.metadata = metadata;
         this.criteria = criteria;
-        this.requestedAgentEnvironment = requestedAgentEnvironment == null
-            ? new AgentEnvironmentRequest.Builder().build()
-            : requestedAgentEnvironment;
+        this.requestedJobEnvironment = requestedJobEnvironment == null
+            ? new JobEnvironmentRequest.Builder().build()
+            : requestedJobEnvironment;
         this.requestedAgentConfig = requestedAgentConfig == null
             ? new AgentConfigRequest.Builder().build()
             : requestedAgentConfig;

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/JobEnvironmentSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/JobEnvironmentSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.dto.v4
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.google.common.collect.ImmutableMap
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link JobEnvironment}.
+ *
+ * @author tgianos
+ */
+class JobEnvironmentSpec extends Specification {
+
+    def "Generated instances are immutable and correct"() {
+        def memory = 1_512
+        def cpu = 3
+        def environmentVariables = ImmutableMap.of(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString()
+        )
+        def ext = Mock(JsonNode)
+
+        def builder = new JobEnvironment.Builder(memory)
+
+        when:
+        def environment = builder.build()
+
+        then:
+        environment.getMemory() == memory
+        environment.getCpu() == 1
+        environment.getEnvironmentVariables().isEmpty()
+        !environment.getExt().isPresent()
+
+        when:
+        environment = builder.withCpu(cpu).withEnvironmentVariables(environmentVariables).withExt(ext).build()
+
+        then:
+        environment.getMemory() == memory
+        environment.getCpu() == cpu
+        environment.getEnvironmentVariables() == environmentVariables
+        environment.getExt().orElse(null) == ext
+
+        when:
+        def environment2 = builder.build()
+        def environment3 = builder.withMemory(memory + 1).build()
+
+        then:
+        environment == environment2
+        environment != environment3
+        environment.hashCode() == environment2.hashCode()
+        environment.hashCode() != environment3.hashCode()
+        environment.toString() == environment2.toString()
+        environment.toString() != environment3.toString()
+    }
+}

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/JobRequestSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/JobRequestSpec.groovy
@@ -51,7 +51,7 @@ class JobRequestSpec extends Specification {
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString()
         )
-        def requestedAgentEnvironment = new AgentEnvironmentRequest.Builder()
+        def requestedJobEnvironment = new JobEnvironmentRequest.Builder()
             .withRequestedJobCpu(3)
             .withRequestedJobMemory(10_000)
             .withRequestedEnvironmentVariables(requestedEnvironmentVariables)
@@ -76,7 +76,7 @@ class JobRequestSpec extends Specification {
             .withRequestedId(requestedId)
             .withCommandArgs(commandArgs)
             .withResources(jobResources)
-            .withRequestedAgentEnvironment(requestedAgentEnvironment)
+            .withRequestedAgentEnvironment(requestedJobEnvironment)
             .withRequestedAgentConfig(requestedAgentConfig)
             .withRequestedJobArchivalData(requestedJobArchivalData)
             .build()
@@ -88,7 +88,7 @@ class JobRequestSpec extends Specification {
         jobRequest.getCommandArgs() == commandArgs
         jobRequest.getRequestedAgentConfig() == requestedAgentConfig
         jobRequest.getResources() == jobResources
-        jobRequest.getRequestedAgentEnvironment() == requestedAgentEnvironment
+        jobRequest.getRequestedJobEnvironment() == requestedJobEnvironment
         jobRequest.getRequestedJobArchivalData() == requestedJobArchivalData
 
         when:
@@ -100,7 +100,7 @@ class JobRequestSpec extends Specification {
         !jobRequest.getRequestedId().isPresent()
         jobRequest.getCommandArgs().isEmpty()
         jobRequest.getResources() == new ExecutionEnvironment(null, null, null)
-        jobRequest.getRequestedAgentEnvironment() == new AgentEnvironmentRequest.Builder().build()
+        jobRequest.getRequestedJobEnvironment() == new JobEnvironmentRequest.Builder().build()
         jobRequest.getRequestedAgentConfig() == new AgentConfigRequest.Builder().build()
         jobRequest.getRequestedJobArchivalData() == new JobArchivalDataRequest.Builder().build()
 
@@ -118,7 +118,7 @@ class JobRequestSpec extends Specification {
         !jobRequest.getRequestedId().isPresent()
         jobRequest.getCommandArgs().isEmpty()
         jobRequest.getResources() == new ExecutionEnvironment(null, null, null)
-        jobRequest.getRequestedAgentEnvironment() == new AgentEnvironmentRequest.Builder().build()
+        jobRequest.getRequestedJobEnvironment() == new JobEnvironmentRequest.Builder().build()
         jobRequest.getRequestedAgentConfig() == new AgentConfigRequest.Builder().build()
         jobRequest.getRequestedJobArchivalData() == new JobArchivalDataRequest.Builder().build()
 
@@ -136,7 +136,7 @@ class JobRequestSpec extends Specification {
         !jobRequest.getRequestedId().isPresent()
         jobRequest.getCommandArgs().isEmpty()
         jobRequest.getResources() == new ExecutionEnvironment(null, null, null)
-        jobRequest.getRequestedAgentEnvironment() == new AgentEnvironmentRequest.Builder().build()
+        jobRequest.getRequestedJobEnvironment() == new JobEnvironmentRequest.Builder().build()
         jobRequest.getRequestedAgentConfig() == new AgentConfigRequest.Builder().build()
         jobRequest.getRequestedJobArchivalData() == new JobArchivalDataRequest.Builder().build()
     }
@@ -262,7 +262,7 @@ class JobRequestSpec extends Specification {
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString()
         )
-        def requestedAgentEnvironment = new AgentEnvironmentRequest.Builder()
+        def requestedJobEnvironment = new JobEnvironmentRequest.Builder()
             .withRequestedEnvironmentVariables(requestedEnvironmentVariables)
             .withRequestedJobCpu(2)
             .withRequestedJobMemory(10_000)
@@ -289,7 +289,7 @@ class JobRequestSpec extends Specification {
             commandArgs,
             metadata,
             criteria,
-            requestedAgentEnvironment,
+            requestedJobEnvironment,
             requestedAgentConfig,
             requestedJobArchivalData
         )
@@ -301,7 +301,7 @@ class JobRequestSpec extends Specification {
         jobRequest.getCommandArgs() == commandArgs
         jobRequest.getRequestedAgentConfig() == requestedAgentConfig
         jobRequest.getResources() == jobResources
-        jobRequest.getRequestedAgentEnvironment() == requestedAgentEnvironment
+        jobRequest.getRequestedJobEnvironment() == requestedJobEnvironment
         jobRequest.getRequestedJobArchivalData() == requestedJobArchivalData
 
         when:
@@ -322,7 +322,7 @@ class JobRequestSpec extends Specification {
         !jobRequest.getRequestedId().isPresent()
         jobRequest.getCommandArgs().isEmpty()
         jobRequest.getResources() == new ExecutionEnvironment(null, null, null)
-        jobRequest.getRequestedAgentEnvironment() == new AgentEnvironmentRequest.Builder().build()
+        jobRequest.getRequestedJobEnvironment() == new JobEnvironmentRequest.Builder().build()
         jobRequest.getRequestedAgentConfig() == new AgentConfigRequest.Builder().build()
         jobRequest.getRequestedJobArchivalData() == new JobArchivalDataRequest.Builder().build()
 
@@ -345,7 +345,7 @@ class JobRequestSpec extends Specification {
         !jobRequest.getRequestedId().isPresent()
         jobRequest.getCommandArgs().isEmpty()
         jobRequest.getResources() == new ExecutionEnvironment(null, null, null)
-        jobRequest.getRequestedAgentEnvironment() == new AgentEnvironmentRequest.Builder().build()
+        jobRequest.getRequestedJobEnvironment() == new JobEnvironmentRequest.Builder().build()
         jobRequest.getRequestedAgentConfig() == new AgentConfigRequest.Builder().build()
         jobRequest.getRequestedJobArchivalData() == new JobArchivalDataRequest.Builder().build()
     }
@@ -381,11 +381,11 @@ class JobRequestSpec extends Specification {
         when:
         def jobMetadata = Mock(JobMetadata)
         def criteria = Mock(ExecutionResourceCriteria)
-        def agentEnvironmentRequest = new AgentEnvironmentRequest.Builder().build()
+        def jobEnvironmentRequest = new JobEnvironmentRequest.Builder().build()
         def agentConfigRequest = new AgentConfigRequest.Builder().build()
         def jobArchivalDataRequest = new JobArchivalDataRequest.Builder().build()
-        base = new JobRequest(null, null, null, jobMetadata, criteria, agentEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
-        comparable = new JobRequest(null, null, null, jobMetadata, criteria, agentEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
+        base = new JobRequest(null, null, null, jobMetadata, criteria, jobEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
+        comparable = new JobRequest(null, null, null, jobMetadata, criteria, jobEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
 
         then:
         base == comparable
@@ -412,11 +412,11 @@ class JobRequestSpec extends Specification {
         when:
         def jobMetadata = Mock(JobMetadata)
         def criteria = Mock(ExecutionResourceCriteria)
-        def agentEnvironmentRequest = new AgentEnvironmentRequest.Builder().build()
+        def jobEnvironmentRequest = new JobEnvironmentRequest.Builder().build()
         def agentConfigRequest = new AgentConfigRequest.Builder().build()
         def jobArchivalDataRequest = new JobArchivalDataRequest.Builder().build()
-        one = new JobRequest(null, null, null, jobMetadata, criteria, agentEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
-        two = new JobRequest(null, null, null, jobMetadata, criteria, agentEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
+        one = new JobRequest(null, null, null, jobMetadata, criteria, jobEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
+        two = new JobRequest(null, null, null, jobMetadata, criteria, jobEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
 
         then:
         one.hashCode() == two.hashCode()
@@ -443,11 +443,11 @@ class JobRequestSpec extends Specification {
         when:
         def jobMetadata = Mock(JobMetadata)
         def criteria = Mock(ExecutionResourceCriteria)
-        def agentEnvironmentRequest = new AgentEnvironmentRequest.Builder().build()
+        def jobEnvironmentRequest = new JobEnvironmentRequest.Builder().build()
         def agentConfigRequest = new AgentConfigRequest.Builder().build()
         def jobArchivalDataRequest = new JobArchivalDataRequest.Builder().build()
-        one = new JobRequest(null, null, null, jobMetadata, criteria, agentEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
-        two = new JobRequest(null, null, null, jobMetadata, criteria, agentEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
+        one = new JobRequest(null, null, null, jobMetadata, criteria, jobEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
+        two = new JobRequest(null, null, null, jobMetadata, criteria, jobEnvironmentRequest, agentConfigRequest, jobArchivalDataRequest)
 
         then:
         one.toString() == two.toString()
@@ -474,7 +474,7 @@ class JobRequestSpec extends Specification {
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString()
         )
-        def requestedAgentEnvironment = new AgentEnvironmentRequest.Builder()
+        def requestedJobEnvironment = new JobEnvironmentRequest.Builder()
             .withRequestedEnvironmentVariables(requestedEnvironmentVariables)
             .withRequestedJobCpu(RandomSuppliers.INT.get())
             .withRequestedJobMemory(RandomSuppliers.INT.get())
@@ -498,7 +498,7 @@ class JobRequestSpec extends Specification {
             commandArgs,
             metadata,
             criteria,
-            requestedAgentEnvironment,
+            requestedJobEnvironment,
             requestedAgentConfig,
             requestedJobArchivalData
         )

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -433,46 +433,52 @@ published within the local JVM and available on the Actuator `/metrics` endpoint
 |DiskCleanupTask
 |-
 
-|genie.services.specification.clusterCommandQuery.timer
+|genie.services.jobResolver.clusterCommandQuery.timer
 |Time taken to query the database and find clusters and commands matching the supplied criteria.
 |nanoseconds
-|JobSpecificationServiceImpl
+|JobResolverServiceImpl
 |status, exceptionClass
 
-|genie.services.specification.loadBalancer.counter
+|genie.services.jobResolver.loadBalancer.counter
 |Counter for cluster load balancer algorithms invocations
 |count
-|JobSpecificationServiceImpl
+|JobResolverServiceImpl
 |class, status, clusterName, clusterId, loadBalancerClass
 
-|genie.services.specification.selectApplications.timer
+|genie.services.jobResolver.resolve.timer
+|Time taken to completely resolve the job
+|nanoseconds
+|JobResolverServiceImpl
+|status, exceptionClass, saved
+
+|genie.services.jobResolver.selectApplications.timer
 |Time taken to retrieve applications information for this task
 |nanoseconds
-|JobSpecificationServiceImpl
+|JobResolverServiceImpl
 |status, exceptionClass
 
-|genie.services.specification.selectCluster.timer
+|genie.services.jobResolver.selectCluster.timer
 |Time taken to select a cluster using the load balancing strategy
 |nanoseconds
-|JobSpecificationServiceImpl
+|JobResolverServiceImpl
 |status, exceptionClass
 
-|genie.services.specification.selectCluster.noneSelected.counter
+|genie.services.jobResolver.selectCluster.noneSelected.counter
 |Number of times the cluster load balancing terminated without selecting a cluster
 |count
-|JobSpecificationServiceImpl
+|JobResolverServiceImpl
 |-
 
-|genie.services.specification.selectCluster.noneFound.counter
+|genie.services.jobResolver.selectCluster.noneFound.counter
 |Number of times the criteria for cluster selection does not match any cluster
 |count
-|JobSpecificationServiceImpl
+|JobResolverServiceImpl
 |-
 
-|genie.services.specification.selectCommand.timer
+|genie.services.jobResolver.selectCommand.timer
 |Time taken to resolve a command based on criteria and cluster
 |nanoseconds
-|JobSpecificationServiceImpl
+|JobResolverServiceImpl
 |status, exceptionClass
 
 |genie.health.endpoint.timer

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplIntegrationTest.java
@@ -32,7 +32,7 @@ import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
 import com.netflix.genie.common.internal.dto.v4.AgentConfigRequest;
-import com.netflix.genie.common.internal.dto.v4.AgentEnvironmentRequest;
+import com.netflix.genie.common.internal.dto.v4.JobEnvironmentRequest;
 import com.netflix.genie.common.internal.dto.v4.ApiClientMetadata;
 import com.netflix.genie.common.internal.dto.v4.Application;
 import com.netflix.genie.common.internal.dto.v4.Cluster;
@@ -852,7 +852,7 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
             + "\"" + UUID.randomUUID().toString() + "\": \"" + UUID.randomUUID().toString() + "\", "
             + "\"" + UUID.randomUUID().toString() + "\": \"\""
             + "}";
-        final AgentEnvironmentRequest agentEnvironmentRequest = new AgentEnvironmentRequest
+        final JobEnvironmentRequest jobEnvironmentRequest = new JobEnvironmentRequest
             .Builder()
             .withRequestedEnvironmentVariables(requestedEnvironmentVariables)
             .withExt(GenieObjectMapper.getMapper().readTree(agentEnvironmentExt))
@@ -886,7 +886,7 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
             ),
             jobMetadata,
             criteria,
-            agentEnvironmentRequest,
+            jobEnvironmentRequest,
             agentConfigRequest,
             jobArchivalDataRequest
         );

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplIntegrationTest.java
@@ -40,6 +40,7 @@ import com.netflix.genie.common.internal.dto.v4.Criterion;
 import com.netflix.genie.common.internal.dto.v4.ExecutionEnvironment;
 import com.netflix.genie.common.internal.dto.v4.ExecutionResourceCriteria;
 import com.netflix.genie.common.internal.dto.v4.JobArchivalDataRequest;
+import com.netflix.genie.common.internal.dto.v4.JobEnvironment;
 import com.netflix.genie.common.internal.dto.v4.JobEnvironmentRequest;
 import com.netflix.genie.common.internal.dto.v4.JobMetadata;
 import com.netflix.genie.common.internal.dto.v4.JobRequest;
@@ -56,6 +57,7 @@ import com.netflix.genie.web.data.services.CommandPersistenceService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.dtos.JobSubmission;
+import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.exceptions.checked.IdAlreadyExistsException;
 import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
 import org.assertj.core.api.Assertions;
@@ -498,7 +500,12 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
             jobRequest, UUID.randomUUID().toString()
         );
 
-        this.jobPersistenceService.saveJobSpecification(jobId, jobSpecification);
+        final ResolvedJob resolvedJob = new ResolvedJob(
+            jobSpecification,
+            new JobEnvironment.Builder(1_512).build()
+        );
+
+        this.jobPersistenceService.saveResolvedJob(jobId, resolvedJob);
         Assert.assertThat(
             this.jobPersistenceService.getJobSpecification(jobId).orElse(null),
             Matchers.is(jobSpecification)
@@ -517,7 +524,11 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
 
         final JobSpecification jobSpecification2 = this.createJobSpecification(jobId2, jobRequest2, null);
 
-        this.jobPersistenceService.saveJobSpecification(jobId2, jobSpecification2);
+        final ResolvedJob resolvedJob1 = new ResolvedJob(
+            jobSpecification2,
+            new JobEnvironment.Builder(1_1512).build()
+        );
+        this.jobPersistenceService.saveResolvedJob(jobId2, resolvedJob1);
         Assert.assertThat(
             this.jobPersistenceService.getJobSpecification(jobId2).orElse(null),
             Matchers.is(jobSpecification2)
@@ -554,7 +565,11 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
             jobRequest,
             UUID.randomUUID().toString());
 
-        this.jobPersistenceService.saveJobSpecification(jobId, jobSpecification);
+        final ResolvedJob resolvedJob = new ResolvedJob(
+            jobSpecification,
+            new JobEnvironment.Builder(1_512).build()
+        );
+        this.jobPersistenceService.saveResolvedJob(jobId, resolvedJob);
 
         final JobEntity preClaimedJob = this.jobRepository
             .findByUniqueId(jobId)
@@ -616,7 +631,11 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
             jobRequest,
             UUID.randomUUID().toString());
 
-        this.jobPersistenceService.saveJobSpecification(jobId, jobSpecification);
+        final ResolvedJob resolvedJob = new ResolvedJob(
+            jobSpecification,
+            new JobEnvironment.Builder(1_512).build()
+        );
+        this.jobPersistenceService.saveResolvedJob(jobId, resolvedJob);
 
         final String agentHostname = UUID.randomUUID().toString();
         final String agentVersion = UUID.randomUUID().toString();
@@ -1054,7 +1073,7 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
     private JobSpecification createJobSpecification(
         final String jobId,
         final JobRequest jobRequest,
-        final String archiveLocation
+        @Nullable final String archiveLocation
     ) throws GenieException {
         final String clusterId = "cluster1";
         final String commandId = "command1";

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/AgentLauncher.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/AgentLauncher.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.agent.launchers;
+
+import com.netflix.genie.web.dtos.ResolvedJob;
+import com.netflix.genie.web.exceptions.checked.AgentLaunchException;
+
+/**
+ * A interface which implementations will launch instances of an agent in some manner in order to run a job.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public interface AgentLauncher {
+
+    /**
+     * Launch an agent to execute the given {@link ResolvedJob} information.
+     *
+     * @param resolvedJob The {@link ResolvedJob} information for the agent to act on
+     * @throws AgentLaunchException For any error launching an Agent instance to run the job
+     */
+    void launchAgent(ResolvedJob resolvedJob) throws AgentLaunchException;
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImpl.java
@@ -1,0 +1,169 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.agent.launchers.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.genie.web.agent.launchers.AgentLauncher;
+import com.netflix.genie.web.dtos.ResolvedJob;
+import com.netflix.genie.web.exceptions.checked.AgentLaunchException;
+import com.netflix.genie.web.properties.LocalAgentLauncherProperties;
+import com.netflix.genie.web.util.ExecutorFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecuteResultHandler;
+import org.apache.commons.exec.ExecuteException;
+import org.apache.commons.exec.Executor;
+import org.apache.commons.lang3.SystemUtils;
+
+import javax.validation.Valid;
+import java.io.IOException;
+
+/**
+ * Implementation of {@link AgentLauncher} which launched Agent instances on the local Genie hardware.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public class LocalAgentLauncherImpl implements AgentLauncher {
+
+    private static final String SETS_ID = "setsid";
+    private static final String EXEC_COMMAND = "exec";
+    private static final String SERVER_HOST_OPTION = "--serverHost";
+    private static final String SERVER_HOST_VALUE = "localhost";
+    private static final String SERVER_PORT_OPTION = "--serverPort";
+    private static final String API_JOB_OPTION = "--api-job";
+    private static final String JOB_ID_OPTION = "--jobId";
+    private static final String FULL_CLEANUP_OPTION = "--full-cleanup";
+
+    private final ExecutorFactory executorFactory;
+    private final MeterRegistry registry;
+    private final CommandLine commandTemplate;
+
+    /**
+     * Constructor.
+     *
+     * @param localAgentProperties The properties from the configuration that control agent behavior
+     * @param agentRpcPort         The port the RPC service is listening on for the agent to connect to
+     * @param executorFactory      A {@link ExecutorFactory} to create {@link org.apache.commons.exec.Executor}
+     *                             instances
+     * @param registry             Metrics repository
+     */
+    public LocalAgentLauncherImpl(
+        final LocalAgentLauncherProperties localAgentProperties,
+        final int agentRpcPort,
+        final ExecutorFactory executorFactory,
+        final MeterRegistry registry
+    ) {
+        this.executorFactory = executorFactory;
+        this.registry = registry;
+
+        final String[] agentExecutable = localAgentProperties.getExecutable().toArray(new String[0]);
+
+        if (SystemUtils.IS_OS_LINUX) {
+            this.commandTemplate = new CommandLine(SETS_ID);
+            this.commandTemplate.addArguments(agentExecutable);
+        } else {
+            this.commandTemplate = new CommandLine(agentExecutable[0]);
+            for (int i = 1; i < agentExecutable.length; i++) {
+                // Add the remaining parts of the default executable
+                this.commandTemplate.addArgument(agentExecutable[i]);
+            }
+        }
+
+        // Add the default parameters
+        this.commandTemplate.addArgument(EXEC_COMMAND);
+        this.commandTemplate.addArgument(SERVER_HOST_OPTION);
+        this.commandTemplate.addArgument(SERVER_HOST_VALUE);
+        this.commandTemplate.addArgument(SERVER_PORT_OPTION);
+        this.commandTemplate.addArgument(Integer.toString(agentRpcPort));
+        this.commandTemplate.addArgument(FULL_CLEANUP_OPTION);
+        this.commandTemplate.addArgument(API_JOB_OPTION);
+        this.commandTemplate.addArgument(JOB_ID_OPTION);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void launchAgent(@Valid final ResolvedJob resolvedJob) throws AgentLaunchException {
+        // TODO: What happens if the server crashes? Does the process live on? Make sure this is totally detached
+        final Executor executor = this.executorFactory.newInstance(true);
+        final CommandLine commandLine = new CommandLine(this.commandTemplate);
+        final String jobId = resolvedJob.getJobSpecification().getJob().getId();
+
+        // Should now come after `--jobId`
+        commandLine.addArgument(jobId);
+
+        // TODO: May not exist when agent is started so probably can't set this...?
+        // executor.setWorkingDirectory(jobSpecification.getJobDirectoryLocation());
+
+        final AgentResultHandler resultHandler = new AgentResultHandler(jobId);
+
+        try {
+            executor.execute(commandLine, resultHandler);
+        } catch (final IOException ioe) {
+            throw new AgentLaunchException(
+                "Unable to launch agent using command: " + commandLine.toString(),
+                ioe
+            );
+        }
+    }
+
+    // TODO: Likely need to handle user creation locally to match V3 behavior. Getting basics done first.
+
+    /**
+     * Simple {@link org.apache.commons.exec.ExecuteResultHandler} implementation that logs completion.
+     *
+     * @author tgianos
+     * @since 4.0.0
+     */
+    @Slf4j
+    @VisibleForTesting
+    static class AgentResultHandler extends DefaultExecuteResultHandler {
+
+        private final String jobId;
+
+        /**
+         * Constructor.
+         *
+         * @param jobId The id of the job the agent this handler is attached to is running
+         */
+        AgentResultHandler(final String jobId) {
+            this.jobId = jobId;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onProcessComplete(final int exitValue) {
+            super.onProcessComplete(exitValue);
+            log.info("Agent process for job {} completed with exit value {}", this.jobId, exitValue);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void onProcessFailed(final ExecuteException e) {
+            super.onProcessFailed(e);
+            log.error("Agent process failed for job {} due to {}", this.jobId, e.getMessage(), e);
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Implmentations of interfaces which are used to launch instances of the Genie Agent somewhere to service a job.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.web.agent.launchers.impl;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Interfaces and utilities which are used to launch instances of the Genie Agent somewhere to service a job.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.web.agent.launchers;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
@@ -26,11 +26,11 @@ import com.netflix.genie.common.internal.dto.v4.JobSpecification;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieAgentRejectedException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobSpecificationNotFoundException;
-import com.netflix.genie.web.data.services.JobPersistenceService;
+import com.netflix.genie.web.agent.inspectors.InspectionReport;
 import com.netflix.genie.web.agent.services.AgentFilterService;
 import com.netflix.genie.web.agent.services.AgentJobService;
+import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.services.JobResolverService;
-import com.netflix.genie.web.agent.inspectors.InspectionReport;
 import com.netflix.genie.web.util.MetricsUtils;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -66,10 +66,10 @@ public class AgentJobServiceImpl implements AgentJobService {
     /**
      * Constructor.
      *
-     * @param jobPersistenceService   The persistence service to use
-     * @param jobResolverService The specification service to use
-     * @param agentFilterService      The agent filter service to use
-     * @param meterRegistry           The metrics registry to use
+     * @param jobPersistenceService The persistence service to use
+     * @param jobResolverService    The specification service to use
+     * @param agentFilterService    The agent filter service to use
+     * @param meterRegistry         The metrics registry to use
      */
     public AgentJobServiceImpl(
         final JobPersistenceService jobPersistenceService,
@@ -135,7 +135,9 @@ public class AgentJobServiceImpl implements AgentJobService {
         final JobRequest jobRequest = this.jobPersistenceService
             .getJobRequest(id)
             .orElseThrow(() -> new GenieJobNotFoundException("No job request exists for job id " + id));
-        final JobSpecification jobSpecification = this.jobResolverService.resolveJob(id, jobRequest);
+        final JobSpecification jobSpecification = this.jobResolverService
+            .resolveJob(id, jobRequest)
+            .getJobSpecification();
         this.jobPersistenceService.saveJobSpecification(id, jobSpecification);
         return jobSpecification;
     }
@@ -162,7 +164,7 @@ public class AgentJobServiceImpl implements AgentJobService {
         return this.jobResolverService.resolveJob(
             jobRequest.getRequestedId().orElse(UUID.randomUUID().toString()),
             jobRequest
-        );
+        ).getJobSpecification();
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
@@ -135,7 +135,7 @@ public class AgentJobServiceImpl implements AgentJobService {
         final JobRequest jobRequest = this.jobPersistenceService
             .getJobRequest(id)
             .orElseThrow(() -> new GenieJobNotFoundException("No job request exists for job id " + id));
-        final JobSpecification jobSpecification = this.jobResolverService.resolveJobSpecification(id, jobRequest);
+        final JobSpecification jobSpecification = this.jobResolverService.resolveJob(id, jobRequest);
         this.jobPersistenceService.saveJobSpecification(id, jobSpecification);
         return jobSpecification;
     }
@@ -159,7 +159,7 @@ public class AgentJobServiceImpl implements AgentJobService {
     @Override
     @Transactional(readOnly = true)
     public JobSpecification dryRunJobSpecificationResolution(@Valid final JobRequest jobRequest) {
-        return this.jobResolverService.resolveJobSpecification(
+        return this.jobResolverService.resolveJob(
             jobRequest.getRequestedId().orElse(UUID.randomUUID().toString()),
             jobRequest
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
@@ -33,6 +33,7 @@ import com.netflix.genie.web.agent.services.AgentFilterService;
 import com.netflix.genie.web.agent.services.AgentJobService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.dtos.JobSubmission;
+import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.exceptions.checked.IdAlreadyExistsException;
 import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
 import com.netflix.genie.web.services.JobResolverService;
@@ -150,11 +151,9 @@ public class AgentJobServiceImpl implements AgentJobService {
         final JobRequest jobRequest = this.jobPersistenceService
             .getJobRequest(id)
             .orElseThrow(() -> new GenieJobNotFoundException("No job request exists for job id " + id));
-        final JobSpecification jobSpecification = this.jobResolverService
-            .resolveJob(id, jobRequest)
-            .getJobSpecification();
-        this.jobPersistenceService.saveJobSpecification(id, jobSpecification);
-        return jobSpecification;
+        final ResolvedJob resolvedJob = this.jobResolverService.resolveJob(id, jobRequest);
+        this.jobPersistenceService.saveResolvedJob(id, resolvedJob);
+        return resolvedJob.getJobSpecification();
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/DtoConverters.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.ClusterCriteria;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.internal.dto.v4.AgentConfigRequest;
-import com.netflix.genie.common.internal.dto.v4.AgentEnvironmentRequest;
 import com.netflix.genie.common.internal.dto.v4.Application;
 import com.netflix.genie.common.internal.dto.v4.ApplicationMetadata;
 import com.netflix.genie.common.internal.dto.v4.ApplicationRequest;
@@ -37,6 +36,7 @@ import com.netflix.genie.common.internal.dto.v4.Criterion;
 import com.netflix.genie.common.internal.dto.v4.ExecutionEnvironment;
 import com.netflix.genie.common.internal.dto.v4.ExecutionResourceCriteria;
 import com.netflix.genie.common.internal.dto.v4.JobArchivalDataRequest;
+import com.netflix.genie.common.internal.dto.v4.JobEnvironmentRequest;
 import com.netflix.genie.common.internal.dto.v4.JobMetadata;
 import com.netflix.genie.common.internal.dto.v4.JobRequest;
 import org.apache.commons.lang3.StringUtils;
@@ -380,9 +380,9 @@ public final class DtoConverters {
             v3JobRequest.getApplications()
         );
 
-        final AgentEnvironmentRequest.Builder agentEnvironmentBuilder = new AgentEnvironmentRequest.Builder();
-        v3JobRequest.getCpu().ifPresent(agentEnvironmentBuilder::withRequestedJobCpu);
-        v3JobRequest.getMemory().ifPresent(agentEnvironmentBuilder::withRequestedJobMemory);
+        final JobEnvironmentRequest.Builder jobEnvironmentBuilder = new JobEnvironmentRequest.Builder();
+        v3JobRequest.getCpu().ifPresent(jobEnvironmentBuilder::withRequestedJobCpu);
+        v3JobRequest.getMemory().ifPresent(jobEnvironmentBuilder::withRequestedJobMemory);
 
         final AgentConfigRequest.Builder agentConfigBuilder = new AgentConfigRequest
             .Builder()
@@ -400,7 +400,7 @@ public final class DtoConverters {
             commandArgs,
             metadataBuilder.build(),
             criteria,
-            agentEnvironmentBuilder.build(),
+            jobEnvironmentBuilder.build(),
             agentConfigBuilder.build(),
             jobArchivalDataRequestBuilder.build()
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/data/entities/v4/EntityDtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/entities/v4/EntityDtoConverters.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.internal.dto.v4.AgentConfigRequest;
-import com.netflix.genie.common.internal.dto.v4.AgentEnvironmentRequest;
+import com.netflix.genie.common.internal.dto.v4.JobEnvironmentRequest;
 import com.netflix.genie.common.internal.dto.v4.Application;
 import com.netflix.genie.common.internal.dto.v4.ApplicationMetadata;
 import com.netflix.genie.common.internal.dto.v4.Cluster;
@@ -236,14 +236,14 @@ public final class EntityDtoConverters {
             .ifPresent(jobArchivalDataRequestBuilder::withRequestedArchiveLocationPrefix);
 
         // Rebuild the Agent Environment Request
-        final AgentEnvironmentRequest.Builder agentEnvironmentRequestBuilder = new AgentEnvironmentRequest.Builder();
+        final JobEnvironmentRequest.Builder jobEnvironmentRequestBuilder = new JobEnvironmentRequest.Builder();
         jobRequestProjection
             .getRequestedAgentEnvironmentExt()
-            .ifPresent(ext -> setJsonField(ext, agentEnvironmentRequestBuilder::withExt));
-        agentEnvironmentRequestBuilder
+            .ifPresent(ext -> setJsonField(ext, jobEnvironmentRequestBuilder::withExt));
+        jobEnvironmentRequestBuilder
             .withRequestedEnvironmentVariables(jobRequestProjection.getRequestedEnvironmentVariables());
-        jobRequestProjection.getRequestedCpu().ifPresent(agentEnvironmentRequestBuilder::withRequestedJobCpu);
-        jobRequestProjection.getRequestedMemory().ifPresent(agentEnvironmentRequestBuilder::withRequestedJobMemory);
+        jobRequestProjection.getRequestedCpu().ifPresent(jobEnvironmentRequestBuilder::withRequestedJobCpu);
+        jobRequestProjection.getRequestedMemory().ifPresent(jobEnvironmentRequestBuilder::withRequestedJobMemory);
 
         return new JobRequest(
             requestedId,
@@ -251,7 +251,7 @@ public final class EntityDtoConverters {
             jobRequestProjection.getCommandArgs(),
             jobMetadataBuilder.build(),
             executionResourceCriteria,
-            agentEnvironmentRequestBuilder.build(),
+            jobEnvironmentRequestBuilder.build(),
             agentConfigRequestBuilder.build(),
             jobArchivalDataRequestBuilder.build()
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/JobPersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/JobPersistenceService.java
@@ -24,12 +24,10 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
 import com.netflix.genie.common.internal.dto.v4.JobRequest;
-import com.netflix.genie.common.internal.dto.v4.JobRequestMetadata;
 import com.netflix.genie.common.internal.dto.v4.JobSpecification;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieApplicationNotFoundException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieClusterNotFoundException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieCommandNotFoundException;
-import com.netflix.genie.common.internal.exceptions.unchecked.GenieIdAlreadyExistsException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieInvalidStatusException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobAlreadyClaimedException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
@@ -183,20 +181,6 @@ public interface JobPersistenceService {
     String saveJobSubmission(@Valid JobSubmission jobSubmission) throws
         IdAlreadyExistsException,
         SaveAttachmentException;
-
-    /**
-     * Save the job request information.
-     *
-     * @param jobRequest         All the metadata provided by the user about the job
-     * @param jobRequestMetadata Metadata about the request gathered by the system not provided by the user
-     * @return The id that was reserved in the system for this job
-     * @throws GenieIdAlreadyExistsException When the requested ID is already in use
-     * @throws GenieRuntimeException         On other type of error
-     */
-    String saveJobRequest(
-        @Valid JobRequest jobRequest,
-        @Valid JobRequestMetadata jobRequestMetadata
-    );
 
     /**
      * Get the original request for a job.

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/JobPersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/JobPersistenceService.java
@@ -33,6 +33,7 @@ import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobAlreadyCla
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieRuntimeException;
 import com.netflix.genie.web.dtos.JobSubmission;
+import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.exceptions.checked.IdAlreadyExistsException;
 import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
 import org.springframework.validation.annotation.Validated;
@@ -192,10 +193,10 @@ public interface JobPersistenceService {
     Optional<JobRequest> getJobRequest(@NotBlank(message = "Id is missing and is required") String id);
 
     /**
-     * Save the given job specification details for a job. Sets the job status to {@link JobStatus#RESOLVED}.
+     * Save the given resolved details for a job. Sets the job status to {@link JobStatus#RESOLVED}.
      *
-     * @param id            The id of the job
-     * @param specification The job specification
+     * @param id          The id of the job
+     * @param resolvedJob The resolved information for the job
      * @throws GenieJobNotFoundException         When the job identified by {@code id} can't be found and the
      *                                           specification can't be saved
      * @throws GenieClusterNotFoundException     When the cluster specified in the job specification doesn't actually
@@ -205,9 +206,9 @@ public interface JobPersistenceService {
      * @throws GenieApplicationNotFoundException When an application specified in the job specification doesn't
      *                                           actually exist
      */
-    void saveJobSpecification(
+    void saveResolvedJob(
         @NotBlank(message = "Id is missing and is required") String id,
-        @Valid JobSpecification specification
+        @Valid ResolvedJob resolvedJob
     );
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
@@ -29,11 +29,11 @@ import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata;
 import com.netflix.genie.common.internal.dto.v4.AgentConfigRequest;
-import com.netflix.genie.common.internal.dto.v4.AgentEnvironmentRequest;
 import com.netflix.genie.common.internal.dto.v4.Criterion;
 import com.netflix.genie.common.internal.dto.v4.ExecutionEnvironment;
 import com.netflix.genie.common.internal.dto.v4.ExecutionResourceCriteria;
 import com.netflix.genie.common.internal.dto.v4.JobArchivalDataRequest;
+import com.netflix.genie.common.internal.dto.v4.JobEnvironmentRequest;
 import com.netflix.genie.common.internal.dto.v4.JobMetadata;
 import com.netflix.genie.common.internal.dto.v4.JobRequest;
 import com.netflix.genie.common.internal.dto.v4.JobRequestMetadata;
@@ -335,7 +335,7 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
         this.setJobMetadataFields(jobEntity, jobRequest.getMetadata());
         this.setExecutionEnvironmentFields(jobEntity, jobRequest.getResources());
         this.setExecutionResourceCriteriaFields(jobEntity, jobRequest.getCriteria());
-        this.setRequestedAgentEnvironmentFields(jobEntity, jobRequest.getRequestedAgentEnvironment());
+        this.setRequestedJobEnvironmentFields(jobEntity, jobRequest.getRequestedJobEnvironment());
         this.setRequestedAgentConfigFields(jobEntity, jobRequest.getRequestedAgentConfig());
         this.setRequestedJobArchivalData(jobEntity, jobRequest.getRequestedJobArchivalData());
         this.setRequestMetadataFields(jobEntity, jobRequestMetadata);
@@ -807,14 +807,14 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
         jobEntity.setRequestedApplications(criteria.getApplicationIds());
     }
 
-    private void setRequestedAgentEnvironmentFields(
+    private void setRequestedJobEnvironmentFields(
         final JobEntity jobEntity,
-        final AgentEnvironmentRequest requestedAgentEnvironment
+        final JobEnvironmentRequest requestedJobEnvironment
     ) {
-        jobEntity.setRequestedEnvironmentVariables(requestedAgentEnvironment.getRequestedEnvironmentVariables());
-        requestedAgentEnvironment.getRequestedJobMemory().ifPresent(jobEntity::setRequestedMemory);
-        requestedAgentEnvironment.getRequestedJobCpu().ifPresent(jobEntity::setRequestedCpu);
-        final Optional<JsonNode> agentEnvironmentExt = requestedAgentEnvironment.getExt();
+        jobEntity.setRequestedEnvironmentVariables(requestedJobEnvironment.getRequestedEnvironmentVariables());
+        requestedJobEnvironment.getRequestedJobMemory().ifPresent(jobEntity::setRequestedMemory);
+        requestedJobEnvironment.getRequestedJobCpu().ifPresent(jobEntity::setRequestedCpu);
+        final Optional<JsonNode> agentEnvironmentExt = requestedJobEnvironment.getExt();
         agentEnvironmentExt.ifPresent(
             jsonNode -> EntityDtoConverters.setJsonField(jsonNode, jobEntity::setRequestedAgentEnvironmentExt)
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
@@ -41,7 +41,6 @@ import com.netflix.genie.common.internal.dto.v4.JobSpecification;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieApplicationNotFoundException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieClusterNotFoundException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieCommandNotFoundException;
-import com.netflix.genie.common.internal.exceptions.unchecked.GenieIdAlreadyExistsException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieInvalidStatusException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobAlreadyClaimedException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
@@ -382,26 +381,6 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
                 "A job with id " + jobEntity.getUniqueId() + " already exists. Unable to reserve id.",
                 e
             );
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String saveJobRequest(
-        @Valid final JobRequest jobRequest,
-        @Valid final JobRequestMetadata jobRequestMetadata
-    ) {
-        // TODO: Remove this in favor of saveJobSubmission once that API is stable
-        log.debug("Attempting to save job request {} with request metadata {}", jobRequest, jobRequestMetadata);
-        // Persist. Catch exception if the ID is reused
-        try {
-            return this.saveJobSubmission(new JobSubmission.Builder(jobRequest, jobRequestMetadata).build());
-        } catch (final IdAlreadyExistsException e) {
-            throw new GenieIdAlreadyExistsException(e);
-        } catch (final SaveAttachmentException e) {
-            throw new GenieRuntimeException(e);
         }
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/dtos/ApiJobSubmission.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/dtos/ApiJobSubmission.java
@@ -1,0 +1,138 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.dtos;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.netflix.genie.common.internal.dto.v4.JobRequest;
+import com.netflix.genie.common.internal.dto.v4.JobRequestMetadata;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.core.io.Resource;
+
+import javax.annotation.Nullable;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * The payload of all gathered information from a user request to run a job via the API.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Getter
+@EqualsAndHashCode(
+    doNotUseGetters = true,
+    of = {
+        // Exclude the attachments to save on scanning bytes
+        "jobRequest",
+        "jobRequestMetadata"
+    }
+)
+@ToString(
+    doNotUseGetters = true,
+    of = {
+        // Exclude the attachments to save on scanning bytes
+        "jobRequest",
+        "jobRequestMetadata"
+    }
+)
+@SuppressWarnings("FinalClass")
+public class ApiJobSubmission {
+
+    @NotNull
+    @Valid
+    private final JobRequest jobRequest;
+    @NotNull
+    @Valid
+    private final JobRequestMetadata jobRequestMetadata;
+    @NotNull
+    private final Set<Resource> attachments;
+
+    private ApiJobSubmission(final Builder builder) {
+        this.jobRequest = builder.bJobRequest;
+        this.jobRequestMetadata = builder.bJobRequestMetadata;
+        this.attachments = ImmutableSet.copyOf(builder.bAttachments);
+    }
+
+    /**
+     * Builder for {@link ApiJobSubmission} instances.
+     *
+     * @author tgianos
+     * @since 4.0.0
+     */
+    public static class Builder {
+        private final JobRequest bJobRequest;
+        private final JobRequestMetadata bJobRequestMetadata;
+        private final Set<Resource> bAttachments;
+
+        /**
+         * Constructor with required parameters.
+         *
+         * @param jobRequest         The job request metadata entered by the user
+         * @param jobRequestMetadata The metadata collected by the system about the request
+         */
+        public Builder(final JobRequest jobRequest, final JobRequestMetadata jobRequestMetadata) {
+            this.bJobRequest = jobRequest;
+            this.bJobRequestMetadata = jobRequestMetadata;
+            this.bAttachments = Sets.newHashSet();
+        }
+
+        /**
+         * Set the attachments associated with this submission if there were any.
+         *
+         * @param attachments The attachments as {@link Resource} instances
+         * @return the builder
+         */
+        public Builder withAttachments(@Nullable final Set<Resource> attachments) {
+            this.setAttachments(attachments);
+            return this;
+        }
+
+        /**
+         * Set the attachments associated with this submission.
+         *
+         * @param attachments The attachments as {@link Resource} instances
+         * @return the builder
+         */
+        public Builder withAttachments(final Resource... attachments) {
+            this.setAttachments(Arrays.asList(attachments));
+            return this;
+        }
+
+        /**
+         * Build an immutable {@link ApiJobSubmission} instance based on the current contents of this builder.
+         *
+         * @return An {@link ApiJobSubmission} instance
+         */
+        public ApiJobSubmission build() {
+            return new ApiJobSubmission(this);
+        }
+
+        private void setAttachments(@Nullable final Collection<Resource> attachments) {
+            this.bAttachments.clear();
+            if (attachments != null) {
+                this.bAttachments.addAll(attachments);
+            }
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/dtos/JobSubmission.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/dtos/JobSubmission.java
@@ -57,7 +57,7 @@ import java.util.Set;
     }
 )
 @SuppressWarnings("FinalClass")
-public class ApiJobSubmission {
+public class JobSubmission {
 
     @NotNull
     @Valid
@@ -68,14 +68,14 @@ public class ApiJobSubmission {
     @NotNull
     private final Set<Resource> attachments;
 
-    private ApiJobSubmission(final Builder builder) {
+    private JobSubmission(final Builder builder) {
         this.jobRequest = builder.bJobRequest;
         this.jobRequestMetadata = builder.bJobRequestMetadata;
         this.attachments = ImmutableSet.copyOf(builder.bAttachments);
     }
 
     /**
-     * Builder for {@link ApiJobSubmission} instances.
+     * Builder for {@link JobSubmission} instances.
      *
      * @author tgianos
      * @since 4.0.0
@@ -120,12 +120,12 @@ public class ApiJobSubmission {
         }
 
         /**
-         * Build an immutable {@link ApiJobSubmission} instance based on the current contents of this builder.
+         * Build an immutable {@link JobSubmission} instance based on the current contents of this builder.
          *
-         * @return An {@link ApiJobSubmission} instance
+         * @return An {@link JobSubmission} instance
          */
-        public ApiJobSubmission build() {
-            return new ApiJobSubmission(this);
+        public JobSubmission build() {
+            return new JobSubmission(this);
         }
 
         private void setAttachments(@Nullable final Collection<Resource> attachments) {

--- a/genie-web/src/main/java/com/netflix/genie/web/dtos/ResolvedJob.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/dtos/ResolvedJob.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.dtos;
+
+import com.netflix.genie.common.internal.dto.v4.JobEnvironment;
+import com.netflix.genie.common.internal.dto.v4.JobSpecification;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/**
+ * The payload of information representing all the concrete details the system needs to run a job.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode(doNotUseGetters = true)
+@ToString(doNotUseGetters = true)
+@SuppressWarnings("FinalClass")
+public class ResolvedJob {
+
+    private final JobSpecification jobSpecification;
+    private final JobEnvironment jobEnvironment;
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/dtos/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/dtos/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Immutable DTOs specifically used by the web server.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.web.dtos;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/java/com/netflix/genie/web/exceptions/checked/IdAlreadyExistsException.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/exceptions/checked/IdAlreadyExistsException.java
@@ -1,0 +1,54 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.exceptions.checked;
+
+/**
+ * Exception thrown when an resource is attempting to be saved with a unique ID that already exists in the system.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public class IdAlreadyExistsException extends Exception {
+    /**
+     * Constructor.
+     *
+     * @param message The detail message
+     */
+    public IdAlreadyExistsException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message The detail message
+     * @param cause   The root cause of this exception
+     */
+    public IdAlreadyExistsException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cause The root cause of this exception
+     */
+    public IdAlreadyExistsException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/exceptions/checked/SaveAttachmentException.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/exceptions/checked/SaveAttachmentException.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.exceptions.checked;
+
+/**
+ * Exception thrown when the system tries to save a user attachment to an underlying data store and it fails for
+ * some reason.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public class SaveAttachmentException extends Exception {
+    /**
+     * Constructor.
+     *
+     * @param message The detail message
+     */
+    public SaveAttachmentException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message The detail message
+     * @param cause   The root cause of this exception
+     */
+    public SaveAttachmentException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cause The root cause of this exception
+     */
+    public SaveAttachmentException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/LocalAgentLauncherProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/LocalAgentLauncherProperties.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import com.google.common.collect.Lists;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+
+/**
+ * Properties related to launching Agent processes locally.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@ConfigurationProperties(prefix = LocalAgentLauncherProperties.PROPERTY_PREFIX)
+@Getter
+@Setter
+@Validated
+public class LocalAgentLauncherProperties {
+
+    /**
+     * Prefix for all properties related to the local agent launcher.
+     */
+    public static final String PROPERTY_PREFIX = "genie.agent.launcher.local";
+
+    /**
+     * The command that should be run to execute the Genie agent. Required.
+     */
+    @NotEmpty
+    private List<@NotBlank String> executable = Lists.newArrayList("java", "-jar", "/tmp/genie-agent.jar");
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/AttachmentService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/AttachmentService.java
@@ -18,13 +18,16 @@
 package com.netflix.genie.web.services;
 
 import com.netflix.genie.common.exceptions.GenieException;
+import org.springframework.core.io.Resource;
 import org.springframework.validation.annotation.Validated;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * APIs for dealing with attachments sent in with Genie requests. Implementations will handle where to store them and
@@ -96,4 +99,23 @@ public interface AttachmentService {
      * @throws IOException On error during deletion
      */
     void deleteAll(String id) throws IOException;
+
+    /**
+     * Given the id of a job and the set of attachments associated with that job this API should save the attachments
+     * somewhere that the agent can access as job dependencies once the job runs.
+     *
+     * @param jobId       The id of the job these attachments are for
+     * @param attachments The attachments sent by the user
+     * @return The set of {@link URI} where the attachments were saved
+     * @throws IOException on error when an attachment is attempted to be saved to the underlying storage
+     */
+    Set<URI> saveAttachments(String jobId, Set<Resource> attachments) throws IOException;
+
+    /**
+     * Given the id of a job delete all the attachments that were saved for it.
+     *
+     * @param jobId The id of the job to delete attachments for
+     * @throws IOException on error while deleting the attachments
+     */
+    void deleteAttachments(String jobId) throws IOException;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/AttachmentService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/AttachmentService.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.services;
 
 import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
 import org.springframework.core.io.Resource;
 import org.springframework.validation.annotation.Validated;
 
@@ -107,9 +108,9 @@ public interface AttachmentService {
      * @param jobId       The id of the job these attachments are for
      * @param attachments The attachments sent by the user
      * @return The set of {@link URI} where the attachments were saved
-     * @throws IOException on error when an attachment is attempted to be saved to the underlying storage
+     * @throws SaveAttachmentException on error when an attachment is attempted to be saved to the underlying storage
      */
-    Set<URI> saveAttachments(String jobId, Set<Resource> attachments) throws IOException;
+    Set<URI> saveAttachments(String jobId, Set<Resource> attachments) throws SaveAttachmentException;
 
     /**
      * Given the id of a job delete all the attachments that were saved for it.

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobLaunchService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobLaunchService.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services;
+
+import com.netflix.genie.web.dtos.JobSubmission;
+import com.netflix.genie.web.exceptions.checked.AgentLaunchException;
+import org.springframework.validation.annotation.Validated;
+
+import javax.annotation.Nonnull;
+import javax.validation.Valid;
+
+/**
+ * Top level coordination service responsible for taking a job request and running the job if possible.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Validated
+public interface JobLaunchService {
+
+    /**
+     * Launches a job on behalf of the user.
+     * <p>
+     * Given the information submitted to Genie this service will attempt to run the job which will include:
+     * - Saving the job submission information including attachments
+     * - Resolving the resources needed to run the job and persisting them
+     * - Launching the agent
+     *
+     * @param jobSubmission The payload of metadata and resources making up all the information needed to launch
+     *                      a job
+     * @return The id of the job. Upon return the job will at least be in
+     * {@link com.netflix.genie.common.dto.JobStatus#ACCEPTED} state
+     * @throws AgentLaunchException If the system was unable to launch an agent to handle job execution
+     */
+    @Nonnull
+    String launchJob(@Valid JobSubmission jobSubmission) throws AgentLaunchException;
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
@@ -18,7 +18,7 @@
 package com.netflix.genie.web.services;
 
 import com.netflix.genie.common.internal.dto.v4.JobRequest;
-import com.netflix.genie.common.internal.dto.v4.JobSpecification;
+import com.netflix.genie.web.dtos.ResolvedJob;
 import org.springframework.validation.annotation.Validated;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -40,7 +40,7 @@ public interface JobResolverService {
      *
      * @param id         The id of the job
      * @param jobRequest The job request containing all details a user wants to have for their job
-     * @return The complete job specification
+     * @return The completely resolved job information within a {@link ResolvedJob} instance
      */
-    JobSpecification resolveJob(String id, @Valid JobRequest jobRequest);
+    ResolvedJob resolveJob(String id, @Valid JobRequest jobRequest);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
@@ -32,7 +32,7 @@ import javax.validation.Valid;
  */
 @ParametersAreNonnullByDefault
 @Validated
-public interface JobSpecificationService {
+public interface JobResolverService {
 
     /**
      * Given a job request resolve all the details needed for a complete job specification can be run by the user.

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
@@ -25,7 +25,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import javax.validation.Valid;
 
 /**
- * Service API definition and helper methods for working with Genie Job Specifications to be used by the Agent.
+ * Service API for taking inputs from a user and resolving them to concrete information that the Genie system will use
+ * to execute the users job.
  *
  * @author tgianos
  * @since 4.0.0
@@ -35,11 +36,11 @@ import javax.validation.Valid;
 public interface JobResolverService {
 
     /**
-     * Given a job request resolve all the details needed for a complete job specification can be run by the user.
+     * Given a job request resolve all the details needed to run a job.
      *
      * @param id         The id of the job
      * @param jobRequest The job request containing all details a user wants to have for their job
      * @return The complete job specification
      */
-    JobSpecification resolveJobSpecification(String id, @Valid JobRequest jobRequest);
+    JobSpecification resolveJob(String id, @Valid JobRequest jobRequest);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
@@ -17,11 +17,13 @@
  */
 package com.netflix.genie.web.services;
 
+import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.internal.dto.v4.JobRequest;
+import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
 import com.netflix.genie.web.dtos.ResolvedJob;
 import org.springframework.validation.annotation.Validated;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.Nonnull;
 import javax.validation.Valid;
 
 /**
@@ -31,16 +33,29 @@ import javax.validation.Valid;
  * @author tgianos
  * @since 4.0.0
  */
-@ParametersAreNonnullByDefault
 @Validated
 public interface JobResolverService {
 
     /**
-     * Given a job request resolve all the details needed to run a job.
+     * Given the id of a job that was successfully submitted to the system this API will attempt to resolve all the
+     * concrete details (cluster, command, resources, etc) needed for the system to actually launch the job. Once these
+     * details are determined they are persisted and the job is marked as {@link JobStatus#RESOLVED}.
+     *
+     * @param id The id of the job to resolve. The job must exist and its status must return {@literal true} from
+     *           {@link JobStatus#isResolvable()}
+     * @return A {@link ResolvedJob} instance containing all the concrete information needed to execute the job
+     * @throws GenieJobNotFoundException When there is no job with {@literal id} in the system
+     */
+    @Nonnull
+    ResolvedJob resolveJob(String id) throws GenieJobNotFoundException; // TODO: Fix exception type thrown
+
+    /**
+     * Given a job request resolve all the details needed to run a job. This API is stateless and saves nothing.
      *
      * @param id         The id of the job
      * @param jobRequest The job request containing all details a user wants to have for their job
      * @return The completely resolved job information within a {@link ResolvedJob} instance
      */
+    @Nonnull
     ResolvedJob resolveJob(String id, @Valid JobRequest jobRequest);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/FileSystemAttachmentService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/FileSystemAttachmentService.java
@@ -176,6 +176,9 @@ public class FileSystemAttachmentService implements AttachmentService {
     }
 
     private Set<URI> writeAttachments(final String id, final Set<Resource> attachments) throws IOException {
+        if (attachments.isEmpty()) {
+            return ImmutableSet.of();
+        }
         final Path requestDir = Files.createDirectories(this.attachmentDirectory.resolve(id));
         final ImmutableSet.Builder<URI> uris = ImmutableSet.builder();
 

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/FileSystemAttachmentService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/FileSystemAttachmentService.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
 import com.netflix.genie.web.services.AttachmentService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -154,8 +155,15 @@ public class FileSystemAttachmentService implements AttachmentService {
      * {@inheritDoc}
      */
     @Override
-    public Set<URI> saveAttachments(final String jobId, final Set<Resource> attachments) throws IOException {
-        return this.writeAttachments(jobId, attachments);
+    public Set<URI> saveAttachments(
+        final String jobId,
+        final Set<Resource> attachments
+    ) throws SaveAttachmentException {
+        try {
+            return this.writeAttachments(jobId, attachments);
+        } catch (final IOException ioe) {
+            throw new SaveAttachmentException(ioe);
+        }
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -191,7 +191,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
             log.info("Finding possible clusters and commands for job {}", jobRequest.getId().orElse(NO_ID_FOUND));
             final JobSpecification jobSpecification;
             try {
-                jobSpecification = this.jobResolverService.resolveJobSpecification(
+                jobSpecification = this.jobResolverService.resolveJob(
                     jobId,
                     DtoConverters.toV4JobRequest(jobRequest)
                 );

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -194,7 +194,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
                 jobSpecification = this.jobResolverService.resolveJob(
                     jobId,
                     DtoConverters.toV4JobRequest(jobRequest)
-                );
+                ).getJobSpecification();
             } catch (final RuntimeException re) {
                 //TODO: Here for now as we figure out what to do with exceptions for JobResolverServiceImpl
                 throw new GeniePreconditionException(re.getMessage(), re);

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -45,7 +45,7 @@ import com.netflix.genie.web.properties.JobsActiveLimitProperties;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.JobCoordinatorService;
 import com.netflix.genie.web.services.JobKillService;
-import com.netflix.genie.web.services.JobSpecificationService;
+import com.netflix.genie.web.services.JobResolverService;
 import com.netflix.genie.web.services.JobStateService;
 import com.netflix.genie.web.util.MetricsConstants;
 import com.netflix.genie.web.util.MetricsUtils;
@@ -84,7 +84,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
     private final JobSearchService jobSearchService;
     private final ClusterPersistenceService clusterPersistenceService;
     private final CommandPersistenceService commandPersistenceService;
-    private final JobSpecificationService specificationService;
+    private final JobResolverService jobResolverService;
     private final JobsProperties jobsProperties;
     private final String hostname;
 
@@ -103,7 +103,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
      * @param jobSearchService              Implementation of job search service
      * @param clusterPersistenceService     Implementation of cluster service interface
      * @param commandPersistenceService     Implementation of command service interface
-     * @param specificationService          The job specification service to use
+     * @param jobResolverService            The job specification service to use
      * @param registry                      The registry
      * @param hostname                      The name of the host this Genie instance is running on
      */
@@ -116,7 +116,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
         @NotNull final JobSearchService jobSearchService,
         @NotNull final ClusterPersistenceService clusterPersistenceService,
         @NotNull final CommandPersistenceService commandPersistenceService,
-        @NotNull final JobSpecificationService specificationService,
+        @NotNull final JobResolverService jobResolverService,
         @NotNull final MeterRegistry registry,
         @NotBlank final String hostname
     ) {
@@ -127,7 +127,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
         this.jobSearchService = jobSearchService;
         this.clusterPersistenceService = clusterPersistenceService;
         this.commandPersistenceService = commandPersistenceService;
-        this.specificationService = specificationService;
+        this.jobResolverService = jobResolverService;
         this.jobsProperties = jobsProperties;
         this.hostname = hostname;
 
@@ -191,12 +191,12 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
             log.info("Finding possible clusters and commands for job {}", jobRequest.getId().orElse(NO_ID_FOUND));
             final JobSpecification jobSpecification;
             try {
-                jobSpecification = this.specificationService.resolveJobSpecification(
+                jobSpecification = this.jobResolverService.resolveJobSpecification(
                     jobId,
                     DtoConverters.toV4JobRequest(jobRequest)
                 );
             } catch (final RuntimeException re) {
-                //TODO: Here for now as we figure out what to do with exceptions for JobSpecificationServiceImpl
+                //TODO: Here for now as we figure out what to do with exceptions for JobResolverServiceImpl
                 throw new GeniePreconditionException(re.getMessage(), re);
             }
             final Cluster cluster = this.clusterPersistenceService.getCluster(jobSpecification.getCluster().getId());

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
@@ -1,0 +1,150 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl;
+
+import com.google.common.collect.Sets;
+import com.netflix.genie.common.dto.JobStatus;
+import com.netflix.genie.web.agent.launchers.AgentLauncher;
+import com.netflix.genie.web.data.services.JobPersistenceService;
+import com.netflix.genie.web.dtos.JobSubmission;
+import com.netflix.genie.web.dtos.ResolvedJob;
+import com.netflix.genie.web.exceptions.checked.AgentLaunchException;
+import com.netflix.genie.web.services.JobLaunchService;
+import com.netflix.genie.web.services.JobResolverService;
+import com.netflix.genie.web.util.MetricsUtils;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nonnull;
+import javax.validation.Valid;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Default implementation of the {@link JobLaunchService}.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Slf4j
+public class JobLaunchServiceImpl implements JobLaunchService {
+
+    private static final String LAUNCH_JOB_TIMER = "genie.services.jobLaunch.launchJob.timer";
+
+    private final JobPersistenceService jobPersistenceService;
+    private final JobResolverService jobResolverService;
+    private final AgentLauncher agentLauncher;
+    private final MeterRegistry registry;
+
+    /**
+     * Constructor.
+     *
+     * @param jobPersistenceService {@link JobPersistenceService} implementation to save job data
+     * @param jobResolverService    {@link JobResolverService} implementation used to resolve job details
+     * @param agentLauncher         {@link AgentLauncher} implementation to launch agents
+     * @param registry              {@link MeterRegistry} metrics repository
+     */
+    public JobLaunchServiceImpl(
+        final JobPersistenceService jobPersistenceService,
+        final JobResolverService jobResolverService,
+        final AgentLauncher agentLauncher,
+        final MeterRegistry registry
+    ) {
+        this.jobPersistenceService = jobPersistenceService;
+        this.jobResolverService = jobResolverService;
+        this.agentLauncher = agentLauncher;
+        this.registry = registry;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Nonnull
+    public String launchJob(@Valid final JobSubmission jobSubmission) throws AgentLaunchException {
+        final long start = System.nanoTime();
+        final Set<Tag> tags = Sets.newHashSet();
+        try {
+            /*
+             * Steps:
+             *
+             * 1. Save the job information
+             * 2. Attempt to resolve the job information (includes saving)
+             * 3. Mark the job as accepted
+             * 4. Launch the agent process given the implementation configured for this Genie instance
+             * 5. If the agent launch fails mark the job failed else return
+             */
+
+            final String jobId;
+            try {
+                jobId = this.jobPersistenceService.saveJobSubmission(jobSubmission);
+            } catch (final Throwable t) {
+                // TODO: Really handle this error
+                log.error("TODO", t);
+                throw new AgentLaunchException(t);
+            }
+
+            final ResolvedJob resolvedJob;
+            try {
+                resolvedJob = this.jobResolverService.resolveJob(jobId);
+            } catch (final Throwable t) {
+                // TODO: Clean this up. Mark job as failed?
+                //       Probably should do that in a global catch
+                throw new AgentLaunchException(t);
+            }
+
+            // Job state should be RESOLVED now. Mark it ACCEPTED to avoid race condition with agent starting up
+            // before we get return from launchAgent and trying to set it to CLAIMED
+            try {
+                this.jobPersistenceService.updateJobStatus(
+                    jobId,
+                    JobStatus.RESOLVED,
+                    JobStatus.ACCEPTED,
+                    "The job has been accepted by the system for execution"
+                );
+            } catch (final Throwable t) {
+                // TODO: Failed to update the status to accepted. Try to set it to failed or rely on other cleanup
+                //       mechanism?
+                throw new AgentLaunchException(t);
+            }
+
+            // Already throws an exception
+            try {
+                this.agentLauncher.launchAgent(resolvedJob);
+            } catch (final AgentLaunchException e) {
+                // TODO: this could fail as well
+                this.jobPersistenceService.updateJobStatus(jobId, JobStatus.ACCEPTED, JobStatus.FAILED, e.getMessage());
+                // TODO: How will we get the ID back to the user? Should we add it to an exception? We don't get
+                //       We don't get the ID until after saveJobSubmission so if that fails we'd still return nothing
+                //       Probably need multiple exceptions to be thrown from this API (if we go with checked)
+                throw e;
+            }
+
+            MetricsUtils.addSuccessTags(tags);
+            return jobId;
+        } catch (final Throwable t) {
+            MetricsUtils.addFailureTagsWithException(tags, t);
+            throw t;
+        } finally {
+            this.registry
+                .timer(LAUNCH_JOB_TIMER, tags)
+                .record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
@@ -163,7 +163,7 @@ public class JobResolverServiceImpl implements JobResolverService {
      * {@inheritDoc}
      */
     @Override
-    public JobSpecification resolveJobSpecification(final String id, @Valid final JobRequest jobRequest) {
+    public JobSpecification resolveJob(final String id, @Valid final JobRequest jobRequest) {
         final long start = System.nanoTime();
         final Set<Tag> tags = Sets.newHashSet();
         try {

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
@@ -38,7 +38,7 @@ import com.netflix.genie.web.data.services.ClusterPersistenceService;
 import com.netflix.genie.web.data.services.CommandPersistenceService;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.ClusterLoadBalancer;
-import com.netflix.genie.web.services.JobSpecificationService;
+import com.netflix.genie.web.services.JobResolverService;
 import com.netflix.genie.web.util.MetricsConstants;
 import com.netflix.genie.web.util.MetricsUtils;
 import io.micrometer.core.instrument.Counter;
@@ -63,7 +63,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
- * Implementation of the JobSpecificationService APIs.
+ * Implementation of the JobResolverService APIs.
  *
  * @author tgianos
  * @since 4.0.0
@@ -71,7 +71,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Validated
 @ParametersAreNonnullByDefault
-public class JobSpecificationServiceImpl implements JobSpecificationService {
+public class JobResolverServiceImpl implements JobResolverService {
 
     /**
      * How long it takes to completely resolve a job specification given inputs.
@@ -137,7 +137,7 @@ public class JobSpecificationServiceImpl implements JobSpecificationService {
      * @param registry                      The metrics repository to use
      * @param jobsProperties                The properties for running a job set by the user
      */
-    public JobSpecificationServiceImpl(
+    public JobResolverServiceImpl(
         final ApplicationPersistenceService applicationPersistenceService,
         final ClusterPersistenceService clusterPersistenceService,
         final CommandPersistenceService commandPersistenceService,

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfiguration.java
@@ -29,7 +29,7 @@ import com.netflix.genie.web.agent.services.impl.AgentRoutingServiceImpl;
 import com.netflix.genie.web.agent.inspectors.AgentMetadataInspector;
 import com.netflix.genie.web.data.services.AgentConnectionPersistenceService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
-import com.netflix.genie.web.services.JobSpecificationService;
+import com.netflix.genie.web.services.JobResolverService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -49,7 +49,7 @@ public class AgentServicesAutoConfiguration {
      * Get a {@link AgentJobService} instance if there isn't already one.
      *
      * @param jobPersistenceService   The persistence service to use
-     * @param jobSpecificationService The specification service to use
+     * @param jobResolverService The specification service to use
      * @param agentFilterService      The agent filter service to use
      * @param meterRegistry           The metrics registry to use
      * @return An {@link AgentJobServiceImpl} instance.
@@ -58,13 +58,13 @@ public class AgentServicesAutoConfiguration {
     @ConditionalOnMissingBean(AgentJobService.class)
     public AgentJobService agentJobService(
         final JobPersistenceService jobPersistenceService,
-        final JobSpecificationService jobSpecificationService,
+        final JobResolverService jobResolverService,
         final AgentFilterService agentFilterService,
         final MeterRegistry meterRegistry
     ) {
         return new AgentJobServiceImpl(
             jobPersistenceService,
-            jobSpecificationService,
+            jobResolverService,
             agentFilterService,
             meterRegistry
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/data/DataAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/data/DataAutoConfiguration.java
@@ -42,6 +42,7 @@ import com.netflix.genie.web.data.services.jpa.JpaJobPersistenceServiceImpl;
 import com.netflix.genie.web.data.services.jpa.JpaJobSearchServiceImpl;
 import com.netflix.genie.web.data.services.jpa.JpaTagPersistenceService;
 import com.netflix.genie.web.data.services.jpa.JpaTagPersistenceServiceImpl;
+import com.netflix.genie.web.services.AttachmentService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
@@ -179,6 +180,8 @@ public class DataAutoConfiguration {
      * @param clusterRepository      The {@link JpaClusterRepository} to use
      * @param commandRepository      The {@link JpaCommandRepository} to use
      * @param jobRepository          The {@link JpaJobRepository} to use
+     * @param attachmentService      The {@link AttachmentService} implementation to use to store attachments for a job
+     *                               before they are converted to dependencies
      * @return Instance of {@link JpaJobPersistenceServiceImpl}
      */
     @Bean
@@ -189,7 +192,8 @@ public class DataAutoConfiguration {
         final JpaApplicationRepository applicationRepository,
         final JpaClusterRepository clusterRepository,
         final JpaCommandRepository commandRepository,
-        final JpaJobRepository jobRepository
+        final JpaJobRepository jobRepository,
+        final AttachmentService attachmentService
     ) {
         return new JpaJobPersistenceServiceImpl(
             tagPersistenceService,
@@ -197,7 +201,8 @@ public class DataAutoConfiguration {
             applicationRepository,
             clusterRepository,
             commandRepository,
-            jobRepository
+            jobRepository,
+            attachmentService
         );
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfiguration.java
@@ -206,7 +206,7 @@ public class ServicesAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean(JobKillService.class)
-    public JobKillService jobKillService(
+    public JobKillServiceImpl jobKillService(
         final JobKillServiceV3 jobKillServiceV3,
         final JobKillServiceV4 jobKillServiceV4,
         final JobPersistenceService jobPersistenceService
@@ -341,7 +341,7 @@ public class ServicesAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean(AttachmentService.class)
-    public AttachmentService attachmentService(final JobsProperties jobsProperties) {
+    public FileSystemAttachmentService attachmentService(final JobsProperties jobsProperties) {
         return new FileSystemAttachmentService(jobsProperties.getLocations().getAttachments());
     }
 
@@ -367,7 +367,7 @@ public class ServicesAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean(JobFileService.class)
-    public JobFileService jobFileService(@Qualifier("jobsDir") final Resource jobsDir) throws IOException {
+    public DiskJobFileServiceImpl jobFileService(@Qualifier("jobsDir") final Resource jobsDir) throws IOException {
         return new DiskJobFileServiceImpl(jobsDir);
     }
 
@@ -377,18 +377,20 @@ public class ServicesAutoConfiguration {
      * @param applicationPersistenceService The service to use to manipulate applications
      * @param clusterPersistenceService     The service to use to manipulate clusters
      * @param commandPersistenceService     The service to use to manipulate commands
-     * @param clusterLoadBalancers          The load balancer implementations to use
+     * @param jobPersistenceService         The job persistence service instance to use
+     * @param clusterLoadBalancerImpls      The load balancer implementations to use
      * @param registry                      The metrics repository to use
      * @param jobsProperties                The properties for running a job set by the user
      * @return A {@link JobResolverServiceImpl} instance
      */
     @Bean
     @ConditionalOnMissingBean(JobResolverService.class)
-    public JobResolverService jobResolverService(
+    public JobResolverServiceImpl jobResolverService(
         final ApplicationPersistenceService applicationPersistenceService,
         final ClusterPersistenceService clusterPersistenceService,
         final CommandPersistenceService commandPersistenceService,
-        @NotEmpty final List<ClusterLoadBalancer> clusterLoadBalancers,
+        final JobPersistenceService jobPersistenceService,
+        @NotEmpty final List<ClusterLoadBalancer> clusterLoadBalancerImpls,
         final MeterRegistry registry,
         final JobsProperties jobsProperties
     ) {
@@ -396,7 +398,8 @@ public class ServicesAutoConfiguration {
             applicationPersistenceService,
             clusterPersistenceService,
             commandPersistenceService,
-            clusterLoadBalancers,
+            jobPersistenceService,
+            clusterLoadBalancerImpls,
             registry,
             jobsProperties
         );
@@ -454,7 +457,7 @@ public class ServicesAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean(JobDirectoryServerService.class)
-    public JobDirectoryServerService jobDirectoryServerService(
+    public JobDirectoryServerServiceImpl jobDirectoryServerService(
         final ResourceLoader resourceLoader,
         final JobPersistenceService jobPersistenceService,
         final JobFileService jobFileService,

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfiguration.java
@@ -49,7 +49,7 @@ import com.netflix.genie.web.services.JobDirectoryServerService;
 import com.netflix.genie.web.services.JobFileService;
 import com.netflix.genie.web.services.JobKillService;
 import com.netflix.genie.web.services.JobKillServiceV4;
-import com.netflix.genie.web.services.JobSpecificationService;
+import com.netflix.genie.web.services.JobResolverService;
 import com.netflix.genie.web.services.JobStateService;
 import com.netflix.genie.web.services.JobSubmitterService;
 import com.netflix.genie.web.services.MailService;
@@ -61,7 +61,7 @@ import com.netflix.genie.web.services.impl.JobCoordinatorServiceImpl;
 import com.netflix.genie.web.services.impl.JobDirectoryServerServiceImpl;
 import com.netflix.genie.web.services.impl.JobKillServiceImpl;
 import com.netflix.genie.web.services.impl.JobKillServiceV3;
-import com.netflix.genie.web.services.impl.JobSpecificationServiceImpl;
+import com.netflix.genie.web.services.impl.JobResolverServiceImpl;
 import com.netflix.genie.web.services.impl.LocalFileTransferImpl;
 import com.netflix.genie.web.services.impl.LocalJobRunner;
 import com.netflix.genie.web.services.impl.RandomizedClusterLoadBalancerImpl;
@@ -298,7 +298,7 @@ public class ServicesAutoConfiguration {
      * @param applicationPersistenceService Implementation of application service interface
      * @param clusterPersistenceService     Implementation of cluster service interface
      * @param commandPersistenceService     Implementation of command service interface
-     * @param specificationService          The job specification service to use
+     * @param jobResolverService            The job specification service to use
      * @param registry                      The metrics registry to use
      * @param genieHostInfo                 Information about the host the Genie process is running on
      * @return An instance of the JobCoordinatorService.
@@ -314,7 +314,7 @@ public class ServicesAutoConfiguration {
         final ApplicationPersistenceService applicationPersistenceService,
         final ClusterPersistenceService clusterPersistenceService,
         final CommandPersistenceService commandPersistenceService,
-        final JobSpecificationService specificationService,
+        final JobResolverService jobResolverService,
         final MeterRegistry registry,
         final GenieHostInfo genieHostInfo
     ) {
@@ -327,7 +327,7 @@ public class ServicesAutoConfiguration {
             jobSearchService,
             clusterPersistenceService,
             commandPersistenceService,
-            specificationService,
+            jobResolverService,
             registry,
             genieHostInfo.getHostname()
         );
@@ -372,7 +372,7 @@ public class ServicesAutoConfiguration {
     }
 
     /**
-     * Get an implementation of {@link JobSpecificationService} if one hasn't already been defined.
+     * Get an implementation of {@link JobResolverService} if one hasn't already been defined.
      *
      * @param applicationPersistenceService The service to use to manipulate applications
      * @param clusterPersistenceService     The service to use to manipulate clusters
@@ -380,11 +380,11 @@ public class ServicesAutoConfiguration {
      * @param clusterLoadBalancers          The load balancer implementations to use
      * @param registry                      The metrics repository to use
      * @param jobsProperties                The properties for running a job set by the user
-     * @return A {@link JobSpecificationServiceImpl} instance
+     * @return A {@link JobResolverServiceImpl} instance
      */
     @Bean
-    @ConditionalOnMissingBean(JobSpecificationService.class)
-    public JobSpecificationService jobSpecificationService(
+    @ConditionalOnMissingBean(JobResolverService.class)
+    public JobResolverService jobResolverService(
         final ApplicationPersistenceService applicationPersistenceService,
         final ClusterPersistenceService clusterPersistenceService,
         final CommandPersistenceService commandPersistenceService,
@@ -392,7 +392,7 @@ public class ServicesAutoConfiguration {
         final MeterRegistry registry,
         final JobsProperties jobsProperties
     ) {
-        return new JobSpecificationServiceImpl(
+        return new JobResolverServiceImpl(
             applicationPersistenceService,
             clusterPersistenceService,
             commandPersistenceService,

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImplSpec.groovy
@@ -1,0 +1,128 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.agent.launchers.impl
+
+import com.google.common.collect.Lists
+import com.netflix.genie.common.internal.dto.v4.JobEnvironment
+import com.netflix.genie.common.internal.dto.v4.JobSpecification
+import com.netflix.genie.web.dtos.ResolvedJob
+import com.netflix.genie.web.exceptions.checked.AgentLaunchException
+import com.netflix.genie.web.properties.LocalAgentLauncherProperties
+import com.netflix.genie.web.util.ExecutorFactory
+import io.micrometer.core.instrument.MeterRegistry
+import org.apache.commons.exec.CommandLine
+import org.apache.commons.exec.ExecuteResultHandler
+import org.apache.commons.exec.Executor
+import org.apache.commons.lang3.SystemUtils
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link LocalAgentLauncherImpl}.
+ *
+ * @author tgianos
+ */
+class LocalAgentLauncherImplSpec extends Specification {
+
+    def "Can Launch Agent"() {
+        def executable = Lists.newArrayList("java", "-jar", "genie-agent.jar")
+        def properties = Mock(LocalAgentLauncherProperties)
+        def factory = Mock(ExecutorFactory)
+        def rpcPort = 9090
+        def registry = Mock(MeterRegistry)
+
+        def jobId = UUID.randomUUID().toString()
+        def jobSpecification = Mock(JobSpecification) {
+            getJob() >> Mock(JobSpecification.ExecutionResource) {
+                getId() >> jobId
+            }
+        }
+        def jobEnvironment = Mock(JobEnvironment)
+        def resolvedJob = new ResolvedJob(jobSpecification, jobEnvironment)
+        def executor = Mock(Executor)
+
+        def expectedLinuxExecutable = "setsid"
+        String[] expectedLinuxArguments = [
+            "java",
+            "-jar",
+            "genie-agent.jar",
+            "exec",
+            "--serverHost",
+            "localhost",
+            "--serverPort",
+            Integer.toString(rpcPort),
+            "--full-cleanup",
+            "--api-job",
+            "--jobId",
+            jobId
+        ]
+
+        def expectedNonLinuxExecutable = "java"
+        String[] expectedNonLinuxArguments = [
+            "-jar",
+            "genie-agent.jar",
+            "exec",
+            "--serverHost",
+            "localhost",
+            "--serverPort",
+            Integer.toString(rpcPort),
+            "--full-cleanup",
+            "--api-job",
+            "--jobId",
+            jobId
+        ]
+
+        when:
+        def launcher = new LocalAgentLauncherImpl(properties, rpcPort, factory, registry)
+
+        then:
+        1 * properties.getExecutable() >> executable
+
+        when:
+        launcher.launchAgent(resolvedJob)
+
+        then:
+        1 * factory.newInstance(true) >> executor
+        1 * executor.execute(
+            {
+                CommandLine commandLine ->
+                    if (SystemUtils.IS_OS_LINUX) {
+                        assert commandLine.getExecutable() == expectedLinuxExecutable
+                        assert commandLine.getArguments() == expectedLinuxArguments
+                    } else {
+                        assert commandLine.getExecutable() == expectedNonLinuxExecutable
+                        assert commandLine.getArguments() == expectedNonLinuxArguments
+                    }
+            },
+            {
+                ExecuteResultHandler handler ->
+                    assert handler != null
+                    assert handler instanceof LocalAgentLauncherImpl.AgentResultHandler
+            }
+        )
+
+        when:
+        launcher.launchAgent(resolvedJob)
+
+        then:
+        1 * factory.newInstance(true) >> executor
+        1 * executor.execute(_ as CommandLine, _ as ExecuteResultHandler) >> {
+            throw new IOException("Something broke")
+        }
+        thrown(AgentLaunchException)
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
@@ -29,6 +29,7 @@ import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobSpecificat
 import com.netflix.genie.web.agent.inspectors.InspectionReport
 import com.netflix.genie.web.agent.services.AgentFilterService
 import com.netflix.genie.web.data.services.JobPersistenceService
+import com.netflix.genie.web.dtos.ResolvedJob
 import com.netflix.genie.web.services.JobResolverService
 import com.netflix.genie.web.util.MetricsConstants
 import com.netflix.genie.web.util.MetricsUtils
@@ -169,6 +170,7 @@ class AgentJobServiceImplSpec extends Specification {
     def "Can Resolve Job Specification"() {
         def jobId = UUID.randomUUID().toString()
         def jobRequest = Mock(JobRequest)
+        def resolvedJobMock = Mock(ResolvedJob)
         def jobSpecificationMock = Mock(JobSpecification)
 
         when:
@@ -183,7 +185,8 @@ class AgentJobServiceImplSpec extends Specification {
 
         then:
         1 * jobPersistenceService.getJobRequest(jobId) >> Optional.of(jobRequest)
-        1 * this.jobSpecificationService.resolveJob(jobId, jobRequest) >> jobSpecificationMock
+        1 * this.jobSpecificationService.resolveJob(jobId, jobRequest) >> resolvedJobMock
+        1 * resolvedJobMock.getJobSpecification() >> jobSpecificationMock
         1 * jobPersistenceService.saveJobSpecification(jobId, jobSpecificationMock)
         jobSpecification == jobSpecificationMock
     }
@@ -213,6 +216,7 @@ class AgentJobServiceImplSpec extends Specification {
         def jobRequest = Mock(JobRequest)
 
         def jobSpecificationMock = Mock(JobSpecification)
+        def resolvedJobMock = Mock(ResolvedJob)
         def id = UUID.randomUUID().toString()
 
         when:
@@ -220,7 +224,8 @@ class AgentJobServiceImplSpec extends Specification {
 
         then:
         1 * jobRequest.getRequestedId() >> Optional.empty()
-        1 * jobSpecificationService.resolveJob(_ as String, jobRequest) >> jobSpecificationMock
+        1 * jobSpecificationService.resolveJob(_ as String, jobRequest) >> resolvedJobMock
+        1 * resolvedJobMock.getJobSpecification() >> jobSpecificationMock
         jobSpecification == jobSpecificationMock
 
         when:
@@ -228,7 +233,8 @@ class AgentJobServiceImplSpec extends Specification {
 
         then:
         1 * jobRequest.getRequestedId() >> Optional.of(id)
-        1 * jobSpecificationService.resolveJob(id, jobRequest) >> jobSpecificationMock
+        1 * jobSpecificationService.resolveJob(id, jobRequest) >> resolvedJobMock
+        1 * resolvedJobMock.getJobSpecification() >> jobSpecificationMock
         jobSpecification == jobSpecificationMock
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
@@ -183,7 +183,7 @@ class AgentJobServiceImplSpec extends Specification {
 
         then:
         1 * jobPersistenceService.getJobRequest(jobId) >> Optional.of(jobRequest)
-        1 * this.jobSpecificationService.resolveJobSpecification(jobId, jobRequest) >> jobSpecificationMock
+        1 * this.jobSpecificationService.resolveJob(jobId, jobRequest) >> jobSpecificationMock
         1 * jobPersistenceService.saveJobSpecification(jobId, jobSpecificationMock)
         jobSpecification == jobSpecificationMock
     }
@@ -220,7 +220,7 @@ class AgentJobServiceImplSpec extends Specification {
 
         then:
         1 * jobRequest.getRequestedId() >> Optional.empty()
-        1 * jobSpecificationService.resolveJobSpecification(_ as String, jobRequest) >> jobSpecificationMock
+        1 * jobSpecificationService.resolveJob(_ as String, jobRequest) >> jobSpecificationMock
         jobSpecification == jobSpecificationMock
 
         when:
@@ -228,7 +228,7 @@ class AgentJobServiceImplSpec extends Specification {
 
         then:
         1 * jobRequest.getRequestedId() >> Optional.of(id)
-        1 * jobSpecificationService.resolveJobSpecification(id, jobRequest) >> jobSpecificationMock
+        1 * jobSpecificationService.resolveJob(id, jobRequest) >> jobSpecificationMock
         jobSpecification == jobSpecificationMock
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
@@ -37,6 +37,7 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import spock.lang.Specification
+
 /**
  * Specifications for the {@link com.netflix.genie.web.agent.services.impl.AgentJobServiceImpl} class.
  *
@@ -186,7 +187,7 @@ class AgentJobServiceImplSpec extends Specification {
         1 * jobPersistenceService.getJobRequest(jobId) >> Optional.of(jobRequest)
         1 * this.jobSpecificationService.resolveJob(jobId, jobRequest) >> resolvedJobMock
         1 * resolvedJobMock.getJobSpecification() >> jobSpecificationMock
-        1 * jobPersistenceService.saveJobSpecification(jobId, jobSpecificationMock)
+        1 * jobPersistenceService.saveResolvedJob(jobId, resolvedJobMock)
         jobSpecification == jobSpecificationMock
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
@@ -21,7 +21,6 @@ import com.google.common.collect.Sets
 import com.netflix.genie.common.dto.JobStatus
 import com.netflix.genie.common.internal.dto.v4.AgentClientMetadata
 import com.netflix.genie.common.internal.dto.v4.JobRequest
-import com.netflix.genie.common.internal.dto.v4.JobRequestMetadata
 import com.netflix.genie.common.internal.dto.v4.JobSpecification
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieAgentRejectedException
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException
@@ -29,6 +28,7 @@ import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobSpecificat
 import com.netflix.genie.web.agent.inspectors.InspectionReport
 import com.netflix.genie.web.agent.services.AgentFilterService
 import com.netflix.genie.web.data.services.JobPersistenceService
+import com.netflix.genie.web.dtos.JobSubmission
 import com.netflix.genie.web.dtos.ResolvedJob
 import com.netflix.genie.web.services.JobResolverService
 import com.netflix.genie.web.util.MetricsConstants
@@ -37,7 +37,6 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import spock.lang.Specification
-
 /**
  * Specifications for the {@link com.netflix.genie.web.agent.services.impl.AgentJobServiceImpl} class.
  *
@@ -163,7 +162,7 @@ class AgentJobServiceImplSpec extends Specification {
         def id = service.reserveJobId(jobRequest, agentClientMetadata)
 
         then:
-        1 * jobPersistenceService.saveJobRequest(jobRequest, _ as JobRequestMetadata) >> reservedId
+        1 * jobPersistenceService.saveJobSubmission(_ as JobSubmission) >> reservedId
         id == reservedId
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
@@ -29,7 +29,7 @@ import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobSpecificat
 import com.netflix.genie.web.agent.inspectors.InspectionReport
 import com.netflix.genie.web.agent.services.AgentFilterService
 import com.netflix.genie.web.data.services.JobPersistenceService
-import com.netflix.genie.web.services.JobSpecificationService
+import com.netflix.genie.web.services.JobResolverService
 import com.netflix.genie.web.util.MetricsConstants
 import com.netflix.genie.web.util.MetricsUtils
 import io.micrometer.core.instrument.Counter
@@ -49,7 +49,7 @@ class AgentJobServiceImplSpec extends Specification {
 
 
     JobPersistenceService jobPersistenceService
-    JobSpecificationService jobSpecificationService
+    JobResolverService jobSpecificationService
     AgentFilterService agentFilterService
     MeterRegistry meterRegistry
     AgentJobServiceImpl service
@@ -57,7 +57,7 @@ class AgentJobServiceImplSpec extends Specification {
 
     def setup() {
         this.jobPersistenceService = Mock(JobPersistenceService)
-        this.jobSpecificationService = Mock(JobSpecificationService)
+        this.jobSpecificationService = Mock(JobResolverService)
         this.agentFilterService = Mock(AgentFilterService)
         this.meterRegistry = Mock(MeterRegistry)
         this.counter = Mock(Counter)

--- a/genie-web/src/test/groovy/com/netflix/genie/web/apis/rest/v3/controllers/DtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/apis/rest/v3/controllers/DtoConvertersSpec.groovy
@@ -983,16 +983,16 @@ class DtoConvertersSpec extends Specification {
         v4JobRequest.getMetadata().getTags() == tags
         v4JobRequest.getCriteria().getApplicationIds() == applicationIds
         v4JobRequest.getCommandArgs() == [StringUtils.join(commandArgs, StringUtils.SPACE)] as List
-        v4JobRequest.getRequestedAgentEnvironment().getRequestedJobMemory().orElse(null) == memory
+        v4JobRequest.getRequestedJobEnvironment().getRequestedJobMemory().orElse(null) == memory
         v4JobRequest.getRequestedAgentConfig().getTimeoutRequested().orElse(-1) == timeout
         v4JobRequest.getMetadata().getMetadata().orElse(null) == metadata
         v4JobRequest.getMetadata().getGrouping().orElse(null) == grouping
         v4JobRequest.getMetadata().getGroupingInstance().orElse(null) == groupingInstance
         v4JobRequest.getMetadata().getGroup().orElse(null) == group
         v4JobRequest.getMetadata().getDescription().orElse(null) == description
-        v4JobRequest.getRequestedAgentEnvironment().getRequestedJobCpu().orElse(null) == cpu
+        v4JobRequest.getRequestedJobEnvironment().getRequestedJobCpu().orElse(null) == cpu
         !v4JobRequest.getRequestedAgentConfig().getRequestedJobDirectoryLocation().isPresent()
-        !v4JobRequest.getRequestedAgentEnvironment().getExt().isPresent()
+        !v4JobRequest.getRequestedJobEnvironment().getExt().isPresent()
         v4JobRequest.getResources().getDependencies() == dependencies
         v4JobRequest.getResources().getConfigs() == configs
         v4JobRequest.getResources().getSetupFile().orElse(null) == setupFile

--- a/genie-web/src/test/groovy/com/netflix/genie/web/data/entities/v4/EntityDtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/data/entities/v4/EntityDtoConvertersSpec.groovy
@@ -25,11 +25,11 @@ import com.netflix.genie.common.dto.ApplicationStatus
 import com.netflix.genie.common.dto.ClusterStatus
 import com.netflix.genie.common.dto.CommandStatus
 import com.netflix.genie.common.internal.dto.v4.AgentConfigRequest
-import com.netflix.genie.common.internal.dto.v4.AgentEnvironmentRequest
 import com.netflix.genie.common.internal.dto.v4.Criterion
 import com.netflix.genie.common.internal.dto.v4.ExecutionEnvironment
 import com.netflix.genie.common.internal.dto.v4.ExecutionResourceCriteria
 import com.netflix.genie.common.internal.dto.v4.JobArchivalDataRequest
+import com.netflix.genie.common.internal.dto.v4.JobEnvironmentRequest
 import com.netflix.genie.common.internal.dto.v4.JobMetadata
 import com.netflix.genie.common.internal.dto.v4.JobRequest
 import com.netflix.genie.common.internal.dto.v4.JobSpecification
@@ -414,7 +414,7 @@ class EntityDtoConvertersSpec extends Specification {
             .withRequestedArchiveLocationPrefix(requestedArchiveLocationPrefix)
             .build()
 
-        def agentEnvironmentRequest = new AgentEnvironmentRequest.Builder()
+        def jobEnvironmentRequest = new JobEnvironmentRequest.Builder()
             .withExt(metadata)
             .withRequestedJobMemory(requestedMemory)
             .withRequestedJobCpu(requestedCpu)
@@ -427,7 +427,7 @@ class EntityDtoConvertersSpec extends Specification {
             commandArgs,
             jobMetadata,
             executionResourceCriteria,
-            agentEnvironmentRequest,
+            jobEnvironmentRequest,
             agentConfigRequest,
             null
         )
@@ -437,7 +437,7 @@ class EntityDtoConvertersSpec extends Specification {
             commandArgs,
             jobMetadata,
             executionResourceCriteria,
-            agentEnvironmentRequest,
+            jobEnvironmentRequest,
             agentConfigRequest,
             null
         )
@@ -448,7 +448,7 @@ class EntityDtoConvertersSpec extends Specification {
             commandArgs,
             jobMetadata,
             executionResourceCriteria,
-            agentEnvironmentRequest,
+            jobEnvironmentRequest,
             agentConfigRequest,
             jobArchivalDataRequest
         )

--- a/genie-web/src/test/groovy/com/netflix/genie/web/dtos/ApiJobSubmissionSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/dtos/ApiJobSubmissionSpec.groovy
@@ -1,0 +1,84 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.dtos
+
+
+import com.netflix.genie.common.internal.dto.v4.JobRequest
+import com.netflix.genie.common.internal.dto.v4.JobRequestMetadata
+import org.springframework.core.io.Resource
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link ApiJobSubmission}.
+ *
+ * @author tgianos
+ */
+class ApiJobSubmissionSpec extends Specification {
+
+    def "Can build"() {
+        def jobRequest = Mock(JobRequest)
+        def jobRequestMetadata = Mock(JobRequestMetadata)
+        def attachment1 = Mock(Resource)
+        def attachment2 = Mock(Resource)
+
+        def builder = new ApiJobSubmission.Builder(jobRequest, jobRequestMetadata)
+
+        when:
+        def submission1 = builder.build()
+
+        then:
+        submission1.getJobRequest() == jobRequest
+        submission1.getJobRequestMetadata() == jobRequestMetadata
+        submission1.getAttachments().isEmpty()
+
+        when:
+        def submission2 = builder.withAttachments(attachment1, attachment2).build()
+
+        then:
+        submission2.getJobRequest() == jobRequest
+        submission2.getJobRequestMetadata() == jobRequestMetadata
+        submission2.getAttachments().size() == 2
+        submission2.getAttachments().containsAll([attachment1, attachment2])
+        // note the attachments are ignored
+        submission1.toString() == submission2.toString()
+        submission1.hashCode() == submission2.hashCode()
+        submission1 == submission2
+        submission1.getAttachments() != submission2.getAttachments()
+
+        when:
+        def submission3 = builder.withAttachments([attachment1, attachment2].toSet()).build()
+
+        then:
+        submission3.getJobRequest() == jobRequest
+        submission3.getJobRequestMetadata() == jobRequestMetadata
+        submission3.getAttachments().size() == 2
+        submission3.getAttachments().containsAll([attachment1, attachment2])
+        // note the attachments are ignored
+        submission1.toString() == submission3.toString()
+        submission1.hashCode() == submission3.hashCode()
+        submission1 == submission3
+        submission1.getAttachments() != submission3.getAttachments()
+        submission2.getAttachments() == submission3.getAttachments()
+
+        when:
+        def submission4 = builder.withAttachments(null).build()
+
+        then:
+        submission4.getAttachments().isEmpty()
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/dtos/JobSubmissionSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/dtos/JobSubmissionSpec.groovy
@@ -24,11 +24,11 @@ import org.springframework.core.io.Resource
 import spock.lang.Specification
 
 /**
- * Specifications for {@link ApiJobSubmission}.
+ * Specifications for {@link JobSubmission}.
  *
  * @author tgianos
  */
-class ApiJobSubmissionSpec extends Specification {
+class JobSubmissionSpec extends Specification {
 
     def "Can build"() {
         def jobRequest = Mock(JobRequest)
@@ -36,7 +36,7 @@ class ApiJobSubmissionSpec extends Specification {
         def attachment1 = Mock(Resource)
         def attachment2 = Mock(Resource)
 
-        def builder = new ApiJobSubmission.Builder(jobRequest, jobRequestMetadata)
+        def builder = new JobSubmission.Builder(jobRequest, jobRequestMetadata)
 
         when:
         def submission1 = builder.build()

--- a/genie-web/src/test/groovy/com/netflix/genie/web/dtos/ResolvedJobSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/dtos/ResolvedJobSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.dtos
+
+import com.netflix.genie.common.internal.dto.v4.JobEnvironment
+import com.netflix.genie.common.internal.dto.v4.JobSpecification
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link ResolvedJob}.
+ *
+ * @author tgianos
+ */
+class ResolvedJobSpec extends Specification {
+
+    def "can create and do all POJO operations"() {
+        def jobSpecification = Mock(JobSpecification)
+        def jobEnvironment = Mock(JobEnvironment)
+
+        when:
+        def resolvedJob = new ResolvedJob(jobSpecification, jobEnvironment)
+
+        then:
+        resolvedJob.getJobSpecification() == jobSpecification
+        resolvedJob.getJobEnvironment() == jobEnvironment
+
+        when:
+        def resolvedJob2 = new ResolvedJob(Mock(JobSpecification), Mock(JobEnvironment))
+        def resolvedJob3 = new ResolvedJob(jobSpecification, jobEnvironment)
+
+        then:
+        resolvedJob != resolvedJob2
+        resolvedJob == resolvedJob3
+        resolvedJob.hashCode() != resolvedJob2.hashCode()
+        resolvedJob.hashCode() == resolvedJob3.hashCode()
+        resolvedJob.toString() != resolvedJob2.toString()
+        resolvedJob.toString() == resolvedJob3.toString()
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/exceptions/checked/IdAlreadyExistsExceptionSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/exceptions/checked/IdAlreadyExistsExceptionSpec.groovy
@@ -1,0 +1,63 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.exceptions.checked
+
+import org.springframework.dao.DataIntegrityViolationException
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link IdAlreadyExistsException}.
+ *
+ * @author tgianos
+ */
+class IdAlreadyExistsExceptionSpec extends Specification {
+
+    def "can construct with message"() {
+        def message = "id exists"
+
+        when:
+        def exception = new IdAlreadyExistsException(message)
+
+        then:
+        exception.getMessage() == message
+        exception.getCause() == null
+    }
+
+    def "can construct with cause"() {
+        def cause = new IllegalStateException("some bad state")
+
+        when:
+        def exception = new IdAlreadyExistsException(cause)
+
+        then:
+        exception.getMessage() != null
+        exception.getCause() == cause
+    }
+
+    def "can construct with message and cause"() {
+        def message = "id exists"
+        def cause = new DataIntegrityViolationException("no process")
+
+        when:
+        def exception = new IdAlreadyExistsException(message, cause)
+
+        then:
+        exception.getMessage() == message
+        exception.getCause() == cause
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/exceptions/checked/SaveAttachmentExceptionSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/exceptions/checked/SaveAttachmentExceptionSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.exceptions.checked
+
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link SaveAttachmentException}.
+ *
+ * @author tgianos
+ */
+class SaveAttachmentExceptionSpec extends Specification {
+
+    def "can construct with message"() {
+        def message = "whoops"
+
+        when:
+        def exception = new SaveAttachmentException(message)
+
+        then:
+        exception.getMessage() == message
+        exception.getCause() == null
+    }
+
+    def "can construct with cause"() {
+        def cause = new IllegalStateException("some bad state")
+
+        when:
+        def exception = new SaveAttachmentException(cause)
+
+        then:
+        exception.getMessage() != null
+        exception.getCause() == cause
+    }
+
+    def "can construct with message and cause"() {
+        def message = "boo boo"
+        def cause = new IOException("that didn't work")
+
+        when:
+        def exception = new SaveAttachmentException(message, cause)
+
+        then:
+        exception.getMessage() == message
+        exception.getCause() == cause
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/LocalAgentLauncherPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/LocalAgentLauncherPropertiesSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties
+
+import com.google.common.collect.Lists
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link LocalAgentLauncherProperties}.
+ *
+ * @author tgianos
+ */
+class LocalAgentLauncherPropertiesSpec extends Specification {
+
+    def "the property prefix is correct"() {
+        expect:
+        LocalAgentLauncherProperties.PROPERTY_PREFIX == "genie.agent.launcher.local"
+    }
+
+    def "The default values are correct"() {
+        when:
+        def properties = new LocalAgentLauncherProperties()
+
+        then:
+        properties.getExecutable() == Lists.newArrayList("java", "-jar", "/tmp/genie-agent.jar")
+    }
+
+    def "Setters and getters work properly"() {
+        def newExecutable = Lists.newArrayList("/etc/genie-agent.sh", "run")
+        def properties = new LocalAgentLauncherProperties()
+
+        when:
+        properties.setExecutable(newExecutable)
+
+        then:
+        properties.getExecutable() == newExecutable
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobLaunchServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobLaunchServiceImplSpec.groovy
@@ -1,0 +1,119 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl
+
+import com.netflix.genie.common.dto.JobStatus
+import com.netflix.genie.web.agent.launchers.AgentLauncher
+import com.netflix.genie.web.data.services.JobPersistenceService
+import com.netflix.genie.web.dtos.JobSubmission
+import com.netflix.genie.web.dtos.ResolvedJob
+import com.netflix.genie.web.exceptions.checked.AgentLaunchException
+import com.netflix.genie.web.services.JobResolverService
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link JobLaunchServiceImpl}.
+ *
+ * @author tgianos
+ */
+class JobLaunchServiceImplSpec extends Specification {
+
+    def "successful launch returns the job id"() {
+        def jobPersistenceService = Mock(JobPersistenceService)
+        def jobResolverService = Mock(JobResolverService)
+        def agentLauncher = Mock(AgentLauncher)
+        def registry = new SimpleMeterRegistry()
+        def service = new JobLaunchServiceImpl(jobPersistenceService, jobResolverService, agentLauncher, registry)
+
+        def jobId = UUID.randomUUID().toString()
+        def resolvedJob = Mock(ResolvedJob)
+        def jobSubmission = Mock(JobSubmission)
+
+        when:
+        def savedJobId = service.launchJob(jobSubmission)
+
+        then:
+        1 * jobPersistenceService.saveJobSubmission(jobSubmission) >> jobId
+        1 * jobResolverService.resolveJob(jobId) >> resolvedJob
+        1 * jobPersistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String)
+        1 * agentLauncher.launchAgent(resolvedJob)
+        savedJobId == jobId
+    }
+
+    def "error cases throw expected exceptions"() {
+        def jobPersistenceService = Mock(JobPersistenceService)
+        def jobResolverService = Mock(JobResolverService)
+        def agentLauncher = Mock(AgentLauncher)
+        def registry = new SimpleMeterRegistry()
+        def service = new JobLaunchServiceImpl(jobPersistenceService, jobResolverService, agentLauncher, registry)
+
+        def jobId = UUID.randomUUID().toString()
+        def resolvedJob = Mock(ResolvedJob)
+        def jobSubmission = Mock(JobSubmission)
+
+        when:
+        service.launchJob(jobSubmission)
+
+        then:
+        1 * jobPersistenceService.saveJobSubmission(jobSubmission) >> {
+            throw new IllegalStateException("fail")
+        }
+        0 * jobResolverService.resolveJob(_ as String)
+        0 * jobPersistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String)
+        0 * agentLauncher.launchAgent(_ as ResolvedJob)
+        thrown(AgentLaunchException)
+
+        when:
+        service.launchJob(jobSubmission)
+
+        then:
+        1 * jobPersistenceService.saveJobSubmission(jobSubmission) >> jobId
+        1 * jobResolverService.resolveJob(jobId) >> {
+            throw new IllegalArgumentException("fail")
+        }
+        0 * jobPersistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String)
+        0 * agentLauncher.launchAgent(_ as ResolvedJob)
+        thrown(AgentLaunchException)
+
+        when:
+        service.launchJob(jobSubmission)
+
+        then:
+        1 * jobPersistenceService.saveJobSubmission(jobSubmission) >> jobId
+        1 * jobResolverService.resolveJob(jobId) >> resolvedJob
+        1 * jobPersistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String) >> {
+            throw new RuntimeException("fail")
+        }
+        0 * agentLauncher.launchAgent(_ as ResolvedJob)
+        thrown(AgentLaunchException)
+
+        when:
+        service.launchJob(jobSubmission)
+
+        then:
+        1 * jobPersistenceService.saveJobSubmission(jobSubmission) >> jobId
+        1 * jobResolverService.resolveJob(jobId) >> resolvedJob
+        1 * jobPersistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String)
+        1 * agentLauncher.launchAgent(resolvedJob) >> {
+            throw new AgentLaunchException("that didn't work")
+        }
+        1 * jobPersistenceService.updateJobStatus(jobId, JobStatus.ACCEPTED, JobStatus.FAILED, _ as String)
+        thrown(AgentLaunchException)
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
@@ -162,7 +162,7 @@ class JobResolverServiceImplSpec extends Specification {
         )
 
         when:
-        def jobSpec = service.resolveJobSpecification(jobId, jobRequest)
+        def jobSpec = service.resolveJob(jobId, jobRequest)
 
         then:
         1 * clusterService.findClustersAndCommandsForCriteria(clusterCriteria, commandCriterion) >> clusterCommandMap
@@ -190,7 +190,7 @@ class JobResolverServiceImplSpec extends Specification {
                 .build(),
             null
         )
-        def jobSpecNoArchivalData = service.resolveJobSpecification(jobId, jobRequestNoArchivalData)
+        def jobSpecNoArchivalData = service.resolveJob(jobId, jobRequestNoArchivalData)
 
         then:
         1 * clusterService.findClustersAndCommandsForCriteria(clusterCriteria, commandCriterion) >> clusterCommandMap

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
@@ -48,11 +48,11 @@ import spock.lang.Specification
 import java.time.Instant
 
 /**
- * Specifications for the {@link JobSpecificationServiceImpl} class.
+ * Specifications for the {@link JobResolverServiceImpl} class.
  *
  * @author tgianos
  */
-class JobSpecificationServiceImplSpec extends Specification {
+class JobResolverServiceImplSpec extends Specification {
 
     def "Can generate job specification"() {
         def jobId = UUID.randomUUID().toString()
@@ -152,7 +152,7 @@ class JobSpecificationServiceImplSpec extends Specification {
         def loadBalancer = Mock(ClusterLoadBalancer)
         def applicationService = Mock(ApplicationPersistenceService)
         def commandService = Mock(CommandPersistenceService)
-        def service = new JobSpecificationServiceImpl(
+        def service = new JobResolverServiceImpl(
             applicationService,
             clusterService,
             commandService,
@@ -208,7 +208,7 @@ class JobSpecificationServiceImplSpec extends Specification {
     }
 
     def "Can convert tags to string"() {
-        def service = new JobSpecificationServiceImpl(
+        def service = new JobResolverServiceImpl(
             Mock(ApplicationPersistenceService),
             Mock(ClusterPersistenceService),
             Mock(CommandPersistenceService),
@@ -235,7 +235,7 @@ class JobSpecificationServiceImplSpec extends Specification {
 
     def "Can generate correct environment variables"() {
         def jobsProperties = JobsProperties.getJobsPropertiesDefaults()
-        def service = new JobSpecificationServiceImpl(
+        def service = new JobResolverServiceImpl(
             Mock(ApplicationPersistenceService),
             Mock(ClusterPersistenceService),
             Mock(CommandPersistenceService),
@@ -332,7 +332,7 @@ class JobSpecificationServiceImplSpec extends Specification {
 
     def "Can convert V4 Criterion to V3 tags"() {
         def jobsProperties = JobsProperties.getJobsPropertiesDefaults()
-        def service = new JobSpecificationServiceImpl(
+        def service = new JobResolverServiceImpl(
             Mock(ApplicationPersistenceService),
             Mock(ClusterPersistenceService),
             Mock(CommandPersistenceService),
@@ -412,7 +412,7 @@ class JobSpecificationServiceImplSpec extends Specification {
 
 
         def jobsProperties = JobsProperties.getJobsPropertiesDefaults()
-        def service = new JobSpecificationServiceImpl(
+        def service = new JobResolverServiceImpl(
             Mock(ApplicationPersistenceService),
             Mock(ClusterPersistenceService),
             Mock(CommandPersistenceService),

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
@@ -162,7 +162,8 @@ class JobResolverServiceImplSpec extends Specification {
         )
 
         when:
-        def jobSpec = service.resolveJob(jobId, jobRequest)
+        def resolvedJob = service.resolveJob(jobId, jobRequest)
+        def jobSpec = resolvedJob.getJobSpecification()
 
         then:
         1 * clusterService.findClustersAndCommandsForCriteria(clusterCriteria, commandCriterion) >> clusterCommandMap
@@ -190,7 +191,8 @@ class JobResolverServiceImplSpec extends Specification {
                 .build(),
             null
         )
-        def jobSpecNoArchivalData = service.resolveJob(jobId, jobRequestNoArchivalData)
+        def resolvedJobNoArchivalData = service.resolveJob(jobId, jobRequestNoArchivalData)
+        def jobSpecNoArchivalData = resolvedJobNoArchivalData.getJobSpecification()
 
         then:
         1 * clusterService.findClustersAndCommandsForCriteria(clusterCriteria, commandCriterion) >> clusterCommandMap
@@ -308,7 +310,13 @@ class JobResolverServiceImplSpec extends Specification {
         )
 
         when:
-        def envVariables = service.generateEnvironmentVariables(jobId, jobRequest, cluster, command)
+        def envVariables = service.generateEnvironmentVariables(
+            jobId,
+            jobRequest,
+            cluster,
+            command,
+            jobsProperties.getMemory().getDefaultJobMemory()
+        )
 
         then:
         envVariables.get("GENIE_VERSION") == "4"

--- a/genie-web/src/test/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplTest.java
@@ -50,6 +50,7 @@ import com.netflix.genie.web.data.repositories.jpa.JpaApplicationRepository;
 import com.netflix.genie.web.data.repositories.jpa.JpaClusterRepository;
 import com.netflix.genie.web.data.repositories.jpa.JpaCommandRepository;
 import com.netflix.genie.web.data.repositories.jpa.JpaJobRepository;
+import com.netflix.genie.web.services.AttachmentService;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -107,7 +108,8 @@ public class JpaJobPersistenceServiceImplTest {
             this.applicationRepository,
             this.clusterRepository,
             this.commandRepository,
-            this.jobRepository
+            this.jobRepository,
+            Mockito.mock(AttachmentService.class)
         );
     }
 
@@ -787,10 +789,9 @@ public class JpaJobPersistenceServiceImplTest {
      */
     @Test(expected = GenieJobNotFoundException.class)
     public void v4JobNotFoundThrowsException() {
-        final JobEntity jobEntity = null;
         Mockito
             .when(this.jobRepository.findByUniqueId(Mockito.anyString(), Mockito.eq(IsV4JobProjection.class)))
-            .thenReturn(Optional.ofNullable(jobEntity));
+            .thenReturn(Optional.empty());
 
         this.jobPersistenceService.isV4(UUID.randomUUID().toString());
     }

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/FileSystemAttachmentServiceTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/FileSystemAttachmentServiceTest.java
@@ -23,6 +23,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
 import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -223,6 +224,25 @@ public class FileSystemAttachmentServiceTest {
         // Delete the attachments
         this.service.deleteAttachments(jobId);
         Assert.assertFalse(Files.exists(expectedAttachmentDirectory));
+    }
+
+    /**
+     * Make sure when there are no attachments sent in it does nothing to the file system.
+     *
+     * @throws SaveAttachmentException on error running service API
+     * @throws IOException             listing file system resources
+     */
+    @Test
+    public void emptyAttachmentsIsANoOp() throws SaveAttachmentException, IOException {
+        final Set<Path> currentContents = Files.list(this.folder.getRoot().toPath()).collect(Collectors.toSet());
+        final Set<URI> uris = this.service.saveAttachments(
+            UUID.randomUUID().toString(),
+            Sets.newHashSet()
+        );
+        Assertions.assertThat(uris).isEmpty();
+        Assertions
+            .assertThat(Files.list(this.folder.getRoot().toPath()).collect(Collectors.toSet()))
+            .isEqualTo(currentContents);
     }
 
     private Set<File> saveAttachments(final String jobId) throws GenieException, IOException {

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/FileSystemAttachmentServiceTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/FileSystemAttachmentServiceTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
+import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -193,10 +194,11 @@ public class FileSystemAttachmentServiceTest {
     /**
      * Test that all attachments are saved successfully to disk and can be deleted.
      *
-     * @throws IOException on error
+     * @throws SaveAttachmentException on error running service API
+     * @throws IOException             on error creating test attachments
      */
     @Test
-    public void testSaveAndDeleteAttachments() throws IOException {
+    public void testSaveAndDeleteAttachments() throws SaveAttachmentException, IOException {
         final String jobId = UUID.randomUUID().toString();
         final Path sourceDirectory = this.folder.newFolder().toPath();
         final int numAttachments = 5;

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
@@ -42,7 +42,7 @@ import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.JobKillService;
-import com.netflix.genie.web.services.JobSpecificationService;
+import com.netflix.genie.web.services.JobResolverService;
 import com.netflix.genie.web.services.JobStateService;
 import com.netflix.genie.web.util.MetricsConstants;
 import com.netflix.genie.web.util.MetricsUtils;
@@ -90,7 +90,7 @@ public class JobCoordinatorServiceImplTest {
     private ApplicationPersistenceService applicationPersistenceService;
     private ClusterPersistenceService clusterPersistenceService;
     private CommandPersistenceService commandPersistenceService;
-    private JobSpecificationService specificationService;
+    private JobResolverService specificationService;
     private JobsProperties jobsProperties;
     private MeterRegistry registry;
     private Timer coordinationTimer;
@@ -113,7 +113,7 @@ public class JobCoordinatorServiceImplTest {
         this.applicationPersistenceService = Mockito.mock(ApplicationPersistenceService.class);
         this.clusterPersistenceService = Mockito.mock(ClusterPersistenceService.class);
         this.commandPersistenceService = Mockito.mock(CommandPersistenceService.class);
-        this.specificationService = Mockito.mock(JobSpecificationService.class);
+        this.specificationService = Mockito.mock(JobResolverService.class);
 
         this.registry = Mockito.mock(MeterRegistry.class);
         this.coordinationTimer = Mockito.mock(Timer.class);

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
@@ -169,7 +169,7 @@ public class JobCoordinatorServiceImplTest {
 
         Mockito
             .when(
-                this.specificationService.resolveJobSpecification(
+                this.specificationService.resolveJob(
                     Mockito.anyString(),
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class))
             )
@@ -263,7 +263,7 @@ public class JobCoordinatorServiceImplTest {
 
         Mockito
             .when(
-                this.specificationService.resolveJobSpecification(
+                this.specificationService.resolveJob(
                     Mockito.anyString(),
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
@@ -391,7 +391,7 @@ public class JobCoordinatorServiceImplTest {
 
         Mockito
             .when(
-                this.specificationService.resolveJobSpecification(
+                this.specificationService.resolveJob(
                     Mockito.anyString(),
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
@@ -492,7 +492,7 @@ public class JobCoordinatorServiceImplTest {
 
         Mockito
             .when(
-                this.specificationService.resolveJobSpecification(
+                this.specificationService.resolveJob(
                     Mockito.anyString(),
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
@@ -612,7 +612,7 @@ public class JobCoordinatorServiceImplTest {
 
         Mockito
             .when(
-                this.specificationService.resolveJobSpecification(
+                this.specificationService.resolveJob(
                     Mockito.anyString(),
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
@@ -714,7 +714,7 @@ public class JobCoordinatorServiceImplTest {
 
         Mockito
             .when(
-                this.specificationService.resolveJobSpecification(
+                this.specificationService.resolveJob(
                     Mockito.anyString(),
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
@@ -834,7 +834,7 @@ public class JobCoordinatorServiceImplTest {
 
         Mockito
             .when(
-                this.specificationService.resolveJobSpecification(
+                this.specificationService.resolveJob(
                     Mockito.anyString(),
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
@@ -34,12 +34,14 @@ import com.netflix.genie.common.internal.dto.v4.Application;
 import com.netflix.genie.common.internal.dto.v4.Cluster;
 import com.netflix.genie.common.internal.dto.v4.Command;
 import com.netflix.genie.common.internal.dto.v4.ExecutionEnvironment;
+import com.netflix.genie.common.internal.dto.v4.JobEnvironment;
 import com.netflix.genie.common.internal.dto.v4.JobSpecification;
 import com.netflix.genie.web.data.services.ApplicationPersistenceService;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
 import com.netflix.genie.web.data.services.CommandPersistenceService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
+import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.JobKillService;
 import com.netflix.genie.web.services.JobResolverService;
@@ -260,6 +262,8 @@ public class JobCoordinatorServiceImplTest {
             new File("/tmp/genie/jobs/" + JOB_1_ID),
             archiveLocation
         );
+        final JobEnvironment jobEnvironment = Mockito.mock(JobEnvironment.class);
+        final ResolvedJob resolvedJob = new ResolvedJob(jobSpecification, jobEnvironment);
 
         Mockito
             .when(
@@ -268,7 +272,7 @@ public class JobCoordinatorServiceImplTest {
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
             )
-            .thenReturn(jobSpecification);
+            .thenReturn(resolvedJob);
 
         Mockito.when(this.jobStateService.getUsedMemory()).thenReturn(0);
 
@@ -388,6 +392,8 @@ public class JobCoordinatorServiceImplTest {
             new File("/tmp/genie/jobs/" + JOB_1_ID),
             archiveLocation
         );
+        final JobEnvironment jobEnvironment = Mockito.mock(JobEnvironment.class);
+        final ResolvedJob resolvedJob = new ResolvedJob(jobSpecification, jobEnvironment);
 
         Mockito
             .when(
@@ -396,7 +402,7 @@ public class JobCoordinatorServiceImplTest {
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
             )
-            .thenReturn(jobSpecification);
+            .thenReturn(resolvedJob);
 
         try {
             this.jobCoordinatorService.coordinateJob(jobRequest, jobMetadata);
@@ -489,6 +495,8 @@ public class JobCoordinatorServiceImplTest {
             new File("/tmp/genie/jobs/" + JOB_1_ID),
             archiveLocation
         );
+        final JobEnvironment jobEnvironment = Mockito.mock(JobEnvironment.class);
+        final ResolvedJob resolvedJob = new ResolvedJob(jobSpecification, jobEnvironment);
 
         Mockito
             .when(
@@ -497,7 +505,7 @@ public class JobCoordinatorServiceImplTest {
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
             )
-            .thenReturn(jobSpecification);
+            .thenReturn(resolvedJob);
 
         Mockito
             .when(this.jobStateService.getUsedMemory())
@@ -609,6 +617,8 @@ public class JobCoordinatorServiceImplTest {
             new File("/tmp/genie/jobs/" + JOB_1_ID),
             archiveLocation
         );
+        final JobEnvironment jobEnvironment = Mockito.mock(JobEnvironment.class);
+        final ResolvedJob resolvedJob = new ResolvedJob(jobSpecification, jobEnvironment);
 
         Mockito
             .when(
@@ -617,7 +627,7 @@ public class JobCoordinatorServiceImplTest {
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
             )
-            .thenReturn(jobSpecification);
+            .thenReturn(resolvedJob);
 
         Mockito
             .when(this.jobSearchService.getActiveJobCountForUser(Mockito.any(String.class)))
@@ -711,6 +721,8 @@ public class JobCoordinatorServiceImplTest {
             new File("/tmp/genie/jobs/" + JOB_1_ID),
             archiveLocation
         );
+        final JobEnvironment jobEnvironment = Mockito.mock(JobEnvironment.class);
+        final ResolvedJob resolvedJob = new ResolvedJob(jobSpecification, jobEnvironment);
 
         Mockito
             .when(
@@ -719,7 +731,7 @@ public class JobCoordinatorServiceImplTest {
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
             )
-            .thenReturn(jobSpecification);
+            .thenReturn(resolvedJob);
 
         Mockito
             .when(this.jobSearchService.getActiveJobCountForUser(Mockito.any(String.class)))
@@ -831,6 +843,8 @@ public class JobCoordinatorServiceImplTest {
             new File("/tmp/genie/jobs/" + JOB_1_ID),
             archiveLocation
         );
+        final JobEnvironment jobEnvironment = Mockito.mock(JobEnvironment.class);
+        final ResolvedJob resolvedJob = new ResolvedJob(jobSpecification, jobEnvironment);
 
         Mockito
             .when(
@@ -839,7 +853,7 @@ public class JobCoordinatorServiceImplTest {
                     Mockito.any(com.netflix.genie.common.internal.dto.v4.JobRequest.class)
                 )
             )
-            .thenReturn(jobSpecification);
+            .thenReturn(resolvedJob);
 
         Mockito
             .doThrow(new RuntimeException())

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfigurationTest.java
@@ -40,7 +40,7 @@ import com.netflix.genie.web.properties.JobsUsersProperties;
 import com.netflix.genie.web.services.FileTransferFactory;
 import com.netflix.genie.web.services.JobKillService;
 import com.netflix.genie.web.services.JobKillServiceV4;
-import com.netflix.genie.web.services.JobSpecificationService;
+import com.netflix.genie.web.services.JobResolverService;
 import com.netflix.genie.web.services.JobStateService;
 import com.netflix.genie.web.services.impl.JobKillServiceV3;
 import com.netflix.genie.web.services.impl.LocalFileTransferImpl;
@@ -195,7 +195,7 @@ public class ServicesAutoConfigurationTest {
                 Mockito.mock(ApplicationPersistenceService.class),
                 Mockito.mock(ClusterPersistenceService.class),
                 Mockito.mock(CommandPersistenceService.class),
-                Mockito.mock(JobSpecificationService.class),
+                Mockito.mock(JobResolverService.class),
                 Mockito.mock(MeterRegistry.class),
                 new GenieHostInfo(UUID.randomUUID().toString())
             )


### PR DESCRIPTION
This PR contains a lot of changes to continue modifying the server to execute API submitted jobs using a Genie Agent instance instead of internal job execution logic from V3.

The core changes in this PR are:
- Creation of composite DTOs to enable better transfer of information between components without constant need to change interface definitions
- Modifying `JobSpecificationService` to be `JobResolverService` so it is clear it completely resolves the job not just generating a `specification`
- Modifying the handling of attachments so that they are persisted somewhere between job submission and agent processing. Converting these attachments to ephemeral entities to permanently accessible somewhere and referenced as job `dependencies`
- Modifying `JobPersistenceService` to have more convenient helper APIs for saving various information
- Creation of an `AgentLauncher` interface which can be implemented to handle agent instantiation via various mechanisms
- Creation of a `JobLaunchService` to handle the orchestration of Job launch after API submission