### PR TITLE
Add V4 Resource Resolution Migration Mechanism and Insights

### DIFF
--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerAgentExecutionIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerAgentExecutionIntegrationTest.java
@@ -31,6 +31,7 @@ import org.springframework.test.context.TestPropertySource;
     properties = {
         JobExecutionModeSelector.DEFAULT_EXECUTE_WITH_AGENT_PROPERTY + "=true",
         LocalAgentLauncherProperties.PROPERTY_PREFIX + ".run-as-user=false",
+        "genie.services.job-resolver.v4-probability=1.0",
     }
 )
 public class JobRestControllerAgentExecutionIntegrationTest extends JobRestControllerIntegrationTest {

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
@@ -31,7 +31,7 @@ import com.netflix.genie.common.dto.JobExecution;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.dto.JobStatusMessages;
-import com.netflix.genie.common.exceptions.GeniePreconditionException;
+import com.netflix.genie.common.external.dtos.v4.Criterion;
 import com.netflix.genie.common.external.util.GenieObjectMapper;
 import com.netflix.genie.web.introspection.GenieWebHostInfo;
 import com.netflix.genie.web.properties.JobsLocationsProperties;
@@ -1122,12 +1122,11 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
             .contentType(Matchers.equalToIgnoringCase(MediaType.APPLICATION_JSON_UTF8_VALUE))
             .body(
                 EXCEPTION_MESSAGE_PATH,
-                Matchers.containsString(GeniePreconditionException.class.getCanonicalName())
-            )
-            .body(
-                EXCEPTION_MESSAGE_PATH,
-                Matchers.containsString(
-                    "No cluster/command combination found for the given criteria. Unable to continue"
+                Matchers.anyOf(
+                    Matchers.containsString(
+                        "No cluster/command combination found for the given criteria. Unable to continue"
+                    ),
+                    Matchers.containsString("No cluster selected given criteria for job")
                 )
             )
             .body("stackTrace", Matchers.nullValue());
@@ -1893,6 +1892,11 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
             .withConfigs(configs)
             .withDependencies(commandDependencies)
             .withTags(tags)
+            .withClusterCriteria(
+                Lists.newArrayList(
+                    new Criterion.Builder().withTags(Sets.newHashSet(LOCALHOST_CLUSTER_TAG)).build()
+                )
+            )
             .build();
 
         RestAssured

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfiguration.java
@@ -80,6 +80,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.retry.support.RetryTemplate;
@@ -370,6 +371,7 @@ public class ServicesAutoConfiguration {
      * @param commandSelector               The {@link CommandSelector} implementation to use
      * @param registry                      The metrics repository to use
      * @param jobsProperties                The properties for running a job set by the user
+     * @param environment                   The Spring application {@link Environment} for dynamic property resolution
      * @return A {@link JobResolverServiceImpl} instance
      */
     @Bean
@@ -382,7 +384,8 @@ public class ServicesAutoConfiguration {
         @NotEmpty final List<ClusterSelector> clusterSelectors,
         final CommandSelector commandSelector,
         final MeterRegistry registry,
-        final JobsProperties jobsProperties
+        final JobsProperties jobsProperties,
+        final Environment environment
     ) {
         return new JobResolverServiceImpl(
             applicationPersistenceService,
@@ -392,7 +395,8 @@ public class ServicesAutoConfiguration {
             clusterSelectors,
             commandSelector,
             registry,
-            jobsProperties
+            jobsProperties,
+            environment
         );
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
@@ -139,6 +139,8 @@ class JobResolverServiceImplSpec extends Specification {
             Double.class,
             JobResolverServiceImpl.DEFAULT_V4_PROBABILITY
         ) >> 0.0d
+        1 * this.environment.getProperty(JobResolverServiceImpl.DUAL_RESOLVE_PROPERTY_KEY, Boolean.class, false) >> false
+        0 * this.commandService.findCommandsMatchingCriterion(_ as Criterion, _ as boolean)
         0 * this.jobService.saveResolvedJob(_ as String, _ as ResolvedJob)
         1 * this.clusterService.findClustersAndCommandsForCriteria(
             jobRequest.getCriteria().getClusterCriteria(),
@@ -178,6 +180,11 @@ class JobResolverServiceImplSpec extends Specification {
             Double.class,
             JobResolverServiceImpl.DEFAULT_V4_PROBABILITY
         ) >> 0.0d
+        1 * this.environment.getProperty(JobResolverServiceImpl.DUAL_RESOLVE_PROPERTY_KEY, Boolean.class, false) >> true
+        1 * this.commandService.findCommandsMatchingCriterion(
+            jobRequestNoArchivalData.getCriteria().getCommandCriterion(),
+            true
+        ) >> Sets.newHashSet(createCommand(UUID.randomUUID().toString(), Lists.newArrayList(UUID.randomUUID().toString())))
         1 * this.clusterService.findClustersAndCommandsForCriteria(
             jobRequestNoArchivalData.getCriteria().getClusterCriteria(),
             jobRequestNoArchivalData.getCriteria().getCommandCriterion()
@@ -220,6 +227,8 @@ class JobResolverServiceImplSpec extends Specification {
             Double.class,
             JobResolverServiceImpl.DEFAULT_V4_PROBABILITY
         ) >> 0.0d
+        1 * this.environment.getProperty(JobResolverServiceImpl.DUAL_RESOLVE_PROPERTY_KEY, Boolean.class, false) >> true
+        1 * this.commandService.findCommandsMatchingCriterion(savedJobRequest.getCriteria().getCommandCriterion(), true) >> Sets.newHashSet(command)
         1 * this.jobService.getJobStatus(jobId) >> JobStatus.RESERVED
         1 * this.jobService.isApiJob(jobId) >> false
         1 * this.jobService.getJobRequest(jobId) >> Optional.of(savedJobRequest)
@@ -304,6 +313,7 @@ class JobResolverServiceImplSpec extends Specification {
             Double.class,
             JobResolverServiceImpl.DEFAULT_V4_PROBABILITY
         ) >> 1.0d
+        0 * this.environment.getProperty(JobResolverServiceImpl.DUAL_RESOLVE_PROPERTY_KEY, Boolean.class, false) >> false
         0 * this.jobService.saveResolvedJob(_ as String, _ as ResolvedJob)
         1 * this.commandService.findCommandsMatchingCriterion(jobRequest.getCriteria().getCommandCriterion(), true) >> commands
         1 * this.commandSelector.selectCommand(commands, jobRequest) >> commandSelectionResult
@@ -339,6 +349,7 @@ class JobResolverServiceImplSpec extends Specification {
             Double.class,
             JobResolverServiceImpl.DEFAULT_V4_PROBABILITY
         ) >> 1.0d
+        0 * this.environment.getProperty(JobResolverServiceImpl.DUAL_RESOLVE_PROPERTY_KEY, Boolean.class, false) >> false
         1 * this.commandService.findCommandsMatchingCriterion(jobRequestNoArchivalData.getCriteria().getCommandCriterion(), true) >> commands
         1 * this.commandSelector.selectCommand(commands, jobRequestNoArchivalData) >> commandSelectionResult
         1 * commandSelectionResult.getSelectedResource() >> Optional.of(command0)
@@ -377,6 +388,7 @@ class JobResolverServiceImplSpec extends Specification {
             Double.class,
             JobResolverServiceImpl.DEFAULT_V4_PROBABILITY
         ) >> 1.0d
+        0 * this.environment.getProperty(JobResolverServiceImpl.DUAL_RESOLVE_PROPERTY_KEY, Boolean.class, false) >> false
         1 * this.jobService.getJobStatus(jobId) >> JobStatus.RESERVED
         1 * this.jobService.isApiJob(jobId) >> false
         1 * this.jobService.getJobRequest(jobId) >> Optional.of(savedJobRequest)


### PR DESCRIPTION
This PR contains two commits targeted at helping us migrate from V3 resource resolution algorithm to V4.

- The first adds a dynamic property that can effect the probability the old or new algorithm will be used.
- The second commit adds a dynamic property that will dry run the V4 command resolution logic and capture the results for debugging/inspection by pertinent parties so that we can tackle as many as we can before the property used in the first commit starts being used. This was requested by the internal configuration admin team