### PR TITLE
Accept Command 'executable' field as tokenized array

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/process/JobProcessManager.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/process/JobProcessManager.java
@@ -40,7 +40,8 @@ public interface JobProcessManager extends ApplicationListener<KillService.KillE
      *
      * @param jobDirectory         Job directory
      * @param environmentVariables additional environment variables (to merge on top of inherited environment)
-     * @param commandLine          command-line executable and arguments
+     * @param commandArguments     command-line executable and its fixed arguments arguments
+     * @param jobArguments         job-specific arguments
      * @param interactive          launch in interactive mode (inherit I/O) or batch (no input, write outputs to files)
      * @param timeout              The optional number of seconds this job is allowed to run before the system will
      *                             kill it
@@ -49,7 +50,8 @@ public interface JobProcessManager extends ApplicationListener<KillService.KillE
     void launchProcess(
         File jobDirectory,
         Map<String, String> environmentVariables,
-        List<String> commandLine,
+        List<String> commandArguments,
+        List<String> jobArguments,
         boolean interactive,
         @Nullable Integer timeout
     ) throws JobLaunchException;

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/process/impl/JobProcessManagerImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/process/impl/JobProcessManagerImpl.java
@@ -136,22 +136,28 @@ public class JobProcessManagerImpl implements JobProcessManager {
         final List<String> commandLine = Lists.newArrayList(commandArguments);
         commandLine.addAll(jobArguments);
 
-        // Configure arguments
-        log.info("Job command-line: {}", Arrays.toString(commandLine.toArray()));
+        log.info(
+            "Job command-line: {} arguments: {}",
+            Arrays.toString(commandArguments.toArray()),
+            Arrays.toString(jobArguments.toArray())
+        );
 
-        final List<String> expandedCommandLine;
+        // Configure arguments
+        final List<String> expandedCommandArguments;
         try {
-            expandedCommandLine = expandCommandLineVariables(
-                commandLine,
+            expandedCommandArguments = expandCommandLineVariables(
+                commandArguments,
                 Collections.unmodifiableMap(currentEnvironmentVariables)
             );
         } catch (final EnvUtils.VariableSubstitutionException e) {
-            throw new JobLaunchException("Job command-line arguments variables could not be expanded");
+            throw new JobLaunchException("Command executable and arguments variables could not be expanded");
         }
 
-        if (!commandLine.equals(expandedCommandLine)) {
-            log.info("Job command-line with variables expanded: {}", Arrays.toString(expandedCommandLine.toArray()));
-        }
+        final List<String> expandedCommandLine = Lists.newArrayList();
+        expandedCommandLine.addAll(expandedCommandArguments);
+        expandedCommandLine.addAll(jobArguments);
+
+        log.info("Command-line after expansion: {}", expandedCommandLine);
 
         processBuilder.command(expandedCommandLine);
 

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/process/impl/JobProcessManagerImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/process/impl/JobProcessManagerImpl.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.agent.execution.process.impl;
 
+import com.google.common.collect.Lists;
 import com.netflix.genie.agent.cli.UserConsole;
 import com.netflix.genie.agent.execution.exceptions.JobLaunchException;
 import com.netflix.genie.agent.execution.process.JobProcessManager;
@@ -78,7 +79,8 @@ public class JobProcessManagerImpl implements JobProcessManager {
     public void launchProcess(
         final File jobDirectory,
         final Map<String, String> environmentVariablesMap,
-        final List<String> commandLine,
+        final List<String> commandArguments,
+        final List<String> jobArguments,
         final boolean interactive,
         @Nullable final Integer timeout
     ) throws JobLaunchException {
@@ -125,11 +127,14 @@ public class JobProcessManagerImpl implements JobProcessManager {
         });
 
         // Validate arguments
-        if (commandLine == null) {
+        if (commandArguments == null) {
             throw new JobLaunchException("Job command-line arguments is null");
-        } else if (commandLine.isEmpty()) {
+        } else if (commandArguments.isEmpty()) {
             throw new JobLaunchException("Job command-line arguments are empty");
         }
+
+        final List<String> commandLine = Lists.newArrayList(commandArguments);
+        commandLine.addAll(jobArguments);
 
         // Configure arguments
         log.info("Job command-line: {}", Arrays.toString(commandLine.toArray()));

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/actions/LaunchJobAction.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/actions/LaunchJobAction.java
@@ -30,7 +30,6 @@ import com.netflix.genie.common.internal.dto.v4.JobSpecification;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -74,14 +73,14 @@ class LaunchJobAction extends BaseStateAction implements StateAction.LaunchJob {
         final JobSpecification jobSpec = executionContext.getJobSpecification().get();
         final File jobDirectory = executionContext.getJobDirectory().get();
         final Map<String, String> jobEnvironment = executionContext.getJobEnvironment().get();
-        final List<String> jobCommandLine = jobSpec.getCommandArgs();
         final boolean interactive = jobSpec.isInteractive();
 
         try {
             this.jobProcessManager.launchProcess(
                 jobDirectory,
                 jobEnvironment,
-                jobCommandLine,
+                jobSpec.getExecutableArgs(),
+                jobSpec.getJobArgs(),
                 interactive,
                 jobSpec.getTimeout().orElse(null)
             );

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/ResolveJobSpecCommandSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/ResolveJobSpecCommandSpec.groovy
@@ -172,7 +172,7 @@ class ResolveJobSpecCommandSpec extends Specification {
         1 * jobRequestConverter.agentJobRequestArgsToDTO(jobArgs) >> jobRequest
         1 * service.resolveJobSpecificationDryRun(jobRequest) >> spec
         1 * commandArgs.isPrintRequestDisabled() >> false
-        1 * spec.getCommandArgs() >> { throw new IOException("") }
+        1 * spec.getExecutableArgs() >> { throw new IOException("") }
         def e = thrown(RuntimeException)
         e.getCause() instanceof JsonProcessingException
     }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/process/impl/JobProcessManagerImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/process/impl/JobProcessManagerImplSpec.groovy
@@ -70,7 +70,8 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["touch", expectedFile.getAbsolutePath()],
+            ["touch"],
+            [expectedFile.getAbsolutePath()],
             true,
             null
         )
@@ -101,7 +102,8 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["\${ECHO_COMMAND}", helloWorld],
+            ["\${ECHO_COMMAND}"],
+            [helloWorld],
             false,
             null
         )
@@ -134,6 +136,7 @@ class JobProcessManagerImplSpec extends Specification {
             this.temporaryFolder.getRoot(),
             this.envMap,
             ["env"],
+            [],
             false,
             null
         )
@@ -163,7 +166,8 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["rm", nonExistentFile.absolutePath],
+            ["rm"],
+            [nonExistentFile.absolutePath],
             false,
             null
         )
@@ -194,6 +198,7 @@ class JobProcessManagerImplSpec extends Specification {
             this.temporaryFolder.getRoot(),
             this.envMap,
             [uuid],
+            [],
             false,
             null
         )
@@ -209,6 +214,7 @@ class JobProcessManagerImplSpec extends Specification {
             this.temporaryFolder.getRoot(),
             this.envMap,
             ["\$COMMAND"],
+            [],
             false,
             null
         )
@@ -224,6 +230,7 @@ class JobProcessManagerImplSpec extends Specification {
             null,
             this.envMap,
             ["echo"],
+            [],
             false,
             null
         )
@@ -239,6 +246,7 @@ class JobProcessManagerImplSpec extends Specification {
             this.temporaryFolder.newFile("foo"),
             this.envMap,
             ["echo"],
+            [],
             false,
             null
         )
@@ -254,6 +262,7 @@ class JobProcessManagerImplSpec extends Specification {
             new File(this.temporaryFolder.getRoot(), "foo"),
             this.envMap,
             ["echo"],
+            [],
             false,
             null
         )
@@ -269,6 +278,7 @@ class JobProcessManagerImplSpec extends Specification {
             this.temporaryFolder.getRoot(),
             null,
             ["echo"],
+            [],
             false,
             null
         )
@@ -284,6 +294,7 @@ class JobProcessManagerImplSpec extends Specification {
             this.temporaryFolder.getRoot(),
             this.envMap,
             null,
+            null,
             false,
             null
         )
@@ -298,6 +309,7 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
+            [],
             [],
             false,
             null
@@ -315,7 +327,8 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["sleep", "60"],
+            ["sleep"],
+            ["60"],
             true,
             59
         )
@@ -349,7 +362,8 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["sleep", "60"],
+            ["sleep"],
+            ["60"],
             true,
             null
         )
@@ -385,7 +399,8 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["echo", "foo"],
+            ["echo"],
+            ["foo"],
             true,
             null
         )
@@ -425,7 +440,8 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["echo", "foo"],
+            ["echo"],
+            ["foo"],
             true,
             10
         )
@@ -452,7 +468,8 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["echo", "foo"],
+            ["echo"],
+            ["foo"],
             true,
             null
         )
@@ -465,7 +482,8 @@ class JobProcessManagerImplSpec extends Specification {
         this.manager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["echo", "foo"],
+            ["echo"],
+            ["foo"],
             true,
             null
         )
