### PR TITLE
Bug: REST API produces 406 for file not found

### DIFF
--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/ApplicationRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/ApplicationRestControllerIntegrationTest.java
@@ -1120,4 +1120,27 @@ public class ApplicationRestControllerIntegrationTest extends RestControllerInte
             Assert.assertThat(this.applicationRepository.count(), Matchers.is(++i));
         }
     }
+
+    /**
+     * Test getting an application that does not exist produces the expected error.
+     */
+    @Test
+    public void testApplicationNotFound() {
+        Assert.assertThat(this.applicationRepository.count(), Matchers.is(0L));
+
+        final List<String> paths = Lists.newArrayList("", "/commands");
+
+        for (final String path : paths) {
+            RestAssured
+                .given(this.getRequestSpecification())
+                .when()
+                .port(this.port)
+                .get(APPLICATIONS_API + "/{id}" + path, ID)
+                .then()
+                .statusCode(Matchers.is(HttpStatus.NOT_FOUND.value()))
+                .contentType(Matchers.equalToIgnoringCase(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .body(EXCEPTION_CODE_PATH, Matchers.is(404))
+                .body(EXCEPTION_MESSAGE_PATH, Matchers.startsWith("No application with id " + ID));
+        }
+    }
 }

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/ClusterRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/ClusterRestControllerIntegrationTest.java
@@ -1352,4 +1352,27 @@ public class ClusterRestControllerIntegrationTest extends RestControllerIntegrat
             Assert.assertThat(this.clusterRepository.count(), Matchers.is(++i));
         }
     }
+
+    /**
+     * Test getting a cluster that does not exist produces the expected error.
+     */
+    @Test
+    public void testClusterNotFound() {
+        Assert.assertThat(this.clusterRepository.count(), Matchers.is(0L));
+
+        final List<String> paths = Lists.newArrayList("", "/commands");
+
+        for (final String path : paths) {
+            RestAssured
+                .given(this.getRequestSpecification())
+                .when()
+                .port(this.port)
+                .get(CLUSTERS_API + "/{id}" + path, ID)
+                .then()
+                .statusCode(Matchers.is(HttpStatus.NOT_FOUND.value()))
+                .contentType(Matchers.equalToIgnoringCase(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .body(EXCEPTION_CODE_PATH, Matchers.is(404))
+                .body(EXCEPTION_MESSAGE_PATH, Matchers.startsWith("No cluster with id " + ID));
+        }
+    }
 }

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/CommandRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/CommandRestControllerIntegrationTest.java
@@ -1659,4 +1659,27 @@ public class CommandRestControllerIntegrationTest extends RestControllerIntegrat
             Assert.assertThat(this.commandRepository.count(), Matchers.is(++i));
         }
     }
