### PR TITLE
More work towards local job runs via agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,7 @@ configure(javaProjects) {
             dependency("net.jcip:jcip-annotations:1.0")
             dependency("org.apache.commons:commons-configuration2:2.5")
             dependency("org.apache.commons:commons-exec:1.3")
+            dependency("org.apache.commons:commons-text:1.7")
             dependency("org.apache.tika:tika-core:1.20")
             dependency("org.apache.maven:maven-artifact:3.6.1")
             // For some reason 3.5.3-beta was throwing error with 3.4.x server

--- a/genie-agent-app/build.gradle
+++ b/genie-agent-app/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: "org.springframework.boot"
 //apply plugin: "application"
 
+configurations {
+    agentBootJar
+}
+
 license {
     exclude "*.yml"
     exclude "*.xml"
@@ -42,4 +46,9 @@ jar {
     manifest {
         attributes("Implementation-Version": genieVersion)
     }
+}
+
+// Used to provide convenient way to reference the actual executable jar between projects
+artifacts {
+    agentBootJar bootJar
 }

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/FileSystemJobArchiverImpl.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/FileSystemJobArchiverImpl.java
@@ -83,7 +83,20 @@ public class FileSystemJobArchiverImpl implements JobArchiver {
         private final Path source;
         private final Path target;
 
-        JobDirectoryCopier(final Path source, final Path target) {
+        JobDirectoryCopier(final Path source, final Path target) throws IOException {
+            // If the source doesn't exist or isn't a directory throw an exception
+            if (!Files.exists(source) || !Files.isDirectory(source)) {
+                throw new IOException(source + " doesn't exist or isn't a directory. Unable to copy");
+            }
+            // If the target exists but isn't a directory throw an error
+            if (Files.exists(target) && !Files.isDirectory(target)) {
+                throw new IOException(target + " exists but isn't a directory");
+            }
+            // If the target doesn't exist try to create it
+            if (!Files.exists(target)) {
+                Files.createDirectories(target);
+            }
+
             this.source = source;
             this.target = target;
         }

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/util/GenieHostInfo.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/util/GenieHostInfo.java
@@ -19,6 +19,7 @@ package com.netflix.genie.common.internal.util;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 /**
@@ -27,18 +28,10 @@ import lombok.ToString;
  * @author tgianos
  * @since 4.0.0
  */
+@RequiredArgsConstructor
 @Getter
 @EqualsAndHashCode(doNotUseGetters = true)
 @ToString(doNotUseGetters = true)
 public class GenieHostInfo {
     private final String hostname;
-
-    /**
-     * Constructor.
-     *
-     * @param hostname The hostname of the node this Genie process is running on.
-     */
-    public GenieHostInfo(final String hostname) {
-        this.hostname = hostname;
-    }
 }

--- a/genie-common/build.gradle
+++ b/genie-common/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     implementation("com.google.guava:guava")
     implementation("org.apache.commons:commons-lang3")
+    implementation("org.apache.commons:commons-text")
 
     /*******************************
      * Provided Dependencies

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/Job.java
@@ -249,7 +249,7 @@ public class Job extends CommonDTO {
          * The command arguments to use in conjunction with the command executable selected for this job.
          *
          * @param commandArgs The command args. The maximum combined size of the command args plus 1 space character
-         *                    between each argument must be <= 10,000 characters
+         *                    between each argument must be less than or equal to 10,000 characters
          * @return The builder
          * @since 3.3.0
          */

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobRequest.java
@@ -277,7 +277,7 @@ public class JobRequest extends ExecutionEnvironmentDTO {
          * The command arguments to use in conjunction with the command executable selected for this job.
          *
          * @param commandArgs The command args. The maximum combined length of the command args plus one space between
-         *                    each argument must be <= 10,000 characters
+         *                    each argument must be less than or equal to 10,000 characters
          * @return The builder
          * @since 3.3.0
          */

--- a/genie-common/src/test/groovy/com/netflix/genie/common/util/JsonUtilsSpec.groovy
+++ b/genie-common/src/test/groovy/com/netflix/genie/common/util/JsonUtilsSpec.groovy
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.util
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Specifications for {@link JsonUtils}.
+ *
+ * @author tgianos
+ */
+class JsonUtilsSpec extends Specification {
+
+    @Unroll
+    def "Can split #commandArgsString into expected #expectedArgsList"() {
+        expect:
+        JsonUtils.splitArguments(commandArgsString) == expectedArgsList
+
+        where:
+        commandArgsString                       | expectedArgsList
+        "/bin/bash -xc 'echo hello world!'"     | ["/bin/bash", "-xc", "echo hello world!"]
+        "/bin/bash -xc 'echo \"hello\" world!'" | ["/bin/bash", "-xc", "echo \"hello\" world!"]
+        "arg1   arg2\targ3\narg4\r'arg5' '''"   | ["arg1", "arg2", "arg3", "arg4", "arg5", "'"]
+        "foo/bar --hello '\$world'"             | ["foo/bar", "--hello", "\$world"]
+    }
+
+    @Unroll
+    def "Can join #commandArgsList into expected #expectedString"() {
+        expect:
+        JsonUtils.joinArguments(commandArgsList) == expectedString
+
+        where:
+        commandArgsList                               | expectedString
+        ["/bin/bash", "-xc", "echo hello world!"]     | "'/bin/bash' '-xc' 'echo hello world!'"
+        ["/bin/bash", "-xc", "echo \"hello\" world!"] | "'/bin/bash' '-xc' 'echo \"hello\" world!'"
+        ["arg1", "arg2", "arg3", "arg4", "arg5", "'"] | "'arg1' 'arg2' 'arg3' 'arg4' 'arg5' '''"
+        ["foo/bar", "--hello", "\$world"]             | "'foo/bar' '--hello' '\$world'"
+    }
+}

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/JobRequestTest.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/JobRequestTest.java
@@ -19,7 +19,6 @@ package com.netflix.genie.common.dto;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +29,7 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * Unit tests for the JobRequest class.
+ * Unit tests for the {@link JobRequest} class.
  *
  * @author tgianos
  * @since 3.0.0
@@ -40,7 +39,17 @@ public class JobRequestTest {
     private static final String NAME = UUID.randomUUID().toString();
     private static final String USER = UUID.randomUUID().toString();
     private static final String VERSION = UUID.randomUUID().toString();
-    private static final List<String> COMMAND_ARGS = Lists.newArrayList(UUID.randomUUID().toString());
+    private static final String COMMAND_ARG_1 = UUID.randomUUID().toString();
+    private static final String COMMAND_ARG_2 = UUID.randomUUID().toString() + ' ' + UUID.randomUUID().toString();
+    private static final String COMMAND_ARG_3 = UUID.randomUUID().toString();
+    private static final List<String> COMMAND_ARGS = Lists.newArrayList(
+        COMMAND_ARG_1,
+        COMMAND_ARG_2,
+        COMMAND_ARG_3
+    );
+    private static final String COMMAND_ARGS_INPUT_STRING = COMMAND_ARG_1 + " '" + COMMAND_ARG_2 + "' " + COMMAND_ARG_3;
+    private static final String COMMAND_ARGS_EXPECTED
+        = '\'' + COMMAND_ARG_1 + "' '" + COMMAND_ARG_2 + "' '" + COMMAND_ARG_3 + '\'';
     private static final List<ClusterCriteria> CLUSTER_CRITERIAS = Lists.newArrayList(
         new ClusterCriteria(
             Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
@@ -67,7 +76,7 @@ public class JobRequestTest {
             NAME,
             USER,
             VERSION,
-            StringUtils.join(COMMAND_ARGS, StringUtils.SPACE),
+            COMMAND_ARGS_INPUT_STRING,
             CLUSTER_CRITERIAS,
             COMMAND_CRITERIA
         ).build();
@@ -75,9 +84,10 @@ public class JobRequestTest {
         Assert.assertThat(request.getUser(), Matchers.is(USER));
         Assert.assertThat(request.getVersion(), Matchers.is(VERSION));
         Assert.assertThat(
-            request.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+            request.getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(COMMAND_ARGS_EXPECTED)
         );
+        Assert.assertThat(request.getCommandArgs(), Matchers.is(COMMAND_ARGS));
         Assert.assertThat(request.getClusterCriterias(), Matchers.is(CLUSTER_CRITERIAS));
         Assert.assertThat(request.getCommandCriteria(), Matchers.is(COMMAND_CRITERIA));
         Assert.assertFalse(request.getCpu().isPresent());
@@ -109,7 +119,8 @@ public class JobRequestTest {
         Assert.assertThat(request.getName(), Matchers.is(NAME));
         Assert.assertThat(request.getUser(), Matchers.is(USER));
         Assert.assertThat(request.getVersion(), Matchers.is(VERSION));
-        Assert.assertFalse(request.getCommandArgs().isPresent());
+        Assert.assertFalse(request.getCommandArgsString().isPresent());
+        Assert.assertTrue(request.getCommandArgs().isEmpty());
         Assert.assertThat(request.getClusterCriterias(), Matchers.is(CLUSTER_CRITERIAS));
         Assert.assertThat(request.getCommandCriteria(), Matchers.is(COMMAND_CRITERIA));
         Assert.assertFalse(request.getCpu().isPresent());
@@ -140,7 +151,7 @@ public class JobRequestTest {
         final JobRequest.Builder builder
             = new JobRequest.Builder(NAME, USER, VERSION, CLUSTER_CRITERIAS, COMMAND_CRITERIA);
 
-        builder.withCommandArgs(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE));
+        builder.withCommandArgs(COMMAND_ARGS_EXPECTED);
 
         final int cpu = 5;
         builder.withCpu(cpu);
@@ -215,9 +226,10 @@ public class JobRequestTest {
         Assert.assertThat(request.getUser(), Matchers.is(USER));
         Assert.assertThat(request.getVersion(), Matchers.is(VERSION));
         Assert.assertThat(
-            request.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+            request.getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(COMMAND_ARGS_EXPECTED)
         );
+        Assert.assertThat(request.getCommandArgs(), Matchers.is(COMMAND_ARGS));
         Assert.assertThat(request.getClusterCriterias(), Matchers.is(CLUSTER_CRITERIAS));
         Assert.assertThat(request.getCommandCriteria(), Matchers.is(COMMAND_CRITERIA));
         Assert.assertThat(request.getCpu().orElseThrow(IllegalArgumentException::new), Matchers.is(cpu));
@@ -327,9 +339,10 @@ public class JobRequestTest {
         Assert.assertThat(request.getUser(), Matchers.is(USER));
         Assert.assertThat(request.getVersion(), Matchers.is(VERSION));
         Assert.assertThat(
-            request.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+            request.getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(COMMAND_ARGS_EXPECTED)
         );
+        Assert.assertThat(request.getCommandArgs(), Matchers.is(COMMAND_ARGS));
         Assert.assertThat(request.getClusterCriterias(), Matchers.is(CLUSTER_CRITERIAS));
         Assert.assertThat(request.getCommandCriteria(), Matchers.is(COMMAND_CRITERIA));
         Assert.assertThat(request.getCpu().orElseThrow(IllegalArgumentException::new), Matchers.is(cpu));
@@ -380,7 +393,8 @@ public class JobRequestTest {
         Assert.assertThat(request.getName(), Matchers.is(NAME));
         Assert.assertThat(request.getUser(), Matchers.is(USER));
         Assert.assertThat(request.getVersion(), Matchers.is(VERSION));
-        Assert.assertFalse(request.getCommandArgs().isPresent());
+        Assert.assertFalse(request.getCommandArgsString().isPresent());
+        Assert.assertTrue(request.getCommandArgs().isEmpty());
         Assert.assertThat(request.getClusterCriterias(), Matchers.empty());
         Assert.assertThat(request.getCommandCriteria(), Matchers.empty());
         Assert.assertFalse(request.getCpu().isPresent());
@@ -455,38 +469,5 @@ public class JobRequestTest {
 
         Assert.assertEquals(jobRequest1.hashCode(), jobRequest2.hashCode());
         Assert.assertNotEquals(jobRequest1.hashCode(), jobRequest3.hashCode());
-    }
-
-    /**
-     * Test to prove a bug with command args splitting with trailing whitespace was corrected.
-     */
-    @Test
-    public void testCommandArgsEdgeCases() {
-        final JobRequest.Builder builder
-            = new JobRequest.Builder(NAME, USER, VERSION, Lists.newArrayList(), Sets.newHashSet());
-
-        String commandArgs = " blah ";
-        builder.withCommandArgs(commandArgs);
-        Assert.assertThat(
-            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(" blah ")
-        );
-        commandArgs = " blah    ";
-        builder.withCommandArgs(commandArgs);
-        Assert.assertThat(
-            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(" blah    ")
-        );
-        commandArgs = "  blah blah     blah\nblah\tblah \"blah\" blah  ";
-        builder.withCommandArgs(commandArgs);
-        Assert.assertThat(
-            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("  blah blah     blah\nblah\tblah \"blah\" blah  ")
-        );
-        builder.withCommandArgs(Lists.newArrayList("blah", "blah", "  blah", "\nblah", "\"blah\""));
-        Assert.assertThat(
-            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("blah blah   blah \nblah \"blah\"")
-        );
     }
 }

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/JobTest.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/JobTest.java
@@ -18,8 +18,6 @@
 package com.netflix.genie.common.dto;
 
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.StringUtils;
-import org.assertj.core.util.Lists;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,7 +40,17 @@ public class JobTest {
     private static final String NAME = UUID.randomUUID().toString();
     private static final String USER = UUID.randomUUID().toString();
     private static final String VERSION = UUID.randomUUID().toString();
-    private static final List<String> COMMAND_ARGS = Lists.newArrayList(UUID.randomUUID().toString());
+    private static final String COMMAND_ARG_1 = UUID.randomUUID().toString();
+    private static final String COMMAND_ARG_2 = UUID.randomUUID().toString() + ' ' + UUID.randomUUID().toString();
+    private static final String COMMAND_ARG_3 = UUID.randomUUID().toString();
+    private static final List<String> COMMAND_ARGS = com.google.common.collect.Lists.newArrayList(
+        COMMAND_ARG_1,
+        COMMAND_ARG_2,
+        COMMAND_ARG_3
+    );
+    private static final String COMMAND_ARGS_INPUT_STRING = COMMAND_ARG_1 + " '" + COMMAND_ARG_2 + "' " + COMMAND_ARG_3;
+    private static final String COMMAND_ARGS_EXPECTED
+        = '\'' + COMMAND_ARG_1 + "' '" + COMMAND_ARG_2 + "' '" + COMMAND_ARG_3 + '\'';
 
     /**
      * Test to make sure can build a valid Job using the builder.
@@ -50,14 +58,15 @@ public class JobTest {
     @Test
     @SuppressWarnings("deprecation")
     public void canBuildJobDeprecatedConstructor() {
-        final Job job = new Job.Builder(NAME, USER, VERSION, StringUtils.join(COMMAND_ARGS, StringUtils.SPACE)).build();
+        final Job job = new Job.Builder(NAME, USER, VERSION, COMMAND_ARGS_INPUT_STRING).build();
         Assert.assertThat(job.getName(), Matchers.is(NAME));
         Assert.assertThat(job.getUser(), Matchers.is(USER));
         Assert.assertThat(job.getVersion(), Matchers.is(VERSION));
         Assert.assertThat(
-            job.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+            job.getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(COMMAND_ARGS_EXPECTED)
         );
+        Assert.assertThat(job.getCommandArgs(), Matchers.is(COMMAND_ARGS));
         Assert.assertFalse(job.getArchiveLocation().isPresent());
         Assert.assertFalse(job.getClusterName().isPresent());
         Assert.assertFalse(job.getCommandName().isPresent());
@@ -84,7 +93,8 @@ public class JobTest {
         Assert.assertThat(job.getName(), Matchers.is(NAME));
         Assert.assertThat(job.getUser(), Matchers.is(USER));
         Assert.assertThat(job.getVersion(), Matchers.is(VERSION));
-        Assert.assertThat(job.getCommandArgs(), Matchers.is(Optional.empty()));
+        Assert.assertThat(job.getCommandArgsString(), Matchers.is(Optional.empty()));
+        Assert.assertTrue(job.getCommandArgs().isEmpty());
         Assert.assertFalse(job.getArchiveLocation().isPresent());
         Assert.assertFalse(job.getClusterName().isPresent());
         Assert.assertFalse(job.getCommandName().isPresent());
@@ -110,7 +120,7 @@ public class JobTest {
     public void canBuildJobWithOptionalsDeprecated() {
         final Job.Builder builder = new Job.Builder(NAME, USER, VERSION);
 
-        builder.withCommandArgs(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE));
+        builder.withCommandArgs(COMMAND_ARGS_EXPECTED);
 
         final String archiveLocation = UUID.randomUUID().toString();
         builder.withArchiveLocation(archiveLocation);
@@ -162,9 +172,10 @@ public class JobTest {
         Assert.assertThat(job.getUser(), Matchers.is(USER));
         Assert.assertThat(job.getVersion(), Matchers.is(VERSION));
         Assert.assertThat(
-            job.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+            job.getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(COMMAND_ARGS_EXPECTED)
         );
+        Assert.assertThat(job.getCommandArgs(), Matchers.is(COMMAND_ARGS));
         Assert.assertThat(
             job.getArchiveLocation().orElseThrow(IllegalArgumentException::new), Matchers.is(archiveLocation)
         );
@@ -249,9 +260,10 @@ public class JobTest {
         Assert.assertThat(job.getUser(), Matchers.is(USER));
         Assert.assertThat(job.getVersion(), Matchers.is(VERSION));
         Assert.assertThat(
-            job.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(StringUtils.join(COMMAND_ARGS, StringUtils.SPACE))
+            job.getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(COMMAND_ARGS_EXPECTED)
         );
+        Assert.assertThat(job.getCommandArgs(), Matchers.is(COMMAND_ARGS));
         Assert.assertThat(
             job.getArchiveLocation().orElseThrow(IllegalArgumentException::new), Matchers.is(archiveLocation)
         );
@@ -301,7 +313,8 @@ public class JobTest {
         Assert.assertThat(job.getName(), Matchers.is(NAME));
         Assert.assertThat(job.getUser(), Matchers.is(USER));
         Assert.assertThat(job.getVersion(), Matchers.is(VERSION));
-        Assert.assertFalse(job.getCommandArgs().isPresent());
+        Assert.assertFalse(job.getCommandArgsString().isPresent());
+        Assert.assertTrue(job.getCommandArgs().isEmpty());
         Assert.assertFalse(job.getArchiveLocation().isPresent());
         Assert.assertFalse(job.getClusterName().isPresent());
         Assert.assertFalse(job.getCommandName().isPresent());
@@ -374,37 +387,5 @@ public class JobTest {
 
         Assert.assertEquals(job1.hashCode(), job2.hashCode());
         Assert.assertNotEquals(job1.hashCode(), job3.hashCode());
-    }
-
-    /**
-     * Test to prove a bug with command args splitting with trailing whitespace was corrected.
-     */
-    @Test
-    public void testCommandArgsEdgeCases() {
-        final Job.Builder builder = new Job.Builder(NAME, USER, VERSION);
-
-        String commandArgs = " blah ";
-        builder.withCommandArgs(commandArgs);
-        Assert.assertThat(
-            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(" blah ")
-        );
-        commandArgs = " blah    ";
-        builder.withCommandArgs(commandArgs);
-        Assert.assertThat(
-            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(" blah    ")
-        );
-        commandArgs = "  blah blah     blah\nblah\tblah \"blah\" blah  ";
-        builder.withCommandArgs(commandArgs);
-        Assert.assertThat(
-            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("  blah blah     blah\nblah\tblah \"blah\" blah  ")
-        );
-        builder.withCommandArgs(Lists.newArrayList("blah", "blah", "  blah", "\nblah", "\"blah\""));
-        Assert.assertThat(
-            builder.build().getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("blah blah   blah \nblah \"blah\"")
-        );
     }
 }

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -48,6 +48,21 @@ no value is specified the bucket is assumed to be in the same region as the Geni
 |
 |yes
 
+|genie.agent.launcher.local.executable
+|The system command that the launcher should use to launch an agent process. Ordered list of arguments.
+|java -jar /tmp/genie-agent.jar
+|no
+
+|genie.agent.launcher.local.maxJobMemory
+|The maximum amount of memory, in megabytes, that a job can be allocated while using the local launcher
+|10240
+|no
+
+|genie.agent.launcher.local.maxTotalJobMemory
+|The total number of MB out of the system memory that Genie can use for running agents
+|30720
+|no
+
 |genie.aws.credentials.role
 |The AWS role ARN to assume when connecting to S3. If this is set Genie will create a credentials provider that will
 attempt to assume this role on the host Genie is running on

--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -9,6 +9,10 @@ ext {
     snippetsDir = new File(project.buildDir, "generated-snippets")
 }
 
+configurations {
+    genieAgent
+}
+
 dependencies {
     /*******************************
      * Annotation Processors
@@ -101,6 +105,12 @@ dependencies {
     testCompile("org.springframework.restdocs:spring-restdocs-mockmvc")
     testCompile("org.springframework.restdocs:spring-restdocs-restassured")
     testCompile("io.grpc:grpc-testing")
+
+    /*******************************
+     * Agent Dependencies
+     *******************************/
+
+    genieAgent(project(path: ":genie-agent-app", configuration: "agentBootJar"))
 }
 
 license {
@@ -112,7 +122,9 @@ license {
 }
 
 integrationTest {
+    dependsOn project.findProject(":genie-agent-app").tasks.bootJar
     outputs.dir snippetsDir
+    systemProperty("genie.agent.launcher.local.executable", "java,-jar,${configurations.genieAgent.asPath}")
 }
 
 // This is needed cause some things like attributes for asciidoctor don't serialize project.version properly at runtime

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
@@ -82,6 +82,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Integration tests for Jobs REST API.
@@ -247,7 +248,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     }
 
     /**
-     * Test to make sure command args are limitted to 10,000 characters.
+     * Test to make sure command args are limited to 10,000 characters.
      *
      * @throws Exception On error
      */
@@ -260,7 +261,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
             Lists.newArrayList(new ClusterCriteria(Sets.newHashSet(LOCALHOST_CLUSTER_TAG))),
             Sets.newHashSet(BASH_COMMAND_TAG)
         )
-            .withCommandArgs(StringUtils.leftPad("bad", 10_001))
+            .withCommandArgs(StringUtils.leftPad("bad", 10_001, 'a'))
             .build();
 
         RestAssured
@@ -276,7 +277,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
 
     private void submitAndCheckJob(final int documentationId, final boolean archiveJob) throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
-        final List<String> commandArgs = Lists.newArrayList("-c", "'echo hello world'");
+        final List<String> commandArgs = Lists.newArrayList("-c", "echo hello world");
 
         final String clusterTag = LOCALHOST_CLUSTER_TAG;
         final List<ClusterCriteria> clusterCriteriaList = Lists.newArrayList(
@@ -503,7 +504,15 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
             .body(DESCRIPTION_PATH, Matchers.is(JOB_DESCRIPTION))
             .body(METADATA_PATH + "." + SCHEDULER_JOB_NAME_KEY, Matchers.is(this.schedulerJobName))
             .body(METADATA_PATH + "." + SCHEDULER_RUN_ID_KEY, Matchers.is(this.schedulerRunId))
-            .body(COMMAND_ARGS_PATH, Matchers.is(StringUtils.join(commandArgs, StringUtils.SPACE)))
+            .body(
+                COMMAND_ARGS_PATH,
+                Matchers.is(
+                    commandArgs
+                        .stream()
+                        .map(arg -> '\'' + arg + '\'')
+                        .collect(Collectors.joining(StringUtils.SPACE))
+                )
+            )
             .body(STATUS_PATH, Matchers.is(JobStatus.SUCCEEDED.toString()))
             .body(STATUS_MESSAGE_PATH, Matchers.is(JOB_STATUS_MSG))
             .body(STARTED_PATH, Matchers.not(Instant.EPOCH))
@@ -697,7 +706,15 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
             .body(DESCRIPTION_PATH, Matchers.is(JOB_DESCRIPTION))
             .body(METADATA_PATH + "." + SCHEDULER_JOB_NAME_KEY, Matchers.is(this.schedulerJobName))
             .body(METADATA_PATH + "." + SCHEDULER_RUN_ID_KEY, Matchers.is(this.schedulerRunId))
-            .body(COMMAND_ARGS_PATH, Matchers.is(StringUtils.join(commandArgs, StringUtils.SPACE)))
+            .body(
+                COMMAND_ARGS_PATH,
+                Matchers.is(
+                    commandArgs
+                        .stream()
+                        .map(arg -> '\'' + arg + '\'')
+                        .collect(Collectors.joining(StringUtils.SPACE))
+                )
+            )
             .body(SETUP_FILE_PATH, Matchers.is(setupFile))
             .body(CLUSTER_CRITERIAS_PATH, Matchers.hasSize(1))
             .body(CLUSTER_CRITERIAS_PATH + "[0].tags", Matchers.hasSize(1))
@@ -941,7 +958,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
      */
     @Test
     public void canSubmitJobWithAttachments() throws Exception {
-        final List<String> commandArgs = Lists.newArrayList("-c", "'echo hello world'");
+        final List<String> commandArgs = Lists.newArrayList("-c", "echo hello world");
 
         final List<ClusterCriteria> clusterCriteriaList = Lists.newArrayList(
             new ClusterCriteria(Sets.newHashSet(LOCALHOST_CLUSTER_TAG))
@@ -1004,7 +1021,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     @Test
     public void testSubmitJobMethodMissingCluster() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
-        final List<String> commandArgs = Lists.newArrayList("-c", "'echo hello world'");
+        final List<String> commandArgs = Lists.newArrayList("-c", "echo hello world");
 
         final List<ClusterCriteria> clusterCriteriaList = new ArrayList<>();
         final Set<String> clusterTags = Sets.newHashSet("undefined");
@@ -1047,7 +1064,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     @Test
     public void testSubmitJobMethodInvalidClusterCriteria() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
-        final List<String> commandArgs = Lists.newArrayList("-c", "'echo hello world'");
+        final List<String> commandArgs = Lists.newArrayList("-c", "echo hello world");
 
         final List<ClusterCriteria> clusterCriteriaList
             = Lists.newArrayList(new ClusterCriteria(Sets.newHashSet(" ", "", null)));
@@ -1094,7 +1111,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     @Test
     public void testSubmitJobMethodInvalidCommandCriteria() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
-        final List<String> commandArgs = Lists.newArrayList("-c", "'echo hello world'");
+        final List<String> commandArgs = Lists.newArrayList("-c", "echo hello world");
 
         final List<ClusterCriteria> clusterCriteriaList
             = Lists.newArrayList(new ClusterCriteria(Sets.newHashSet("ok")));
@@ -1141,7 +1158,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     @Test
     public void testSubmitJobMethodMissingCommand() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
-        final List<String> commandArgs = Lists.newArrayList("-c", "'echo hello world'");
+        final List<String> commandArgs = Lists.newArrayList("-c", "echo hello world");
 
         final List<ClusterCriteria> clusterCriteriaList = new ArrayList<>();
         final Set<String> clusterTags = Sets.newHashSet(LOCALHOST_CLUSTER_TAG);
@@ -1184,7 +1201,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     @Test
     public void testSubmitJobMethodKill() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
-        final List<String> commandArgs = Lists.newArrayList("-c", "'sleep 60'");
+        final List<String> commandArgs = Lists.newArrayList("-c", "sleep 60");
 
         final List<ClusterCriteria> clusterCriteriaList = new ArrayList<>();
         final Set<String> clusterTags = Sets.newHashSet(LOCALHOST_CLUSTER_TAG);
@@ -1297,7 +1314,8 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     @Test
     public void testSubmitJobMethodKillOnTimeout() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
-        final List<String> commandArgs = Lists.newArrayList("-c", "'sleep 60'");
+        // To test backwards compatibility
+        final String commandArgString = "-c 'sleep 60'";
 
         final List<ClusterCriteria> clusterCriteriaList = new ArrayList<>();
         final Set<String> clusterTags = Sets.newHashSet(LOCALHOST_CLUSTER_TAG);
@@ -1312,7 +1330,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
             clusterCriteriaList,
             commandCriteria
         )
-            .withCommandArgs(commandArgs)
+            .withCommandArgs(commandArgString)
             .withTimeout(5)
             .withDisableLogArchival(true)
             .build();
@@ -1355,7 +1373,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     @Test
     public void testSubmitJobMethodFailure() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
-        final List<String> commandArgs = Lists.newArrayList("-c", "'exit 1'");
+        final List<String> commandArgs = Lists.newArrayList("-c", "exit 1");
 
         final List<ClusterCriteria> clusterCriteriaList = new ArrayList<>();
         final Set<String> clusterTags = Sets.newHashSet(LOCALHOST_CLUSTER_TAG);
@@ -1414,7 +1432,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     @Test
     public void testResponseContentType() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
-        final List<String> commandArgs = Lists.newArrayList("-c", "'echo hello'");
+        final List<String> commandArgs = Lists.newArrayList("-c", "echo hello");
 
         final JobRequest jobRequest = new JobRequest.Builder(
             JOB_NAME,

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplIntegrationTest.java
@@ -60,6 +60,7 @@ import com.netflix.genie.web.dtos.JobSubmission;
 import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.exceptions.checked.IdAlreadyExistsException;
 import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
+import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
 import org.hamcrest.Matchers;
@@ -746,9 +747,12 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
             Matchers.is(DESCRIPTION)
         );
         Assert.assertThat(
-            savedJobRequest.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(COMMAND_ARGS.get(0))
+            savedJobRequest.getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(
+                COMMAND_ARGS.stream().map(arg -> '\'' + arg + '\'').collect(Collectors.joining(StringUtils.SPACE))
+            )
         );
+        Assert.assertThat(savedJobRequest.getCommandArgs(), Matchers.is(COMMAND_ARGS));
         Assert.assertThat(
             savedJobRequest.getGroup().orElseThrow(IllegalArgumentException::new),
             Matchers.is(GROUP)
@@ -799,9 +803,12 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
             Matchers.is(DESCRIPTION)
         );
         Assert.assertThat(
-            savedJob.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(COMMAND_ARGS.get(0))
+            savedJob.getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is(
+                COMMAND_ARGS.stream().map(arg -> '\'' + arg + '\'').collect(Collectors.joining(StringUtils.SPACE))
+            )
         );
+        Assert.assertThat(savedJob.getCommandArgs(), Matchers.is(COMMAND_ARGS));
         Assert.assertThat(savedJob.getTags(), Matchers.is(TAGS));
         Assert.assertThat(
             savedJob.getArchiveLocation().orElseThrow(IllegalArgumentException::new),

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplIntegrationTest.java
@@ -32,6 +32,7 @@ import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.test.suppliers.RandomSuppliers;
 import com.netflix.genie.web.data.services.JobSearchService;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.util.Lists;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -517,9 +518,10 @@ public class JpaJobSearchServiceImplIntegrationTest extends DBIntegrationTestBas
     public void canGetJobRequest() throws GenieException {
         final JobRequest job1Request = this.service.getJobRequest(JOB_1_ID);
         Assert.assertThat(
-            job1Request.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("-f query.q")
+            job1Request.getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is("'-f' 'query.q'")
         );
+        Assert.assertThat(job1Request.getCommandArgs(), Matchers.is(Lists.newArrayList("-f", "query.q")));
         Assert.assertThat(
             job1Request.getClusterCriterias().size(),
             Matchers.is(2)
@@ -548,12 +550,12 @@ public class JpaJobSearchServiceImplIntegrationTest extends DBIntegrationTestBas
             Matchers.is(Sets.newHashSet("type:spark", "ver:1.6.0", "genie.name:spark"))
         );
         Assert.assertThat(
-            this.service.getJobRequest(JOB_2_ID).getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("-f spark.jar")
+            this.service.getJobRequest(JOB_2_ID).getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is("'-f' 'spark.jar'")
         );
         Assert.assertThat(
-            this.service.getJobRequest(JOB_3_ID).getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("-f spark.jar")
+            this.service.getJobRequest(JOB_3_ID).getCommandArgsString().orElseThrow(IllegalArgumentException::new),
+            Matchers.is("'-f' 'spark.jar'")
         );
 
         try {

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplIntegrationTest.java
@@ -31,6 +31,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.test.suppliers.RandomSuppliers;
 import com.netflix.genie.web.data.services.JobSearchService;
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -682,5 +683,38 @@ public class JpaJobSearchServiceImplIntegrationTest extends DBIntegrationTestBas
         final Set<String> jobs = this.service.getActiveDisconnectedAgentJobs();
         Assert.assertThat(jobs.size(), Matchers.is(1));
         Assert.assertThat(jobs, Matchers.contains("agentJob1"));
+    }
+
+    /**
+     * Make sure the amount of allocated memory for active jobs is correct.
+     */
+    @Test
+    public void canGetAllocatedMemoryOnHost() {
+        Assertions.assertThat(this.service.getAllocatedMemoryOnHost("a.netflix.com")).isEqualTo(2048L);
+        Assertions.assertThat(this.service.getAllocatedMemoryOnHost("b.netflix.com")).isEqualTo(2048L);
+        Assertions.assertThat(this.service.getAllocatedMemoryOnHost("agent.netflix.com")).isEqualTo(4096L);
+        Assertions.assertThat(this.service.getAllocatedMemoryOnHost(UUID.randomUUID().toString())).isEqualTo(0L);
+    }
+
+    /**
+     * Make sure the amount of used memory for running jobs is correct.
+     */
+    @Test
+    public void canGetUsedMemoryOnHost() {
+        Assertions.assertThat(this.service.getUsedMemoryOnHost("a.netflix.com")).isEqualTo(2048L);
+        Assertions.assertThat(this.service.getUsedMemoryOnHost("b.netflix.com")).isEqualTo(2048L);
+        Assertions.assertThat(this.service.getUsedMemoryOnHost("agent.netflix.com")).isEqualTo(4096L);
+        Assertions.assertThat(this.service.getUsedMemoryOnHost(UUID.randomUUID().toString())).isEqualTo(0L);
+    }
+
+    /**
+     * Make sure the amount of used memory for active jobs is correct.
+     */
+    @Test
+    public void canGetCountOfActiveJobsOnHost() {
+        Assertions.assertThat(this.service.getActiveJobCountOnHost("a.netflix.com")).isEqualTo(1L);
+        Assertions.assertThat(this.service.getActiveJobCountOnHost("b.netflix.com")).isEqualTo(1L);
+        Assertions.assertThat(this.service.getActiveJobCountOnHost("agent.netflix.com")).isEqualTo(2L);
+        Assertions.assertThat(this.service.getActiveJobCountOnHost(UUID.randomUUID().toString())).isEqualTo(0L);
     }
 }

--- a/genie-web/src/integTest/resources/application-integration.yml
+++ b/genie-web/src/integTest/resources/application-integration.yml
@@ -44,3 +44,9 @@ spring:
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+#  # Leaving this in for reference as it can be helpful for debugging
+#  jpa:
+#    show-sql: true
+#    properties:
+#      hibernate:
+#        format_sql: true

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/linux-runsh.txt
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/linux-runsh.txt
@@ -121,7 +121,7 @@ source ${GENIE_JOB_DIR}/jobsetupfile
 env | sort > ${GENIE_JOB_DIR}/genie/logs/env.log
 
 # Kick off the command in background mode and wait for it using its pid
-/bin/bash -c 'echo hello world' > ${GENIE_JOB_DIR}/stdout 2> ${GENIE_JOB_DIR}/stderr &
+/bin/bash '-c' 'echo hello world' > ${GENIE_JOB_DIR}/stdout 2> ${GENIE_JOB_DIR}/stderr &
 export CHILDREN_PID=$!
 wait ${CHILDREN_PID}
 

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/non-linux-runsh.txt
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/non-linux-runsh.txt
@@ -121,7 +121,7 @@ source ${GENIE_JOB_DIR}/jobsetupfile
 env | sort > ${GENIE_JOB_DIR}/genie/logs/env.log
 
 # Kick off the command in background mode and wait for it using its pid
-/bin/bash -c 'echo hello world' > ${GENIE_JOB_DIR}/stdout 2> ${GENIE_JOB_DIR}/stderr &
+/bin/bash '-c' 'echo hello world' > ${GENIE_JOB_DIR}/stdout 2> ${GENIE_JOB_DIR}/stderr &
 export CHILDREN_PID=$!
 wait ${CHILDREN_PID}
 

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplIntegrationTest/init.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplIntegrationTest/init.xml
@@ -503,6 +503,7 @@
         command_criterion="3"
         requested_cpu="2"
         requested_memory="2048"
+        memory_used="2048"
         archiving_disabled="false"
         requested_timeout="608400"
         num_attachments="3"

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImpl.java
@@ -32,6 +32,8 @@ import org.apache.commons.exec.DefaultExecuteResultHandler;
 import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.lang3.SystemUtils;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
 
 import javax.validation.Valid;
 import java.io.IOException;
@@ -42,7 +44,19 @@ import java.io.IOException;
  * @author tgianos
  * @since 4.0.0
  */
-public class LocalAgentLauncherImpl implements AgentLauncher {
+@Slf4j
+public class LocalAgentLauncherImpl implements AgentLauncher, HealthIndicator {
+
+    @VisibleForTesting
+    static final String NUMBER_RUNNING_JOBS_KEY = "numRunningJobs";
+    @VisibleForTesting
+    static final String ALLOCATED_MEMORY_KEY = "allocatedMemory";
+    @VisibleForTesting
+    static final String USED_MEMORY_KEY = "usedMemory";
+    @VisibleForTesting
+    static final String AVAILABLE_MEMORY = "availableMemory";
+    @VisibleForTesting
+    static final String AVAILABLE_MAX_JOB_CAPACITY = "availableMaxJobCapacity";
 
     private static final String SETS_ID = "setsid";
     private static final String EXEC_COMMAND = "exec";
@@ -117,6 +131,8 @@ public class LocalAgentLauncherImpl implements AgentLauncher {
      */
     @Override
     public void launchAgent(@Valid final ResolvedJob resolvedJob) throws AgentLaunchException {
+        log.debug("Received request to launch local agent to run job: {}", resolvedJob);
+
         // Check error conditions
         final int jobMemory = resolvedJob.getJobEnvironment().getMemory();
         final String jobId = resolvedJob.getJobSpecification().getJob().getId();
@@ -171,6 +187,39 @@ public class LocalAgentLauncherImpl implements AgentLauncher {
                 ioe
             );
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Health health() {
+        final long allocatedMemoryOnHost = this.jobSearchService.getAllocatedMemoryOnHost(this.hostname);
+        final long usedMemoryOnHost = this.jobSearchService.getUsedMemoryOnHost(this.hostname);
+
+        // Use allocated memory to make the host go OOS early enough that we don't throw as many exceptions on
+        // accepted jobs during launch
+        final long availableMemory = this.launcherProperties.getMaxTotalJobMemory() - allocatedMemoryOnHost;
+        final int maxJobMemory = this.launcherProperties.getMaxJobMemory();
+
+        final Health.Builder builder;
+
+        // If we can fit one more max job in we're still healthy
+        if (availableMemory >= maxJobMemory) {
+            builder = Health.up();
+        } else {
+            builder = Health.down();
+        }
+
+        return builder
+            .withDetail(NUMBER_RUNNING_JOBS_KEY, this.jobSearchService.getActiveJobCountOnHost(this.hostname))
+            .withDetail(ALLOCATED_MEMORY_KEY, allocatedMemoryOnHost)
+            .withDetail(AVAILABLE_MEMORY, availableMemory)
+            .withDetail(USED_MEMORY_KEY, usedMemoryOnHost)
+            .withDetail(
+                AVAILABLE_MAX_JOB_CAPACITY,
+                (availableMemory >= 0 && maxJobMemory > 0) ? (availableMemory / maxJobMemory) : 0)
+            .build();
     }
 
     // TODO: Likely need to handle user creation locally to match V3 behavior. Getting basics done first.

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/resources/AgentFileProtocolResolver.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/resources/AgentFileProtocolResolver.java
@@ -34,7 +34,7 @@ import java.nio.file.Paths;
 
 /**
  * Resource resolver for files local to an agent running a job that can be streamed to the server and served via API.
- * The URI for such resources is: agent://\<jobId\>/\<relativePath\>.
+ * The URI for such resources is: {@literal agent://<jobId>/<relativePath>}.
  *
  * @author mprimi
  * @since 4.0.0

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/DtoConverters.java
@@ -392,12 +392,10 @@ public final class DtoConverters {
 
         final JobArchivalDataRequest.Builder jobArchivalDataRequestBuilder = new JobArchivalDataRequest.Builder();
 
-        final List<String> commandArgs = Lists.newArrayList();
-        v3JobRequest.getCommandArgs().ifPresent(commandArgs::add);
         return new JobRequest(
             v3JobRequest.getId().orElse(null),
             resources,
-            commandArgs,
+            v3JobRequest.getCommandArgs(),
             metadataBuilder.build(),
             criteria,
             jobEnvironmentBuilder.build(),

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
@@ -306,9 +306,9 @@ public class JobRestController {
                 .withTags(jobRequest.getTags())
                 .withConfigs(jobRequest.getConfigs())
                 .withDependencies(jobRequest.getDependencies())
-                .withApplications(jobRequest.getApplications());
+                .withApplications(jobRequest.getApplications())
+                .withCommandArgs(jobRequest.getCommandArgs());
 
-            jobRequest.getCommandArgs().ifPresent(builder::withCommandArgs);
             jobRequest.getCpu().ifPresent(builder::withCpu);
             jobRequest.getMemory().ifPresent(builder::withMemory);
             jobRequest.getGroup().ifPresent(builder::withGroup);

--- a/genie-web/src/main/java/com/netflix/genie/web/data/repositories/jpa/JpaJobRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/repositories/jpa/JpaJobRepository.java
@@ -54,6 +54,32 @@ public interface JpaJobRepository extends JpaBaseRepository<JobEntity> {
     Set<JobProjection> findByAgentHostnameAndStatusIn(String agentHostname, Set<JobStatus> statuses);
 
     /**
+     * Get the number of agent jobs on a given host with the given statuses.
+     *
+     * @param agentHostname The hostname of the agent
+     * @param statuses      The statuses the job should be in e.g. {@link JobStatus#getActiveStatuses()}
+     * @return The number of jobs in the given statuses on that node
+     */
+    long countByAgentHostnameAndStatusIn(String agentHostname, Set<JobStatus> statuses);
+
+    /**
+     * Given the hostname that agents are running on return the total memory their jobs are currently using.
+     *
+     * @param agentHostname The agent hostname
+     * @param statuses      The job statuses to filter by e.g. {@link JobStatus#getActiveStatuses()}
+     * @return The total memory used in MB
+     */
+    @Query(
+        "SELECT COALESCE(SUM(j.memoryUsed), 0)"
+            + " FROM JobEntity j"
+            + " WHERE j.agentHostname = :agentHostname AND j.status IN (:statuses)"
+    )
+    long getTotalMemoryUsedOnHost(
+        @Param("agentHostname") String agentHostname,
+        @Param("statuses") Set<JobStatus> statuses
+    );
+
+    /**
      * Find the jobs with one of the statuses entered.
      *
      * @param statuses The statuses to search

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/JobPersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/JobPersistenceService.java
@@ -163,7 +163,7 @@ public interface JobPersistenceService {
      * <p>
      * The job record will be created with initial state of {@link JobStatus#RESERVED} meaning that the unique id
      * returned by this API has been reserved within Genie and no other job can use it. If
-     * {@link JobSubmission#getAttachments()} contains some attachments these attachments will be persisted to a
+     * {@link JobSubmission} contains some attachments these attachments will be persisted to a
      * configured storage system (i.e. local disk, S3, etc) and added to the set of dependencies for the job.
      * The underlying attachment storage system must be accessible by the agent process configured by the system. For
      * example if the server is set up to write attachments to local disk but the agent is not running locally but

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/JobSearchService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/JobSearchService.java
@@ -211,4 +211,34 @@ public interface JobSearchService {
      * @return a set of job ids
      */
     Set<String> getActiveDisconnectedAgentJobs();
+
+    /**
+     * Get the amount of memory currently allocated on the given host by Genie jobs that are currently active.
+     *
+     * @param hostname The hostname to get the memory for
+     * @return The amount of memory reserved in MB by all active jobs on the given host
+     * @see JobStatus#getActiveStatuses()
+     */
+    long getAllocatedMemoryOnHost(String hostname);
+
+    /**
+     * Get the amount of memory currently used on the given host by Genie jobs in any of the following states.
+     * <p>
+     * {@link JobStatus#CLAIMED}
+     * {@link JobStatus#INIT}
+     * {@link JobStatus#RUNNING}
+     *
+     * @param hostname The hostname to get the memory for
+     * @return The amount of memory being used in MB by all jobs
+     */
+    long getUsedMemoryOnHost(String hostname);
+
+    /**
+     * Get the number of active Genie jobs on a given host.
+     *
+     * @param hostname The host to get the count for
+     * @return The count of jobs in an active state on the given host
+     * @see JobStatus#getActiveStatuses()
+     */
+    long getActiveJobCountOnHost(String hostname);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
@@ -700,7 +700,7 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
             .getMetadata()
             .ifPresent(metadata -> EntityDtoConverters.setJsonField(metadata, jobEntity::setMetadata));
         JpaServiceUtils.setEntityMetadata(GenieObjectMapper.getMapper(), jobRequest, jobEntity);
-        jobRequest.getCommandArgs().ifPresent(commandArgs -> jobEntity.setCommandArgs(Lists.newArrayList(commandArgs)));
+        jobEntity.setCommandArgs(jobRequest.getCommandArgs());
         jobRequest.getGroup().ifPresent(jobEntity::setGenieUserGroup);
         final FileEntity setupFile = jobRequest.getSetupFile().isPresent()
             ? this.createAndGetFileEntity(jobRequest.getSetupFile().get())

--- a/genie-web/src/main/java/com/netflix/genie/web/dtos/GenieWebHostInfo.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/dtos/GenieWebHostInfo.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.dtos;
+
+import com.netflix.genie.common.internal.util.GenieHostInfo;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+/**
+ * Extension of {@link GenieHostInfo} which adds metadata specific to the web server.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Getter
+@EqualsAndHashCode(doNotUseGetters = true, callSuper = true)
+@ToString(doNotUseGetters = true, callSuper = true)
+public class GenieWebHostInfo extends GenieHostInfo {
+
+    @Min(value = 1, message = "The minimum value for the RPC port is 1")
+    @Max(value = 65_535, message = "The maximum value for the RPC port is 65,535")
+    private final int rpcPort;
+
+    /**
+     * Constructor.
+     *
+     * @param hostname The hostname of this Genie web instance
+     * @param rpcPort  The port the RPC server is listening on to receive calls from Agent instances
+     */
+    public GenieWebHostInfo(final String hostname, final int rpcPort) {
+        super(hostname);
+        this.rpcPort = rpcPort;
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/health/LocalAgentLauncherHealthIndicator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/health/LocalAgentLauncherHealthIndicator.java
@@ -1,0 +1,100 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.health;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.genie.common.internal.util.GenieHostInfo;
+import com.netflix.genie.web.data.services.JobSearchService;
+import com.netflix.genie.web.properties.LocalAgentLauncherProperties;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+/**
+ * Health indicator based on data related to the health of the systems ability to launch more agent processes locally.
+ * health.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+public class LocalAgentLauncherHealthIndicator implements HealthIndicator {
+
+    @VisibleForTesting
+    static final String NUMBER_RUNNING_JOBS_KEY = "numRunningJobs";
+    @VisibleForTesting
+    static final String ALLOCATED_MEMORY_KEY = "allocatedMemory";
+    @VisibleForTesting
+    static final String USED_MEMORY_KEY = "usedMemory";
+    @VisibleForTesting
+    static final String AVAILABLE_MEMORY = "availableMemory";
+    @VisibleForTesting
+    static final String AVAILABLE_MAX_JOB_CAPACITY = "availableMaxJobCapacity";
+
+    private final JobSearchService jobSearchService;
+    private final LocalAgentLauncherProperties launcherProperties;
+    private final String hostname;
+
+    /**
+     * Constructor.
+     *
+     * @param jobSearchService   The {@link JobSearchService} implementation to use
+     * @param launcherProperties The properties related to local agent launch
+     * @param genieHostInfo      The {@link GenieHostInfo} object containing metadata about the current Genie host
+     */
+    public LocalAgentLauncherHealthIndicator(
+        final JobSearchService jobSearchService,
+        final LocalAgentLauncherProperties launcherProperties,
+        final GenieHostInfo genieHostInfo
+    ) {
+        this.jobSearchService = jobSearchService;
+        this.launcherProperties = launcherProperties;
+        this.hostname = genieHostInfo.getHostname();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Health health() {
+        final long allocatedMemoryOnHost = this.jobSearchService.getAllocatedMemoryOnHost(this.hostname);
+        final long usedMemoryOnHost = this.jobSearchService.getUsedMemoryOnHost(this.hostname);
+
+        // Use allocated memory to make the host go OOS early enough that we don't throw as many exceptions on
+        // accepted jobs during launch
+        final long availableMemory = this.launcherProperties.getMaxTotalJobMemory() - allocatedMemoryOnHost;
+        final int maxJobMemory = this.launcherProperties.getMaxJobMemory();
+
+        final Health.Builder builder;
+
+        // If we can fit one more max job in we're still healthy
+        if (availableMemory >= maxJobMemory) {
+            builder = Health.up();
+        } else {
+            builder = Health.down();
+        }
+
+        return builder
+            .withDetail(NUMBER_RUNNING_JOBS_KEY, this.jobSearchService.getActiveJobCountOnHost(this.hostname))
+            .withDetail(ALLOCATED_MEMORY_KEY, allocatedMemoryOnHost)
+            .withDetail(AVAILABLE_MEMORY, availableMemory)
+            .withDetail(USED_MEMORY_KEY, usedMemoryOnHost)
+            .withDetail(
+                AVAILABLE_MAX_JOB_CAPACITY,
+                (availableMemory >= 0 && maxJobMemory > 0) ? (availableMemory / maxJobMemory) : 0)
+            .build();
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/JobTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/jobs/workflow/impl/JobTask.java
@@ -147,7 +147,7 @@ public class JobTask extends GenieBaseTask {
             writer.write(
                 StringUtils.join(jobExecEnv.getCommand().getExecutable(), StringUtils.SPACE)
                     + JobConstants.WHITE_SPACE
-                    + jobExecEnv.getJobRequest().getCommandArgs().orElse(EMPTY_STRING)
+                    + jobExecEnv.getJobRequest().getCommandArgsString().orElse(EMPTY_STRING)
                     + JobConstants.STDOUT_REDIRECT
                     + "${" + JobConstants.GENIE_JOB_DIR_ENV_VAR + "}/" + JobConstants.STDOUT_LOG_FILE_NAME
                     + JobConstants.STDERR_REDIRECT

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/LocalAgentLauncherProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/LocalAgentLauncherProperties.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import java.util.List;
@@ -47,6 +48,18 @@ public class LocalAgentLauncherProperties {
     /**
      * The command that should be run to execute the Genie agent. Required.
      */
-    @NotEmpty
+    @NotEmpty(message = "The agent executable cannot be empty or it will be impossible to launch an agent process")
     private List<@NotBlank String> executable = Lists.newArrayList("java", "-jar", "/tmp/genie-agent.jar");
+
+    /**
+     * Defaults to 10 GB (10,240 MB).
+     */
+    @Min(value = 1, message = "The minimum value is 1MB but the value should likely be much higher")
+    private int maxJobMemory = 10_240;
+
+    /**
+     * Default to 30 GB (30,720 MB).
+     */
+    @Min(value = 1L, message = "The minimum value is 1MB but the value should likely be set much higher")
+    private long maxTotalJobMemory = 30_720L;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobLaunchService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobLaunchService.java
@@ -17,8 +17,11 @@
  */
 package com.netflix.genie.web.services;
 
+import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.web.dtos.JobSubmission;
 import com.netflix.genie.web.exceptions.checked.AgentLaunchException;
+import com.netflix.genie.web.exceptions.checked.IdAlreadyExistsException;
+import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
 import org.springframework.validation.annotation.Validated;
 
 import javax.annotation.Nonnull;
@@ -43,10 +46,14 @@ public interface JobLaunchService {
      *
      * @param jobSubmission The payload of metadata and resources making up all the information needed to launch
      *                      a job
-     * @return The id of the job. Upon return the job will at least be in
-     * {@link com.netflix.genie.common.dto.JobStatus#ACCEPTED} state
-     * @throws AgentLaunchException If the system was unable to launch an agent to handle job execution
+     * @return The id of the job. Upon return the job will at least be in {@link JobStatus#ACCEPTED} state
+     * @throws AgentLaunchException     If the system was unable to launch an agent to handle job execution
+     * @throws IdAlreadyExistsException If the unique identifier for the job conflicts with an already existing job
+     * @throws SaveAttachmentException  When a job is submitted with attachments but there is an error saving them
      */
     @Nonnull
-    String launchJob(@Valid JobSubmission jobSubmission) throws AgentLaunchException;
+    String launchJob(@Valid JobSubmission jobSubmission) throws
+        AgentLaunchException,
+        IdAlreadyExistsException,
+        SaveAttachmentException;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -164,7 +164,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
                 .withStatus(JobStatus.INIT)
                 .withStatusMsg("Job Accepted and in initialization phase.");
 
-            jobRequest.getCommandArgs().ifPresent(jobBuilder::withCommandArgs);
+            jobBuilder.withCommandArgs(jobRequest.getCommandArgs());
             jobRequest.getDescription().ifPresent(jobBuilder::withDescription);
 
             // TODO: Disabling this check for now to force archival for all jobs during internal V4 migration.

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
@@ -24,6 +24,8 @@ import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.dtos.JobSubmission;
 import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.exceptions.checked.AgentLaunchException;
+import com.netflix.genie.web.exceptions.checked.IdAlreadyExistsException;
+import com.netflix.genie.web.exceptions.checked.SaveAttachmentException;
 import com.netflix.genie.web.services.JobLaunchService;
 import com.netflix.genie.web.services.JobResolverService;
 import com.netflix.genie.web.util.MetricsUtils;
@@ -77,7 +79,9 @@ public class JobLaunchServiceImpl implements JobLaunchService {
      */
     @Override
     @Nonnull
-    public String launchJob(@Valid final JobSubmission jobSubmission) throws AgentLaunchException {
+    public String launchJob(
+        @Valid final JobSubmission jobSubmission
+    ) throws AgentLaunchException, IdAlreadyExistsException, SaveAttachmentException {
         final long start = System.nanoTime();
         final Set<Tag> tags = Sets.newHashSet();
         try {
@@ -91,14 +95,7 @@ public class JobLaunchServiceImpl implements JobLaunchService {
              * 5. If the agent launch fails mark the job failed else return
              */
 
-            final String jobId;
-            try {
-                jobId = this.jobPersistenceService.saveJobSubmission(jobSubmission);
-            } catch (final Throwable t) {
-                // TODO: Really handle this error
-                log.error("TODO", t);
-                throw new AgentLaunchException(t);
-            }
+            final String jobId = this.jobPersistenceService.saveJobSubmission(jobSubmission);
 
             final ResolvedJob resolvedJob;
             try {

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/health/HealthAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/health/HealthAutoConfiguration.java
@@ -17,12 +17,18 @@
  */
 package com.netflix.genie.web.spring.autoconfigure.health;
 
+import com.netflix.genie.common.internal.util.GenieHostInfo;
+import com.netflix.genie.web.agent.launchers.impl.LocalAgentLauncherImpl;
 import com.netflix.genie.web.agent.services.AgentMetricsService;
+import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.health.GenieAgentHealthIndicator;
 import com.netflix.genie.web.health.GenieMemoryHealthIndicator;
+import com.netflix.genie.web.health.LocalAgentLauncherHealthIndicator;
 import com.netflix.genie.web.properties.HealthProperties;
 import com.netflix.genie.web.properties.JobsProperties;
+import com.netflix.genie.web.properties.LocalAgentLauncherProperties;
 import com.netflix.genie.web.services.JobMetricsService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -69,5 +75,29 @@ public class HealthAutoConfiguration {
     @ConditionalOnMissingBean(GenieAgentHealthIndicator.class)
     public GenieAgentHealthIndicator genieAgentHealthIndicator(final AgentMetricsService agentMetricsService) {
         return new GenieAgentHealthIndicator(agentMetricsService);
+    }
+
+    /**
+     * Provide a health indicator tied to the ability to launch jobs with agents on the local hardware.
+     *
+     * @param jobSearchService   The {@link JobSearchService} implementation to use
+     * @param launcherProperties The properties related to launching agent jobs locally
+     * @param genieHostInfo      The {@link GenieHostInfo} to use
+     * @return A {@link LocalAgentLauncherHealthIndicator} instance
+     */
+    @Bean
+    @ConditionalOnMissingBean(LocalAgentLauncherHealthIndicator.class)
+    @ConditionalOnBean(
+        {
+            LocalAgentLauncherProperties.class,
+            LocalAgentLauncherImpl.class
+        }
+    )
+    public LocalAgentLauncherHealthIndicator localAgentLauncherHealthIndicator(
+        final JobSearchService jobSearchService,
+        final LocalAgentLauncherProperties launcherProperties,
+        final GenieHostInfo genieHostInfo
+    ) {
+        return new LocalAgentLauncherHealthIndicator(jobSearchService, launcherProperties, genieHostInfo);
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImplSpec.groovy
@@ -27,12 +27,10 @@ import com.netflix.genie.web.exceptions.checked.AgentLaunchException
 import com.netflix.genie.web.properties.LocalAgentLauncherProperties
 import com.netflix.genie.web.util.ExecutorFactory
 import io.micrometer.core.instrument.MeterRegistry
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.apache.commons.exec.CommandLine
 import org.apache.commons.exec.ExecuteResultHandler
 import org.apache.commons.exec.Executor
 import org.apache.commons.lang3.SystemUtils
-import org.springframework.boot.actuate.health.Status
 import spock.lang.Specification
 
 /**
@@ -171,74 +169,5 @@ class LocalAgentLauncherImplSpec extends Specification {
             throw new IOException("Something broke")
         }
         thrown(AgentLaunchException)
-    }
-
-    def "Can report health"() {
-        def hostname = UUID.randomUUID().toString()
-        def genieHostInfo = Mock(GenieHostInfo) {
-            getHostname() >> hostname
-        }
-        def jobSearchService = Mock(JobSearchService)
-        def maxTotalJobMemory = 100_003L
-        def maxJobMemory = 10_000
-        def properties = Mock(LocalAgentLauncherProperties) {
-            getMaxTotalJobMemory() >> maxTotalJobMemory
-            getMaxJobMemory() >> maxJobMemory
-            getExecutable() >> ["java", "-jar", "/tmp/genie-agent.jar"]
-        }
-        def rpcPort = 8990
-        def executorFactory = Mock(ExecutorFactory)
-        def meterRegistry = new SimpleMeterRegistry()
-
-        def launcher = new LocalAgentLauncherImpl(
-            genieHostInfo,
-            jobSearchService,
-            properties,
-            rpcPort,
-            executorFactory,
-            meterRegistry
-        )
-
-        when: "Available memory is equal to one max job"
-        def health = launcher.health()
-
-        then: "The system reports healthy"
-        1 * jobSearchService.getAllocatedMemoryOnHost(hostname) >> maxTotalJobMemory - maxJobMemory
-        1 * jobSearchService.getUsedMemoryOnHost(hostname) >> maxTotalJobMemory - 2 * maxJobMemory
-        1 * jobSearchService.getActiveJobCountOnHost(hostname) >> 335L
-        health.getStatus() == Status.UP
-        health.getDetails().get(LocalAgentLauncherImpl.NUMBER_RUNNING_JOBS_KEY) == 335L
-        health.getDetails().get(LocalAgentLauncherImpl.ALLOCATED_MEMORY_KEY) == maxTotalJobMemory - maxJobMemory
-        health.getDetails().get(LocalAgentLauncherImpl.AVAILABLE_MEMORY) == maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory)
-        health.getDetails().get(LocalAgentLauncherImpl.USED_MEMORY_KEY) == maxTotalJobMemory - 2 * maxJobMemory
-        health.getDetails().get(LocalAgentLauncherImpl.AVAILABLE_MAX_JOB_CAPACITY) == ((maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory)) / maxJobMemory).toInteger()
-
-        when: "Available memory is equal to more than one max job"
-        health = launcher.health()
-
-        then: "The system reports healthy"
-        1 * jobSearchService.getAllocatedMemoryOnHost(hostname) >> maxTotalJobMemory - maxJobMemory - 1
-        1 * jobSearchService.getUsedMemoryOnHost(hostname) >> maxTotalJobMemory - 2 * maxJobMemory
-        1 * jobSearchService.getActiveJobCountOnHost(hostname) >> 337L
-        health.getStatus() == Status.UP
-        health.getDetails().get(LocalAgentLauncherImpl.NUMBER_RUNNING_JOBS_KEY) == 337L
-        health.getDetails().get(LocalAgentLauncherImpl.ALLOCATED_MEMORY_KEY) == maxTotalJobMemory - maxJobMemory - 1
-        health.getDetails().get(LocalAgentLauncherImpl.AVAILABLE_MEMORY) == maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory - 1)
-        health.getDetails().get(LocalAgentLauncherImpl.USED_MEMORY_KEY) == maxTotalJobMemory - 2 * maxJobMemory
-        health.getDetails().get(LocalAgentLauncherImpl.AVAILABLE_MAX_JOB_CAPACITY) == ((maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory - 1)) / maxJobMemory).toInteger()
-
-        when: "Available memory is less than one max job"
-        health = launcher.health()
-
-        then: "The system reports down"
-        1 * jobSearchService.getAllocatedMemoryOnHost(hostname) >> maxTotalJobMemory - maxJobMemory + 1
-        1 * jobSearchService.getUsedMemoryOnHost(hostname) >> maxTotalJobMemory - 2 * maxJobMemory
-        1 * jobSearchService.getActiveJobCountOnHost(hostname) >> 343L
-        health.getStatus() == Status.DOWN
-        health.getDetails().get(LocalAgentLauncherImpl.NUMBER_RUNNING_JOBS_KEY) == 343L
-        health.getDetails().get(LocalAgentLauncherImpl.ALLOCATED_MEMORY_KEY) == maxTotalJobMemory - maxJobMemory + 1
-        health.getDetails().get(LocalAgentLauncherImpl.AVAILABLE_MEMORY) == maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory + 1)
-        health.getDetails().get(LocalAgentLauncherImpl.USED_MEMORY_KEY) == maxTotalJobMemory - 2 * maxJobMemory
-        health.getDetails().get(LocalAgentLauncherImpl.AVAILABLE_MAX_JOB_CAPACITY) == ((maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory + 1)) / maxJobMemory).toInteger()
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/apis/rest/v3/controllers/DtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/apis/rest/v3/controllers/DtoConvertersSpec.groovy
@@ -39,10 +39,10 @@ import com.netflix.genie.common.internal.dto.v4.ExecutionResourceCriteria
 import com.netflix.genie.common.internal.dto.v4.JobMetadata
 import com.netflix.genie.common.internal.dto.v4.JobRequest
 import com.netflix.genie.common.util.GenieObjectMapper
-import org.apache.commons.lang3.StringUtils
 import spock.lang.Specification
 
 import java.time.Instant
+import java.util.stream.Collectors
 
 /**
  * Specifications for the {@link DtoConverters} class which handles converting between v3 and v4 DTOs for API
@@ -897,7 +897,8 @@ class DtoConvertersSpec extends Specification {
         v3JobRequest.getVersion() == version
         v3JobRequest.getTags() == tags
         v3JobRequest.getApplications() == applicationIds
-        v3JobRequest.getCommandArgs().orElse(UUID.randomUUID().toString()) == StringUtils.join(commandArgs, " ")
+        v3JobRequest.getCommandArgsString().orElse(UUID.randomUUID().toString()) ==
+            commandArgs.stream().map { it -> '\'' + it + '\'' }.collect(Collectors.joining(' '))
         !v3JobRequest.getMemory().isPresent()
         v3JobRequest.getTimeout().orElse(-1) == timeout
         v3JobRequest.getMetadata().orElse(null) == metadata
@@ -982,7 +983,7 @@ class DtoConvertersSpec extends Specification {
         v4JobRequest.getMetadata().getVersion() == version
         v4JobRequest.getMetadata().getTags() == tags
         v4JobRequest.getCriteria().getApplicationIds() == applicationIds
-        v4JobRequest.getCommandArgs() == [StringUtils.join(commandArgs, StringUtils.SPACE)] as List
+        v4JobRequest.getCommandArgs() == commandArgs
         v4JobRequest.getRequestedJobEnvironment().getRequestedJobMemory().orElse(null) == memory
         v4JobRequest.getRequestedAgentConfig().getTimeoutRequested().orElse(-1) == timeout
         v4JobRequest.getMetadata().getMetadata().orElse(null) == metadata

--- a/genie-web/src/test/groovy/com/netflix/genie/web/data/services/jpa/JpaServiceUtilsSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/data/services/jpa/JpaServiceUtilsSpec.groovy
@@ -39,6 +39,7 @@ import org.apache.commons.lang3.StringUtils
 import spock.lang.Specification
 
 import java.time.Instant
+import java.util.stream.Collectors
 
 /**
  * Specifications for the JpaServiceUtils class.
@@ -512,7 +513,9 @@ class JpaServiceUtilsSpec extends Specification {
         request.getCreated().orElseGet(RandomSuppliers.INSTANT) == created
         request.getUpdated().orElseGet(RandomSuppliers.INSTANT) == updated
         request.getTags() == tags
-        request.getCommandArgs().orElseGet(RandomSuppliers.STRING) == StringUtils.join(commandArgs, StringUtils.SPACE)
+        request.getCommandArgsString().orElseGet(RandomSuppliers.STRING) ==
+            commandArgs.stream().map { it -> '\'' + it + '\'' }.collect(Collectors.joining(StringUtils.SPACE))
+        request.getCommandArgs() == commandArgs
 
         def criterias = request.getClusterCriterias()
         criterias.size() == 3

--- a/genie-web/src/test/groovy/com/netflix/genie/web/dtos/GenieWebHostInfoSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/dtos/GenieWebHostInfoSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.dtos
+
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link GenieWebHostInfo}.
+ *
+ * @author tgianos
+ */
+class GenieWebHostInfoSpec extends Specification {
+
+    def "can create and execute POJO methods"() {
+        def hostname = UUID.randomUUID().toString()
+        def rpcPort = 33_352
+
+        when:
+        def info = new GenieWebHostInfo(hostname, rpcPort)
+
+        then:
+        info.getHostname() == hostname
+        info.getRpcPort() == rpcPort
+
+        when:
+        def info2 = new GenieWebHostInfo(hostname, rpcPort)
+        def info3 = new GenieWebHostInfo(hostname + UUID.randomUUID().toString(), rpcPort + 1)
+
+        then:
+        info == info2
+        info != info3
+        info.hashCode() == info2.hashCode()
+        info2.hashCode() != info3.hashCode()
+        info.toString() == info2.toString()
+        info.toString() != info3.toString()
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/health/LocalAgentLauncherHealthIndicatorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/health/LocalAgentLauncherHealthIndicatorSpec.groovy
@@ -1,0 +1,95 @@
+/*
+ *
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.health
+
+import com.netflix.genie.common.internal.util.GenieHostInfo
+import com.netflix.genie.web.data.services.JobSearchService
+import com.netflix.genie.web.properties.LocalAgentLauncherProperties
+import org.springframework.boot.actuate.health.Status
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link LocalAgentLauncherHealthIndicator}.
+ *
+ * @author tgianos
+ */
+class LocalAgentLauncherHealthIndicatorSpec extends Specification {
+
+    def "Can report health"() {
+        def hostname = UUID.randomUUID().toString()
+        def genieHostInfo = Mock(GenieHostInfo) {
+            getHostname() >> hostname
+        }
+        def jobSearchService = Mock(JobSearchService)
+        def maxTotalJobMemory = 100_003L
+        def maxJobMemory = 10_000
+        def properties = Mock(LocalAgentLauncherProperties) {
+            getMaxTotalJobMemory() >> maxTotalJobMemory
+            getMaxJobMemory() >> maxJobMemory
+            getExecutable() >> ["java", "-jar", "/tmp/genie-agent.jar"]
+        }
+
+        def healthIndicator = new LocalAgentLauncherHealthIndicator(
+            jobSearchService,
+            properties,
+            genieHostInfo
+        )
+
+        when: "Available memory is equal to one max job"
+        def health = healthIndicator.health()
+
+        then: "The system reports healthy"
+        1 * jobSearchService.getAllocatedMemoryOnHost(hostname) >> maxTotalJobMemory - maxJobMemory
+        1 * jobSearchService.getUsedMemoryOnHost(hostname) >> maxTotalJobMemory - 2 * maxJobMemory
+        1 * jobSearchService.getActiveJobCountOnHost(hostname) >> 335L
+        health.getStatus() == Status.UP
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.NUMBER_RUNNING_JOBS_KEY) == 335L
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.ALLOCATED_MEMORY_KEY) == maxTotalJobMemory - maxJobMemory
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.AVAILABLE_MEMORY) == maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory)
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.USED_MEMORY_KEY) == maxTotalJobMemory - 2 * maxJobMemory
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.AVAILABLE_MAX_JOB_CAPACITY) == ((maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory)) / maxJobMemory).toInteger()
+
+        when: "Available memory is equal to more than one max job"
+        health = healthIndicator.health()
+
+        then: "The system reports healthy"
+        1 * jobSearchService.getAllocatedMemoryOnHost(hostname) >> maxTotalJobMemory - maxJobMemory - 1
+        1 * jobSearchService.getUsedMemoryOnHost(hostname) >> maxTotalJobMemory - 2 * maxJobMemory
+        1 * jobSearchService.getActiveJobCountOnHost(hostname) >> 337L
+        health.getStatus() == Status.UP
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.NUMBER_RUNNING_JOBS_KEY) == 337L
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.ALLOCATED_MEMORY_KEY) == maxTotalJobMemory - maxJobMemory - 1
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.AVAILABLE_MEMORY) == maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory - 1)
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.USED_MEMORY_KEY) == maxTotalJobMemory - 2 * maxJobMemory
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.AVAILABLE_MAX_JOB_CAPACITY) == ((maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory - 1)) / maxJobMemory).toInteger()
+
+        when: "Available memory is less than one max job"
+        health = healthIndicator.health()
+
+        then: "The system reports down"
+        1 * jobSearchService.getAllocatedMemoryOnHost(hostname) >> maxTotalJobMemory - maxJobMemory + 1
+        1 * jobSearchService.getUsedMemoryOnHost(hostname) >> maxTotalJobMemory - 2 * maxJobMemory
+        1 * jobSearchService.getActiveJobCountOnHost(hostname) >> 343L
+        health.getStatus() == Status.DOWN
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.NUMBER_RUNNING_JOBS_KEY) == 343L
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.ALLOCATED_MEMORY_KEY) == maxTotalJobMemory - maxJobMemory + 1
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.AVAILABLE_MEMORY) == maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory + 1)
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.USED_MEMORY_KEY) == maxTotalJobMemory - 2 * maxJobMemory
+        health.getDetails().get(LocalAgentLauncherHealthIndicator.AVAILABLE_MAX_JOB_CAPACITY) == ((maxTotalJobMemory - (maxTotalJobMemory - maxJobMemory + 1)) / maxJobMemory).toInteger()
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/LocalAgentLauncherPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/LocalAgentLauncherPropertiesSpec.groovy
@@ -38,16 +38,24 @@ class LocalAgentLauncherPropertiesSpec extends Specification {
 
         then:
         properties.getExecutable() == Lists.newArrayList("java", "-jar", "/tmp/genie-agent.jar")
+        properties.getMaxJobMemory() == 10_240
+        properties.getMaxTotalJobMemory() == 30_720L
     }
 
     def "Setters and getters work properly"() {
         def newExecutable = Lists.newArrayList("/etc/genie-agent.sh", "run")
+        def newMaxJobMemory = 30_000
+        def newMaxTotalJobMemory = 900_000L
         def properties = new LocalAgentLauncherProperties()
 
         when:
         properties.setExecutable(newExecutable)
+        properties.setMaxJobMemory(newMaxJobMemory)
+        properties.setMaxTotalJobMemory(newMaxTotalJobMemory)
 
         then:
         properties.getExecutable() == newExecutable
+        properties.getMaxJobMemory() == newMaxJobMemory
+        properties.getMaxTotalJobMemory() == newMaxTotalJobMemory
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
@@ -51,6 +51,7 @@ import wiremock.com.google.common.collect.ImmutableMap
 
 import javax.annotation.Nullable
 import java.time.Instant
+import java.util.stream.Collectors
 
 /**
  * Specifications for the {@link JobResolverServiceImpl} class.
@@ -462,7 +463,9 @@ class JobResolverServiceImplSpec extends Specification {
         v3JobRequest.getVersion() == version
         v3JobRequest.getTags() == tags
         v3JobRequest.getApplications() == applicationIds
-        v3JobRequest.getCommandArgs().orElse(UUID.randomUUID().toString()) == StringUtils.join(commandArgs, " ")
+        v3JobRequest.getCommandArgsString().orElse(UUID.randomUUID().toString()) ==
+            commandArgs.stream().map { it -> '\'' + it + '\'' }.collect(Collectors.joining(StringUtils.SPACE))
+        v3JobRequest.getCommandArgs() == commandArgs
         !v3JobRequest.getMemory().isPresent()
         v3JobRequest.getTimeout().orElse(-1) == timeout
         v3JobRequest.getMetadata().orElse(null) == metadata

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
@@ -156,7 +156,12 @@ class JobResolverServiceImplSpec extends Specification {
         jobSpecNoArchivalData.getApplications().isEmpty()
         !jobSpecNoArchivalData.isInteractive()
         jobSpecNoArchivalData.getEnvironmentVariables().size() == 17
-        jobSpecNoArchivalData.getArchiveLocation() == Optional.empty()
+        jobSpecNoArchivalData.getArchiveLocation() ==
+            Optional.of(
+                StringUtils.endsWith(jobsProperties.getLocations().getArchives(), File.separator)
+                    ? jobsProperties.getLocations().getArchives() + jobId
+                    : jobsProperties.getLocations().getArchives() + File.separator + jobId
+            )
         jobEnvironmentNoArchivalData.getEnvironmentVariables() == jobSpecNoArchivalData.getEnvironmentVariables()
         jobEnvironmentNoArchivalData.getMemory() == jobsProperties.getMemory().getDefaultJobMemory()
         jobEnvironmentNoArchivalData.getCpu() == 1
@@ -185,7 +190,12 @@ class JobResolverServiceImplSpec extends Specification {
         jobSpecSavedData.getApplications().isEmpty()
         !jobSpecSavedData.isInteractive()
         jobSpecSavedData.getEnvironmentVariables().size() == 17
-        jobSpecSavedData.getArchiveLocation() == Optional.empty()
+        jobSpecSavedData.getArchiveLocation() ==
+            Optional.of(
+                StringUtils.endsWith(jobsProperties.getLocations().getArchives(), File.separator)
+                    ? jobsProperties.getLocations().getArchives() + jobId
+                    : jobsProperties.getLocations().getArchives() + File.separator + jobId
+            )
         jobEnvironmentSavedData.getEnvironmentVariables() == jobSpecSavedData.getEnvironmentVariables()
         jobEnvironmentSavedData.getMemory() == requestedMemory
         jobEnvironmentSavedData.getCpu() == 1

--- a/genie-web/src/test/java/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplTest.java
@@ -36,12 +36,14 @@ import com.netflix.genie.web.data.entities.projections.UniqueIdProjection;
 import com.netflix.genie.web.data.repositories.jpa.JpaClusterRepository;
 import com.netflix.genie.web.data.repositories.jpa.JpaCommandRepository;
 import com.netflix.genie.web.data.repositories.jpa.JpaJobRepository;
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.UUID;
@@ -302,4 +304,51 @@ public class JpaJobSearchServiceImplTest {
         );
     }
 
+    /**
+     * Make sure the right repository method is called.
+     */
+    @Test
+    public void canGetAllocatedMemoryOnHost() {
+        final String hostname = UUID.randomUUID().toString();
+        final long totalMemory = 213_382L;
+
+        Mockito
+            .when(this.jobRepository.getTotalMemoryUsedOnHost(hostname, JobStatus.getActiveStatuses()))
+            .thenReturn(totalMemory);
+
+        Assertions.assertThat(this.service.getAllocatedMemoryOnHost(hostname)).isEqualTo(totalMemory);
+    }
+
+    /**
+     * Make sure the right repository method is called.
+     */
+    @Test
+    public void canGetUsedMemoryOnHost() {
+        final String hostname = UUID.randomUUID().toString();
+        final long totalMemory = 213_328L;
+
+        Mockito
+            .when(this.jobRepository.getTotalMemoryUsedOnHost(
+                hostname,
+                EnumSet.of(JobStatus.RUNNING, JobStatus.CLAIMED, JobStatus.INIT))
+            )
+            .thenReturn(totalMemory);
+
+        Assertions.assertThat(this.service.getUsedMemoryOnHost(hostname)).isEqualTo(totalMemory);
+    }
+
+    /**
+     * Make sure the right repository method is called.
+     */
+    @Test
+    public void canGetCountActiveJobsOnHost() {
+        final String hostname = UUID.randomUUID().toString();
+        final long totalJobs = 32L;
+
+        Mockito
+            .when(this.jobRepository.countByAgentHostnameAndStatusIn(hostname, JobStatus.getActiveStatuses()))
+            .thenReturn(totalJobs);
+
+        Assertions.assertThat(this.service.getActiveJobCountOnHost(hostname)).isEqualTo(totalJobs);
+    }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/health/HealthAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/health/HealthAutoConfigurationTest.java
@@ -33,7 +33,6 @@ import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Unit tests for {@link HealthAutoConfiguration}.
@@ -85,7 +84,6 @@ public class HealthAutoConfigurationTest {
     /**
      * Provide some junk beans if needed.
      */
-    @Configuration
     static class UserConfiguration {
         @Bean
         public JobMetricsService jobMetricsService() {
@@ -117,7 +115,6 @@ public class HealthAutoConfigurationTest {
     /**
      * Mock configuration for local agent launch health beans.
      */
-    @Configuration
     static class LocalAgentLaunchMockConfiguration {
         @Bean
         public LocalAgentLauncherProperties localAgentLauncherProperties() {


### PR DESCRIPTION
Much of this PR is work towards being able to launch a job locally on Genie hardware using the agent instead of the old V3 logic. It's still groundwork and isn't hooked up to the actual API yet.

The primary change here, and why this is a PR now, is changing how arguments are parsed on a V3 job submission. The agent changed, for the better, how we handled job arguments. This change didn't work well with how V3 was treating the command args as one unified string. Effectively without escaping single quotes properly after submission the agent would treat the string as one big argument instead of N arguments as was the intent by the user. This PR contains a change, as the final commit, which splits the V3 command arg string on whitespace and `'` and from there on treats all the arguments as independent. In serializing to the V3 run script, and as responses to `GET` requests, it will re-wrap all arguments in `'`. This means that the command arg string won't look exactly like what the user originally submitted however it will behave more correctly across V3 and V4 going forward.

The hope here is to merge this, test it with a `RC` to make sure it doesn't really break anything and then move forward with the continued port of job launch to agent on top of this change.