### PR TITLE
Update client image base image

### DIFF
--- a/genie-demo/src/main/docker/client/Dockerfile
+++ b/genie-demo/src/main/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-from alpine:3.4
+from alpine:3.11
 MAINTAINER NetflixOSS <netflixoss@netflix.com>
 
 RUN apk --no-cache add vim python py-pip python-dev bash g++ \

--- a/genie-demo/src/main/docker/client/example/init_demo.py
+++ b/genie-demo/src/main/docker/client/example/init_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 
 # Copyright 2016 Netflix, Inc.
 #

--- a/genie-demo/src/main/docker/client/example/move_tags.py
+++ b/genie-demo/src/main/docker/client/example/move_tags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 
 # Copyright 2016 Netflix, Inc.
 #

--- a/genie-demo/src/main/docker/client/example/reset_tags.py
+++ b/genie-demo/src/main/docker/client/example/reset_tags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 
 # Copyright 2016 Netflix, Inc.
 #

--- a/genie-demo/src/main/docker/client/example/run_hadoop_job.py
+++ b/genie-demo/src/main/docker/client/example/run_hadoop_job.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 
 # Copyright 2016 Netflix, Inc.
 #

--- a/genie-demo/src/main/docker/client/example/run_hdfs_job.py
+++ b/genie-demo/src/main/docker/client/example/run_hdfs_job.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 
 # Copyright 2016 Netflix, Inc.
 #

--- a/genie-demo/src/main/docker/client/example/run_spark_shell_job.py
+++ b/genie-demo/src/main/docker/client/example/run_spark_shell_job.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 
 # Copyright 2016 Netflix, Inc.
 #

--- a/genie-demo/src/main/docker/client/example/run_spark_submit_job.py
+++ b/genie-demo/src/main/docker/client/example/run_spark_submit_job.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 
 # Copyright 2016 Netflix, Inc.
 #

--- a/genie-demo/src/main/docker/client/example/run_yarn_job.py
+++ b/genie-demo/src/main/docker/client/example/run_yarn_job.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 
 # Copyright 2016 Netflix, Inc.
 #


### PR DESCRIPTION
Have been pinned on Alpine 3.4 for a long time. Looks like this breaks now that python 3 is the latest. Updating to Alpine 3.11 lets the build succeed. Not sure about the operation of the client example itself right now but it's something we'll have to resolve before fully releasing 4.0.0 in OSS.