+
+    /**
+     * Test getting a command that does not exist produces the expected error.
+     */
+    @Test
+    public void testCommandNotFound() {
+        Assert.assertThat(this.commandRepository.count(), Matchers.is(0L));
+
+        final List<String> paths = Lists.newArrayList("", "/applications", "/clusters");
+
+        for (final String relationPath : paths) {
+            RestAssured
+                .given(this.getRequestSpecification())
+                .when()
+                .port(this.port)
+                .get(COMMANDS_API + "/{id}" + relationPath, ID)
+                .then()
+                .statusCode(Matchers.is(HttpStatus.NOT_FOUND.value()))
+                .contentType(Matchers.equalToIgnoringCase(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .body(EXCEPTION_CODE_PATH, Matchers.is(404))
+                .body(EXCEPTION_MESSAGE_PATH, Matchers.is("No command with id " + ID + " exists."));
+        }
+    }
 }

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
@@ -46,7 +46,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1651,7 +1650,6 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
      * @throws Exception If there is a problem.
      */
     @Test
-    @Ignore(value = "This test is ignored since it fails. It produces a response with status 406 rather than 404")
     public void testFileNotFound() throws Exception {
         Assume.assumeTrue(SystemUtils.IS_OS_UNIX);
         final List<String> commandArgs = Lists.newArrayList("-c", "'echo hello world'");

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/RestControllerIntegrationTestBase.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/RestControllerIntegrationTestBase.java
@@ -92,6 +92,7 @@ public abstract class RestControllerIntegrationTestBase {
     static final String LINKS_PATH = "_links";
     static final String EMBEDDED_PATH = "_embedded";
     static final String EXCEPTION_MESSAGE_PATH = "message";
+    static final String EXCEPTION_CODE_PATH = "errorCode";
 
     // Link Keys
     static final String SELF_LINK_KEY = "self";

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/JobPersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/JobPersistenceService.java
@@ -273,11 +273,11 @@ public interface JobPersistenceService {
      *
      * @param id The id of the job
      * @return true if its a v4 job
-     * @throws GenieJobNotFoundException If no job with {@code id} exists
+     * @throws GenieNotFoundException If no job with the given {@code id} exists
      */
     boolean isV4(
         @NotBlank(message = "Id is missing and is required") String id
-    );
+    ) throws GenieNotFoundException;;
 
     /**
      * Get the status for a job with the given {@code id}.

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
@@ -630,7 +630,7 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
             .findByUniqueId(id, IsV4JobProjection.class)
             .orElseThrow(
                 () -> {
-                    final String errorMessage = "No job with id " + id + "exists. Unable to get v4 flag.";
+                    final String errorMessage = "No job with id " + id + " exists. Unable to get v4 flag.";
                     log.error(errorMessage);
                     return new GenieNotFoundException(errorMessage);
                 }

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImpl.java
@@ -624,7 +624,7 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
     @Transactional(readOnly = true)
     public boolean isV4(
         @NotBlank(message = "Id is missing and is required") final String id
-    ) {
+    ) throws GenieNotFoundException {
         log.debug("Read v4 flag from db for job {} ", id);
         return this.jobRepository
             .findByUniqueId(id, IsV4JobProjection.class)
@@ -632,7 +632,7 @@ public class JpaJobPersistenceServiceImpl extends JpaBaseService implements JobP
                 () -> {
                     final String errorMessage = "No job with id " + id + "exists. Unable to get v4 flag.";
                     log.error(errorMessage);
-                    return new GenieJobNotFoundException(errorMessage);
+                    return new GenieNotFoundException(errorMessage);
                 }
             ).isV4();
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobDirectoryServerService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobDirectoryServerService.java
@@ -17,12 +17,11 @@
  */
 package com.netflix.genie.web.services;
 
+import com.netflix.genie.common.exceptions.GenieException;
 import org.springframework.validation.annotation.Validated;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.net.URL;
 
 /**
@@ -45,8 +44,7 @@ public interface JobDirectoryServerService {
      * @param relativePath The relative path from the root of the job directory of the expected resource
      * @param request      The HTTP request containing all information about the request
      * @param response     The HTTP response where all results should be written
-     * @throws IOException      If there is an error interacting with the response
-     * @throws ServletException If there is an error interacting with the Java Servlet objects
+     * @throws GenieException If there is an error serving the response
      */
     void serveResource(
         String jobId,
@@ -54,5 +52,5 @@ public interface JobDirectoryServerService {
         String relativePath,
         HttpServletRequest request,
         HttpServletResponse response
-    ) throws IOException, ServletException;
+    ) throws GenieException;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Lists;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.common.internal.dto.DirectoryManifest;
-import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
 import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorService;
 import com.netflix.genie.common.util.GenieObjectMapper;
 import com.netflix.genie.web.agent.resources.AgentFileProtocolResolver;
@@ -164,7 +163,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
         final boolean isV4;
         try {
             isV4 = this.jobPersistenceService.isV4(jobId);
-        } catch (final GenieJobNotFoundException nfe) {
+        } catch (final GenieNotFoundException nfe) {
             // Really after the last check this shouldn't happen but just in case
             log.error(nfe.getMessage(), nfe);
             response.sendError(HttpStatus.NOT_FOUND.value(), nfe.getMessage());

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/jobs/JobsAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/jobs/JobsAutoConfiguration.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.spring.autoconfigure.jobs;
 
 import com.netflix.genie.common.internal.aws.s3.S3ClientFactory;
+import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorService;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.web.jobs.workflow.impl.ApplicationTask;
 import com.netflix.genie.web.jobs.workflow.impl.ClusterTask;
@@ -212,10 +213,11 @@ public class JobsAutoConfiguration {
     /**
      * Create an Job Kickoff Task bean that runs the job.
      *
-     * @param jobsProperties The various jobs properties
-     * @param executor       An instance of an executor
-     * @param genieHostInfo  Info about the host Genie is running on
-     * @param registry       The metrics registry to use
+     * @param jobsProperties                     The various jobs properties
+     * @param executor                           An instance of an executor
+     * @param genieHostInfo                      Info about the host Genie is running on
+     * @param registry                           The metrics registry to use
+     * @param jobDirectoryManifestCreatorService The manifest creation service
      * @return An application task object
      */
     @Bean
@@ -225,14 +227,16 @@ public class JobsAutoConfiguration {
         final JobsProperties jobsProperties,
         final Executor executor,
         final GenieHostInfo genieHostInfo,
-        final MeterRegistry registry
+        final MeterRegistry registry,
+        final JobDirectoryManifestCreatorService jobDirectoryManifestCreatorService
     ) {
         return new JobKickoffTask(
             jobsProperties.getUsers().isRunAsUserEnabled(),
             jobsProperties.getUsers().isCreationEnabled(),
             executor,
             genieHostInfo.getHostname(),
-            registry
+            registry,
+            jobDirectoryManifestCreatorService
         );
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
@@ -111,7 +111,7 @@ class JobDirectoryServerServiceImplSpec extends Specification {
 
     def "ServeResource -- job not found (v4)"() {
         setup:
-        Exception e = new GenieJobNotFoundException("...")
+        Exception e = new GenieNotFoundException("...")
 
         when:
         this.service.serveResource(JOB_ID, BASE_URL, REL_PATH, request, response)

--- a/genie-web/src/test/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/data/services/jpa/JpaJobPersistenceServiceImplTest.java
@@ -750,9 +750,11 @@ public class JpaJobPersistenceServiceImplTest {
 
     /**
      * If a job isn't found on querying for v4 flag.
+     *
+     * @throws GenieNotFoundException if the job is not found
      */
-    @Test(expected = GenieJobNotFoundException.class)
-    public void noJobUnableToGetV4() {
+    @Test(expected = GenieNotFoundException.class)
+    public void noJobUnableToGetV4() throws GenieNotFoundException {
         Mockito
             .when(this.jobRepository.findByUniqueId(Mockito.anyString(), Mockito.eq(IsV4JobProjection.class)))
             .thenReturn(Optional.empty());
@@ -762,9 +764,11 @@ public class JpaJobPersistenceServiceImplTest {
 
     /**
      * If v4 is false in db then return false.
+     *
+     * @throws GenieNotFoundException if the job is not found
      */
     @Test
-    public void v4JobFalseReturnsFalse() {
+    public void v4JobFalseReturnsFalse() throws GenieNotFoundException {
         final JobEntity jobEntity = Mockito.mock(JobEntity.class);
         Mockito
             .when(this.jobRepository.findByUniqueId(Mockito.anyString(), Mockito.eq(IsV4JobProjection.class)))
@@ -777,9 +781,11 @@ public class JpaJobPersistenceServiceImplTest {
 
     /**
      * If v4 is true in db then return true.
+     *
+     * @throws GenieNotFoundException if the job is not found
      */
     @Test
-    public void v4JobTrueReturnsTrue() {
+    public void v4JobTrueReturnsTrue() throws GenieNotFoundException {
         final JobEntity jobEntity = Mockito.mock(JobEntity.class);
         Mockito
             .when(this.jobRepository.findByUniqueId(Mockito.anyString(), Mockito.eq(IsV4JobProjection.class)))
@@ -792,9 +798,11 @@ public class JpaJobPersistenceServiceImplTest {
 
     /**
      * If v4 job is not found in the db then throw a Exception.
+     *
+     * @throws GenieNotFoundException if the job is not found
      */
-    @Test(expected = GenieJobNotFoundException.class)
-    public void v4JobNotFoundThrowsException() {
+    @Test(expected = GenieNotFoundException.class)
+    public void v4JobNotFoundThrowsException() throws GenieNotFoundException {
         Mockito
             .when(this.jobRepository.findByUniqueId(Mockito.anyString(), Mockito.eq(IsV4JobProjection.class)))
             .thenReturn(Optional.empty());

--- a/genie-web/src/test/java/com/netflix/genie/web/jobs/workflow/impl/JobKickoffTaskTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/jobs/workflow/impl/JobKickoffTaskTest.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.jobs.workflow.impl;
 
+import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorService;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.commons.exec.Executor;
 import org.junit.Before;
@@ -40,7 +41,8 @@ public class JobKickoffTaskTest {
             false,
             Mockito.mock(Executor.class),
             "localhost",
-            new SimpleMeterRegistry()
+            new SimpleMeterRegistry(),
+            Mockito.mock(JobDirectoryManifestCreatorService.class)
         );
     }
 }


### PR DESCRIPTION
This PR addresses an observed misbehavior of the REST API.

When a file is requested that does not exist (or is not yet present in the manifest), the API produces a 406 error (content-negotiation failure), rather than the expected 404.

This PR adds tests and does some refactoring to solve this problem.