### PR TITLE
Add double quote parsing to arguments

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/util/JsonUtils.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/util/JsonUtils.java
@@ -100,7 +100,7 @@ public final class JsonUtils {
         final StringTokenizer tokenizer = new StringTokenizer(
             commandArgs,
             StringMatcherFactory.INSTANCE.splitMatcher(),
-            StringMatcherFactory.INSTANCE.singleQuoteMatcher()
+            StringMatcherFactory.INSTANCE.quoteMatcher()
         );
 
         return tokenizer.getTokenList();

--- a/genie-common/src/test/groovy/com/netflix/genie/common/util/JsonUtilsSpec.groovy
+++ b/genie-common/src/test/groovy/com/netflix/genie/common/util/JsonUtilsSpec.groovy
@@ -38,6 +38,8 @@ class JsonUtilsSpec extends Specification {
         "/bin/bash -xc 'echo \"hello\" world!'" | ["/bin/bash", "-xc", "echo \"hello\" world!"]
         "arg1   arg2\targ3\narg4\r'arg5' '''"   | ["arg1", "arg2", "arg3", "arg4", "arg5", "'"]
         "foo/bar --hello '\$world'"             | ["foo/bar", "--hello", "\$world"]
+        "foo/bar \" --hello\" \"\$world\""      | ["foo/bar", " --hello", "\$world"]
+        "foo/bar \"'hello'\""                   | ["foo/bar", "'hello'"]
     }
 
     @Unroll


### PR DESCRIPTION
Modifies previous command arg parsing commit (b01a44f522c0ef03428376d869262b4bafcf54cb) to include respecting double quotes