### PR TITLE
Make range requests for job output return proper 416

### DIFF
--- a/genie-ui/src/integTest/resources/application-integration.yml
+++ b/genie-ui/src/integTest/resources/application-integration.yml
@@ -2,10 +2,6 @@ grpc:
   server:
     port: 0
 
-local:
-  server:
-    port: 0
-
 spring:
   autoconfigure:
     exclude:

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
@@ -678,9 +678,6 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
         }
 
         // Range request, out of range
-        // This documents known issue where spring produces 406 (in case of boot <= 2.2.2) or 500 (boot > 2.2.2)
-        // Removal of `produces = MediaType.ALL_VALUE` solves this problem but need to wait for internal client update
-        // before truly fixing
         RestAssured
             .given(this.getRequestSpecification())
             .header(HttpHeaders.RANGE, "bytes=10000-")
@@ -688,8 +685,7 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
             .port(this.port)
             .get(JOBS_API + "/{id}/output/{filePath}", id, "stdout")
             .then()
-            .statusCode(Matchers.is(HttpStatus.NOT_ACCEPTABLE.value()));
-//            .statusCode(Matchers.is(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE.value()));
+            .statusCode(Matchers.is(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE.value()));
     }
 
     private void checkJobRequest(

--- a/genie-web/src/integTest/resources/application-integration.yml
+++ b/genie-web/src/integTest/resources/application-integration.yml
@@ -39,10 +39,6 @@ grpc:
   server:
     port: 0
 
-local:
-  server:
-    port: 0
-
 spring:
   autoconfigure:
     exclude:

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
@@ -663,15 +663,14 @@ public class JobRestController {
      * @param forwardedFrom The host this request was forwarded from if present
      * @param request       the servlet request
      * @param response      the servlet response
-     * @throws GenieException   on any Genie internal error
+     * @throws GenieException on any Genie internal error
      */
     @GetMapping(
         value = {
             "/{id}/output",
             "/{id}/output/",
             "/{id}/output/**"
-        },
-        produces = MediaType.ALL_VALUE
+        }
     )
     public void getJobOutput(
         @PathVariable("id") final String id,


### PR DESCRIPTION
Follow-up to #946 

Also revert commit that didn't have intended effect on travis builds for race condition with server port resolution