### PR TITLE
Fix Postgresql migration script for non-admin users

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImpl.java
@@ -601,15 +601,7 @@ public class JpaCommandPersistenceServiceImpl extends JpaBaseService implements 
             id
         );
         final CommandEntity commandEntity = this.findCommand(id);
-        // First remove all the old criteria
-        this.deleteAllClusterCriteria(commandEntity);
-        // Set the new criteria
-        commandEntity.setClusterCriteria(
-            clusterCriteria
-                .stream()
-                .map(this::toCriterionEntity)
-                .collect(Collectors.toList())
-        );
+        this.updateClusterCriteria(commandEntity, clusterCriteria);
     }
 
     /**
@@ -715,6 +707,8 @@ public class JpaCommandPersistenceServiceImpl extends JpaBaseService implements 
         entity.setCheckDelay(dto.getCheckDelay());
         entity.setExecutable(dto.getExecutable());
         entity.setMemory(dto.getMemory().orElse(null));
+
+        this.updateClusterCriteria(entity, dto.getClusterCriteria());
     }
 
     // TODO: Try to reuse code here once big bang changes are done
@@ -727,6 +721,18 @@ public class JpaCommandPersistenceServiceImpl extends JpaBaseService implements 
         entity.setDescription(metadata.getDescription().orElse(null));
         entity.setStatus(metadata.getStatus().name());
         EntityDtoConverters.setJsonField(metadata.getMetadata().orElse(null), entity::setMetadata);
+    }
+
+    private void updateClusterCriteria(final CommandEntity commandEntity, final List<Criterion> clusterCriteria) {
+        // First remove all the old criteria
+        this.deleteAllClusterCriteria(commandEntity);
+        // Set the new criteria
+        commandEntity.setClusterCriteria(
+            clusterCriteria
+                .stream()
+                .map(this::toCriterionEntity)
+                .collect(Collectors.toList())
+        );
     }
 
     private void deleteAllClusterCriteria(final CommandEntity commandEntity) {

--- a/genie-web/src/main/resources/db/migration/postgresql/V3_2_0__Base_Version.sql
+++ b/genie-web/src/main/resources/db/migration/postgresql/V3_2_0__Base_Version.sql
@@ -32,19 +32,6 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
 
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 SET search_path = public, pg_catalog;
 


### PR DESCRIPTION
The original file was dumped from a Postgres install on a developer machine (mine) that was created with a user having admin rights. This resulted in some statements being included that require admin capabilities to execute. This would fail for uses running on shared posgresql instances as non-admin users. We've known about this but avoided fixing it for fear of breaking existing users who had already installed and had `flyway_schema_history` tables with values.

At this point this is affecting more users than not so fixing it has value going forward.

For users that have already installed there are two options:
1. Set `spring.flyway.baseline-version=3.3.0` which will cause the system to skip evaluating the initial migration state
2. Update flyway schema history to have the new correct checksum: `update flyway_schema_history set checksum = -1400680873 where installed_rank = 1;`

Both of these options have been tested and work.

This should unblock new users from adopting Genie with non-admin installs of postgres.

New migration script tested against non-admin user on Postgres 12.

Should fix #767