@@ -496,7 +514,8 @@ class JobProcessManagerImplSpec extends Specification {
         realManager.launchProcess(
             this.temporaryFolder.getRoot(),
             this.envMap,
-            ["sleep", "60"],
+            ["sleep"],
+            ["60"],
             true,
             1
         )

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/actions/LaunchJobActionSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/actions/LaunchJobActionSpec.groovy
@@ -36,7 +36,8 @@ class LaunchJobActionSpec extends Specification {
     JobProcessManager jobProcessManager
     AgentJobService agentJobService
     File jobDirectory
-    List<String> jobCommandLine
+    List<String> commandArgs
+    List<String> jobArgs
     boolean interactive
 
     void setup() {
@@ -45,7 +46,8 @@ class LaunchJobActionSpec extends Specification {
         this.jobSpec = Mock(JobSpecification)
         this.jobDirectory = Mock(File)
         this.jobEnvironment = Mock(Map)
-        this.jobCommandLine = Mock(List)
+        this.commandArgs = Mock(List)
+        this.jobArgs = Mock(List)
         this.interactive = true
         this.jobProcessManager = Mock(JobProcessManager)
         this.agentJobService = Mock(AgentJobService)
@@ -63,10 +65,11 @@ class LaunchJobActionSpec extends Specification {
         1 * executionContext.getJobSpecification() >> Optional.of(jobSpec)
         1 * executionContext.getJobDirectory() >> Optional.of(jobDirectory)
         1 * executionContext.getJobEnvironment() >> Optional.of(jobEnvironment)
-        1 * jobSpec.getCommandArgs() >> jobCommandLine
+        1 * jobSpec.getExecutableArgs() >> commandArgs
+        1 * jobSpec.getJobArgs() >> jobArgs
         1 * jobSpec.isInteractive() >> interactive
         1 * jobSpec.getTimeout() >> Optional.ofNullable(10)
-        1 * jobProcessManager.launchProcess(jobDirectory, jobEnvironment, jobCommandLine, interactive, 10)
+        1 * jobProcessManager.launchProcess(jobDirectory, jobEnvironment, commandArgs, jobArgs, interactive, 10)
         1 * executionContext.getClaimedJobId() >> Optional.of(id)
         1 * agentJobService.changeJobStatus(id, JobStatus.INIT, JobStatus.RUNNING, _ as String)
         1 * executionContext.setCurrentJobStatus(JobStatus.RUNNING)
@@ -85,10 +88,11 @@ class LaunchJobActionSpec extends Specification {
         1 * executionContext.getJobSpecification() >> Optional.of(jobSpec)
         1 * executionContext.getJobDirectory() >> Optional.of(jobDirectory)
         1 * executionContext.getJobEnvironment() >> Optional.of(jobEnvironment)
-        1 * jobSpec.getCommandArgs() >> jobCommandLine
+        1 * jobSpec.getExecutableArgs() >> commandArgs
+        1 * jobSpec.getJobArgs() >> jobArgs
         1 * jobSpec.isInteractive() >> interactive
         1 * jobSpec.getTimeout() >> Optional.ofNullable(null)
-        1 * jobProcessManager.launchProcess(jobDirectory, jobEnvironment, jobCommandLine, interactive, null) >> {
+        1 * jobProcessManager.launchProcess(jobDirectory, jobEnvironment, commandArgs, jobArgs, interactive, null) >> {
             throw exception
         }
         def e = thrown(RuntimeException)
@@ -105,10 +109,11 @@ class LaunchJobActionSpec extends Specification {
         1 * executionContext.getJobSpecification() >> Optional.of(jobSpec)
         1 * executionContext.getJobDirectory() >> Optional.of(jobDirectory)
         1 * executionContext.getJobEnvironment() >> Optional.of(jobEnvironment)
-        1 * jobSpec.getCommandArgs() >> jobCommandLine
+        1 * jobSpec.getExecutableArgs() >> commandArgs
+        1 * jobSpec.getJobArgs() >> jobArgs
         1 * jobSpec.isInteractive() >> interactive
         1 * jobSpec.getTimeout() >> Optional.ofNullable(null)
-        1 * jobProcessManager.launchProcess(jobDirectory, jobEnvironment, jobCommandLine, interactive, null)
+        1 * jobProcessManager.launchProcess(jobDirectory, jobEnvironment, commandArgs, jobArgs, interactive, null)
         1 * executionContext.getClaimedJobId() >> Optional.of(id)
         1 * agentJobService.changeJobStatus(id, JobStatus.INIT, JobStatus.RUNNING, _ as String) >> { throw exception }
         0 * executionContext.setCurrentJobStatus(_)

--- a/genie-client/src/integTest/java/com/netflix/genie/client/ClusterClientIntegrationTest.java
+++ b/genie-client/src/integTest/java/com/netflix/genie/client/ClusterClientIntegrationTest.java
@@ -429,12 +429,14 @@ public class ClusterClientIntegrationTest extends GenieClientIntegrationTestBase
     @Test
     public void testClusterCommandsMethods() throws Exception {
 
+        final List<String> executableAndArgs = Lists.newArrayList("exec");
+
         final Command foo = new Command.Builder(
             "name",
             "user",
             "version",
             CommandStatus.ACTIVE,
-            "exec",
+            executableAndArgs,
             5
         ).withId("foo")
             .build();
@@ -446,7 +448,7 @@ public class ClusterClientIntegrationTest extends GenieClientIntegrationTestBase
             "user",
             "version",
             CommandStatus.ACTIVE,
-            "exec",
+            executableAndArgs,
             5
         ).withId("bar")
             .build();
@@ -458,7 +460,7 @@ public class ClusterClientIntegrationTest extends GenieClientIntegrationTestBase
             "user",
             "version",
             CommandStatus.ACTIVE,
-            "exec",
+            executableAndArgs,
             5
         ).withId("pi")
             .build();

--- a/genie-client/src/integTest/java/com/netflix/genie/client/CommandClientIntegrationTest.java
+++ b/genie-client/src/integTest/java/com/netflix/genie/client/CommandClientIntegrationTest.java
@@ -116,12 +116,14 @@ public class CommandClientIntegrationTest extends GenieClientIntegrationTestBase
         final Set<String> command1Tags = Sets.newHashSet("foo", "pi");
         final Set<String> command2Tags = Sets.newHashSet("bar", "pi");
 
+        final List<String> executableAndArgs = Lists.newArrayList("exec");
+
         final Command command1 = new Command.Builder(
             "command1name",
             "command1user",
             "1.0",
             CommandStatus.ACTIVE,
-            "exec",
+            executableAndArgs,
             1000
         )
             .withId(command1Id)
@@ -134,7 +136,7 @@ public class CommandClientIntegrationTest extends GenieClientIntegrationTestBase
                 "command2user",
                 "2.0",
                 CommandStatus.INACTIVE,
-                "exec",
+                executableAndArgs,
                 1000
             )
                 .withId(command2Id)
@@ -261,8 +263,10 @@ public class CommandClientIntegrationTest extends GenieClientIntegrationTestBase
         final Command command2 = commandClient.getCommand(command1.getId().orElseThrow(IllegalArgumentException::new));
         Assert.assertEquals(command2.getName(), command1.getName());
 
+        final List<String> executableAndArgs = Lists.newArrayList("exec");
+
         final Command command3 = new
-            Command.Builder("newname", "newuser", "new version", CommandStatus.ACTIVE, "exec", 1000)
+            Command.Builder("newname", "newuser", "new version", CommandStatus.ACTIVE, executableAndArgs, 1000)
             .withId(command1.getId().orElseThrow(IllegalArgumentException::new))
             .build();
 
@@ -273,6 +277,7 @@ public class CommandClientIntegrationTest extends GenieClientIntegrationTestBase
         Assert.assertEquals("newname", command4.getName());
         Assert.assertEquals("newuser", command4.getUser());
         Assert.assertEquals("new version", command4.getVersion());
+        Assert.assertEquals(executableAndArgs, command4.getExecutableAndArguments());
         Assert.assertEquals(CommandStatus.ACTIVE, command4.getStatus());
         Assert.assertFalse(command4.getSetupFile().isPresent());
         Assert.assertFalse(command4.getDescription().isPresent());
@@ -290,8 +295,9 @@ public class CommandClientIntegrationTest extends GenieClientIntegrationTestBase
 
         final Set<String> initialTags = Sets.newHashSet("foo", "bar");
         final Set<String> configList = Sets.newHashSet("config1", "configs2");
+        final List<String> executable = Lists.newArrayList("exec");
 
-        final Command command = new Command.Builder("name", "user", "1.0", CommandStatus.ACTIVE, "exec", 1000)
+        final Command command = new Command.Builder("name", "user", "1.0", CommandStatus.ACTIVE, executable, 1000)
             .withId("command1")
             .withDescription("client Test")
             .withSetupFile("path to set up file")
@@ -346,8 +352,9 @@ public class CommandClientIntegrationTest extends GenieClientIntegrationTestBase
     public void testCommandConfigsMethods() throws Exception {
 
         final Set<String> initialConfigs = Sets.newHashSet("foo", "bar");
+        final List<String> executable = Lists.newArrayList("exec");
 
-        final Command command = new Command.Builder("name", "user", "1.0", CommandStatus.ACTIVE, "exec", 1000)
+        final Command command = new Command.Builder("name", "user", "1.0", CommandStatus.ACTIVE, executable, 1000)
             .withId("command1")
             .withDescription("client Test")
             .withSetupFile("path to set up file")
@@ -394,8 +401,9 @@ public class CommandClientIntegrationTest extends GenieClientIntegrationTestBase
     public void testCommandDependenciesMethods() throws Exception {
 
         final Set<String> initialDependencies = Sets.newHashSet("foo", "bar");
+        final List<String> executable = Lists.newArrayList("exec");
 
-        final Command command = new Command.Builder("name", "user", "1.0", CommandStatus.ACTIVE, "exec", 1000)
+        final Command command = new Command.Builder("name", "user", "1.0", CommandStatus.ACTIVE, executable, 1000)
             .withId("command1")
             .withDescription("client Test")
             .withSetupFile("path to set up file")

--- a/genie-client/src/integTest/java/com/netflix/genie/client/GenieClientIntegrationTestBase.java
+++ b/genie-client/src/integTest/java/com/netflix/genie/client/GenieClientIntegrationTestBase.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.client;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.netflix.genie.GenieTestApp;
 import com.netflix.genie.common.dto.Application;
@@ -32,6 +33,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -107,8 +109,9 @@ public abstract class GenieClientIntegrationTestBase {
         final Set<String> tags = Sets.newHashSet("foo", "bar");
         final Set<String> configList = Sets.newHashSet("config1", "configs2");
         final Set<String> dependenciesList = Sets.newHashSet("command-dep1", "command-dep2");
+        final List<String> executableAndArgs = Lists.newArrayList("exec");
 
-        return new Command.Builder("name", "user", "1.0", CommandStatus.ACTIVE, "exec", 1000)
+        return new Command.Builder("name", "user", "1.0", CommandStatus.ACTIVE, executableAndArgs, 1000)
             .withId(commandId)
             .withDescription("client Test")
             .withSetupFile("path to set up file")

--- a/genie-client/src/integTest/java/com/netflix/genie/client/JobClientIntegrationTest.java
+++ b/genie-client/src/integTest/java/com/netflix/genie/client/JobClientIntegrationTest.java
@@ -800,6 +800,7 @@ public class JobClientIntegrationTest extends GenieClientIntegrationTestBase {
     private void createClusterAndCommandForTest() throws Exception {
 
         final Set<String> tags = Sets.newHashSet("laptop");
+        final List<String> executableAndArgs = Lists.newArrayList("bash");
 
         final Cluster cluster = new Cluster.Builder(
             CLUSTER_NAME,
@@ -819,7 +820,7 @@ public class JobClientIntegrationTest extends GenieClientIntegrationTestBase {
             "user",
             "version",
             CommandStatus.ACTIVE,
-            "bash",
+            executableAndArgs,
             1000
         )
             .withTags(tags).build();

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/JobSpecification.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/JobSpecification.java
@@ -24,14 +24,12 @@ import com.google.common.collect.ImmutableMap;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * This DTO represents all the information needed to execute a job by the Genie Agent.
@@ -44,7 +42,8 @@ import java.util.stream.Collectors;
 @ToString(doNotUseGetters = true)
 public class JobSpecification {
 
-    private final ImmutableList<String> commandArgs;
+    private final ImmutableList<String> executableArgs;
+    private final ImmutableList<String> jobArgs;
     private final ExecutionResource job;
     private final ExecutionResource cluster;
     private final ExecutionResource command;
@@ -58,7 +57,8 @@ public class JobSpecification {
     /**
      * Constructor.
      *
-     * @param commandArgs          Any command arguments for the job. Optional. Any blanks will be removed
+     * @param executableArgs       Executable and its fixed argument provided by the Command
+     * @param jobArgs              Job arguments provided by the user for this job
      * @param job                  The execution resources for a specific job
      * @param cluster              The execution resources for a specific cluster used for a job
      * @param command              The execution resources for a specific command used for a job
@@ -72,7 +72,8 @@ public class JobSpecification {
      */
     @JsonCreator
     public JobSpecification(
-        @JsonProperty("commandArgs") @Nullable final List<String> commandArgs,
+        @JsonProperty("executableArgs") @Nullable final List<String> executableArgs,
+        @JsonProperty("jobArgs") @Nullable final List<String> jobArgs,
         @JsonProperty(value = "job", required = true) final ExecutionResource job,
         @JsonProperty(value = "cluster", required = true) final ExecutionResource cluster,
         @JsonProperty(value = "command", required = true) final ExecutionResource command,
@@ -83,12 +84,9 @@ public class JobSpecification {
         @JsonProperty(value = "archiveLocation") @Nullable final String archiveLocation,
         @JsonProperty(value = "timeout") @Nullable final Integer timeout
     ) {
-        this.commandArgs = commandArgs == null ? ImmutableList.of() : ImmutableList.copyOf(
-            commandArgs
-                .stream()
-                .filter(StringUtils::isNotBlank)
-                .collect(Collectors.toList())
-        );
+
+        this.executableArgs = executableArgs == null ? ImmutableList.of() : ImmutableList.copyOf(executableArgs);
+        this.jobArgs = jobArgs == null ? ImmutableList.of() : ImmutableList.copyOf(jobArgs);
         this.job = job;
         this.cluster = cluster;
         this.command = command;
@@ -103,12 +101,21 @@ public class JobSpecification {
     }
 
     /**
-     * Returns an unmodifiable list of the command args for this job specification.
+     * Returns an unmodifiable list of executable and arguments provided by the Command resolved to.
      *
-     * @return A view of the list of command args that will throw exception if modifications are attempted
+     * @return A list of executable and arguments that will throw exception if modifications are attempted
      */
-    public List<String> getCommandArgs() {
-        return this.commandArgs;
+    public List<String> getExecutableArgs() {
+        return executableArgs;
+    }
+
+    /**
+     * Returns an unmodifiable list of arguments provided by the user for this job.
+     *
+     * @return A list of arguments that will throw exception if modifications are attempted
+     */
+    public List<String> getJobArgs() {
+        return jobArgs;
     }
 
     /**

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/converters/JobServiceProtoConverter.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dto/v4/converters/JobServiceProtoConverter.java
@@ -184,7 +184,8 @@ public class JobServiceProtoConverter {
         final com.netflix.genie.proto.JobSpecification protoSpec
     ) {
         return new JobSpecification(
-            protoSpec.getCommandArgsList(),
+            protoSpec.getExecutableAndArgsList(),
+            protoSpec.getJobArgsList(),
             toExecutionResourceDto(protoSpec.getJob()),
             toExecutionResourceDto(protoSpec.getCluster()),
             toExecutionResourceDto(protoSpec.getCommand()),
@@ -211,7 +212,11 @@ public class JobServiceProtoConverter {
         final com.netflix.genie.proto.JobSpecification.Builder builder
             = com.netflix.genie.proto.JobSpecification.newBuilder();
 
-        builder.addAllCommandArgs(jobSpecification.getCommandArgs());
+        builder.addAllExecutableAndArgs(jobSpecification.getExecutableArgs());
+        builder.addAllJobArgs(jobSpecification.getJobArgs());
+        // Keep populating commandArgs for backward compatibility
+        builder.addAllCommandArgs(jobSpecification.getExecutableArgs());
+        builder.addAllCommandArgs(jobSpecification.getJobArgs());
         builder.setJob(toExecutionResourceProto(jobSpecification.getJob()));
         builder.setCluster(toExecutionResourceProto(jobSpecification.getCluster()));
         builder.setCommand(toExecutionResourceProto(jobSpecification.getCommand()));

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/JobSpecificationSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/JobSpecificationSpec.groovy
@@ -39,10 +39,11 @@ class JobSpecificationSpec extends Specification {
         def command = new JobSpecification.ExecutionResource(commandId, new ExecutionEnvironment(null, null, null))
 
         when:
-        def jobSpecification = new JobSpecification(null, job, cluster, command, null, null, true, null, null, null)
+        def jobSpecification = new JobSpecification(null, null, job, cluster, command, null, null, true, null, null, null)
 
         then:
-        jobSpecification.getCommandArgs().isEmpty()
+        jobSpecification.getExecutableArgs().isEmpty()
+        jobSpecification.getJobArgs().isEmpty()
         jobSpecification.getJob() == job
         jobSpecification.getCluster() == cluster
         jobSpecification.getCommand() == command
@@ -60,6 +61,7 @@ class JobSpecificationSpec extends Specification {
         def applicationId = UUID.randomUUID().toString()
 
         def commandArgs = Lists.newArrayList("one", "two", "three")
+        def jobArgs = Lists.newArrayList("X", "Y", "Z")
         def job = new JobSpecification.ExecutionResource(jobId, new ExecutionEnvironment(null, null, null))
         def cluster = new JobSpecification.ExecutionResource(clusterId, new ExecutionEnvironment(null, null, null))
         def command = new JobSpecification.ExecutionResource(commandId, new ExecutionEnvironment(null, null, null))
@@ -77,6 +79,7 @@ class JobSpecificationSpec extends Specification {
         when:
         def jobSpecification = new JobSpecification(
             commandArgs,
+            jobArgs,
             job,
             cluster,
             command,
@@ -89,7 +92,8 @@ class JobSpecificationSpec extends Specification {
         )
 
         then:
-        jobSpecification.getCommandArgs() == commandArgs
+        jobSpecification.getExecutableArgs() == commandArgs
+        jobSpecification.getJobArgs() == jobArgs
         jobSpecification.getJob() == job
         jobSpecification.getCluster() == cluster
         jobSpecification.getCommand() == command
@@ -107,9 +111,8 @@ class JobSpecificationSpec extends Specification {
         def commandId = UUID.randomUUID().toString()
         def applicationId = UUID.randomUUID().toString()
 
-        def commandArgs = Lists.newArrayList("one", "two", "three")
-        def emptyCommandArgs = Lists.newArrayList(commandArgs)
-        emptyCommandArgs.add("\n\n")
+        def commandArgs = Lists.newArrayList("one", "", "three")
+        def jobArgs = Lists.newArrayList("X", "", "Z")
         def job = new JobSpecification.ExecutionResource(jobId, new ExecutionEnvironment(null, null, null))
         def cluster = new JobSpecification.ExecutionResource(clusterId, new ExecutionEnvironment(null, null, null))
         def command = new JobSpecification.ExecutionResource(commandId, new ExecutionEnvironment(null, null, null))
@@ -126,7 +129,8 @@ class JobSpecificationSpec extends Specification {
 
         when:
         def jobSpecification = new JobSpecification(
-            emptyCommandArgs,
+            commandArgs,
+            jobArgs,
             job,
             cluster,
             command,
@@ -139,7 +143,8 @@ class JobSpecificationSpec extends Specification {
         )
 
         then:
-        jobSpecification.getCommandArgs() == commandArgs
+        jobSpecification.getExecutableArgs() == commandArgs
+        jobSpecification.getJobArgs() == jobArgs
         jobSpecification.getJob() == job
         jobSpecification.getCluster() == cluster
         jobSpecification.getCommand() == command
@@ -209,7 +214,8 @@ class JobSpecificationSpec extends Specification {
         base != comparable
 
         when:
-        def commandArg = UUID.randomUUID().toString()
+        def commandArgs = Lists.newArrayList(UUID.randomUUID().toString())
+        def jobArgs = Lists.newArrayList()
         def job = Mock(JobSpecification.ExecutionResource)
         def cluster = Mock(JobSpecification.ExecutionResource)
         def command = Mock(JobSpecification.ExecutionResource)
@@ -221,7 +227,8 @@ class JobSpecificationSpec extends Specification {
         def timeout = 232_281
 
         base = new JobSpecification(
-            Lists.newArrayList(commandArg),
+            commandArgs,
+            jobArgs,
             job,
             cluster,
             command,
@@ -233,7 +240,8 @@ class JobSpecificationSpec extends Specification {
             timeout
         )
         comparable = new JobSpecification(
-            Lists.newArrayList(commandArg),
+            commandArgs,
+            jobArgs,
             job,
             cluster,
             command,
@@ -268,7 +276,8 @@ class JobSpecificationSpec extends Specification {
         one.hashCode() != two.hashCode()
 
         when:
-        def commandArg = UUID.randomUUID().toString()
+        def commandArgs = Lists.newArrayList(UUID.randomUUID().toString())
+        def jobArgs = Lists.newArrayList()
         def job = Mock(JobSpecification.ExecutionResource)
         def cluster = Mock(JobSpecification.ExecutionResource)
         def command = Mock(JobSpecification.ExecutionResource)
@@ -280,7 +289,8 @@ class JobSpecificationSpec extends Specification {
         def timeout = 2_233
 
         one = new JobSpecification(
-            Lists.newArrayList(commandArg),
+            commandArgs,
+            jobArgs,
             job,
             cluster,
             command,
@@ -292,7 +302,8 @@ class JobSpecificationSpec extends Specification {
             timeout
         )
         two = new JobSpecification(
-            Lists.newArrayList(commandArg),
+            commandArgs,
+            jobArgs,
             job,
             cluster,
             command,
@@ -327,7 +338,8 @@ class JobSpecificationSpec extends Specification {
         one.toString() != two.toString()
 
         when:
-        def commandArg = UUID.randomUUID().toString()
+        def commandArgs = Lists.newArrayList(UUID.randomUUID().toString())
+        def jobArgs = Lists.newArrayList()
         def job = Mock(JobSpecification.ExecutionResource)
         def cluster = Mock(JobSpecification.ExecutionResource)
         def command = Mock(JobSpecification.ExecutionResource)
@@ -339,7 +351,8 @@ class JobSpecificationSpec extends Specification {
         def timeout = 38_382
 
         one = new JobSpecification(
-            Lists.newArrayList(commandArg),
+            commandArgs,
+            jobArgs,
             job,
             cluster,
             command,
@@ -351,7 +364,8 @@ class JobSpecificationSpec extends Specification {
             timeout
         )
         two = new JobSpecification(
-            Lists.newArrayList(commandArg),
+            commandArgs,
+            jobArgs,
             job,
             cluster,
             command,
@@ -374,6 +388,7 @@ class JobSpecificationSpec extends Specification {
         def applicationId = UUID.randomUUID().toString()
 
         def commandArgs = Lists.newArrayList(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        def jobArgs = Lists.newArrayList(UUID.randomUUID().toString(), UUID.randomUUID().toString())
         def job = new JobSpecification.ExecutionResource(jobId, new ExecutionEnvironment(null, null, null))
         def cluster = new JobSpecification.ExecutionResource(clusterId, new ExecutionEnvironment(null, null, null))
         def command = new JobSpecification.ExecutionResource(commandId, new ExecutionEnvironment(null, null, null))
@@ -390,6 +405,7 @@ class JobSpecificationSpec extends Specification {
 
         return new JobSpecification(
             commandArgs,
+            jobArgs,
             job,
             cluster,
             command,

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/converters/JobServiceProtoConverterSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dto/v4/converters/JobServiceProtoConverterSpec.groovy
@@ -71,8 +71,11 @@ class JobServiceProtoConverterSpec extends Specification {
     def interactive = true
     def requestedArchiveLocationPrefix = UUID.randomUUID().toString()
     def archiveLocation = UUID.randomUUID().toString()
-    def commandArgs = Lists.newArrayList(
+    def executableArgs = Lists.newArrayList(
         UUID.randomUUID().toString(),
+        UUID.randomUUID().toString()
+    )
+    def jobArgs = Lists.newArrayList(
         UUID.randomUUID().toString(),
         UUID.randomUUID().toString()
     )
@@ -287,6 +290,7 @@ class JobServiceProtoConverterSpec extends Specification {
         setup:
         def originalSpecification = new JobSpecification(
             ["echo"].asList(),
+            [].asList(),
             new JobSpecification.ExecutionResource(
                 "my-job",
                 new ExecutionEnvironment(null, null, null)
@@ -477,7 +481,7 @@ class JobServiceProtoConverterSpec extends Specification {
 
         return new AgentJobRequest.Builder(jobMetadata, executionResourceCriteria, agentConfigRequest, jobArchivalDataRequest)
             .withRequestedId(id)
-            .withCommandArgs(commandArgs)
+            .withCommandArgs(executableArgs)
             .withResources(new ExecutionEnvironment(configs, dependencies, setupFile))
             .build()
     }
@@ -529,7 +533,8 @@ class JobServiceProtoConverterSpec extends Specification {
 
     JobSpecification createJobSpecification() {
         return new JobSpecification(
-            commandArgs,
+            executableArgs,
+            jobArgs,
             new JobSpecification.ExecutionResource(
                 id,
                 new ExecutionEnvironment(configs, dependencies, setupFile)
@@ -614,7 +619,10 @@ class JobServiceProtoConverterSpec extends Specification {
             .setIsInteractive(interactive)
             .setJobDirectoryLocation(jobDirectoryLocation)
             .putAllEnvironmentVariables(environmentVariables)
-            .addAllCommandArgs(commandArgs)
+            .addAllExecutableAndArgs(executableArgs)
+            .addAllJobArgs(jobArgs)
+            .addAllCommandArgs(executableArgs)
+            .addAllCommandArgs(jobArgs)
             .setJob(job)
             .setCluster(cluster)
             .setCommand(command)
@@ -642,7 +650,7 @@ class JobServiceProtoConverterSpec extends Specification {
             .setSetupFile(setupFile)
             .addAllConfigs(configs)
             .addAllDependencies(dependencies)
-            .addAllCommandArgs(commandArgs)
+            .addAllCommandArgs(executableArgs)
             .build()
     }
 

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/Command.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/Command.java
@@ -49,7 +49,7 @@ public class Command extends ExecutionEnvironmentDTO {
     @NotNull(message = "A valid command status is required")
     private final CommandStatus status;
     @NotEmpty(message = "An executable is required")
-    @Size(max = 255, message = "Executable path can't be longer than 255 characters")
+    @Size(max = 1024, message = "Executable path can't be longer than 1024 characters")
     private final String executable;
     @Min(
         value = 1,

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/Command.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/Command.java
@@ -17,9 +17,13 @@
  */
 package com.netflix.genie.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
@@ -27,6 +31,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -51,6 +56,8 @@ public class Command extends ExecutionEnvironmentDTO {
     @NotEmpty(message = "An executable is required")
     @Size(max = 1024, message = "Executable path can't be longer than 1024 characters")
     private final String executable;
+    @NotEmpty(message = "An executable is required")
+    private final List<@NotEmpty @Size(max = 1024) String> executableAndArguments;
     @Min(
         value = 1,
         message = "The delay between checks must be at least 1 millisecond. Probably should be much more than that"
@@ -70,9 +77,17 @@ public class Command extends ExecutionEnvironmentDTO {
     protected Command(@Valid final Builder builder) {
         super(builder);
         this.status = builder.bStatus;
-        this.executable = builder.bExecutable;
         this.checkDelay = builder.bCheckDelay;
         this.memory = builder.bMemory;
+        if (!builder.bExecutableAndArguments.isEmpty()) {
+            this.executableAndArguments = ImmutableList.copyOf(builder.bExecutableAndArguments);
+            this.executable = StringUtils.join(builder.bExecutableAndArguments, ' ');
+        } else if (builder.bExecutable != null && !builder.bExecutable.isEmpty()) {
+            this.executable = builder.bExecutable;
+            this.executableAndArguments = ImmutableList.copyOf(StringUtils.split(builder.bExecutable, ' '));
+        } else {
+            throw new IllegalArgumentException("Cannot build command without 'executable' OR 'executableAndArguments'");
+        }
     }
 
     /**
@@ -93,9 +108,10 @@ public class Command extends ExecutionEnvironmentDTO {
     public static class Builder extends ExecutionEnvironmentDTO.Builder<Builder> {
 
         private final CommandStatus bStatus;
-        private final String bExecutable;
         private final long bCheckDelay;
+        private String bExecutable;
         private Integer bMemory;
+        private final List<String> bExecutableAndArguments = Lists.newArrayList();
 
         /**
          * Constructor which has required fields.
@@ -107,18 +123,62 @@ public class Command extends ExecutionEnvironmentDTO {
          * @param executable The executable for the command
          * @param checkDelay How long the system should go between checking the status of jobs run with this command.
          *                   In milliseconds.
+         * @deprecated Use {@link Command.Builder#Builder(String, String, String, CommandStatus, List, long)}
          */
+        @Deprecated
         public Builder(
-            @JsonProperty("name") final String name,
-            @JsonProperty("user") final String user,
-            @JsonProperty("version") final String version,
-            @JsonProperty("status") final CommandStatus status,
-            @JsonProperty("executable") final String executable,
-            @JsonProperty("checkDelay") final long checkDelay
+            final String name,
+            final String user,
+            final String version,
+            final CommandStatus status,
+            final String executable,
+            final long checkDelay
         ) {
             super(name, user, version);
             this.bStatus = status;
             this.bExecutable = executable;
+            this.bCheckDelay = checkDelay;
+        }
+
+        /**
+         * Constructor with required fields.
+         *
+         * @param name                   The name to use for the Command
+         * @param user                   The user to use for the Command
+         * @param version                The version to use for the Command
+         * @param status                 The status of the Command
+         * @param executableAndArguments The executable for the command and its fixed arguments
+         * @param checkDelay             How long the system should go between checking the status of jobs run with this
+         *                               command. In milliseconds.
+         */
+        public Builder(
+            final String name,
+            final String user,
+            final String version,
+            final CommandStatus status,
+            final List<String> executableAndArguments,
+            final long checkDelay
+        ) {
+            super(name, user, version);
+            this.bStatus = status;
+            this.bExecutableAndArguments.addAll(executableAndArguments);
+            this.bCheckDelay = checkDelay;
+        }
+
+        /*
+         * This constructor is provided just for JSON deserialization and considers both the old 'executable' and the
+         * new 'executableAndArguments' fields optional for API backward compatibility.
+         */
+        @JsonCreator
+        Builder(
+            @JsonProperty("name") final String name,
+            @JsonProperty("user") final String user,
+            @JsonProperty("version") final String version,
+            @JsonProperty("status") final CommandStatus status,
+            @JsonProperty("checkDelay") final long checkDelay
+        ) {
+            super(name, user, version);
+            this.bStatus = status;
             this.bCheckDelay = checkDelay;
         }
 
@@ -130,6 +190,42 @@ public class Command extends ExecutionEnvironmentDTO {
          */
         public Builder withMemory(@Nullable final Integer memory) {
             this.bMemory = memory;
+            return this;
+        }
+
+        /**
+         * Set the executable and its fixed arguments for this command.
+         * Note that this string is tokenized with a naive strategy (split on space) to break apart the executable from
+         * its fixed arguments. Escape characters and quotes are ignored in this process. To avoid this tokenization,
+         * use {@link #withExecutableAndArguments(List)}
+         *
+         * @param executable the executable, possibly followed by arguments
+         * @return The builder
+         * @deprecated this setter is provided transitionally to make both 'executable' and 'executableAndArguments'
+         * optional for API backward compatibility. The proper way to construct a Command is via the constructor
+         * {@link Command.Builder#Builder(String, String, String, CommandStatus, List, long)}.
+         */
+        @Deprecated
+        public Builder withExecutable(final String executable) {
+            this.bExecutable = executable;
+            return this;
+        }
+
+        /**
+         * Set the executable and its fixed arguments for this command.
+         *
+         * @param executableAndArguments the executable and its argument
+         * @return The builder
+         * @deprecated this setter is provided transitionally to make both 'executable' and 'executableAndArguments'
+         * optional for API backward compatibility. The proper way to construct a Command is via the constructor
+         * {@link Command.Builder#Builder(String, String, String, CommandStatus, List, long)}.
+         */
+        @Deprecated
+        public Builder withExecutableAndArguments(@Nullable final List<String> executableAndArguments) {
+            this.bExecutableAndArguments.clear();
+            if (executableAndArguments != null) {
+                this.bExecutableAndArguments.addAll(executableAndArguments);
+            }
             return this;
         }
 

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/CommandTest.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/CommandTest.java
@@ -214,7 +214,7 @@ public class CommandTest {
     @Test
     public void canUseHashCode() {
         final Command.Builder builder
-            = new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY);
+            = new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY);
         builder.withSetupFile(null);
         builder.withConfigs(null);
         builder.withDependencies(null);

--- a/genie-proto/src/main/proto/genie.proto
+++ b/genie-proto/src/main/proto/genie.proto
@@ -154,7 +154,7 @@ message ExecutionResource {
 }
 
 message JobSpecification {
-    repeated string command_args = 1;
+    repeated string command_args = 1; // Deprecated by fields 11 & 12. Populated for backward compatibility.
     ExecutionResource job = 2;
     ExecutionResource cluster = 3;
     ExecutionResource command = 4;
@@ -164,6 +164,8 @@ message JobSpecification {
     string job_directory_location = 8;
     string archive_location = 9;
     google.protobuf.Int32Value timeout = 10; // Optional number of seconds from start when the job should timeout
+    repeated string executable_and_args = 11;
+    repeated string job_args = 12;
 }
 
 message JobSpecificationError {

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/ApplicationRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/ApplicationRestControllerIntegrationTest.java
@@ -69,6 +69,7 @@ public class ApplicationRestControllerIntegrationTest extends RestControllerInte
     private static final String APPLICATIONS_ID_LIST_PATH = APPLICATIONS_LIST_PATH + ".id";
     private static final String APPLICATION_COMMANDS_LINK_PATH = "_links.commands.href";
     private static final String APPLICATIONS_COMMANDS_LINK_PATH = APPLICATIONS_LIST_PATH + "._links.commands.href";
+    private static final List<String> EXECUTABLE_AND_ARGS = Lists.newArrayList("bash");
 
     /**
      * {@inheritDoc}
@@ -956,21 +957,21 @@ public class ApplicationRestControllerIntegrationTest extends RestControllerInte
         final String command3Id = UUID.randomUUID().toString();
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 1000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 1000L)
                 .withId(command1Id)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.INACTIVE, placeholder, 1100L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.INACTIVE, EXECUTABLE_AND_ARGS, 1100L)
                 .withId(command2Id)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.DEPRECATED, placeholder, 1200L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.DEPRECATED, EXECUTABLE_AND_ARGS, 1200L)
                 .withId(command3Id)
                 .build(),
             null

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/ClusterRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/ClusterRestControllerIntegrationTest.java
@@ -70,6 +70,7 @@ public class ClusterRestControllerIntegrationTest extends RestControllerIntegrat
     private static final String CLUSTERS_ID_LIST_PATH = CLUSTERS_LIST_PATH + ".id";
     private static final String CLUSTER_COMMANDS_LINK_PATH = "_links.commands.href";
     private static final String CLUSTERS_COMMANDS_LINK_PATH = CLUSTERS_LIST_PATH + "._links.commands.href";
+    private static final  List<String> EXECUTABLE_AND_ARGS = Lists.newArrayList("bash");
 
     /**
      * {@inheritDoc}
@@ -799,16 +800,18 @@ public class ClusterRestControllerIntegrationTest extends RestControllerIntegrat
         final String placeholder = UUID.randomUUID().toString();
         final String commandId1 = UUID.randomUUID().toString();
         final String commandId2 = UUID.randomUUID().toString();
+        final List<String> executableAndArgs = Lists.newArrayList("exec");
+
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 1000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 1000L)
                 .withId(commandId1)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 2000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 2000L)
                 .withId(commandId2)
                 .build(),
             null
@@ -863,7 +866,7 @@ public class ClusterRestControllerIntegrationTest extends RestControllerIntegrat
         final String commandId3 = UUID.randomUUID().toString();
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.INACTIVE, placeholder, 1000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.INACTIVE, executableAndArgs, 1000L)
                 .withId(commandId3)
                 .build(),
             null
@@ -952,14 +955,14 @@ public class ClusterRestControllerIntegrationTest extends RestControllerIntegrat
         final String commandId2 = UUID.randomUUID().toString();
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 4000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 4000L)
                 .withId(commandId1)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 5000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 5000L)
                 .withId(commandId2)
                 .build(),
             null
@@ -1037,14 +1040,14 @@ public class ClusterRestControllerIntegrationTest extends RestControllerIntegrat
         final String commandId2 = UUID.randomUUID().toString();
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 7000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 7000L)
                 .withId(commandId1)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 8000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 8000L)
                 .withId(commandId2)
                 .build(),
             null
@@ -1101,21 +1104,21 @@ public class ClusterRestControllerIntegrationTest extends RestControllerIntegrat
         final String commandId3 = UUID.randomUUID().toString();
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 1000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 1000L)
                 .withId(commandId1)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 2000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 2000L)
                 .withId(commandId2)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, placeholder, 3000L)
+                .Builder(placeholder, placeholder, placeholder, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, 3000L)
                 .withId(commandId3)
                 .build(),
             null

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/CommandRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/CommandRestControllerIntegrationTest.java
@@ -123,7 +123,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         );
 
         final String id = this.createConfigResource(
-            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withDescription(DESCRIPTION)
                 .withMemory(MEMORY)
                 .withConfigs(CONFIGS)
@@ -204,7 +204,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     public void canCreateCommandWithId() throws Exception {
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
-            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .withDescription(DESCRIPTION)
                 .withMemory(MEMORY)
@@ -277,7 +277,8 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     @Test
     public void canHandleBadInputToCreateCommand() throws Exception {
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
-        final Command cluster = new Command.Builder(" ", " ", " ", CommandStatus.ACTIVE, " ", -1L).build();
+        final Command cluster =
+            new Command.Builder(" ", " ", " ", CommandStatus.ACTIVE, Lists.newArrayList(""), -1L).build();
         RestAssured
             .given(this.getRequestSpecification())
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -311,13 +312,10 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         final String version1 = UUID.randomUUID().toString();
         final String version2 = UUID.randomUUID().toString();
         final String version3 = UUID.randomUUID().toString();
-        final String executable1 = UUID.randomUUID().toString();
-        final String executable2 = UUID.randomUUID().toString();
-        final String executable3 = UUID.randomUUID().toString();
 
         this.createConfigResource(
             new Command
-                .Builder(name1, user1, version1, CommandStatus.ACTIVE, executable1, CHECK_DELAY)
+                .Builder(name1, user1, version1, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(id1)
                 .build(),
             null
@@ -325,7 +323,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Thread.sleep(1000);
         this.createConfigResource(
             new Command
-                .Builder(name2, user2, version2, CommandStatus.DEPRECATED, executable2, CHECK_DELAY)
+                .Builder(name2, user2, version2, CommandStatus.DEPRECATED, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(id2)
                 .build(),
             null
@@ -333,7 +331,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Thread.sleep(1000);
         this.createConfigResource(
             new Command
-                .Builder(name3, user3, version3, CommandStatus.INACTIVE, executable3, CHECK_DELAY)
+                .Builder(name3, user3, version3, CommandStatus.INACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(id3)
                 .build(),
             null
@@ -465,7 +463,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -546,7 +544,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         final String id = this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -607,19 +605,19 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.DEPRECATED, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.DEPRECATED, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.INACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.INACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .build(),
             null
         );
@@ -661,27 +659,24 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         final String version1 = UUID.randomUUID().toString();
         final String version2 = UUID.randomUUID().toString();
         final String version3 = UUID.randomUUID().toString();
-        final String executable1 = UUID.randomUUID().toString();
-        final String executable2 = UUID.randomUUID().toString();
-        final String executable3 = UUID.randomUUID().toString();
 
         this.createConfigResource(
             new Command
-                .Builder(name1, user1, version1, CommandStatus.ACTIVE, executable1, CHECK_DELAY)
+                .Builder(name1, user1, version1, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(id1)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(name2, user2, version2, CommandStatus.ACTIVE, executable2, CHECK_DELAY)
+                .Builder(name2, user2, version2, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(id2)
                 .build(),
             null
         );
         this.createConfigResource(
             new Command
-                .Builder(name3, user3, version3, CommandStatus.ACTIVE, executable3, CHECK_DELAY)
+                .Builder(name3, user3, version3, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(id3)
                 .build(),
             null
@@ -723,7 +718,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -754,7 +749,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -779,7 +774,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -801,7 +796,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     public void canAddDependenciesToCommand() throws Exception {
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
-            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -836,7 +831,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     public void canUpdateDependenciesForCommand() throws Exception {
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
-            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -864,7 +859,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     public void canDeleteDependenciesForCommand() throws Exception {
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
-            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -891,7 +886,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -923,7 +918,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -949,7 +944,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -973,7 +968,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -998,7 +993,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     public void canAddApplicationsForACommand() throws Exception {
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -1138,7 +1133,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     public void canSetApplicationsForACommand() throws Exception {
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -1297,7 +1292,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     public void canRemoveApplicationsFromACommand() throws Exception {
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -1366,7 +1361,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     public void canRemoveApplicationFromACommand() throws Exception {
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -1486,7 +1481,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     public void canGetClustersForCommand() throws Exception {
         this.createConfigResource(
             new Command
-                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+                .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(ID)
                 .build(),
             null
@@ -1608,23 +1603,23 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
         final Set<String> stringSetWithBlank = Sets.newHashSet("foo", " ");
 
         final List<Command> invalidCommandResources = Lists.newArrayList(
-            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(UUID.randomUUID().toString())
                 .withSetupFile(" ")
                 .build(),
 
-            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(UUID.randomUUID().toString())
                 .withConfigs(stringSetWithBlank)
                 .build(),
 
-            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(UUID.randomUUID().toString())
                 .withDependencies(stringSetWithBlank)
 
                 .build(),
 
-            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
                 .withId(UUID.randomUUID().toString())
                 .withTags(stringSetWithBlank)
                 .build()

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/CommandRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/CommandRestControllerIntegrationTest.java
@@ -63,6 +63,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     private static final String USER = "genie";
     private static final String VERSION = "1.0.0";
     private static final String EXECUTABLE = "/apps/hive/bin/hive";
+    private static final List<String> EXECUTABLE_AND_ARGS = Lists.newArrayList("/apps/hive/bin/hive");
     private static final long CHECK_DELAY = 10000L;
     private static final String DESCRIPTION = "Hive command v" + VERSION;
     private static final int MEMORY = 1024;
@@ -77,6 +78,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
     private static final Set<String> TAGS = Sets.newHashSet(TAG_1, TAG_2);
 
     private static final String EXECUTABLE_PATH = "executable";
+    private static final String EXECUTABLE_AND_ARGS_PATH = "executableAndArguments";
     private static final String CHECK_DELAY_PATH = "checkDelay";
     private static final String MEMORY_PATH = "memory";
     private static final String COMMANDS_LIST_PATH = EMBEDDED_PATH + ".commandList";
@@ -229,6 +231,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
             .body(VERSION_PATH, Matchers.is(VERSION))
             .body(STATUS_PATH, Matchers.is(CommandStatus.ACTIVE.toString()))
             .body(EXECUTABLE_PATH, Matchers.is(EXECUTABLE))
+            .body(EXECUTABLE_AND_ARGS_PATH, Matchers.is(EXECUTABLE_AND_ARGS))
             .body(CHECK_DELAY_PATH, Matchers.is((int) CHECK_DELAY))
             .body(DESCRIPTION_PATH, Matchers.is(DESCRIPTION))
             .body(MEMORY_PATH, Matchers.is(MEMORY))
@@ -489,7 +492,7 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
             createdCommand.getUser(),
             createdCommand.getVersion(),
             CommandStatus.INACTIVE,
-            createdCommand.getExecutable(),
+            createdCommand.getExecutableAndArguments(),
             createdCommand.getCheckDelay()
         )
             .withId(createdCommand.getId().orElseThrow(IllegalArgumentException::new))

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
@@ -148,6 +148,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
     private static final String CMD1_USER = "genie";
     private static final String CMD1_VERSION = "1.0";
     private static final String CMD1_EXECUTABLE = "/bin/bash";
+    private static final ArrayList<String> CMD1_EXECUTABLE_AND_ARGS = Lists.newArrayList(CMD1_EXECUTABLE);
     private static final String CMD1_TAGS
         = BASH_COMMAND_TAG + ","
         + "genie.id:" + CMD1_ID + ","
@@ -823,7 +824,8 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
             .body(NAME_PATH, Matchers.is(CMD1_NAME))
             .body(USER_PATH, Matchers.is(CMD1_USER))
             .body(VERSION_PATH, Matchers.is(CMD1_VERSION))
-            .body("executable", Matchers.is(CMD1_EXECUTABLE));
+            .body("executable", Matchers.is(CMD1_EXECUTABLE))
+            .body("executableAndArguments", Matchers.equalTo(CMD1_EXECUTABLE_AND_ARGS));
     }
 
     private void checkJobApplications(final int documentationId, final String id) {
@@ -1737,7 +1739,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
             CMD1_USER,
             CMD1_VERSION,
             CommandStatus.ACTIVE,
-            CMD1_EXECUTABLE,
+            CMD1_EXECUTABLE_AND_ARGS,
             CHECK_DELAY
         )
             .withId(CMD1_ID)

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/Snippets.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/Snippets.java
@@ -745,6 +745,14 @@ final class Snippets {
                 .description("The executable to run on the Genie node when this command is used. e.g. /usr/bin/hadoop")
                 .type(JsonFieldType.STRING),
             PayloadDocumentation
+                .fieldWithPath("executableAndArguments")
+                .attributes(getConstraintsForField(COMMAND_CONSTRAINTS, "executableAndArguments"))
+                .description(
+                    "The executable and arguments to run on the Genie node when this command is used."
+                        + " e.g. /usr/bin/hadoop"
+                )
+                .type(JsonFieldType.ARRAY),
+            PayloadDocumentation
                 .fieldWithPath("checkDelay")
                 .attributes(getConstraintsForField(COMMAND_CONSTRAINTS, "checkDelay"))
                 .description(

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplIntegrationTest.java
@@ -1209,11 +1209,9 @@ public class JpaJobPersistenceServiceImplIntegrationTest extends DBIntegrationTe
 
         final File jobDirectoryLocation = new File("/tmp/genie/jobs/" + jobId);
 
-        final List<String> commandArgs = Lists.newArrayList(command.getExecutable());
-        commandArgs.addAll(jobRequest.getCommandArgs());
-
         return new JobSpecification(
-            commandArgs,
+            command.getExecutable(),
+            jobRequest.getCommandArgs(),
             new JobSpecification.ExecutionResource(
                 jobId,
                 jobRequest.getResources()

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/DtoConverters.java
@@ -39,7 +39,6 @@ import com.netflix.genie.common.internal.dto.v4.JobArchivalDataRequest;
 import com.netflix.genie.common.internal.dto.v4.JobEnvironmentRequest;
 import com.netflix.genie.common.internal.dto.v4.JobMetadata;
 import com.netflix.genie.common.internal.dto.v4.JobRequest;
-import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
 import java.util.List;
@@ -320,7 +319,7 @@ public final class DtoConverters {
             commandMetadata.getUser(),
             commandMetadata.getVersion(),
             commandMetadata.getStatus(),
-            StringUtils.join(v4Command.getExecutable(), ' '),
+            v4Command.getExecutable(),
             v4Command.getCheckDelay()
         )
             .withId(v4Command.getId())

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/DtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/DtoConverters.java
@@ -259,7 +259,7 @@ public final class DtoConverters {
         v3Command.getMetadata().ifPresent(metadataBuilder::withMetadata);
         v3Command.getDescription().ifPresent(metadataBuilder::withDescription);
 
-        final List<String> executable = Lists.newArrayList(StringUtils.split(v3Command.getExecutable(), ' '));
+        final List<String> executable = v3Command.getExecutableAndArguments();
         final CommandRequest.Builder builder = new CommandRequest
             .Builder(metadataBuilder.build(), executable)
             .withCheckDelay(v3Command.getCheckDelay());
@@ -306,7 +306,7 @@ public final class DtoConverters {
             v3Command.getUpdated().orElse(Instant.now()),
             resources,
             metadataBuilder.build(),
-            Lists.newArrayList(StringUtils.split(v3Command.getExecutable())),
+            v3Command.getExecutableAndArguments(),
             v3Command.getMemory().orElse(null),
             v3Command.getCheckDelay()
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/data/entities/v4/EntityDtoConverters.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/entities/v4/EntityDtoConverters.java
@@ -20,7 +20,6 @@ package com.netflix.genie.web.data.entities.v4;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.internal.dto.v4.AgentConfigRequest;
 import com.netflix.genie.common.internal.dto.v4.Application;
@@ -462,11 +461,9 @@ public final class EntityDtoConverters {
             )
             .collect(Collectors.toList());
 
-        final List<String> commandArgs = Lists.newArrayList(commandEntity.getExecutable());
-        commandArgs.addAll(jobSpecificationProjection.getCommandArgs());
-
         return new JobSpecification(
-            commandArgs,
+            commandEntity.getExecutable(),
+            jobSpecificationProjection.getCommandArgs(),
             job,
             cluster,
             command,

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaServiceUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaServiceUtils.java
@@ -45,7 +45,6 @@ import com.netflix.genie.web.data.entities.projections.JobProjection;
 import com.netflix.genie.web.data.entities.projections.JobRequestProjection;
 import com.netflix.genie.web.data.entities.v4.EntityDtoConverters;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -134,7 +133,7 @@ public final class JpaServiceUtils {
             commandEntity.getUser(),
             commandEntity.getVersion(),
             commandEntity.getStatus(),
-            StringUtils.join(commandEntity.getExecutable(), ' '),
+            commandEntity.getExecutable(),
             commandEntity.getCheckDelay()
         )
             .withId(commandEntity.getUniqueId())

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
@@ -268,9 +268,6 @@ public class JobResolverServiceImpl implements JobResolverService {
             );
         }
 
-        final List<String> commandArgs = Lists.newArrayList(command.getExecutable());
-        commandArgs.addAll(jobRequest.getCommandArgs());
-
         final int jobMemory = this.resolveJobMemory(jobRequest, command);
 
         final Map<String, String> environmentVariables
@@ -287,7 +284,8 @@ public class JobResolverServiceImpl implements JobResolverService {
         }
 
         final JobSpecification jobSpecification = new JobSpecification(
-            commandArgs,
+            command.getExecutable(),
+            jobRequest.getCommandArgs(),
             new JobSpecification.ExecutionResource(id, jobRequest.getResources()),
             new JobSpecification.ExecutionResource(cluster.getId(), cluster.getResources()),
             new JobSpecification.ExecutionResource(command.getId(), command.getResources()),

--- a/genie-web/src/test/groovy/com/netflix/genie/web/apis/rest/v3/controllers/DtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/apis/rest/v3/controllers/DtoConvertersSpec.groovy
@@ -533,7 +533,7 @@ class DtoConvertersSpec extends Specification {
         )
         def binary = UUID.randomUUID().toString()
         def defaultBinaryArgument = UUID.randomUUID().toString()
-        def executable = binary + ' ' + defaultBinaryArgument + ' '
+        def executableAndArgs = Lists.newArrayList(binary, defaultBinaryArgument)
         def memory = 128_347
         def metadata = "{\"" + UUID.randomUUID().toString() + "\":\"" + UUID.randomUUID().toString() + "\"}"
         def description = UUID.randomUUID().toString()
@@ -557,7 +557,7 @@ class DtoConvertersSpec extends Specification {
             user,
             version,
             status,
-            executable,
+            executableAndArgs,
             checkDelay
         )
             .withId(id)
@@ -595,7 +595,7 @@ class DtoConvertersSpec extends Specification {
             user,
             version,
             status,
-            executable,
+            executableAndArgs,
             checkDelay
         ).build()
         commandRequest = DtoConverters.toV4CommandRequest(v3Command)
@@ -633,7 +633,7 @@ class DtoConvertersSpec extends Specification {
         )
         def binary = UUID.randomUUID().toString()
         def defaultBinaryArgument = UUID.randomUUID().toString()
-        def executable = Lists.newArrayList(binary, defaultBinaryArgument)
+        def executableAndArgs = Lists.newArrayList(binary, defaultBinaryArgument)
         def memory = 128_347
         def metadata = "{\"" + UUID.randomUUID().toString() + "\":\"" + UUID.randomUUID().toString() + "\"}"
         def description = UUID.randomUUID().toString()
@@ -659,7 +659,7 @@ class DtoConvertersSpec extends Specification {
             user,
             version,
             status,
-            binary + ' ' + defaultBinaryArgument,
+            executableAndArgs,
             checkDelay
         )
             .withId(id)
@@ -681,7 +681,7 @@ class DtoConvertersSpec extends Specification {
         v4Command.getUpdated() == updated
         v4Command.getCheckDelay() == checkDelay
         v4Command.getMemory().orElse(null) == memory
-        v4Command.getExecutable() == executable
+        v4Command.getExecutable() == executableAndArgs
         v4Command.getMetadata().getName() == name
         v4Command.getMetadata().getUser() == user
         v4Command.getMetadata().getVersion() == version
@@ -701,7 +701,7 @@ class DtoConvertersSpec extends Specification {
             user,
             version,
             status,
-            binary + ' ' + defaultBinaryArgument,
+            executableAndArgs,
             checkDelay
         )
             .withId(id)
@@ -714,7 +714,7 @@ class DtoConvertersSpec extends Specification {
         v4Command.getUpdated() != null
         v4Command.getCheckDelay() == checkDelay
         !v4Command.getMemory().isPresent()
-        v4Command.getExecutable() == executable
+        v4Command.getExecutable() == executableAndArgs
         v4Command.getMetadata().getName() == name
         v4Command.getMetadata().getUser() == user
         v4Command.getMetadata().getVersion() == version

--- a/genie-web/src/test/groovy/com/netflix/genie/web/data/entities/v4/EntityDtoConvertersSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/data/entities/v4/EntityDtoConvertersSpec.groovy
@@ -581,7 +581,7 @@ class EntityDtoConvertersSpec extends Specification {
             UUID.randomUUID().toString()
         )
         def jobDirectoryLocation = UUID.randomUUID().toString()
-        def commandArgs = Lists.newArrayList(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        def jobArgs = Lists.newArrayList(UUID.randomUUID().toString(), UUID.randomUUID().toString())
         def interactive = true
         def jobConfigs = Sets.newHashSet(UUID.randomUUID().toString())
         def jobDependencies = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
@@ -606,7 +606,7 @@ class EntityDtoConvertersSpec extends Specification {
         def commandConfigs = Sets.newHashSet(UUID.randomUUID().toString())
         def commandDependencies = Sets.newHashSet(UUID.randomUUID().toString(), UUID.randomUUID().toString())
         def commandSetupFile = UUID.randomUUID().toString()
-        def executable = Lists.newArrayList(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        def executableArgs = Lists.newArrayList(UUID.randomUUID().toString(), UUID.randomUUID().toString())
         def commandEntity = Mock(CommandEntity) {
             1 * getUniqueId() >> commandId
             1 * getConfigs() >> commandConfigs
@@ -616,7 +616,7 @@ class EntityDtoConvertersSpec extends Specification {
                 .collect({ dependency -> new FileEntity(dependency) })
                 .toSet()
             1 * getSetupFile() >> Optional.ofNullable(new FileEntity(commandSetupFile))
-            1 * getExecutable() >> executable
+            1 * getExecutable() >> executableArgs
         }
 
         def application0Id = UUID.randomUUID().toString()
@@ -690,7 +690,7 @@ class EntityDtoConvertersSpec extends Specification {
         1 * jobSpecificationProjection.getArchiveLocation() >> Optional.of(UUID.randomUUID().toString())
         1 * jobSpecificationProjection.getJobDirectoryLocation() >> Optional.of(jobDirectoryLocation)
         1 * jobSpecificationProjection.getApplications() >> applications
-        1 * jobSpecificationProjection.getCommandArgs() >> commandArgs
+        1 * jobSpecificationProjection.getCommandArgs() >> jobArgs
         1 * jobSpecificationProjection.isInteractive() >> interactive
         1 * jobSpecificationProjection.getConfigs() >> jobConfigs
             .collect({ config -> new FileEntity(config) })
@@ -702,7 +702,8 @@ class EntityDtoConvertersSpec extends Specification {
         1 * jobSpecificationProjection.getEnvironmentVariables() >> environmentVariables
         1 * jobSpecificationProjection.getTimeoutUsed() >> Optional.ofNullable(timeout)
         jobSpecification.isInteractive()
-        jobSpecification.getCommandArgs() == executable + commandArgs
+        jobSpecification.getExecutableArgs() == executableArgs
+        jobSpecification.getJobArgs() == jobArgs
         jobSpecification.getEnvironmentVariables() == environmentVariables
         jobSpecification.getJobDirectoryLocation() == new File(jobDirectoryLocation)
         jobSpecification.getJob() == new JobSpecification.ExecutionResource(

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
@@ -71,6 +71,7 @@ class JobResolverServiceImplSpec extends Specification {
         def executableArgument0 = UUID.randomUUID().toString()
         def executableArgument1 = UUID.randomUUID().toString()
         def executable = Lists.newArrayList(executableBinary, executableArgument0, executableArgument1)
+        def arguments = Lists.newArrayList(UUID.randomUUID().toString())
         def command = createCommand(commandId, executable)
 
         def jobId = UUID.randomUUID().toString()
@@ -84,13 +85,14 @@ class JobResolverServiceImplSpec extends Specification {
         )
         def requestedArchiveLocationPrefix = UUID.randomUUID().toString()
 
-        def expectedJobCommandArgs = Lists.newArrayList(executableBinary, executableArgument0, executableArgument1)
-        expectedJobCommandArgs.addAll(commandArgs)
+        def expectedCommandArgs = executable
+        def expectedJobArgs = arguments
+
         Map<Cluster, String> clusterCommandMap = ImmutableMap.of(cluster1, commandId, cluster2, commandId)
-        def jobRequest = createJobRequest(commandArgs, requestedArchiveLocationPrefix, null, null)
-        def jobRequestNoArchivalData = createJobRequest(commandArgs, null, null, 5_002)
+        def jobRequest = createJobRequest(arguments, requestedArchiveLocationPrefix, null, null)
+        def jobRequestNoArchivalData = createJobRequest(arguments, null, null, 5_002)
         def requestedMemory = 6_323
-        def savedJobRequest = createJobRequest(commandArgs, null, requestedMemory, null)
+        def savedJobRequest = createJobRequest(arguments, null, requestedMemory, null)
 
         def clusterService = Mock(ClusterPersistenceService)
         def loadBalancer = Mock(ClusterLoadBalancer)
@@ -122,7 +124,8 @@ class JobResolverServiceImplSpec extends Specification {
         1 * loadBalancer.selectCluster(clusters, _ as com.netflix.genie.common.dto.JobRequest) >> cluster1
         1 * commandService.getCommand(commandId) >> command
         1 * commandService.getApplicationsForCommand(commandId) >> Lists.newArrayList()
-        jobSpec.getCommandArgs() == expectedJobCommandArgs
+        jobSpec.getExecutableArgs() == expectedCommandArgs
+        jobSpec.getJobArgs() == expectedJobArgs
         jobSpec.getJob().getId() == jobId
         jobSpec.getCluster().getId() == cluster1Id
         jobSpec.getCommand().getId() == commandId
@@ -150,7 +153,8 @@ class JobResolverServiceImplSpec extends Specification {
         1 * loadBalancer.selectCluster(clusters, _ as com.netflix.genie.common.dto.JobRequest) >> cluster1
         1 * commandService.getCommand(commandId) >> command
         1 * commandService.getApplicationsForCommand(commandId) >> Lists.newArrayList()
-        jobSpecNoArchivalData.getCommandArgs() == expectedJobCommandArgs
+        jobSpecNoArchivalData.getExecutableArgs() == expectedCommandArgs
+        jobSpecNoArchivalData.getJobArgs() == expectedJobArgs
         jobSpecNoArchivalData.getJob().getId() == jobId
         jobSpecNoArchivalData.getCluster().getId() == cluster1Id
         jobSpecNoArchivalData.getCommand().getId() == commandId
@@ -186,7 +190,8 @@ class JobResolverServiceImplSpec extends Specification {
         1 * commandService.getCommand(commandId) >> command
         1 * commandService.getApplicationsForCommand(commandId) >> Lists.newArrayList()
         1 * jobPersistenceService.saveResolvedJob(jobId, _ as ResolvedJob)
-        jobSpecSavedData.getCommandArgs() == expectedJobCommandArgs
+        jobSpecSavedData.getExecutableArgs() == expectedCommandArgs
+        jobSpecSavedData.getJobArgs() == expectedJobArgs
         jobSpecSavedData.getJob().getId() == jobId
         jobSpecSavedData.getCluster().getId() == cluster1Id
         jobSpecSavedData.getCommand().getId() == commandId

--- a/genie-web/src/test/java/com/netflix/genie/web/apis/rest/v3/hateoas/assemblers/CommandResourceAssemblerTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/apis/rest/v3/hateoas/assemblers/CommandResourceAssemblerTest.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.apis.rest.v3.hateoas.assemblers;
 
+import com.google.common.collect.Lists;
 import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.CommandStatus;
 import com.netflix.genie.web.apis.rest.v3.hateoas.resources.CommandResource;
@@ -26,6 +27,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -40,7 +42,7 @@ public class CommandResourceAssemblerTest {
     private static final String NAME = UUID.randomUUID().toString();
     private static final String USER = UUID.randomUUID().toString();
     private static final String VERSION = UUID.randomUUID().toString();
-    private static final String EXECUTABLE = UUID.randomUUID().toString();
+    private static final List<String> EXECUTABLE_AND_ARGS = Lists.newArrayList(UUID.randomUUID().toString());
     private static final long CHECK_DELAY = 1000L;
 
     private Command command;
@@ -51,7 +53,7 @@ public class CommandResourceAssemblerTest {
      */
     @Before
     public void setup() {
-        this.command = new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+        this.command = new Command.Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
             .withId(ID)
             .build();
         this.assembler = new CommandResourceAssembler();

--- a/genie-web/src/test/java/com/netflix/genie/web/apis/rest/v3/hateoas/resources/CommandResourceTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/apis/rest/v3/hateoas/resources/CommandResourceTest.java
@@ -17,12 +17,14 @@
  */
 package com.netflix.genie.web.apis.rest.v3.hateoas.resources;
 
+import com.google.common.collect.Lists;
 import com.netflix.genie.common.dto.Command;
 import com.netflix.genie.common.dto.CommandStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -37,7 +39,7 @@ public class CommandResourceTest {
     private static final String NAME = UUID.randomUUID().toString();
     private static final String USER = UUID.randomUUID().toString();
     private static final String VERSION = UUID.randomUUID().toString();
-    private static final String EXECUTABLE = UUID.randomUUID().toString();
+    private static final List<String> EXECUTABLE_AND_ARGS = Lists.newArrayList(UUID.randomUUID().toString());
     private static final long CHECK_DELAY = 1380L;
 
     private Command command;
@@ -48,7 +50,7 @@ public class CommandResourceTest {
     @Before
     public void setup() {
         this.command = new Command
-            .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE, CHECK_DELAY)
+            .Builder(NAME, USER, VERSION, CommandStatus.ACTIVE, EXECUTABLE_AND_ARGS, CHECK_DELAY)
             .withId(ID)
             .build();
     }

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
@@ -242,6 +242,7 @@ public class JobCoordinatorServiceImplTest {
 
         final JobSpecification jobSpecification = new JobSpecification(
             null,
+            null,
             new JobSpecification.ExecutionResource(
                 jobRequest.getId().orElseThrow(IllegalArgumentException::new),
                 new ExecutionEnvironment(null, null, null)
@@ -375,6 +376,7 @@ public class JobCoordinatorServiceImplTest {
 
         final JobSpecification jobSpecification = new JobSpecification(
             null,
+            null,
             new JobSpecification.ExecutionResource(
                 jobRequest.getId().orElseThrow(IllegalArgumentException::new),
                 new ExecutionEnvironment(null, null, null)
@@ -480,6 +482,7 @@ public class JobCoordinatorServiceImplTest {
         final String archiveLocation = UUID.randomUUID().toString();
 
         final JobSpecification jobSpecification = new JobSpecification(
+            null,
             null,
             new JobSpecification.ExecutionResource(
                 jobRequest.getId().orElseThrow(IllegalArgumentException::new),
@@ -606,6 +609,7 @@ public class JobCoordinatorServiceImplTest {
 
         final JobSpecification jobSpecification = new JobSpecification(
             null,
+            null,
             new JobSpecification.ExecutionResource(
                 jobRequest.getId().orElseThrow(IllegalArgumentException::new),
                 new ExecutionEnvironment(null, null, null)
@@ -712,6 +716,7 @@ public class JobCoordinatorServiceImplTest {
         final String archiveLocation = UUID.randomUUID().toString();
 
         final JobSpecification jobSpecification = new JobSpecification(
+            null,
             null,
             new JobSpecification.ExecutionResource(
                 jobRequest.getId().orElseThrow(IllegalArgumentException::new),
@@ -837,6 +842,7 @@ public class JobCoordinatorServiceImplTest {
         final String archiveLocation = UUID.randomUUID().toString();
 
         final JobSpecification jobSpecification = new JobSpecification(
+            null,
             null,
             new JobSpecification.ExecutionResource(
                 jobRequest.getId().orElseThrow(IllegalArgumentException::new),


### PR DESCRIPTION
 - Update V3 API so that 'executable' can be sent as array of strings (while retaining backward compatibility with existing clients and agent)
 - Update gRPC protocol between server and agent protocol to send executable and its arguments separately from user-provided, job-specific arguments
