### PR TITLE
Upgrade OkHttp and Retrofit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,8 @@ configure(javaProjects) {
             dependency("com.github.fge:json-patch:1.9")
             dependency("com.github.springtestdbunit:spring-test-dbunit:1.3.0")
             dependency("com.github.spotbugs:spotbugs-annotations:3.1.12")
-            dependencySet(group: "com.squareup.retrofit2", version: "2.1.0") {
+            dependency("com.squareup.okhttp3:okhttp:3.11.0")
+            dependencySet(group: "com.squareup.retrofit2", version: "2.6.1") {
                 entry "retrofit"
                 entry "converter-jackson"
             }


### PR DESCRIPTION
These libraries haven't been updated in the Java client in a long time. Updating them to newer versions to better align with internal recommended versions.