### PR TITLE
ClusterChecker NPE and Health 

### DIFF
--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -17,6 +17,24 @@ It will have to be added if one is desired otherwise metrics are just published 
 |AgentMetricsServiceImpl
 |-
 
+|genie.agents.heartbeating.gauge
+|The number of agents sending heartbeats to the server
+|count
+|GRpcHeartBeatServiceImpl
+|-
+
+|genie.agents.fileTransfers.pending.gauge
+|The number of pending file transfers requested from connected agents
+|count
+|GRpcHeartBeatServiceImpl
+|-
+
+|genie.agents.fileTransfers.inProgress.gauge
+|The number of in progress file transfers from connected agents
+|count
+|GRpcAgentFileStreamServiceImpl
+|-
+
 |genie.api.v3.jobs.submitJobWithoutAttachments.rate
 |Counts the number of jobs submitted without an attachment
 |count

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -89,23 +89,11 @@ It will have to be added if one is desired otherwise metrics are just published 
 |S3FileTransferImpl
 |status, exceptionClass
 
-|genie.health.endpoint.timer
-|Time taken for the Health endpoint to collect and aggregate state from health indicators
-|nanoseconds
-|HealthCheckMetricsAspect
-|status, exceptionClass
-
-|genie.health.failure.counter
-|Counter for calls each health indicator that reports status other than UP
-|count
-|HealthCheckMetricsAspect
-|status, exceptionClass, healthIndicatorName
-
 |genie.health.indicator.timer
 |Time taken for each health indicator to report its status
 |nanoseconds
 |HealthCheckMetricsAspect
-|status, exceptionClass, healthIndicatorClass
+|healthIndicatorClass, healthIndicatorStatus
 
 |genie.jobs.active.gauge
 |Number of jobs currently active locally

--- a/genie-ui/src/integTest/resources/application-integration.yml
+++ b/genie-ui/src/integTest/resources/application-integration.yml
@@ -2,6 +2,10 @@ grpc:
   server:
     port: 0
 
+local:
+  server:
+    port: 0
+
 spring:
   autoconfigure:
     exclude:

--- a/genie-web/src/integTest/resources/application-integration.yml
+++ b/genie-web/src/integTest/resources/application-integration.yml
@@ -39,6 +39,10 @@ grpc:
   server:
     port: 0
 
+local:
+  server:
+    port: 0
+
 spring:
   autoconfigure:
     exclude:

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/apis/rpc/v4/endpoints/AgentRpcEndpointsAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/apis/rpc/v4/endpoints/AgentRpcEndpointsAutoConfiguration.java
@@ -34,6 +34,7 @@ import com.netflix.genie.web.agent.apis.rpc.v4.endpoints.JobServiceProtoErrorCom
 import com.netflix.genie.web.agent.services.AgentJobService;
 import com.netflix.genie.web.agent.services.AgentRoutingService;
 import com.netflix.genie.web.data.services.JobSearchService;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -84,15 +85,17 @@ public class AgentRpcEndpointsAutoConfiguration {
      *
      * @param converter     The {@link JobDirectoryManifestProtoConverter} instance to use
      * @param taskScheduler The {@link TaskScheduler} to use to schedule tasks
+     * @param registry      The meter registry
      * @return An instance of {@link GRpcAgentFileStreamServiceImpl}
      */
     @Bean
     @ConditionalOnMissingBean(FileStreamServiceGrpc.FileStreamServiceImplBase.class)
     public GRpcAgentFileStreamServiceImpl gRpcAgentFileStreamService(
         final JobDirectoryManifestProtoConverter converter,
-        @Qualifier("genieTaskScheduler") final TaskScheduler taskScheduler
+        @Qualifier("genieTaskScheduler") final TaskScheduler taskScheduler,
+        final MeterRegistry registry
     ) {
-        return new GRpcAgentFileStreamServiceImpl(converter, taskScheduler);
+        return new GRpcAgentFileStreamServiceImpl(converter, taskScheduler, registry);
     }
 
     /**
@@ -101,15 +104,17 @@ public class AgentRpcEndpointsAutoConfiguration {
      *
      * @param agentRoutingService The {@link AgentRoutingService} implementation to use
      * @param taskScheduler       The {@link TaskScheduler} instance to use
+     * @param registry      The meter registry
      * @return A {@link GRpcHeartBeatServiceImpl} instance
      */
     @Bean
     @ConditionalOnMissingBean(HeartBeatServiceGrpc.HeartBeatServiceImplBase.class)
     public GRpcHeartBeatServiceImpl gRpcHeartBeatService(
         final AgentRoutingService agentRoutingService,
-        @Qualifier("heartBeatServiceTaskScheduler") final TaskScheduler taskScheduler
+        @Qualifier("heartBeatServiceTaskScheduler") final TaskScheduler taskScheduler,
+        final MeterRegistry registry
     ) {
-        return new GRpcHeartBeatServiceImpl(agentRoutingService, taskScheduler);
+        return new GRpcHeartBeatServiceImpl(agentRoutingService, taskScheduler, registry);
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.tasks.leader;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.Maps;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobStatus;
@@ -325,7 +326,7 @@ public class ClusterCheckerTask extends LeadershipTask {
     @NoArgsConstructor
     private static class HealthIndicatorDetails {
         private Status status;
-        private Map<String, Object> details;
+        private Map<String, Object> details = Maps.newHashMap();
     }
 
     @Getter
@@ -333,6 +334,6 @@ public class ClusterCheckerTask extends LeadershipTask {
     @NoArgsConstructor
     private static class HealthEndpointResponse {
         private Status status;
-        private Map<String, HealthIndicatorDetails> components;
+        private Map<String, HealthIndicatorDetails> components = Maps.newHashMap();
     }
 }

--- a/genie-web/src/main/resources/genie-web-defaults.yml
+++ b/genie-web/src/main/resources/genie-web-defaults.yml
@@ -115,6 +115,9 @@ management:
   endpoints:
     web:
       base-path: /admin
+    health:
+      show-components: always
+      show-details: always
 
 spring:
   application:

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcAgentFileStreamServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcAgentFileStreamServiceImplSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.genie.proto.AgentManifestMessage
 import com.netflix.genie.proto.ServerAckMessage
 import com.netflix.genie.proto.ServerControlMessage
 import io.grpc.stub.StreamObserver
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.springframework.core.io.Resource
@@ -62,7 +63,8 @@ class GRpcAgentFileStreamServiceImplSpec extends Specification {
         this.taskScheduler = Mock(TaskScheduler)
         this.service = new GRpcAgentFileStreamServiceImpl(
             converter,
-            taskScheduler
+            taskScheduler,
+            new SimpleMeterRegistry()
         )
         this.serverControlObserver = Mock(StreamObserver)
         this.serverTransmitObserver = Mock(StreamObserver)

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcHeartBeatServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcHeartBeatServiceImplSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.genie.proto.AgentHeartBeat
 import com.netflix.genie.proto.ServerHeartBeat
 import com.netflix.genie.web.agent.services.AgentRoutingService
 import io.grpc.stub.StreamObserver
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.springframework.scheduling.TaskScheduler
 import spock.lang.Specification
 
@@ -45,7 +46,7 @@ class GRpcHeartBeatServiceImplSpec extends Specification {
         }
         this.agentRoutingService = Mock(AgentRoutingService)
         this.responseObserver = Mock(StreamObserver)
-        this.service = new GRpcHeartBeatServiceImpl(agentRoutingService, taskScheduler)
+        this.service = new GRpcHeartBeatServiceImpl(agentRoutingService, taskScheduler, new SimpleMeterRegistry())
         assert task != null
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/aspects/HealthCheckMetricsAspectSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/aspects/HealthCheckMetricsAspectSpec.groovy
@@ -17,14 +17,15 @@
  */
 package com.netflix.genie.web.aspects
 
-import com.google.common.collect.Sets
+import com.google.common.collect.ImmutableSet
 import com.netflix.genie.web.health.GenieCpuHealthIndicator
-import com.netflix.genie.web.util.MetricsConstants
-import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.Signature
 import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.actuate.health.Status
 import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
@@ -32,223 +33,71 @@ import java.util.concurrent.TimeUnit
 /**
  * Unit tests for HealthCheckMetricsAspect
  *
- * @author mprimi* @since 3.2.4
+ * @author mprimi
+ * @since 3.2.4
  */
 class HealthCheckMetricsAspectSpec extends Specification {
     MeterRegistry registry
     io.micrometer.core.instrument.Timer timer
-    Counter counter
     HealthCheckMetricsAspect aspect
+    HealthIndicator healthIndicator
+    Object[] args
+    Health health
+    ProceedingJoinPoint joinPoint
+    Signature signature
 
     def setup() {
-        registry = Mock(MeterRegistry.class)
-        timer = Mock(io.micrometer.core.instrument.Timer.class)
-        counter = Mock(Counter.class)
-//        registry.counter(_ as String, _ as Set<Tag>) >> counter
-        aspect = new HealthCheckMetricsAspect(registry)
+        this.registry = Mock(MeterRegistry.class)
+        this.timer = Mock(io.micrometer.core.instrument.Timer.class)
+        this.healthIndicator = Mock(GenieCpuHealthIndicator.class)
+        this.joinPoint = Mock(ProceedingJoinPoint.class)
+        this.signature = Mock(Signature.class)
+
+        this.health = Health.up().build()
+        this.args = new Object[0]
+
+        this.aspect = new HealthCheckMetricsAspect(registry)
     }
 
-    def testHealthEndpointTimer() {
-        given:
-        def expectedTags = Sets.newHashSet(Tag.of(MetricsConstants.TagKeys.STATUS, "UP"))
-        def joinPoint = Mock(ProceedingJoinPoint.class)
-        def health = new Health.Builder().up().build()
-        joinPoint.getArgs() >> new Object[0]
-        joinPoint.proceed(_ as Object[]) >> health
-        Health retVal
-
+    def "Around HealthIndicator::getHealth(...)"() {
         when:
-        retVal = aspect.healthEndpointInvokeMonitor(joinPoint)
+        Health h = this.aspect.aroundHealthIndicatorGetHealth(joinPoint)
 
         then:
-        1 * registry.timer(HealthCheckMetricsAspect.HEALTH_ENDPOINT_TIMER_NAME, expectedTags) >> timer
-        1 * timer.record(_ as Long, TimeUnit.NANOSECONDS)
-        retVal == health
-    }
-
-    def testHealthEndpointTimerException() {
-        given:
-        def expectedTags = Sets.newHashSet(
-            Tag.of("status", "UNKNOWN"),
-            Tag.of("exceptionClass", "java.lang.RuntimeException")
-        )
-        def joinPoint = Mock(ProceedingJoinPoint.class)
-        joinPoint.getArgs() >> new Object[0]
-        joinPoint.proceed(_ as Object[]) >> { throw new RuntimeException("test") }
-
-        when:
-        aspect.healthEndpointInvokeMonitor(joinPoint)
-
-        then:
-        1 * registry.timer(HealthCheckMetricsAspect.HEALTH_ENDPOINT_TIMER_NAME, expectedTags) >> timer
-        1 * timer.record(_ as Long, TimeUnit.NANOSECONDS)
-        thrown(RuntimeException.class)
-    }
-
-    def testHealthIndicatorTimer() {
-        given:
-        def health = new Health.Builder().up().build()
-        def target = Mock(GenieCpuHealthIndicator.class)
-        target.getClass() >> GenieCpuHealthIndicator.class
-        def joinPoint = Mock(ProceedingJoinPoint.class)
-        joinPoint.getTarget() >> target
-        joinPoint.getArgs() >> new Object[0]
-        joinPoint.proceed(_ as Object[]) >> health
-        Set<Tag> timerTagsCapture
-        registry.timer(HealthCheckMetricsAspect.HEALTH_INDICATOR_TIMER_METRIC_NAME, _ as Set<Tag>) >> {
-            args ->
-                timerTagsCapture = (Set<Tag>) args[1]
-                return timer
-        }
-        Health retVal
-
-        when:
-        retVal = aspect.healthIndicatorHealthMonitor(joinPoint)
-
-        then:
-        1 * timer.record(_ as Long, TimeUnit.NANOSECONDS)
-        timerTagsCapture.size() == 2
-        timerTagsCapture.each { tag ->
-            if (tag.key == "status") {
-                tag.value == "success"
-            } else if (tag.key == "healthIndicatorClass") {
-                tag.value.startsWith(GenieCpuHealthIndicator.class.getSimpleName())
-            }
-        }
-        retVal == health
-    }
-
-    def testHealthIndicatorTimerException() {
-        given:
-        def target = Mock(GenieCpuHealthIndicator.class)
-        target.getClass() >> GenieCpuHealthIndicator.class
-        def joinPoint = Mock(ProceedingJoinPoint.class)
-        joinPoint.getTarget() >> target
-        joinPoint.getArgs() >> new Object[0]
-        joinPoint.proceed(_ as Object[]) >> { throw new RuntimeException("test") }
-
-        when:
-        aspect.healthIndicatorHealthMonitor(joinPoint)
-
-        then:
-        1 * timer.record(_ as Long, TimeUnit.NANOSECONDS)
+        1 * joinPoint.getTarget() >> healthIndicator
+        1 * joinPoint.getSignature() >> signature
+        1 * signature.getName() >> "getHealth"
+        2 * joinPoint.getArgs() >> args
+        1 * joinPoint.proceed(args) >> health
         1 * registry.timer(
             HealthCheckMetricsAspect.HEALTH_INDICATOR_TIMER_METRIC_NAME,
-            Sets.newHashSet(
-                Tag.of("status", "failure"),
-                Tag.of("exceptionClass", RuntimeException.getCanonicalName()),
-                Tag.of("healthIndicatorClass", target.getClass().getSimpleName())
+            ImmutableSet.of(
+                Tag.of(HealthCheckMetricsAspect.HEALTH_INDICATOR_CLASS_TAG_NAME, GenieCpuHealthIndicator.class.getSimpleName()),
+                Tag.of(HealthCheckMetricsAspect.HEALTH_INDICATOR_STATUS_TAG_NAME, Status.UP.getCode())
             )
         ) >> timer
-        thrown(RuntimeException.class)
-    }
-
-    def testAbstractHealthIndicatorTimer() {
-        given:
-        def target = Mock(GenieCpuHealthIndicator.class)
-        target.getClass() >> GenieCpuHealthIndicator.class
-        def joinPoint = Mock(ProceedingJoinPoint.class)
-        joinPoint.getTarget() >> target
-        joinPoint.getArgs() >> new Object[0]
-        joinPoint.proceed(_ as Object[]) >> new Health.Builder().up().build()
-        Set<Tag> timerTagsCapture
-        registry.timer(HealthCheckMetricsAspect.HEALTH_INDICATOR_TIMER_METRIC_NAME, _ as Set<Tag>) >> {
-            args ->
-                timerTagsCapture = (Set<Tag>) args[1]
-                return timer
-        }
+        1 * timer.record(_ as Long, TimeUnit.NANOSECONDS)
+        h == health
 
         when:
-        aspect.abstractHealthIndicatorDoHealthCheckMonitor(joinPoint)
+        Throwable exception = new RuntimeException("...")
+        this.aspect.aroundHealthIndicatorGetHealth(joinPoint)
 
         then:
-        1 * timer.record(_ as Long, TimeUnit.NANOSECONDS)
-        timerTagsCapture.size() == 2
-        timerTagsCapture.each { tag ->
-            if (tag.key == "status") {
-                tag.value == "success"
-            } else if (tag.key == "healthIndicatorClass") {
-                tag.value.startsWith(GenieCpuHealthIndicator.class.getSimpleName())
-            }
-        }
-    }
-
-    def testAbstractHealthIndicatorTimerException() {
-        given:
-        def target = Mock(GenieCpuHealthIndicator.class)
-        target.getClass() >> GenieCpuHealthIndicator.class
-        def joinPoint = Mock(ProceedingJoinPoint.class)
-        joinPoint.getTarget() >> target
-        joinPoint.getArgs() >> new Object[0]
-        joinPoint.proceed(_ as Object[]) >> { throw new RuntimeException("test") }
-
-        when:
-        aspect.abstractHealthIndicatorDoHealthCheckMonitor(joinPoint)
-
-        then:
-        1 * timer.record(_ as Long, TimeUnit.NANOSECONDS)
+        1 * joinPoint.getTarget() >> healthIndicator
+        1 * joinPoint.getSignature() >> signature
+        1 * signature.getName() >> "getHealth"
+        2 * joinPoint.getArgs() >> args
+        1 * joinPoint.proceed(args) >> { throw exception }
         1 * registry.timer(
             HealthCheckMetricsAspect.HEALTH_INDICATOR_TIMER_METRIC_NAME,
-            Sets.newHashSet(
-                Tag.of("status", "failure"),
-                Tag.of("exceptionClass", RuntimeException.class.getCanonicalName()),
-                Tag.of("healthIndicatorClass", target.getClass().getSimpleName())
+            ImmutableSet.of(
+                Tag.of(HealthCheckMetricsAspect.HEALTH_INDICATOR_CLASS_TAG_NAME, GenieCpuHealthIndicator.class.getSimpleName()),
+                Tag.of(HealthCheckMetricsAspect.HEALTH_INDICATOR_STATUS_TAG_NAME, Status.UNKNOWN.getCode())
             )
         ) >> timer
-        thrown(RuntimeException.class)
+        1 * timer.record(_ as Long, TimeUnit.NANOSECONDS)
+        Throwable t = thrown(RuntimeException.class)
+        t == exception
     }
-
-    def testAbstractHealthAggregatorCounters() {
-        given:
-        def joinPoint = Mock(ProceedingJoinPoint.class)
-        def detailsMap = [
-            indicator1: new Health.Builder().up().build(),
-            indicator2: new Health.Builder().outOfService().build(),
-        ]
-        joinPoint.getArgs() >> [detailsMap]
-
-        def expectedTags1 = Sets.newHashSet(
-            Tag.of("healthIndicatorName", "indicator1"),
-            Tag.of("status", "UP")
-        )
-        def expectedTags2 = Sets.newHashSet(
-            Tag.of("healthIndicatorName", "indicator2"),
-            Tag.of("status", "OUT_OF_SERVICE")
-        )
-
-        def counterTagsCapture = new ArrayList<Set<Tag>>()
-        registry.counter(_ as String, _ as Set<Tag>) >> { args ->
-            counterTagsCapture.add((Set<Tag>) args[1])
-            return counter
-        }
-
-        when:
-        aspect.abstractHealthAggregatorAggregateDetailsMonitor(joinPoint)
-
-        then:
-        2 * counter.increment()
-        1 * counter.increment(0)
-        1 * counter.increment(1)
-
-        counterTagsCapture.size() == 4
-
-        counterTagsCapture.get(0) == expectedTags1
-        counterTagsCapture.get(1) == expectedTags1
-        counterTagsCapture.get(2) == expectedTags2
-        counterTagsCapture.get(3) == expectedTags2
-    }
-
-    def testAbstractHealthAggregatorCountersError() {
-        given:
-        def joinPoint = Mock(ProceedingJoinPoint.class)
-        joinPoint.getArgs() >> new Object[0]
-
-        when:
-        aspect.abstractHealthAggregatorAggregateDetailsMonitor(joinPoint)
-
-        then:
-        0 * counter.increment()
-        0 * counter.increment(_ as double)
-    }
-
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/apis/rpc/v4/endpoints/AgentRpcEndpointsAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/apis/rpc/v4/endpoints/AgentRpcEndpointsAutoConfigurationTest.java
@@ -32,6 +32,7 @@ import com.netflix.genie.web.agent.apis.rpc.v4.endpoints.JobServiceProtoErrorCom
 import com.netflix.genie.web.agent.services.AgentJobService;
 import com.netflix.genie.web.agent.services.AgentRoutingService;
 import com.netflix.genie.web.data.services.JobSearchService;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -178,6 +179,11 @@ class AgentRpcEndpointsAutoConfigurationTest {
         @Bean
         GenieHostInfo genieHostInfo() {
             return Mockito.mock(GenieHostInfo.class);
+        }
+
+        @Bean
+        MeterRegistry meterRegistry() {
+            return Mockito.mock(MeterRegistry.class);
         }
     }
 


### PR DESCRIPTION
Small adjustements following changes to Health-related components that came with Boot 2.2

 * Change of format and authorization to `/health` exposed a possible NPE in `ClusterCheckerTask`
 * Restore unauthorized access to `/health`
 * Fix `HealthCheckMetricsAspect`
 * Add new metrics tracking active gRPC streams (`FileTransfer` and `Heartbeat` services)