### PR TITLE
Command and Application Lifecycle Support

### DIFF
--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -482,6 +482,25 @@ had a status different than UP
 |ClusterCheckerTask
 |host
 
+|genie.tasks.databaseCleanup.clusterDeletion.timer
+|Time taken to delete cluster records from the database
+|nanoseconds
+|DatabaseCleanupTask
+|status, exceptionClass
+
+
+|genie.tasks.databaseCleanup.fileDeletion.timer
+|Time taken to delete file records from the database
+|nanoseconds
+|DatabaseCleanupTask
+|status, exceptionClass
+
+|genie.tasks.databaseCleanup.tagDeletion.timer
+|Time taken to delete tag records from the database
+|nanoseconds
+|DatabaseCleanupTask
+|status, exceptionClass
+
 |genie.tasks.databaseCleanup.duration.timer
 |Time taken to cleanup database records for jobs that executed over a given amount of time in the past
 |nanoseconds

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -482,12 +482,29 @@ had a status different than UP
 |ClusterCheckerTask
 |host
 
+|genie.tasks.databaseCleanup.applicationDeletion.timer
+|Time taken to delete application records from the database
+|nanoseconds
+|DatabaseCleanupTask
+|status, exceptionClass
+
 |genie.tasks.databaseCleanup.clusterDeletion.timer
 |Time taken to delete cluster records from the database
 |nanoseconds
 |DatabaseCleanupTask
 |status, exceptionClass
 
+|genie.tasks.databaseCleanup.commandDeactivation.timer
+|Time taken to deactivate command records in the database
+|nanoseconds
+|DatabaseCleanupTask
+|status, exceptionClass
+
+|genie.tasks.databaseCleanup.commandDeletion.timer
+|Time taken to delete command records from the database
+|nanoseconds
+|DatabaseCleanupTask
+|status, exceptionClass
 
 |genie.tasks.databaseCleanup.fileDeletion.timer
 |Time taken to delete file records from the database
@@ -507,8 +524,26 @@ had a status different than UP
 |DatabaseCleanupTask
 |status, exceptionClass
 
+|genie.tasks.databaseCleanup.numDeletedApplications.gauge
+|Number of deleted application records purged during the last database cleanup pass
+|amount
+|DatabaseCleanupTask
+|-
+
+|genie.tasks.databaseCleanup.numDeactivatedCommands.gauge
+|Number of command records set to INACTIVE during the last database cleanup pass
+|amount
+|DatabaseCleanupTask
+|-
+
 |genie.tasks.databaseCleanup.numDeletedClusters.gauge
 |Number of terminated cluster records purged during the last database cleanup pass
+|amount
+|DatabaseCleanupTask
+|-
+
+|genie.tasks.databaseCleanup.numDeletedCommands.gauge
+|Number of deleted command records purged during the last database cleanup pass
 |amount
 |DatabaseCleanupTask
 |-

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -451,7 +451,7 @@ See: `genie.tasks.database-cleanup.expression`
 |genie.tasks.database-cleanup.expression
 |The cron expression for how often to run the database cleanup task
 |0 0 0 * * *
-|no
+|yes
 
 |genie.tasks.database-cleanup.maxDeletedPerTransaction
 |The number of job records (across multiple tables) to delete from the database
@@ -459,37 +459,37 @@ in a single transaction. Genie will loop and perform multiple transactions until
 all jobs older than the retention time are deleted.
 This is a soft limit, it could be rounded up to the next multiple of page size.
 |1000
-|no
+|yes
 
 |genie.tasks.database-cleanup.pageSize
 |The page size used within each cleanup transaction to iterate through the job records
 |1000
-|no
+|yes
 
 |genie.tasks.database-cleanup.retention
 |The number of days to retain jobs in the database
 |90
-|no
+|yes
 
 |genie.tasks.database-cleanup.skipClustersCleanup
 |Skip the Clusters table when performing database cleanup
 |false
-|no
+|yes
 
 |genie.tasks.database-cleanup.skipFilesCleanup
 |Skip the Files table when performing database cleanup
 |false
-|no
+|yes
 
 |genie.tasks.database-cleanup.skipJobsCleanup
 |Skip the Jobs table when performing database cleanup
 |false
-|no
+|yes
 
 |genie.tasks.database-cleanup.skipTagsCleanup
 |Skip the Tags table when performing database cleanup
 |false
-|no
+|yes
 
 |genie.tasks.disk-cleanup.enabled
 |Whether or not to remove old job directories on the Genie node or not

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -442,8 +442,35 @@ lost and failed by the Genie leader
 |http
 |no
 
+|genie.tasks.database-cleanup.application-cleanup.skip
+|Skip the Applications table when performing database cleanup
+|false
+|yes
+
 |genie.tasks.database-cleanup.cluster-cleanup.skip
 |Skip the Clusters table when performing database cleanup
+|false
+|yes
+
+|genie.tasks.database-cleanup.command-cleanup.skip
+|Skip the Commands table when performing database cleanup
+|false
+|yes
+
+|genie.tasks.database-cleanup.command-deactivation.commandCreationThreshold
+|The number of days before the current cleanup run that a command must have been created before in the system to be
+considered for deactivation.
+|false
+|yes
+
+|genie.tasks.database-cleanup.command-deactivation.jobCreationThreshold
+|The number of days before the current cleanup run that command must not have been used in a job for that command to be
+considered for deactivation.
+|false
+|yes
+
+|genie.tasks.database-cleanup.command-deactivation.skip
+|Skip deactivating Commands when performing database cleanup
 |false
 |yes
 
@@ -487,16 +514,6 @@ This is a soft limit, it could be rounded up to the next multiple of page size.
 |yes
 
 |genie.tasks.database-cleanup.tag-cleanup.skip
-|Skip the Tags table when performing database cleanup
-|false
-|yes
-
-|genie.tasks.database-cleanup.skipJobsCleanup
-|Skip the Jobs table when performing database cleanup
-|false
-|yes
-
-|genie.tasks.database-cleanup.skipTagsCleanup
 |Skip the Tags table when performing database cleanup
 |false
 |yes

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -442,6 +442,11 @@ lost and failed by the Genie leader
 |http
 |no
 
+|genie.tasks.database-cleanup.cluster-cleanup.skip
+|Skip the Clusters table when performing database cleanup
+|false
+|yes
+
 |genie.tasks.database-cleanup.enabled
 |Whether or not to delete old and unused records from the database at a scheduled interval.
 See: `genie.tasks.database-cleanup.expression`
@@ -453,7 +458,17 @@ See: `genie.tasks.database-cleanup.expression`
 |0 0 0 * * *
 |yes
 
-|genie.tasks.database-cleanup.maxDeletedPerTransaction
+|genie.tasks.database-cleanup.file-cleanup.skip
+|Skip the Files table when performing database cleanup
+|false
+|yes
+
+|genie.tasks.database-cleanup.job-cleanup.skip
+|Skip the Jobs table when performing database cleanup
+|false
+|yes
+
+|genie.tasks.database-cleanup.job-cleanup.maxDeletedPerTransaction
 |The number of job records (across multiple tables) to delete from the database
 in a single transaction. Genie will loop and perform multiple transactions until
 all jobs older than the retention time are deleted.
@@ -461,23 +476,18 @@ This is a soft limit, it could be rounded up to the next multiple of page size.
 |1000
 |yes
 
-|genie.tasks.database-cleanup.pageSize
+|genie.tasks.database-cleanup.job-cleanup.pageSize
 |The page size used within each cleanup transaction to iterate through the job records
 |1000
 |yes
 
-|genie.tasks.database-cleanup.retention
+|genie.tasks.database-cleanup.job-cleanup.retention
 |The number of days to retain jobs in the database
 |90
 |yes
 
-|genie.tasks.database-cleanup.skipClustersCleanup
-|Skip the Clusters table when performing database cleanup
-|false
-|yes
-
-|genie.tasks.database-cleanup.skipFilesCleanup
-|Skip the Files table when performing database cleanup
+|genie.tasks.database-cleanup.tag-cleanup.skip
+|Skip the Tags table when performing database cleanup
 |false
 |yes
 

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/DBIntegrationTestBase.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/DBIntegrationTestBase.java
@@ -27,13 +27,13 @@ import com.netflix.genie.web.data.repositories.jpa.JpaCriterionRepository;
 import com.netflix.genie.web.data.repositories.jpa.JpaFileRepository;
 import com.netflix.genie.web.data.repositories.jpa.JpaJobRepository;
 import com.netflix.genie.web.data.repositories.jpa.JpaTagRepository;
-import org.junit.After;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 
@@ -42,9 +42,9 @@ import org.springframework.test.context.support.DirtiesContextTestExecutionListe
  *
  * @author tgianos
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 //@DataJpaTest
-@SpringBootTest(classes = GenieTestApp.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@SpringBootTest(classes = GenieTestApp.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestExecutionListeners(
     {
         DependencyInjectionTestExecutionListener.class,
@@ -60,7 +60,7 @@ import org.springframework.test.context.support.DirtiesContextTestExecutionListe
         "db-h2",
     }
 )
-public abstract class DBIntegrationTestBase {
+abstract class DBIntegrationTestBase {
 
     @Autowired
     protected JpaApplicationRepository applicationRepository;
@@ -89,8 +89,8 @@ public abstract class DBIntegrationTestBase {
     /**
      * Clean out the db after every test.
      */
-    @After
-    public void cleanup() {
+    @AfterEach
+    void cleanup() {
         this.jobRepository.deleteAll();
         this.clusterRepository.deleteAll();
         this.commandRepository.deleteAll();

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImplIntegrationTest.java
@@ -29,12 +29,9 @@ import com.netflix.genie.common.external.dtos.v4.ApplicationRequest;
 import com.netflix.genie.common.external.dtos.v4.ApplicationStatus;
 import com.netflix.genie.common.external.dtos.v4.Command;
 import com.netflix.genie.common.external.util.GenieObjectMapper;
-import com.netflix.genie.test.suppliers.RandomSuppliers;
-import com.netflix.genie.web.data.services.ApplicationPersistenceService;
 import com.netflix.genie.web.data.services.CommandPersistenceService;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -43,20 +40,18 @@ import org.springframework.data.domain.Sort;
 
 import javax.validation.ConstraintViolationException;
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 
 /**
- * Integration tests for the JpaApplicationPersistenceServiceImpl.
+ * Integration tests for {@link JpaApplicationPersistenceServiceImpl}.
  *
  * @author tgianos
  * @since 2.0.0
  */
-@DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
 @DatabaseTearDown("cleanup.xml")
-public class JpaApplicationPersistenceServiceImplIntegrationTest extends DBIntegrationTestBase {
+class JpaApplicationPersistenceServiceImplIntegrationTest extends DBIntegrationTestBase {
 
     private static final String APP_1_ID = "app1";
     private static final String APP_1_NAME = "tez";
@@ -83,215 +78,186 @@ public class JpaApplicationPersistenceServiceImplIntegrationTest extends DBInteg
     private static final Pageable PAGEABLE = PageRequest.of(0, 10, Sort.Direction.DESC, "updated");
 
     @Autowired
-    private ApplicationPersistenceService appService;
+    private JpaApplicationPersistenceServiceImpl appService;
 
     @Autowired
     private CommandPersistenceService commandPersistenceService;
 
-    /**
-     * Test the get application method.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplication() throws GenieException {
         final Application app = this.appService.getApplication(APP_1_ID);
-        Assert.assertEquals(APP_1_ID, app.getId());
-        Assert.assertEquals(APP_1_NAME, app.getMetadata().getName());
-        Assert.assertEquals(APP_1_USER, app.getMetadata().getUser());
-        Assert.assertEquals(APP_1_VERSION, app.getMetadata().getVersion());
-        Assert.assertEquals(APP_1_STATUS, app.getMetadata().getStatus());
-        Assert.assertFalse(app.getMetadata().getType().isPresent());
-        Assert.assertEquals(1, app.getMetadata().getTags().size());
-        Assert.assertEquals(2, app.getResources().getConfigs().size());
-        Assert.assertEquals(2, app.getResources().getDependencies().size());
+        Assertions.assertThat(app.getId()).isEqualTo(APP_1_ID);
+        final ApplicationMetadata appMetadata = app.getMetadata();
+        Assertions.assertThat(appMetadata.getName()).isEqualTo(APP_1_NAME);
+        Assertions.assertThat(appMetadata.getUser()).isEqualTo(APP_1_USER);
+        Assertions.assertThat(appMetadata.getVersion()).isEqualTo(APP_1_VERSION);
+        Assertions.assertThat(appMetadata.getStatus()).isEqualByComparingTo(APP_1_STATUS);
+        Assertions.assertThat(appMetadata.getType()).isNotPresent();
+        Assertions.assertThat(appMetadata.getTags()).hasSize(1);
+        Assertions.assertThat(app.getResources().getConfigs()).hasSize(2);
+        Assertions.assertThat(app.getResources().getDependencies()).hasSize(2);
 
         final Application app2 = this.appService.getApplication(APP_2_ID);
-        Assert.assertEquals(APP_2_ID, app2.getId());
-        Assert.assertEquals(APP_2_NAME, app2.getMetadata().getName());
-        Assert.assertEquals(APP_2_USER, app2.getMetadata().getUser());
-        Assert.assertEquals(APP_2_VERSION, app2.getMetadata().getVersion());
-        Assert.assertEquals(APP_2_STATUS, app2.getMetadata().getStatus());
-        Assert.assertThat(app2.getMetadata().getType().orElseGet(RandomSuppliers.STRING), Matchers.is(APP_2_TYPE));
-        Assert.assertEquals(2, app2.getMetadata().getTags().size());
-        Assert.assertEquals(2, app2.getResources().getConfigs().size());
-        Assert.assertEquals(1, app2.getResources().getDependencies().size());
+        Assertions.assertThat(app2.getId()).isEqualTo(APP_2_ID);
+        final ApplicationMetadata app2Metadata = app2.getMetadata();
+        Assertions.assertThat(app2Metadata.getName()).isEqualTo(APP_2_NAME);
+        Assertions.assertThat(app2Metadata.getUser()).isEqualTo(APP_2_USER);
+        Assertions.assertThat(app2Metadata.getVersion()).isEqualTo(APP_2_VERSION);
+        Assertions.assertThat(app2Metadata.getStatus()).isEqualByComparingTo(APP_2_STATUS);
+        Assertions.assertThat(app2Metadata.getType()).isPresent().contains(APP_2_TYPE);
+        Assertions.assertThat(app2Metadata.getTags()).hasSize(2);
+        Assertions.assertThat(app2.getResources().getConfigs()).hasSize(2);
+        Assertions.assertThat(app2.getResources().getDependencies()).hasSize(1);
 
         final Application app3 = this.appService.getApplication(APP_3_ID);
-        Assert.assertEquals(APP_3_ID, app3.getId());
-        Assert.assertEquals(APP_3_NAME, app3.getMetadata().getName());
-        Assert.assertEquals(APP_3_USER, app3.getMetadata().getUser());
-        Assert.assertEquals(APP_3_VERSION, app3.getMetadata().getVersion());
-        Assert.assertEquals(APP_3_STATUS, app3.getMetadata().getStatus());
-        Assert.assertThat(app3.getMetadata().getType().orElseGet(RandomSuppliers.STRING), Matchers.is(APP_3_TYPE));
-        Assert.assertEquals(1, app3.getMetadata().getTags().size());
-        Assert.assertEquals(1, app3.getResources().getConfigs().size());
-        Assert.assertEquals(2, app3.getResources().getDependencies().size());
+        Assertions.assertThat(app3.getId()).isEqualTo(APP_3_ID);
+        final ApplicationMetadata app3Metadata = app3.getMetadata();
+        Assertions.assertThat(app3Metadata.getName()).isEqualTo(APP_3_NAME);
+        Assertions.assertThat(app3Metadata.getUser()).isEqualTo(APP_3_USER);
+        Assertions.assertThat(app3Metadata.getVersion()).isEqualTo(APP_3_VERSION);
+        Assertions.assertThat(app3Metadata.getStatus()).isEqualByComparingTo(APP_3_STATUS);
+        Assertions.assertThat(app3Metadata.getType()).isPresent().contains(APP_3_TYPE);
+        Assertions.assertThat(app3Metadata.getTags()).hasSize(1);
+        Assertions.assertThat(app3.getResources().getConfigs()).hasSize(1);
+        Assertions.assertThat(app3.getResources().getDependencies()).hasSize(2);
     }
 
-    /**
-     * Test the get application method.
-     *
-     * @throws GenieException For any problem
-     */
-    @Test(expected = ConstraintViolationException.class)
-    public void testGetApplicationEmpty() throws GenieException {
-        this.appService.getApplication("");
-    }
-
-    /**
-     * Test the get applications method.
-     */
     @Test
-    public void testGetApplicationsByName() {
+    void testGetApplicationEmpty() {
+        Assertions
+            .assertThatExceptionOfType(ConstraintViolationException.class)
+            .isThrownBy(() -> this.appService.getApplication(""));
+    }
+
+    @Test
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsByName() {
         final Page<Application> apps = this.appService.getApplications(APP_2_NAME, null, null, null, null, PAGEABLE);
-        Assert.assertEquals(1, apps.getNumberOfElements());
-        Assert.assertThat(apps.getContent().get(0).getId(), Matchers.is(APP_2_ID));
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(1);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_2_ID);
     }
 
-    /**
-     * Test the get applications method.
-     */
     @Test
-    public void testGetApplicationsByUser() {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsByUser() {
         final Page<Application> apps = this.appService.getApplications(null, APP_1_USER, null, null, null, PAGEABLE);
-        Assert.assertEquals(2, apps.getNumberOfElements());
-        Assert.assertEquals(APP_3_ID, apps.getContent().get(0).getId());
-        Assert.assertEquals(APP_1_ID, apps.getContent().get(1).getId());
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(2);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_3_ID);
+        Assertions.assertThat(apps.getContent().get(1).getId()).isEqualTo(APP_1_ID);
     }
 
-    /**
-     * Test the get applications method.
-     */
     @Test
-    public void testGetApplicationsByStatuses() {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsByStatuses() {
         final Set<ApplicationStatus> statuses = Sets.newHashSet(ApplicationStatus.ACTIVE, ApplicationStatus.INACTIVE);
         final Page<Application> apps = this.appService.getApplications(null, null, statuses, null, null, PAGEABLE);
-        Assert.assertEquals(2, apps.getNumberOfElements());
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId());
-        Assert.assertEquals(APP_1_ID, apps.getContent().get(1).getId());
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(2);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_2_ID);
+        Assertions.assertThat(apps.getContent().get(1).getId()).isEqualTo(APP_1_ID);
     }
 
-    /**
-     * Test the get applications method.
-     */
     @Test
-    public void testGetApplicationsByTags() {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsByTags() {
         final Set<String> tags = Sets.newHashSet("prod");
         Page<Application> apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
-        Assert.assertEquals(3, apps.getNumberOfElements());
-        Assert.assertEquals(APP_3_ID, apps.getContent().get(0).getId());
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(1).getId());
-        Assert.assertEquals(APP_1_ID, apps.getContent().get(2).getId());
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(3);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_3_ID);
+        Assertions.assertThat(apps.getContent().get(1).getId()).isEqualTo(APP_2_ID);
+        Assertions.assertThat(apps.getContent().get(2).getId()).isEqualTo(APP_1_ID);
 
         tags.add("yarn");
         apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
-        Assert.assertEquals(1, apps.getNumberOfElements());
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId());
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(1);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_2_ID);
 
         tags.add("somethingThatWouldNeverReallyExist");
         apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
-        Assert.assertThat(apps.getNumberOfElements(), Matchers.is(0));
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(0);
 
         tags.clear();
         apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
-        Assert.assertEquals(3, apps.getNumberOfElements());
-        Assert.assertEquals(APP_3_ID, apps.getContent().get(0).getId());
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(1).getId());
-        Assert.assertEquals(APP_1_ID, apps.getContent().get(2).getId());
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(3);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_3_ID);
+        Assertions.assertThat(apps.getContent().get(1).getId()).isEqualTo(APP_2_ID);
+        Assertions.assertThat(apps.getContent().get(2).getId()).isEqualTo(APP_1_ID);
     }
 
-    /**
-     * Test the get applications method when a tag doesn't exist in the database.
-     */
     @Test
-    public void testGetApplicationsByTagsWhenOneDoesntExist() {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsByTagsWhenOneDoesntExist() {
         final Set<String> tags = Sets.newHashSet("prod", UUID.randomUUID().toString());
         final Page<Application> apps = this.appService.getApplications(null, null, null, tags, null, PAGEABLE);
-        Assert.assertEquals(0, apps.getNumberOfElements());
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(0);
     }
 
-    /**
-     * Test the get applications method.
-     */
     @Test
-    public void testGetApplicationsByType() {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsByType() {
         final Page<Application> apps = this.appService.getApplications(null, null, null, null, APP_2_TYPE, PAGEABLE);
-        Assert.assertEquals(1, apps.getNumberOfElements());
-        Assert.assertEquals(APP_2_ID, apps.getContent().get(0).getId());
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(1);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_2_ID);
     }
 
-    /**
-     * Test the get applications method with descending sort.
-     */
     @Test
-    public void testGetApplicationsDescending() {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsDescending() {
         //Default to order by Updated
-        final Page<Application> applications = this.appService.getApplications(null, null, null, null, null, PAGEABLE);
-        Assert.assertEquals(3, applications.getNumberOfElements());
-        Assert.assertEquals(APP_3_ID, applications.getContent().get(0).getId());
-        Assert.assertEquals(APP_2_ID, applications.getContent().get(1).getId());
-        Assert.assertEquals(APP_1_ID, applications.getContent().get(2).getId());
+        final Page<Application> apps = this.appService.getApplications(null, null, null, null, null, PAGEABLE);
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(3);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_3_ID);
+        Assertions.assertThat(apps.getContent().get(1).getId()).isEqualTo(APP_2_ID);
+        Assertions.assertThat(apps.getContent().get(2).getId()).isEqualTo(APP_1_ID);
     }
 
-    /**
-     * Test the get applications method with ascending sort.
-     */
     @Test
-    public void testGetApplicationsAscending() {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsAscending() {
         //Default to order by Updated
         final Pageable ascendingPage = PageRequest.of(0, 10, Sort.Direction.ASC, "updated");
-        final Page<Application> applications
-            = this.appService.getApplications(null, null, null, null, null, ascendingPage);
-        Assert.assertEquals(3, applications.getNumberOfElements());
-        Assert.assertEquals(APP_1_ID, applications.getContent().get(0).getId());
-        Assert.assertEquals(APP_2_ID, applications.getContent().get(1).getId());
-        Assert.assertEquals(APP_3_ID, applications.getContent().get(2).getId());
+        final Page<Application> apps = this.appService.getApplications(null, null, null, null, null, ascendingPage);
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(3);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_1_ID);
+        Assertions.assertThat(apps.getContent().get(1).getId()).isEqualTo(APP_2_ID);
+        Assertions.assertThat(apps.getContent().get(2).getId()).isEqualTo(APP_3_ID);
     }
 
-    /**
-     * Test the get applications method default order by.
-     */
     @Test
-    public void testGetApplicationsOrderBysDefault() {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsOrderBysDefault() {
         //Default to order by Updated
-        final Page<Application> applications = this.appService.getApplications(null, null, null, null, null, PAGEABLE);
-        Assert.assertEquals(3, applications.getNumberOfElements());
-        Assert.assertEquals(APP_3_ID, applications.getContent().get(0).getId());
-        Assert.assertEquals(APP_2_ID, applications.getContent().get(1).getId());
-        Assert.assertEquals(APP_1_ID, applications.getContent().get(2).getId());
+        final Page<Application> apps = this.appService.getApplications(null, null, null, null, null, PAGEABLE);
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(3);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_3_ID);
+        Assertions.assertThat(apps.getContent().get(1).getId()).isEqualTo(APP_2_ID);
+        Assertions.assertThat(apps.getContent().get(2).getId()).isEqualTo(APP_1_ID);
     }
 
-    /**
-     * Test the get applications method order by name.
-     */
     @Test
-    public void testGetApplicationsOrderBysName() {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsOrderBysName() {
         final Pageable orderByNamePage = PageRequest.of(0, 10, Sort.Direction.DESC, "name");
-        final Page<Application> applications
-            = this.appService.getApplications(null, null, null, null, null, orderByNamePage);
-        Assert.assertEquals(3, applications.getNumberOfElements());
-        Assert.assertEquals(APP_1_ID, applications.getContent().get(0).getId());
-        Assert.assertEquals(APP_3_ID, applications.getContent().get(1).getId());
-        Assert.assertEquals(APP_2_ID, applications.getContent().get(2).getId());
+        final Page<Application> apps = this.appService.getApplications(null, null, null, null, null, orderByNamePage);
+        Assertions.assertThat(apps.getNumberOfElements()).isEqualTo(3);
+        Assertions.assertThat(apps.getContent().get(0).getId()).isEqualTo(APP_1_ID);
+        Assertions.assertThat(apps.getContent().get(1).getId()).isEqualTo(APP_3_ID);
+        Assertions.assertThat(apps.getContent().get(2).getId()).isEqualTo(APP_2_ID);
     }
 
     /**
      * Test the get applications method order by an invalid field should return the order by default value (updated).
      */
-    @Test(expected = RuntimeException.class)
-    public void testGetApplicationsOrderBysInvalidField() {
+    @Test
+    void testGetApplicationsOrderBysInvalidField() {
         final Pageable orderByInvalidPage = PageRequest.of(0, 10, Sort.Direction.DESC, "I'mNotAValidField");
-        this.appService.getApplications(null, null, null, null, null, orderByInvalidPage);
+        Assertions
+            .assertThatExceptionOfType(RuntimeException.class)
+            .isThrownBy(() -> this.appService.getApplications(null, null, null, null, null, orderByInvalidPage));
     }
 
-    /**
-     * Test the create method.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testCreateApplication() throws GenieException {
+    void testCreateApplication() throws GenieException {
         final String id = UUID.randomUUID().toString();
         final ApplicationRequest app = new ApplicationRequest.Builder(
             new ApplicationMetadata.Builder(
@@ -305,32 +271,21 @@ public class JpaApplicationPersistenceServiceImplIntegrationTest extends DBInteg
             .withRequestedId(id)
             .build();
         final String createdId = this.appService.createApplication(app);
-        Assert.assertThat(createdId, Matchers.is(id));
+        Assertions.assertThat(createdId).isEqualTo(id);
         final Application created = this.appService.getApplication(id);
-        Assert.assertNotNull(created);
-        Assert.assertEquals(id, created.getId());
-        Assert.assertEquals(APP_1_NAME, created.getMetadata().getName());
-        Assert.assertEquals(APP_1_USER, created.getMetadata().getUser());
-        Assert.assertEquals(ApplicationStatus.ACTIVE, created.getMetadata().getStatus());
+        Assertions.assertThat(created.getId()).isEqualTo(createdId);
+        final ApplicationMetadata appMetadata = created.getMetadata();
+        Assertions.assertThat(appMetadata.getName()).isEqualTo(APP_1_NAME);
+        Assertions.assertThat(appMetadata.getUser()).isEqualTo(APP_1_USER);
+        Assertions.assertThat(appMetadata.getStatus()).isEqualByComparingTo(ApplicationStatus.ACTIVE);
         this.appService.deleteApplication(id);
-        try {
-            this.appService.getApplication(id);
-            Assert.fail("Should have thrown exception");
-        } catch (final GenieException ge) {
-            Assert.assertEquals(
-                HttpURLConnection.HTTP_NOT_FOUND,
-                ge.getErrorCode()
-            );
-        }
+        Assertions
+            .assertThatExceptionOfType(GenieNotFoundException.class)
+            .isThrownBy(() -> this.appService.getApplication(id));
     }
 
-    /**
-     * Test the create method when no id is entered.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testCreateApplicationNoId() throws GenieException {
+    void testCreateApplicationNoId() throws GenieException {
         final ApplicationRequest app = new ApplicationRequest.Builder(
             new ApplicationMetadata.Builder(
                 APP_1_NAME,
@@ -343,33 +298,23 @@ public class JpaApplicationPersistenceServiceImplIntegrationTest extends DBInteg
             .build();
         final String id = this.appService.createApplication(app);
         final Application created = this.appService.getApplication(id);
-        Assert.assertNotNull(created);
-        Assert.assertEquals(APP_1_NAME, created.getMetadata().getName());
-        Assert.assertEquals(APP_1_USER, created.getMetadata().getUser());
-        Assert.assertEquals(ApplicationStatus.ACTIVE, created.getMetadata().getStatus());
-        this.appService.deleteApplication(created.getId());
-        try {
-            this.appService.getApplication(created.getId());
-            Assert.fail();
-        } catch (final GenieException ge) {
-            Assert.assertEquals(
-                HttpURLConnection.HTTP_NOT_FOUND,
-                ge.getErrorCode()
-            );
-        }
+        final ApplicationMetadata appMetadata = created.getMetadata();
+        Assertions.assertThat(appMetadata.getName()).isEqualTo(APP_1_NAME);
+        Assertions.assertThat(appMetadata.getUser()).isEqualTo(APP_1_USER);
+        Assertions.assertThat(appMetadata.getStatus()).isEqualByComparingTo(ApplicationStatus.ACTIVE);
+        this.appService.deleteApplication(id);
+        Assertions
+            .assertThatExceptionOfType(GenieNotFoundException.class)
+            .isThrownBy(() -> this.appService.getApplication(id));
     }
 
-    /**
-     * Test to update an application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateApplication() throws GenieException {
         final Application getApp = this.appService.getApplication(APP_1_ID);
-        Assert.assertEquals(APP_1_USER, getApp.getMetadata().getUser());
-        Assert.assertEquals(ApplicationStatus.INACTIVE, getApp.getMetadata().getStatus());
-        Assert.assertEquals(1, getApp.getMetadata().getTags().size());
+        Assertions.assertThat(getApp.getMetadata().getUser()).isEqualTo(APP_1_USER);
+        Assertions.assertThat(getApp.getMetadata().getStatus()).isEqualByComparingTo(ApplicationStatus.INACTIVE);
+        Assertions.assertThat(getApp.getMetadata().getTags().size()).isEqualTo(1);
         final Instant updateTime = getApp.getUpdated();
 
         final Set<String> tags = Sets.newHashSet("prod", "tez", "yarn", "hadoop");
@@ -394,19 +339,15 @@ public class JpaApplicationPersistenceServiceImplIntegrationTest extends DBInteg
         this.appService.updateApplication(APP_1_ID, updateApp);
 
         final Application updated = this.appService.getApplication(APP_1_ID);
-        Assert.assertNotEquals(updated.getUpdated(), Matchers.is(updateTime));
-        Assert.assertEquals(APP_2_USER, updated.getMetadata().getUser());
-        Assert.assertEquals(ApplicationStatus.ACTIVE, updated.getMetadata().getStatus());
-        Assert.assertEquals(tags, updated.getMetadata().getTags());
+        Assertions.assertThat(updated.getUpdated()).isNotEqualTo(updateTime);
+        Assertions.assertThat(updated.getMetadata().getUser()).isEqualTo(APP_2_USER);
+        Assertions.assertThat(updated.getMetadata().getStatus()).isEqualByComparingTo(ApplicationStatus.ACTIVE);
+        Assertions.assertThat(updated.getMetadata().getTags()).isEqualTo(tags);
     }
 
-    /**
-     * Test to make sure setting the created and updated outside the system control doesn't change record in database.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateCreateAndUpdate() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateCreateAndUpdate() throws GenieException {
         final Application init = this.appService.getApplication(APP_1_ID);
         final Instant created = init.getCreated();
         final Instant updated = init.getUpdated();
@@ -414,21 +355,15 @@ public class JpaApplicationPersistenceServiceImplIntegrationTest extends DBInteg
         this.appService.updateApplication(APP_1_ID, init);
 
         final Application updatedApp = this.appService.getApplication(APP_1_ID);
-        Assert.assertEquals(created, updatedApp.getCreated());
-        Assert.assertThat(updatedApp.getUpdated(), Matchers.not(updated));
-        Assert.assertNotEquals(Instant.EPOCH, updatedApp.getUpdated());
+        Assertions.assertThat(updatedApp.getCreated()).isEqualTo(created);
+        Assertions.assertThat(updatedApp.getUpdated()).isNotEqualTo(updated).isNotEqualTo(Instant.EPOCH);
     }
 
-    /**
-     * Test to patch an application.
-     *
-     * @throws GenieException For any problem
-     * @throws IOException    For Json serialization problem
-     */
     @Test
-    public void testPatchApplication() throws GenieException, IOException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testPatchApplication() throws GenieException, IOException {
         final Application getApp = this.appService.getApplication(APP_1_ID);
-        Assert.assertEquals(APP_1_USER, getApp.getMetadata().getUser());
+        Assertions.assertThat(getApp.getMetadata().getUser()).isEqualTo(APP_1_USER);
         final Instant updateTime = getApp.getUpdated();
 
         final String patchString
@@ -438,304 +373,209 @@ public class JpaApplicationPersistenceServiceImplIntegrationTest extends DBInteg
         this.appService.patchApplication(APP_1_ID, patch);
 
         final Application updated = this.appService.getApplication(APP_1_ID);
-        Assert.assertNotEquals(updated.getUpdated(), Matchers.is(updateTime));
-        Assert.assertEquals(APP_2_USER, updated.getMetadata().getUser());
+        Assertions.assertThat(updated.getUpdated()).isNotEqualTo(updateTime);
+        Assertions.assertThat(updated.getMetadata().getUser()).isEqualTo(APP_2_USER);
     }
 
-    /**
-     * Test delete all.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testDeleteAll() throws GenieException {
-        Assert.assertEquals(
-            3,
-            this.appService.getApplications(null, null, null, null, null, PAGEABLE).getNumberOfElements()
-        );
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testDeleteAll() throws GenieException {
+        Assertions
+            .assertThat(this.appService.getApplications(null, null, null, null, null, PAGEABLE).getNumberOfElements())
+            .isEqualTo(3);
         // To solve referential integrity problem
         this.commandPersistenceService.deleteCommand(COMMAND_1_ID);
         this.appService.deleteAllApplications();
-        Assert.assertTrue(
-            this.appService.getApplications(null, null, null, null, null, PAGEABLE).getNumberOfElements() == 0
-        );
+        Assertions
+            .assertThat(this.appService.getApplications(null, null, null, null, null, PAGEABLE).getNumberOfElements())
+            .isEqualTo(0);
     }
 
-    /**
-     * Test delete.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testDelete() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testDelete() throws GenieException {
         this.appService.deleteApplication(APP_3_ID);
-        try {
-            this.appService.getApplication(APP_3_ID);
-            Assert.fail();
-        } catch (final GenieNotFoundException gnfe) {
-            Assert.assertTrue(true);
-        }
+        Assertions
+            .assertThatExceptionOfType(GenieNotFoundException.class)
+            .isThrownBy(() -> this.appService.getApplication(APP_3_ID));
     }
 
-    /**
-     * Test add configurations to application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testAddConfigsToApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testAddConfigsToApplication() throws GenieException {
         final String newConfig1 = UUID.randomUUID().toString();
         final String newConfig2 = UUID.randomUUID().toString();
         final String newConfig3 = UUID.randomUUID().toString();
 
         final Set<String> newConfigs = Sets.newHashSet(newConfig1, newConfig2, newConfig3);
 
-        Assert.assertEquals(2, this.appService.getConfigsForApplication(APP_1_ID).size());
+        Assertions.assertThat(this.appService.getConfigsForApplication(APP_1_ID)).hasSize(2);
         this.appService.addConfigsToApplication(APP_1_ID, newConfigs);
         final Set<String> finalConfigs = this.appService.getConfigsForApplication(APP_1_ID);
-        Assert.assertEquals(5, finalConfigs.size());
-        Assert.assertTrue(finalConfigs.contains(newConfig1));
-        Assert.assertTrue(finalConfigs.contains(newConfig2));
-        Assert.assertTrue(finalConfigs.contains(newConfig3));
+        Assertions.assertThat(finalConfigs).hasSize(5).containsAll(newConfigs);
     }
 
-    /**
-     * Test update configurations for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateConfigsForApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateConfigsForApplication() throws GenieException {
         final String newConfig1 = UUID.randomUUID().toString();
         final String newConfig2 = UUID.randomUUID().toString();
         final String newConfig3 = UUID.randomUUID().toString();
 
         final Set<String> newConfigs = Sets.newHashSet(newConfig1, newConfig2, newConfig3);
 
-        Assert.assertEquals(2, this.appService.getConfigsForApplication(APP_1_ID).size());
+        Assertions.assertThat(this.appService.getConfigsForApplication(APP_1_ID)).hasSize(2);
         this.appService.updateConfigsForApplication(APP_1_ID, newConfigs);
         final Set<String> finalConfigs = this.appService.getConfigsForApplication(APP_1_ID);
-        Assert.assertEquals(3, finalConfigs.size());
-        Assert.assertTrue(finalConfigs.contains(newConfig1));
-        Assert.assertTrue(finalConfigs.contains(newConfig2));
-        Assert.assertTrue(finalConfigs.contains(newConfig3));
+        Assertions.assertThat(finalConfigs).hasSize(3).containsAll(newConfigs);
     }
 
-    /**
-     * Test get configurations for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetConfigsForApplication() throws GenieException {
-        Assert.assertEquals(2, this.appService.getConfigsForApplication(APP_1_ID).size());
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetConfigsForApplication() throws GenieException {
+        Assertions.assertThat(this.appService.getConfigsForApplication(APP_1_ID)).hasSize(2);
     }
 
-    /**
-     * Test remove all configurations for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveAllConfigsForApplication() throws GenieException {
-        Assert.assertEquals(2, this.appService.getConfigsForApplication(APP_1_ID).size());
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveAllConfigsForApplication() throws GenieException {
+        Assertions.assertThat(this.appService.getConfigsForApplication(APP_1_ID)).hasSize(2);
         this.appService.removeAllConfigsForApplication(APP_1_ID);
-        Assert.assertEquals(0, this.appService.getConfigsForApplication(APP_1_ID).size());
+        Assertions.assertThat(this.appService.getConfigsForApplication(APP_1_ID)).isEmpty();
     }
 
-    /**
-     * Test remove configuration for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveConfigForApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveConfigForApplication() throws GenieException {
         final Set<String> configs = this.appService.getConfigsForApplication(APP_1_ID);
-        Assert.assertEquals(2, configs.size());
+        Assertions.assertThat(configs).hasSize(2);
         final String removedConfig = configs.iterator().next();
         this.appService.removeConfigForApplication(APP_1_ID, removedConfig);
-        Assert.assertFalse(this.appService.getConfigsForApplication(APP_1_ID).contains(removedConfig));
+        Assertions.assertThat(this.appService.getConfigsForApplication(APP_1_ID)).doesNotContain(removedConfig);
     }
 
-    /**
-     * Test add dependencies to application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testAddDependenciesToApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testAddDependenciesToApplication() throws GenieException {
         final String newDependency1 = UUID.randomUUID().toString();
         final String newDependency2 = UUID.randomUUID().toString();
         final String newDependency3 = UUID.randomUUID().toString();
 
         final Set<String> newDependencies = Sets.newHashSet(newDependency1, newDependency2, newDependency3);
 
-        Assert.assertEquals(2, this.appService.getDependenciesForApplication(APP_1_ID).size());
+        Assertions.assertThat(this.appService.getDependenciesForApplication(APP_1_ID)).hasSize(2);
         this.appService.addDependenciesForApplication(APP_1_ID, newDependencies);
         final Set<String> finalDependencies = this.appService.getDependenciesForApplication(APP_1_ID);
-        Assert.assertEquals(5, finalDependencies.size());
-        Assert.assertTrue(finalDependencies.contains(newDependency1));
-        Assert.assertTrue(finalDependencies.contains(newDependency2));
-        Assert.assertTrue(finalDependencies.contains(newDependency3));
+        Assertions.assertThat(finalDependencies).hasSize(5).containsAll(newDependencies);
     }
 
-    /**
-     * Test update dependencies for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateDependenciesForApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateDependenciesForApplication() throws GenieException {
         final String newDependency1 = UUID.randomUUID().toString();
         final String newDependency2 = UUID.randomUUID().toString();
         final String newDependency3 = UUID.randomUUID().toString();
 
         final Set<String> newDependencies = Sets.newHashSet(newDependency1, newDependency2, newDependency3);
 
-        Assert.assertEquals(2, this.appService.getDependenciesForApplication(APP_1_ID).size());
+        Assertions.assertThat(this.appService.getDependenciesForApplication(APP_1_ID)).hasSize(2);
         this.appService.updateDependenciesForApplication(APP_1_ID, newDependencies);
         final Set<String> finalDependencies = this.appService.getDependenciesForApplication(APP_1_ID);
-        Assert.assertEquals(3, finalDependencies.size());
-        Assert.assertTrue(finalDependencies.contains(newDependency1));
-        Assert.assertTrue(finalDependencies.contains(newDependency2));
-        Assert.assertTrue(finalDependencies.contains(newDependency3));
+        Assertions.assertThat(finalDependencies).hasSize(3).containsAll(newDependencies);
     }
 
-    /**
-     * Test get dependencies for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetDependenciesForApplication() throws GenieException {
-        Assert.assertEquals(2,
-            this.appService.getDependenciesForApplication(APP_1_ID).size());
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetDependenciesForApplication() throws GenieException {
+        Assertions.assertThat(this.appService.getDependenciesForApplication(APP_1_ID)).hasSize(2);
     }
 
-    /**
-     * Test remove all dependencies for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveAllDependenciesForApplication() throws GenieException {
-        Assert.assertEquals(2, this.appService.getDependenciesForApplication(APP_1_ID).size());
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveAllDependenciesForApplication() throws GenieException {
+        Assertions.assertThat(this.appService.getDependenciesForApplication(APP_1_ID)).hasSize(2);
         this.appService.removeAllDependenciesForApplication(APP_1_ID);
-        Assert.assertEquals(0, this.appService.getDependenciesForApplication(APP_1_ID).size());
+        Assertions.assertThat(this.appService.getDependenciesForApplication(APP_1_ID)).isEmpty();
     }
 
-    /**
-     * Test remove configuration for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveDependencyForApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveDependencyForApplication() throws GenieException {
         final Set<String> dependencies = this.appService.getDependenciesForApplication(APP_1_ID);
-        Assert.assertEquals(2, dependencies.size());
+        Assertions.assertThat(dependencies).hasSize(2);
         final String removedDependency = dependencies.iterator().next();
         this.appService.removeDependencyForApplication(APP_1_ID, removedDependency);
-        Assert.assertFalse(this.appService.getDependenciesForApplication(APP_1_ID).contains(removedDependency));
+        Assertions
+            .assertThat(this.appService.getDependenciesForApplication(APP_1_ID))
+            .doesNotContain(removedDependency);
     }
 
-    /**
-     * Test add tags to application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testAddTagsToApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testAddTagsToApplication() throws GenieException {
         final String newTag1 = UUID.randomUUID().toString();
         final String newTag2 = UUID.randomUUID().toString();
         final String newTag3 = UUID.randomUUID().toString();
 
         final Set<String> newTags = Sets.newHashSet(newTag1, newTag2, newTag3);
 
-        Assert.assertEquals(1, this.appService.getTagsForApplication(APP_1_ID).size());
+        Assertions.assertThat(this.appService.getTagsForApplication(APP_1_ID)).hasSize(1);
         this.appService.addTagsForApplication(APP_1_ID, newTags);
         final Set<String> finalTags = this.appService.getTagsForApplication(APP_1_ID);
-        Assert.assertEquals(4, finalTags.size());
-        Assert.assertTrue(finalTags.contains(newTag1));
-        Assert.assertTrue(finalTags.contains(newTag2));
-        Assert.assertTrue(finalTags.contains(newTag3));
+        Assertions.assertThat(finalTags).hasSize(4).containsAll(newTags);
     }
 
-    /**
-     * Test update tags for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateTagsForApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateTagsForApplication() throws GenieException {
         final String newTag1 = UUID.randomUUID().toString();
         final String newTag2 = UUID.randomUUID().toString();
         final String newTag3 = UUID.randomUUID().toString();
 
         final Set<String> newTags = Sets.newHashSet(newTag1, newTag2, newTag3);
 
-        Assert.assertEquals(1, this.appService.getTagsForApplication(APP_1_ID).size());
+        Assertions.assertThat(this.appService.getTagsForApplication(APP_1_ID)).hasSize(1);
         this.appService.updateTagsForApplication(APP_1_ID, newTags);
         final Set<String> finalTags = this.appService.getTagsForApplication(APP_1_ID);
-        Assert.assertEquals(3, finalTags.size());
-        Assert.assertTrue(finalTags.contains(newTag1));
-        Assert.assertTrue(finalTags.contains(newTag2));
-        Assert.assertTrue(finalTags.contains(newTag3));
+        Assertions.assertThat(finalTags).hasSize(3).containsAll(newTags);
     }
 
-    /**
-     * Test get tags for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetTagsForApplication() throws GenieException {
-        Assert.assertEquals(1, this.appService.getTagsForApplication(APP_1_ID).size());
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetTagsForApplication() throws GenieException {
+        Assertions.assertThat(this.appService.getTagsForApplication(APP_1_ID)).hasSize(1);
     }
 
-    /**
-     * Test remove all tags for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveAllTagsForApplication() throws GenieException {
-        Assert.assertEquals(1, this.appService.getTagsForApplication(APP_1_ID).size());
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveAllTagsForApplication() throws GenieException {
+        Assertions.assertThat(this.appService.getTagsForApplication(APP_1_ID)).hasSize(1);
         this.appService.removeAllTagsForApplication(APP_1_ID);
-        Assert.assertEquals(0, this.appService.getTagsForApplication(APP_1_ID).size());
+        Assertions.assertThat(this.appService.getTagsForApplication(APP_1_ID)).isEmpty();
     }
 
-    /**
-     * Test remove tag for application.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveTagForApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveTagForApplication() throws GenieException {
         final Set<String> tags = this.appService.getTagsForApplication(APP_1_ID);
-        Assert.assertEquals(1, tags.size());
+        Assertions.assertThat(tags).contains("prod");
         this.appService.removeTagForApplication(APP_1_ID, "prod");
-        Assert.assertFalse(this.appService.getTagsForApplication(APP_1_ID).contains("prod"));
+        Assertions.assertThat(this.appService.getTagsForApplication(APP_1_ID)).doesNotContain("prod");
     }
 
-    /**
-     * Test the Get commands for application method.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetCommandsForApplication() throws GenieException {
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommandsForApplication() throws GenieException {
         final Set<Command> commands = this.appService.getCommandsForApplication(APP_1_ID, null);
-        Assert.assertEquals(1, commands.size());
-        Assert.assertEquals(COMMAND_1_ID, commands.iterator().next().getId());
+        Assertions
+            .assertThat(commands).hasSize(1)
+            .hasOnlyOneElementSatisfying(command -> Assertions.assertThat(command.getId()).isEqualTo(COMMAND_1_ID));
     }
 
-    /**
-     * Test the Get commands for application method.
-     *
-     * @throws GenieException For any problem
-     */
-    @Test(expected = ConstraintViolationException.class)
-    public void testGetCommandsForApplicationNoId() throws GenieException {
-        this.appService.getCommandsForApplication("", null);
+    @Test
+    void testGetCommandsForApplicationNoId() {
+        Assertions
+            .assertThatExceptionOfType(ConstraintViolationException.class)
+            .isThrownBy(() -> this.appService.getCommandsForApplication("", null));
     }
 }

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImplIntegrationTest.java
@@ -578,4 +578,24 @@ class JpaApplicationPersistenceServiceImplIntegrationTest extends DBIntegrationT
             .assertThatExceptionOfType(ConstraintViolationException.class)
             .isThrownBy(() -> this.appService.getCommandsForApplication("", null));
     }
+
+    @Test
+    @DatabaseSetup("JpaApplicationPersistenceServiceImplIntegrationTest/deleteUnusedApplications/before.xml")
+        /*
+         * Unfortunately this doesn't seem to work due to how we have an after each that deletes the records out of
+         * database before this check can happen. I don't want to break all the other tests but leaving for now as
+         * might be a nice way to do it without so many java assertions
+         */
+//    @ExpectedDatabase(
+//        value = "JpaApplicationPersistenceServiceImplIntegrationTest/deleteUnusedApplications/after.xml",
+//        assertionMode = DatabaseAssertionMode.NON_STRICT
+//    )
+    void testDeleteUnusedApplications() {
+        Assertions.assertThat(this.applicationRepository.existsByUniqueId("app2")).isTrue();
+        Assertions.assertThat(this.applicationRepository.count()).isEqualTo(6);
+        final Instant createdThreshold = Instant.parse("2020-03-10T02:44:00.000Z");
+        Assertions.assertThat(this.appService.deleteUnusedApplicationsCreatedBefore(createdThreshold)).isEqualTo(1);
+        Assertions.assertThat(this.applicationRepository.count()).isEqualTo(5);
+        Assertions.assertThat(this.applicationRepository.existsByUniqueId("app2")).isFalse();
+    }
 }

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest.java
@@ -36,9 +36,8 @@ import com.netflix.genie.common.external.util.GenieObjectMapper;
 import com.netflix.genie.web.data.repositories.jpa.JpaCriterionRepository;
 import com.netflix.genie.web.data.services.ApplicationPersistenceService;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
-import com.netflix.genie.web.data.services.CommandPersistenceService;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -58,9 +57,8 @@ import java.util.UUID;
  *
  * @author tgianos
  */
-@DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
 @DatabaseTearDown("cleanup.xml")
-public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrationTestBase {
+class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrationTestBase {
 
     private static final String APP_1_ID = "app1";
     private static final String CLUSTER_1_ID = "cluster1";
@@ -90,7 +88,7 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
     private static final Pageable PAGE = PageRequest.of(0, 10, Sort.Direction.DESC, "updated");
 
     @Autowired
-    private CommandPersistenceService service;
+    private JpaCommandPersistenceServiceImpl service;
 
     @Autowired
     private ClusterPersistenceService clusterPersistenceService;
@@ -101,13 +99,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
     @Autowired
     private JpaCriterionRepository criterionRepository;
 
-    /**
-     * Test the get command method.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommand() throws GenieException {
         final Command command1 = this.service.getCommand(COMMAND_1_ID);
         Assertions.assertThat(command1.getId()).isEqualTo(COMMAND_1_ID);
         Assertions.assertThat(command1.getMetadata().getName()).isEqualTo(COMMAND_1_NAME);
@@ -142,32 +136,26 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(command3.getResources().getDependencies().size()).isEqualTo(2);
     }
 
-    /**
-     * Test the get commands method.
-     */
     @Test
-    public void testGetCommandsByName() {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommandsByName() {
         final Page<Command> commands = this.service.getCommands(COMMAND_2_NAME, null, null, null, PAGE);
         Assertions.assertThat(commands.getNumberOfElements()).isEqualTo(1);
         Assertions.assertThat(commands.getContent().get(0).getId()).isEqualTo(COMMAND_2_ID);
     }
 
-    /**
-     * Test the get commands method.
-     */
     @Test
-    public void testGetCommandsByUserName() {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommandsByUserName() {
         final Page<Command> commands = this.service.getCommands(null, COMMAND_1_USER, null, null, PAGE);
         Assertions.assertThat(commands.getNumberOfElements()).isEqualTo(2);
         Assertions.assertThat(commands.getContent().get(0).getId()).isEqualTo(COMMAND_3_ID);
         Assertions.assertThat(commands.getContent().get(1).getId()).isEqualTo(COMMAND_1_ID);
     }
 
-    /**
-     * Test the get commands method.
-     */
     @Test
-    public void testGetCommandsByStatuses() {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommandsByStatuses() {
         final Set<CommandStatus> statuses = Sets.newHashSet(CommandStatus.INACTIVE, CommandStatus.DEPRECATED);
         final Page<Command> commands = this.service.getCommands(null, null, statuses, null, PAGE);
         Assertions.assertThat(commands.getNumberOfElements()).isEqualTo(2);
@@ -175,11 +163,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(commands.getContent().get(1).getId()).isEqualTo(COMMAND_3_ID);
     }
 
-    /**
-     * Test the get commands method.
-     */
     @Test
-    public void testGetCommandsByTags() {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommandsByTags() {
         final Set<String> tags = Sets.newHashSet("prod");
         Page<Command> commands = this.service.getCommands(null, null, null, tags, PAGE);
         Assertions.assertThat(commands.getNumberOfElements()).isEqualTo(3);
@@ -211,11 +197,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(commands.getContent().get(2).getId()).isEqualTo(COMMAND_1_ID);
     }
 
-    /**
-     * Test the get commands method with descending sort.
-     */
     @Test
-    public void testGetCommandsDescending() {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommandsDescending() {
         //Default to order by Updated
         final Page<Command> commands = this.service.getCommands(null, null, null, null, PAGE);
         Assertions.assertThat(commands.getNumberOfElements()).isEqualTo(3);
@@ -228,7 +212,8 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
      * Test the get commands method with ascending sort.
      */
     @Test
-    public void testGetCommandsAscending() {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommandsAscending() {
         final Pageable ascending = PageRequest.of(0, 10, Sort.Direction.ASC, "updated");
         //Default to order by Updated
         final Page<Command> commands = this.service.getCommands(null, null, null, null, ascending);
@@ -238,11 +223,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(commands.getContent().get(2).getId()).isEqualTo(COMMAND_2_ID);
     }
 
-    /**
-     * Test the get commands method order by name.
-     */
     @Test
-    public void testGetCommandsOrderBysName() {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommandsOrderBysName() {
         final Pageable name = PageRequest.of(0, 10, Sort.Direction.DESC, "name");
         final Page<Command> commands = this.service.getCommands(null, null, null, null, name);
         Assertions.assertThat(commands.getNumberOfElements()).isEqualTo(3);
@@ -251,24 +234,17 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(commands.getContent().get(2).getId()).isEqualTo(COMMAND_2_ID);
     }
 
-    /**
-     * Test the get commands method order by an invalid field should return the order by default value (updated).
-     */
     @Test
-    public void testGetCommandsOrderBysInvalidField() {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetCommandsOrderBysInvalidField() {
         final Pageable invalid = PageRequest.of(0, 10, Sort.Direction.DESC, "I'mNotAValidField");
         Assertions
             .assertThatExceptionOfType(RuntimeException.class)
             .isThrownBy(() -> this.service.getCommands(null, null, null, null, invalid));
     }
 
-    /**
-     * Test the create method.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testCreateCommand() throws GenieException {
+    void testCreateCommand() throws GenieException {
         final String id = UUID.randomUUID().toString();
         final CommandRequest command = new CommandRequest.Builder(
             new CommandMetadata.Builder(
@@ -307,7 +283,7 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
      * @throws GenieException For any problem
      */
     @Test
-    public void testCreateCommandNoId() throws GenieException {
+    void testCreateCommandNoId() throws GenieException {
         final List<Criterion> clusterCriteria = Lists.newArrayList(
             new Criterion.Builder().withId(UUID.randomUUID().toString()).build(),
             new Criterion
@@ -346,13 +322,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
             .isThrownBy(() -> this.service.getCommand(id));
     }
 
-    /**
-     * Test to update a command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateCommand() throws GenieException {
         final Command command = this.service.getCommand(COMMAND_1_ID);
         Assertions.assertThat(command.getMetadata().getUser()).isEqualTo(COMMAND_1_USER);
         Assertions.assertThat(command.getMetadata().getStatus()).isEqualByComparingTo(CommandStatus.ACTIVE);
@@ -392,13 +364,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(updated.getMemory()).isPresent().contains(memory);
     }
 
-    /**
-     * Test to make sure when a command with criterion is updated everything is valid.
-     *
-     * @throws Exception on error
-     */
     @Test
-    public void testUpdateCommandWithClusterCriteria() throws Exception {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateCommandWithClusterCriteria() throws Exception {
         Assertions.assertThat(this.criterionRepository.count()).isEqualTo(0L);
         final List<Criterion> criteria0 = Lists.newArrayList(
             new Criterion.Builder()
@@ -450,13 +418,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(this.criterionRepository.count()).isEqualTo(3L);
     }
 
-    /**
-     * Test to update a command with invalid content. Should throw ConstraintViolationException from JPA layer.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateCommandWithInvalidCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateCommandWithInvalidCommand() throws GenieException {
         final Command command = this.service.getCommand(COMMAND_1_ID);
 
         final Command updateCommand = new Command(
@@ -485,13 +449,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
             .isThrownBy(() -> this.service.updateCommand(COMMAND_1_ID, updateCommand));
     }
 
-    /**
-     * Test to make sure setting the created and updated outside the system control doesn't change record in database.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateCreateAndUpdate() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateCreateAndUpdate() throws GenieException {
         final Command init = this.service.getCommand(COMMAND_1_ID);
         final Instant created = init.getCreated();
         final Instant updated = init.getUpdated();
@@ -515,14 +475,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(updatedCommand.getUpdated()).isNotEqualTo(Instant.EPOCH);
     }
 
-    /**
-     * Test to patch a command.
-     *
-     * @throws GenieException For any problem
-     * @throws IOException    For Json serialization problem
-     */
     @Test
-    public void testPatchCommand() throws GenieException, IOException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testPatchCommand() throws GenieException, IOException {
         final Command getCommand = this.service.getCommand(COMMAND_1_ID);
         Assertions.assertThat(getCommand.getMetadata().getName()).isEqualTo(COMMAND_1_NAME);
         final Instant updateTime = getCommand.getUpdated();
@@ -538,13 +493,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(updated.getMetadata().getName()).isEqualTo(COMMAND_2_NAME);
     }
 
-    /**
-     * Test delete all.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testDeleteAll() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testDeleteAll() throws GenieException {
         Assertions
             .assertThat(this.service.getCommands(null, null, null, null, PAGE).getNumberOfElements())
             .isEqualTo(3);
@@ -552,13 +503,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(this.service.getCommands(null, null, null, null, PAGE).getContent()).isEmpty();
     }
 
-    /**
-     * Test delete.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testDelete() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testDelete() throws GenieException {
         List<Command> commands = this.clusterPersistenceService.getCommandsForCluster(CLUSTER_1_ID, null);
         Assertions.assertThat(commands).hasSize(3);
         boolean found = false;
@@ -602,13 +549,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         this.service.deleteCommand(COMMAND_3_ID);
     }
 
-    /**
-     * Test add configurations to command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testAddConfigsToCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testAddConfigsToCommand() throws GenieException {
         final String newConfig1 = UUID.randomUUID().toString();
         final String newConfig2 = UUID.randomUUID().toString();
         final String newConfig3 = UUID.randomUUID().toString();
@@ -621,13 +564,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(finalConfigs).hasSize(5).contains(newConfig1, newConfig2, newConfig3);
     }
 
-    /**
-     * Test update configurations for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateConfigsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateConfigsForCommand() throws GenieException {
         final String newConfig1 = UUID.randomUUID().toString();
         final String newConfig2 = UUID.randomUUID().toString();
         final String newConfig3 = UUID.randomUUID().toString();
@@ -640,35 +579,23 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(finalConfigs).hasSize(3).contains(newConfig1, newConfig2, newConfig3);
     }
 
-    /**
-     * Test get configurations for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetConfigsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetConfigsForCommand() throws GenieException {
         Assertions.assertThat(this.service.getConfigsForCommand(COMMAND_1_ID)).hasSize(2);
     }
 
-    /**
-     * Test remove all configurations for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveAllConfigsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveAllConfigsForCommand() throws GenieException {
         Assertions.assertThat(this.service.getConfigsForCommand(COMMAND_1_ID)).hasSize(2);
         this.service.removeAllConfigsForCommand(COMMAND_1_ID);
         Assertions.assertThat(this.service.getConfigsForCommand(COMMAND_1_ID)).isEmpty();
     }
 
-    /**
-     * Test remove configuration for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveConfigForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveConfigForCommand() throws GenieException {
         final Set<String> configs = this.service.getConfigsForCommand(COMMAND_1_ID);
         Assertions.assertThat(configs).hasSize(2);
         final String removedConfig = configs.iterator().next();
@@ -676,13 +603,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(this.service.getConfigsForCommand(COMMAND_1_ID)).doesNotContain(removedConfig);
     }
 
-    /**
-     * Test add dependencies to command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testAddDependenciesToCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testAddDependenciesToCommand() throws GenieException {
         final String newDependency1 = UUID.randomUUID().toString();
         final String newDependency2 = UUID.randomUUID().toString();
         final String newDependency3 = UUID.randomUUID().toString();
@@ -695,13 +618,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(finalDependencies).hasSize(5).contains(newDependency1, newDependency2, newDependency3);
     }
 
-    /**
-     * Test update dependencies for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateDependenciesForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateDependenciesForCommand() throws GenieException {
         final String newDependency1 = UUID.randomUUID().toString();
         final String newDependency2 = UUID.randomUUID().toString();
         final String newDependency3 = UUID.randomUUID().toString();
@@ -714,35 +633,23 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(finalDependencies).hasSize(3).contains(newDependency1, newDependency2, newDependency3);
     }
 
-    /**
-     * Test get dependencies for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetDependenciesForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetDependenciesForCommand() throws GenieException {
         Assertions.assertThat(this.service.getDependenciesForCommand(COMMAND_2_ID)).hasSize(1);
     }
 
-    /**
-     * Test remove all dependencies for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveAllDependenciesForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveAllDependenciesForCommand() throws GenieException {
         Assertions.assertThat(this.service.getDependenciesForCommand(COMMAND_3_ID)).hasSize(2);
         this.service.removeAllDependenciesForCommand(COMMAND_3_ID);
         Assertions.assertThat(this.service.getDependenciesForCommand(COMMAND_3_ID)).isEmpty();
     }
 
-    /**
-     * Test remove dependencies for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveDependencyForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveDependencyForCommand() throws GenieException {
         final Set<String> dependencies = this.service.getDependenciesForCommand(COMMAND_3_ID);
         Assertions.assertThat(dependencies).hasSize(2);
         final String removedDependency = dependencies.iterator().next();
@@ -750,13 +657,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(this.service.getDependenciesForCommand(COMMAND_3_ID)).doesNotContain(removedDependency);
     }
 
-    /**
-     * Test setting the applications for a given command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testAddApplicationsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testAddApplicationsForCommand() throws GenieException {
         Assertions.assertThat(this.service.getApplicationsForCommand(COMMAND_2_ID)).isEmpty();
 
         final List<String> appIds = Lists.newArrayList(APP_1_ID);
@@ -777,13 +680,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
             .isEqualTo(APP_1_ID);
     }
 
-    /**
-     * Test setting the applications for a given command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testSetApplicationsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testSetApplicationsForCommand() throws GenieException {
         Assertions.assertThat(this.service.getApplicationsForCommand(COMMAND_2_ID)).isEmpty();
 
         final List<String> appIds = Lists.newArrayList(APP_1_ID);
@@ -802,49 +701,33 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
             .hasOnlyOneElementSatisfying(application -> Assertions.assertThat(application.getId()).isEqualTo(APP_1_ID));
     }
 
-    /**
-     * Test get applications for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetApplicationsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetApplicationsForCommand() throws GenieException {
         Assertions
             .assertThat(this.service.getApplicationsForCommand(COMMAND_1_ID))
             .hasOnlyOneElementSatisfying(application -> Assertions.assertThat(application.getId()).isEqualTo(APP_1_ID));
     }
 
-    /**
-     * Test remove applications for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveApplicationsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveApplicationsForCommand() throws GenieException {
         Assertions.assertThat(this.service.getApplicationsForCommand(COMMAND_1_ID)).hasSize(1);
         this.service.removeApplicationsForCommand(COMMAND_1_ID);
         Assertions.assertThat(this.service.getApplicationsForCommand(COMMAND_1_ID)).isEmpty();
     }
 
-    /**
-     * Test remove application for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveApplicationForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveApplicationForCommand() throws GenieException {
         Assertions.assertThat(this.service.getApplicationsForCommand(COMMAND_1_ID)).hasSize(1);
         this.service.removeApplicationForCommand(COMMAND_1_ID, APP_1_ID);
         Assertions.assertThat(this.service.getApplicationsForCommand(COMMAND_1_ID)).isEmpty();
     }
 
-    /**
-     * Test add tags to command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testAddTagsToCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testAddTagsToCommand() throws GenieException {
         final String newTag1 = UUID.randomUUID().toString();
         final String newTag2 = UUID.randomUUID().toString();
         final String newTag3 = UUID.randomUUID().toString();
@@ -857,13 +740,9 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(finalTags).hasSize(6).contains(newTag1, newTag2, newTag3);
     }
 
-    /**
-     * Test update tags for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testUpdateTagsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testUpdateTagsForCommand() throws GenieException {
         final String newTag1 = UUID.randomUUID().toString();
         final String newTag2 = UUID.randomUUID().toString();
         final String newTag3 = UUID.randomUUID().toString();
@@ -876,47 +755,31 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(finalTags).hasSize(3).contains(newTag1, newTag2, newTag3);
     }
 
-    /**
-     * Test get tags for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetTagsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetTagsForCommand() throws GenieException {
         Assertions.assertThat(this.service.getTagsForCommand(COMMAND_1_ID)).hasSize(3);
     }
 
-    /**
-     * Test remove all tags for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveAllTagsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveAllTagsForCommand() throws GenieException {
         Assertions.assertThat(this.service.getTagsForCommand(COMMAND_1_ID)).hasSize(3);
         this.service.removeAllTagsForCommand(COMMAND_1_ID);
         Assertions.assertThat(this.service.getTagsForCommand(COMMAND_1_ID)).isEmpty();
     }
 
-    /**
-     * Test remove tag for command.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testRemoveTagForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testRemoveTagForCommand() throws GenieException {
         Assertions.assertThat(this.service.getTagsForCommand(COMMAND_1_ID)).contains("tez");
         this.service.removeTagForCommand(COMMAND_1_ID, "tez");
         Assertions.assertThat(this.service.getTagsForCommand(COMMAND_1_ID)).doesNotContain("tez");
     }
 
-    /**
-     * Test the Get clusters for command function.
-     *
-     * @throws GenieException For any problem
-     */
     @Test
-    public void testGetCommandsForCommand() throws GenieException {
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/init.xml")
+    void testGetClustersForCommand() throws GenieException {
         final Set<Cluster> clusters = this.service.getClustersForCommand(COMMAND_1_ID, null);
         Assertions
             .assertThat(clusters)
@@ -924,23 +787,15 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
             .hasOnlyOneElementSatisfying(cluster -> Assertions.assertThat(cluster.getId()).isEqualTo(CLUSTER_1_ID));
     }
 
-    /**
-     * Test the Get clusters for command function.
-     */
     @Test
-    public void testGetClustersForCommandNoId() {
+    void testGetClustersForCommandNoId() {
         Assertions
             .assertThatExceptionOfType(ConstraintViolationException.class)
             .isThrownBy(() -> this.service.getClustersForCommand("", null));
     }
 
-    /**
-     * Test to validate how cluster criteria can be manipulated for a command.
-     *
-     * @throws GenieException On unexpected error
-     */
     @Test
-    public void testClusterCriteriaManipulation() throws GenieException {
+    void testClusterCriteriaManipulation() throws GenieException {
         final Criterion criterion0 = new Criterion.Builder().withId(UUID.randomUUID().toString()).build();
         final Criterion criterion1 = new Criterion.Builder().withStatus(UUID.randomUUID().toString()).build();
         final Criterion criterion2 = new Criterion.Builder().withVersion(UUID.randomUUID().toString()).build();
@@ -1004,13 +859,8 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
         Assertions.assertThat(this.service.getClusterCriteriaForCommand(id)).isEqualTo(clusterCriteria);
     }
 
-    /**
-     * Test the various permutations of finding commands with criterion.
-     *
-     * @throws Exception on unexpected error
-     */
     @Test
-    public void testFindCommandsMatchingCriterion() throws Exception {
+    void testFindCommandsMatchingCriterion() throws Exception {
         // Create some commands to test with
         final Command command0 = this.createTestCommand(null, null, null);
         final Command command1 = this.createTestCommand(null, null, null);
@@ -1053,19 +903,6 @@ public class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrati
             )
             .hasSize(1)
             .containsExactlyInAnyOrder(command1);
-
-        // This comes from the init.xml
-        Assertions
-            .assertThat(
-                this.service.findCommandsMatchingCriterion(
-                    new Criterion.Builder().withStatus(CommandStatus.INACTIVE.name()).build(),
-                    false
-                )
-            )
-            .hasSize(1)
-            .extracting(Command::getId)
-            .element(0)
-            .isEqualTo("command2");
 
         Assertions
             .assertThat(

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest.java
@@ -1006,6 +1006,34 @@ class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrationTestB
             .isEqualByComparingTo(CommandStatus.INACTIVE);
     }
 
+    @Test
+    @DatabaseSetup("JpaCommandPersistenceServiceImplIntegrationTest/deleteUnusedCommands/before.xml")
+    void testDeleteUnusedCommands() {
+        final Instant present = Instant.parse("2020-03-24T00:00:00.000Z");
+        final Instant createdThreshold = present.minus(1, ChronoUnit.DAYS);
+        Assertions.assertThat(this.commandRepository.count()).isEqualTo(7);
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command0")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command1")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command2")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command3")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command4")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command5")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command6")).isTrue();
+        Assertions.assertThat(
+            this.service.deleteUnusedCommands(
+                EnumSet.of(CommandStatus.INACTIVE, CommandStatus.DEPRECATED),
+                createdThreshold
+            )
+        ).isEqualTo(2);
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command0")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command1")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command2")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command3")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command4")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command5")).isFalse();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command6")).isFalse();
+    }
+
     private Command createTestCommand(
         @Nullable final String id,
         @Nullable final Set<String> tags,

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaJobSearchServiceImplIntegrationTest.java
@@ -20,42 +20,35 @@ package com.netflix.genie.web.data.services.jpa;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import com.google.common.collect.Sets;
-import com.netflix.genie.common.dto.Application;
-import com.netflix.genie.common.dto.Job;
+import com.netflix.genie.common.dto.BaseDTO;
 import com.netflix.genie.common.dto.JobMetadata;
 import com.netflix.genie.common.dto.JobRequest;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.dto.UserResourcesSummary;
+import com.netflix.genie.common.dto.search.BaseSearchResult;
 import com.netflix.genie.common.dto.search.JobSearchResult;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
-import com.netflix.genie.test.suppliers.RandomSuppliers;
-import com.netflix.genie.web.data.services.JobSearchService;
 import org.assertj.core.api.Assertions;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 /**
- * Integration tests for the Job Search Service using JPA.
+ * Integration tests for the {@link JpaJobSearchServiceImpl} class.
  *
  * @author tgianos
  * @since 3.0.0
  */
-@DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
 @DatabaseTearDown("cleanup.xml")
-public class JpaJobSearchServiceImplIntegrationTest extends DBIntegrationTestBase {
+class JpaJobSearchServiceImplIntegrationTest extends DBIntegrationTestBase {
 
     private static final String JOB_1_ID = "job1";
     private static final String JOB_2_ID = "job2";
@@ -63,250 +56,209 @@ public class JpaJobSearchServiceImplIntegrationTest extends DBIntegrationTestBas
 
     // This needs to be injected as a Spring Bean otherwise transactions don't work as there is no proxy
     @Autowired
-    private JobSearchService service;
+    private JpaJobSearchServiceImpl service;
 
-    /**
-     * Make sure we can search jobs successfully.
-     */
     @Test
-    public void canFindJobs() {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canFindJobs() {
         //TODO: add more cases
         final Pageable page = PageRequest.of(0, 10, Sort.Direction.DESC, "updated");
-        Page<JobSearchResult> jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(5L));
-
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                Sets.newHashSet(JobStatus.RUNNING),
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(3L));
-        Assert.assertThat(
-            jobs
-                .getContent()
-                .stream()
-                .filter(job -> job.getId().equals(JOB_3_ID))
-                .count(),
-            Matchers.is(1L)
+        Page<JobSearchResult> jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
         );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(5L);
 
-        jobs = this.service
-            .findJobs(
-                JOB_1_ID,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(1L));
-        Assert.assertThat(
-            jobs
-                .getContent()
-                .stream()
-                .filter(job -> job.getId().equals(JOB_1_ID))
-                .count(),
-            Matchers.is(1L)
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            Sets.newHashSet(JobStatus.RUNNING),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
         );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(3L);
+        Assertions.assertThat(jobs.getContent()).hasSize(3).extracting(BaseSearchResult::getId).contains(JOB_3_ID);
 
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                "job3Grouping",
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(1L));
-        Assert.assertThat(
-            jobs
-                .getContent()
-                .stream()
-                .filter(job -> job.getId().equals(JOB_3_ID))
-                .count(),
-            Matchers.is(1L)
+        jobs = this.service.findJobs(
+            JOB_1_ID,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
         );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(1L);
+        Assertions.assertThat(jobs.getContent()).hasSize(1).extracting(BaseSearchResult::getId).containsOnly(JOB_1_ID);
 
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                "job2%",
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(1L));
-        Assert.assertThat(
-            jobs
-                .getContent()
-                .stream()
-                .filter(job -> job.getId().equals(JOB_2_ID))
-                .count(),
-            Matchers.is(1L)
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "job3Grouping",
+            null,
+            page
         );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(1L);
+        Assertions.assertThat(jobs.getContent()).hasSize(1).extracting(BaseSearchResult::getId).containsOnly(JOB_3_ID);
 
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                "job1%",
-                "job2%",
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(0L));
-        Assert.assertTrue(jobs.getContent().isEmpty());
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "job2%",
+            page
+        );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(1L);
+        Assertions.assertThat(jobs.getContent()).hasSize(1).extracting(BaseSearchResult::getId).containsOnly(JOB_2_ID);
+
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "job1%",
+            "job2%",
+            page
+        );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(0L);
+        Assertions.assertThat(jobs.getContent()).isEmpty();
     }
 
-    /**
-     * Specific searches for jobs by cluster or command variables which behave special due to joins.
-     */
     @Test
-    public void canFindJobsByClusterAndCommand() {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canFindJobsByClusterAndCommand() {
         final String clusterId = "cluster1";
         final String clusterName = "h2query";
         final String commandId = "command1";
         final String commandName = "spark";
         final Pageable page = PageRequest.of(0, 10, Sort.Direction.DESC, "updated");
-        Page<JobSearchResult> jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                UUID.randomUUID().toString(),
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(0L));
-        Assert.assertTrue(jobs.getContent().isEmpty());
+        Page<JobSearchResult> jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            UUID.randomUUID().toString(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
+        );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(0L);
+        Assertions.assertThat(jobs.getContent()).isEmpty();
 
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                UUID.randomUUID().toString(),
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(0L));
-        Assert.assertTrue(jobs.getContent().isEmpty());
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            UUID.randomUUID().toString(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
+        );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(0L);
+        Assertions.assertThat(jobs.getContent()).isEmpty();
 
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                clusterId,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(5L));
-        Assert.assertThat(jobs.getContent().size(), Matchers.is(5));
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            clusterId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
+        );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(5L);
+        Assertions.assertThat(jobs.getContent().size()).isEqualTo(5);
 
         jobs = this.service
             .findJobs(
@@ -327,391 +279,278 @@ public class JpaJobSearchServiceImplIntegrationTest extends DBIntegrationTestBas
                 null,
                 page
             );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(5L));
-        Assert.assertThat(jobs.getContent().size(), Matchers.is(5));
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(5L);
+        Assertions.assertThat(jobs.getContent().size()).isEqualTo(5);
 
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                clusterId,
-                null,
-                commandId,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(5L));
-        Assert.assertThat(jobs.getContent().size(), Matchers.is(5));
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            clusterId,
+            null,
+            commandId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
+        );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(5L);
+        Assertions.assertThat(jobs.getContent().size()).isEqualTo(5);
 
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                clusterName,
-                clusterId,
-                commandName,
-                commandId,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(5L));
-        Assert.assertThat(jobs.getContent().size(), Matchers.is(5));
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            clusterName,
+            clusterId,
+            commandName,
+            commandId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
+        );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(5L);
+        Assertions.assertThat(jobs.getContent().size()).isEqualTo(5);
 
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                UUID.randomUUID().toString(),
-                clusterId,
-                commandName,
-                commandId,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(0L));
-        Assert.assertTrue(jobs.getContent().isEmpty());
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            UUID.randomUUID().toString(),
+            clusterId,
+            commandName,
+            commandId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
+        );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(0L);
+        Assertions.assertThat(jobs.getContent()).isEmpty();
 
-        jobs = this.service
-            .findJobs(
-                null,
-                null,
-                null,
-                null,
-                null,
-                clusterName,
-                clusterId,
-                UUID.randomUUID().toString(),
-                commandId,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                page
-            );
-        Assert.assertThat(jobs.getTotalElements(), Matchers.is(0L));
-        Assert.assertTrue(jobs.getContent().isEmpty());
+        jobs = this.service.findJobs(
+            null,
+            null,
+            null,
+            null,
+            null,
+            clusterName,
+            clusterId,
+            UUID.randomUUID().toString(),
+            commandId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            page
+        );
+        Assertions.assertThat(jobs.getTotalElements()).isEqualTo(0L);
+        Assertions.assertThat(jobs.getContent()).isEmpty();
     }
 
-    /**
-     * Make sure we can get the correct number of jobs which are active on a given host.
-     */
     @Test
-    public void canFindActiveJobsByHostName() {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canFindActiveJobsByHostName() {
         final String hostA = "a.netflix.com";
         final String hostB = "b.netflix.com";
         final String hostC = "c.netflix.com";
 
-        Set<Job> jobs = this.service.getAllActiveJobsOnHost(hostA);
-        Assert.assertThat(jobs.size(), Matchers.is(1));
-        Assert.assertThat(
-            jobs
-                .stream()
-                .filter(
-                    jobExecution ->
-                        JOB_2_ID.equals(jobExecution.getId().orElseThrow(IllegalArgumentException::new))
-                )
-                .count(),
-            Matchers.is(1L)
-        );
+        Assertions
+            .assertThat(this.service.getAllActiveJobsOnHost(hostA))
+            .hasSize(1)
+            .extracting(BaseDTO::getId)
+            .filteredOn(Optional::isPresent)
+            .extracting(Optional::get)
+            .containsOnly(JOB_2_ID);
 
-        jobs = this.service.getAllActiveJobsOnHost(hostB);
-        Assert.assertThat(jobs.size(), Matchers.is(1));
-        Assert.assertThat(
-            jobs
-                .stream()
-                .filter(
-                    jobExecution -> JOB_3_ID.equals(jobExecution.getId().orElseThrow(IllegalArgumentException::new))
-                )
-                .count(),
-            Matchers.is(1L)
-        );
+        Assertions
+            .assertThat(this.service.getAllActiveJobsOnHost(hostB))
+            .hasSize(1)
+            .extracting(BaseDTO::getId)
+            .filteredOn(Optional::isPresent)
+            .extracting(Optional::get)
+            .containsOnly(JOB_3_ID);
 
-        jobs = this.service.getAllActiveJobsOnHost(hostC);
-        Assert.assertTrue(jobs.isEmpty());
+        Assertions.assertThat(this.service.getAllActiveJobsOnHost(hostC)).isEmpty();
     }
 
-    /**
-     * Make sure we can get the host names of nodes currently running jobs.
-     */
     @Test
-    public void canFindHostNamesOfActiveJobs() {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canFindHostNamesOfActiveJobs() {
         final String hostA = "a.netflix.com";
         final String hostB = "b.netflix.com";
 
-        final Set<String> hostNames = this.service.getAllHostsWithActiveJobs();
-        Assert.assertThat(hostNames.size(), Matchers.is(2));
-        Assert.assertThat(hostNames, Matchers.hasItems(hostA, hostB));
+        Assertions
+            .assertThat(this.service.getAllHostsWithActiveJobs())
+            .hasSize(2)
+            .containsExactlyInAnyOrder(hostA, hostB);
     }
 
-    /**
-     * Make sure the getting job method works.
-     *
-     * @throws GenieException on error
-     */
     @Test
-    public void canGetJob() throws GenieException {
-        Assert.assertThat(this.service.getJob(JOB_1_ID).getName(), Matchers.is("testSparkJob"));
-        Assert.assertThat(this.service.getJob(JOB_2_ID).getName(), Matchers.is("testSparkJob1"));
-        Assert.assertThat(this.service.getJob(JOB_3_ID).getName(), Matchers.is("testSparkJob2"));
-
-        try {
-            this.service.getJobStatus(UUID.randomUUID().toString());
-            Assert.fail();
-        } catch (final GenieException ge) {
-            Assert.assertTrue(ge instanceof GenieNotFoundException);
-        }
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetJob() throws GenieException {
+        Assertions.assertThat(this.service.getJob(JOB_1_ID).getName()).isEqualTo("testSparkJob");
+        Assertions.assertThat(this.service.getJob(JOB_2_ID).getName()).isEqualTo("testSparkJob1");
+        Assertions.assertThat(this.service.getJob(JOB_3_ID).getName()).isEqualTo("testSparkJob2");
+        Assertions
+            .assertThatExceptionOfType(GenieNotFoundException.class)
+            .isThrownBy(() -> this.service.getJob(UUID.randomUUID().toString()));
     }
 
-    /**
-     * Make sure the job status method works.
-     *
-     * @throws GenieException on error
-     */
     @Test
-    public void canGetJobStatus() throws GenieException {
-        Assert.assertThat(this.service.getJobStatus(JOB_1_ID), Matchers.is(JobStatus.SUCCEEDED));
-        Assert.assertThat(this.service.getJobStatus(JOB_2_ID), Matchers.is(JobStatus.INIT));
-        Assert.assertThat(this.service.getJobStatus(JOB_3_ID), Matchers.is(JobStatus.RUNNING));
-
-        try {
-            this.service.getJobStatus(UUID.randomUUID().toString());
-            Assert.fail();
-        } catch (final GenieException ge) {
-            Assert.assertTrue(ge instanceof GenieNotFoundException);
-        }
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetJobStatus() throws GenieException {
+        Assertions.assertThat(this.service.getJobStatus(JOB_1_ID)).isEqualTo(JobStatus.SUCCEEDED);
+        Assertions.assertThat(this.service.getJobStatus(JOB_2_ID)).isEqualTo(JobStatus.INIT);
+        Assertions.assertThat(this.service.getJobStatus(JOB_3_ID)).isEqualTo(JobStatus.RUNNING);
+        Assertions
+            .assertThatExceptionOfType(GenieNotFoundException.class)
+            .isThrownBy(() -> this.service.getJobStatus(UUID.randomUUID().toString()));
     }
 
-    /**
-     * Make sure the getting job request method works.
-     *
-     * @throws GenieException on error
-     */
     @Test
-    public void canGetJobRequest() throws GenieException {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetJobRequest() throws GenieException {
         final JobRequest job1Request = this.service.getJobRequest(JOB_1_ID);
-        Assert.assertThat(
-            job1Request.getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("-f query.q")
-        );
-        Assert.assertThat(
-            job1Request.getClusterCriterias().size(),
-            Matchers.is(2)
-        );
-        final Set<String> clusterCriterion0Tags = job1Request.getClusterCriterias().get(0).getTags();
-        Assert.assertThat(
-            clusterCriterion0Tags.size(),
-            Matchers.is(4)
-        );
-        Assert.assertThat(
-            clusterCriterion0Tags,
-            Matchers.is(Sets.newHashSet("genie.id:cluster1", "genie.name:h2query", "sla", "yarn"))
-        );
-        final Set<String> clusterCriterion1Tags = job1Request.getClusterCriterias().get(1).getTags();
-        Assert.assertThat(
-            clusterCriterion1Tags.size(),
-            Matchers.is(2)
-        );
-        Assert.assertThat(
-            clusterCriterion1Tags,
-            Matchers.is(Sets.newHashSet("sla", "adhoc"))
-        );
-        final Set<String> commandCriterionTags = job1Request.getCommandCriteria();
-        Assert.assertThat(
-            commandCriterionTags,
-            Matchers.is(Sets.newHashSet("type:spark", "ver:1.6.0", "genie.name:spark"))
-        );
-        Assert.assertThat(
-            this.service.getJobRequest(JOB_2_ID).getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("-f spark.jar")
-        );
-        Assert.assertThat(
-            this.service.getJobRequest(JOB_3_ID).getCommandArgs().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("-f spark.jar")
-        );
-
-        try {
-            this.service.getJobRequest(UUID.randomUUID().toString());
-            Assert.fail();
-        } catch (final GenieException ge) {
-            Assert.assertTrue(ge instanceof GenieNotFoundException);
-        }
+        Assertions.assertThat(job1Request.getCommandArgs()).contains("-f query.q");
+        Assertions.assertThat(job1Request.getClusterCriterias()).hasSize(2);
+        Assertions
+            .assertThat(job1Request.getClusterCriterias().get(0).getTags())
+            .hasSize(4)
+            .containsExactlyInAnyOrder("genie.id:cluster1", "genie.name:h2query", "sla", "yarn");
+        Assertions
+            .assertThat(job1Request.getClusterCriterias().get(1).getTags())
+            .hasSize(2)
+            .containsExactlyInAnyOrder("sla", "adhoc");
+        Assertions
+            .assertThat(job1Request.getCommandCriteria())
+            .hasSize(3)
+            .containsExactlyInAnyOrder("type:spark", "ver:1.6.0", "genie.name:spark");
+        Assertions.assertThat(this.service.getJobRequest(JOB_2_ID).getCommandArgs()).contains("-f spark.jar");
+        Assertions.assertThat(this.service.getJobRequest(JOB_3_ID).getCommandArgs()).contains("-f spark.jar");
+        Assertions
+            .assertThatExceptionOfType(GenieNotFoundException.class)
+            .isThrownBy(() -> this.service.getJobRequest(UUID.randomUUID().toString()));
     }
 
-    /**
-     * Make sure the getting job execution method works.
-     *
-     * @throws GenieException on error
-     */
     @Test
-    public void canGetJobExecution() throws GenieException {
-        Assert.assertThat(
-            this.service.getJobExecution(JOB_1_ID).getProcessId().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(317)
-        );
-        Assert.assertThat(
-            this.service.getJobExecution(JOB_2_ID).getProcessId().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(318)
-        );
-        Assert.assertThat(
-            this.service.getJobExecution(JOB_3_ID).getProcessId().orElseThrow(IllegalArgumentException::new),
-            Matchers.is(319)
-        );
-
-        try {
-            this.service.getJobExecution(UUID.randomUUID().toString());
-            Assert.fail();
-        } catch (final GenieException ge) {
-            Assert.assertTrue(ge instanceof GenieNotFoundException);
-        }
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetJobExecution() throws GenieException {
+        Assertions.assertThat(this.service.getJobExecution(JOB_1_ID).getProcessId()).contains(317);
+        Assertions.assertThat(this.service.getJobExecution(JOB_2_ID).getProcessId()).contains(318);
+        Assertions.assertThat(this.service.getJobExecution(JOB_3_ID).getProcessId()).contains(319);
+        Assertions
+            .assertThatExceptionOfType(GenieNotFoundException.class)
+            .isThrownBy(() -> this.service.getJobExecution(UUID.randomUUID().toString()));
     }
 
-    /**
-     * Make sure getting the job cluster method returns a valid cluster.
-     *
-     * @throws GenieException on error
-     */
     @Test
-    public void canGetJobCluster() throws GenieException {
-        Assert.assertThat(
-            this.service.getJobCluster(JOB_1_ID).getId().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("cluster1")
-        );
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetJobCluster() throws GenieException {
+        Assertions.assertThat(this.service.getJobCluster(JOB_1_ID).getId()).contains("cluster1");
     }
 
-    /**
-     * Make sure getting the job command method returns a valid command.
-     *
-     * @throws GenieException on error
-     */
     @Test
-    public void canGetJobCommand() throws GenieException {
-        Assert.assertThat(
-            this.service.getJobCommand(JOB_1_ID).getId().orElseThrow(IllegalArgumentException::new),
-            Matchers.is("command1")
-        );
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetJobCommand() throws GenieException {
+        Assertions.assertThat(this.service.getJobCommand(JOB_1_ID).getId()).contains("command1");
     }
 
-    /**
-     * Make sure getting the job applications method returns a valid list of applications.
-     *
-     * @throws GenieException on error
-     */
     @Test
-    public void canGetJobApplications() throws GenieException {
-        List<Application> applications = this.service.getJobApplications(JOB_1_ID);
-        Assert.assertThat(applications.size(), Matchers.is(2));
-        Assert.assertThat(applications.get(0).getId().orElseGet(RandomSuppliers.STRING), Matchers.is("app1"));
-        Assert.assertThat(applications.get(1).getId().orElseGet(RandomSuppliers.STRING), Matchers.is("app3"));
-        applications = this.service.getJobApplications(JOB_2_ID);
-        Assert.assertThat(applications.size(), Matchers.is(2));
-        Assert.assertThat(applications.get(0).getId().orElseGet(RandomSuppliers.STRING), Matchers.is("app1"));
-        Assert.assertThat(applications.get(1).getId().orElseGet(RandomSuppliers.STRING), Matchers.is("app2"));
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetJobApplications() throws GenieException {
+        Assertions
+            .assertThat(this.service.getJobApplications(JOB_1_ID))
+            .hasSize(2)
+            .extracting(BaseDTO::getId)
+            .filteredOn(Optional::isPresent)
+            .extracting(Optional::get)
+            .containsExactly("app1", "app3");
+        Assertions
+            .assertThat(this.service.getJobApplications(JOB_2_ID))
+            .hasSize(2)
+            .extracting(BaseDTO::getId)
+            .filteredOn(Optional::isPresent)
+            .extracting(Optional::get)
+            .containsExactly("app1", "app2");
     }
 
-    /**
-     * Make sure we can get the correct number of jobs which are active for a given user.
-     *
-     * @throws GenieException on error
-     */
     @Test
-    public void canGetActiveJobCountForUser() throws GenieException {
-        Assert.assertThat(this.service.getActiveJobCountForUser("nobody"), Matchers.is(0L));
-        Assert.assertThat(this.service.getActiveJobCountForUser("tgianos"), Matchers.is(4L));
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetActiveJobCountForUser() throws GenieException {
+        Assertions.assertThat(this.service.getActiveJobCountForUser("nobody")).isEqualTo(0L);
+        Assertions.assertThat(this.service.getActiveJobCountForUser("tgianos")).isEqualTo(4L);
     }
 
-    /**
-     * Make sure the getting job execution method works.
-     *
-     * @throws GenieException on error
-     */
     @Test
-    public void canGetJobMetadata() throws GenieException {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetJobMetadata() throws GenieException {
         final JobMetadata jobMetadata = this.service.getJobMetadata(JOB_1_ID);
-        Assert.assertThat(jobMetadata.getClientHost(), Matchers.is(Optional.empty()));
-        Assert.assertThat(jobMetadata.getUserAgent(), Matchers.is(Optional.empty()));
-        Assert.assertThat(jobMetadata.getNumAttachments(), Matchers.is(Optional.of(2)));
-        Assert.assertThat(jobMetadata.getTotalSizeOfAttachments(), Matchers.is(Optional.of(38083L)));
-        Assert.assertThat(jobMetadata.getStdErrSize(), Matchers.is(Optional.empty()));
-        Assert.assertThat(jobMetadata.getStdOutSize(), Matchers.is(Optional.empty()));
+        Assertions.assertThat(jobMetadata.getClientHost()).isNotPresent();
+        Assertions.assertThat(jobMetadata.getUserAgent()).isNotPresent();
+        Assertions.assertThat(jobMetadata.getNumAttachments()).contains(2);
+        Assertions.assertThat(jobMetadata.getTotalSizeOfAttachments()).contains(38083L);
+        Assertions.assertThat(jobMetadata.getStdErrSize()).isNotPresent();
+        Assertions.assertThat(jobMetadata.getStdOutSize()).isNotPresent();
     }
 
-    /**
-     * Make sure the getting user resource summaries works.
-     */
     @Test
-    public void canGetUserResourceSummaries() {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetUserResourceSummaries() {
         final Map<String, UserResourcesSummary> summaries = this.service.getUserResourcesSummaries();
-        Assert.assertThat(summaries.keySet(), Matchers.contains("tgianos"));
+        Assertions.assertThat(summaries.keySet()).contains("tgianos");
         final UserResourcesSummary userResourcesSummary = summaries.get("tgianos");
-        Assert.assertThat(userResourcesSummary.getUser(), Matchers.is("tgianos"));
-        Assert.assertThat(userResourcesSummary.getRunningJobsCount(), Matchers.is(1L));
-        Assert.assertThat(userResourcesSummary.getUsedMemory(), Matchers.is(2048L));
+        Assertions.assertThat(userResourcesSummary.getUser()).isEqualTo("tgianos");
+        Assertions.assertThat(userResourcesSummary.getRunningJobsCount()).isEqualTo(1L);
+        Assertions.assertThat(userResourcesSummary.getUsedMemory()).isEqualTo(2048L);
     }
 
-    /**
-     * Make sure the getting active agent jobs without an active connection works.
-     */
     @Test
-    public void canGetActiveDisconnectedAgentJobs() {
-        final Set<String> jobs = this.service.getActiveDisconnectedAgentJobs();
-        Assert.assertThat(jobs.size(), Matchers.is(1));
-        Assert.assertThat(jobs, Matchers.contains("agentJob1"));
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetActiveDisconnectedAgentJobs() {
+        Assertions.assertThat(this.service.getActiveDisconnectedAgentJobs()).hasSize(1).containsOnly("agentJob1");
     }
 
-    /**
-     * Make sure the amount of allocated memory for active jobs is correct.
-     */
     @Test
-    public void canGetAllocatedMemoryOnHost() {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetAllocatedMemoryOnHost() {
         Assertions.assertThat(this.service.getAllocatedMemoryOnHost("a.netflix.com")).isEqualTo(2048L);
         Assertions.assertThat(this.service.getAllocatedMemoryOnHost("b.netflix.com")).isEqualTo(2048L);
         Assertions.assertThat(this.service.getAllocatedMemoryOnHost("agent.netflix.com")).isEqualTo(4096L);
         Assertions.assertThat(this.service.getAllocatedMemoryOnHost(UUID.randomUUID().toString())).isEqualTo(0L);
     }
 
-    /**
-     * Make sure the amount of used memory for running jobs is correct.
-     */
     @Test
-    public void canGetUsedMemoryOnHost() {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetUsedMemoryOnHost() {
         Assertions.assertThat(this.service.getUsedMemoryOnHost("a.netflix.com")).isEqualTo(2048L);
         Assertions.assertThat(this.service.getUsedMemoryOnHost("b.netflix.com")).isEqualTo(2048L);
         Assertions.assertThat(this.service.getUsedMemoryOnHost("agent.netflix.com")).isEqualTo(4096L);
         Assertions.assertThat(this.service.getUsedMemoryOnHost(UUID.randomUUID().toString())).isEqualTo(0L);
     }
 
-    /**
-     * Make sure the amount of used memory for active jobs is correct.
-     */
     @Test
-    public void canGetCountOfActiveJobsOnHost() {
+    @DatabaseSetup("JpaJobSearchServiceImplIntegrationTest/init.xml")
+    void canGetCountOfActiveJobsOnHost() {
         Assertions.assertThat(this.service.getActiveJobCountOnHost("a.netflix.com")).isEqualTo(1L);
         Assertions.assertThat(this.service.getActiveJobCountOnHost("b.netflix.com")).isEqualTo(1L);
         Assertions.assertThat(this.service.getActiveJobCountOnHost("agent.netflix.com")).isEqualTo(2L);

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImplIntegrationTest/deleteUnusedApplications/after.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImplIntegrationTest/deleteUnusedApplications/after.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<dataset>
+    <applications
+        id="0"
+        created="2014-08-08 01:45:00"
+        updated="2014-08-08 01:50:00"
+        entity_version="0"
+        unique_id="app1"
+        genie_user="tgianos"
+        name="tez"
+        version="1.2.3"
+        status="ACTIVE"
+    />
+
+    <applications
+        id="2"
+        created="2014-08-10 01:45:00"
+        updated="2014-08-10 01:50:00"
+        entity_version="0"
+        unique_id="app3"
+        genie_user="tgianos"
+        name="storm"
+        version="7.8.9"
+        status="ACTIVE"
+        type="storm"
+    />
+
+    <applications
+        id="3"
+        created="2020-03-10 01:45:00"
+        updated="2020-03-10 01:50:00"
+        entity_version="0"
+        unique_id="app4"
+        genie_user="tgianos"
+        name="sparksql"
+        version="4.0.0"
+        status="ACTIVE"
+        type="spark"
+    />
+
+    <applications
+        id="4"
+        created="2020-03-10 02:45:00"
+        updated="2020-03-10 02:50:00"
+        entity_version="0"
+        unique_id="app5"
+        genie_user="tgianos"
+        name="sparksql"
+        version="4.0.0"
+        status="ACTIVE"
+        type="spark"
+    />
+
+    <applications
+        id="5"
+        created="2020-03-10 02:45:00"
+        updated="2020-03-10 02:50:00"
+        entity_version="0"
+        unique_id="app6"
+        genie_user="tgianos"
+        name="sparksql"
+        version="4.0.0"
+        status="ACTIVE"
+        type="spark"
+    />
+
+    <commands
+        id="0"
+        created="2014-08-08 01:47:00"
+        updated="2014-08-08 01:59:00"
+        entity_version="0"
+        unique_id="command1"
+        genie_user="tgianos"
+        name="sparksql"
+        version="1.2.3"
+        check_delay="10000"
+        status="ACTIVE"
+    />
+
+    <commands_applications command_id="0" application_id="0" application_order="0"/>
+    <commands_applications command_id="0" application_id="2" application_order="1"/>
+
+    <command_executable_arguments
+        command_id="0"
+        argument="sparksql"
+        argument_order="0"
+    />
+
+    <criteria
+        id="0"
+    />
+    <jobs
+        id="0"
+        created="2016-02-24 01:48:00"
+        updated="2016-02-24 02:59:00"
+        entity_version="1"
+        unique_id="job3"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="2"
+        requested_memory="2048"
+        archiving_disabled="true"
+        requested_timeout="608400"
+        num_attachments="1"
+        total_size_of_attachments="382"
+        status="RUNNING"
+        command_id="0"
+        agent_hostname="b.netflix.com"
+        exit_code="-1"
+        process_id="319"
+        check_delay="12000"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/3"
+        resolved="true"
+        api="true"
+    />
+
+    <jobs_applications job_id="0" application_id="0" application_order="0"/>
+    <jobs_applications job_id="0" application_id="2" application_order="1"/>
+    <jobs_applications job_id="0" application_id="3" application_order="2"/>
+</dataset>

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImplIntegrationTest/deleteUnusedApplications/before.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImplIntegrationTest/deleteUnusedApplications/before.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<dataset>
+    <applications
+        id="0"
+        created="2014-08-08 01:45:00"
+        updated="2014-08-08 01:50:00"
+        entity_version="0"
+        unique_id="app1"
+        genie_user="tgianos"
+        name="tez"
+        version="1.2.3"
+        status="ACTIVE"
+    />
+
+    <applications
+        id="1"
+        created="2014-08-09 01:45:00"
+        updated="2014-08-09 01:50:00"
+        entity_version="0"
+        unique_id="app2"
+        genie_user="amsharma"
+        name="spark"
+        version="4.5.6"
+        status="ACTIVE"
+        type="spark"
+    />
+
+    <applications
+        id="2"
+        created="2014-08-10 01:45:00"
+        updated="2014-08-10 01:50:00"
+        entity_version="0"
+        unique_id="app3"
+        genie_user="tgianos"
+        name="storm"
+        version="7.8.9"
+        status="ACTIVE"
+        type="storm"
+    />
+
+    <applications
+        id="3"
+        created="2020-03-10 01:45:00"
+        updated="2020-03-10 01:50:00"
+        entity_version="0"
+        unique_id="app4"
+        genie_user="tgianos"
+        name="sparksql"
+        version="4.0.0"
+        status="ACTIVE"
+        type="spark"
+    />
+
+    <applications
+        id="4"
+        created="2020-03-10 02:45:00"
+        updated="2020-03-10 02:50:00"
+        entity_version="0"
+        unique_id="app5"
+        genie_user="tgianos"
+        name="sparksql"
+        version="4.0.0"
+        status="ACTIVE"
+        type="spark"
+    />
+
+    <applications
+        id="5"
+        created="2020-03-10 02:45:00"
+        updated="2020-03-10 02:50:00"
+        entity_version="0"
+        unique_id="app6"
+        genie_user="tgianos"
+        name="sparksql"
+        version="4.0.0"
+        status="ACTIVE"
+        type="spark"
+    />
+
+    <commands
+        id="0"
+        created="2014-08-08 01:47:00"
+        updated="2014-08-08 01:59:00"
+        entity_version="0"
+        unique_id="command1"
+        genie_user="tgianos"
+        name="sparksql"
+        version="1.2.3"
+        check_delay="10000"
+        status="ACTIVE"
+    />
+
+    <commands_applications command_id="0" application_id="0" application_order="0"/>
+    <commands_applications command_id="0" application_id="2" application_order="1"/>
+
+    <command_executable_arguments
+        command_id="0"
+        argument="sparksql"
+        argument_order="0"
+    />
+
+    <criteria
+        id="0"
+    />
+    <jobs
+        id="0"
+        created="2016-02-24 01:48:00"
+        updated="2016-02-24 02:59:00"
+        entity_version="1"
+        unique_id="job3"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="2"
+        requested_memory="2048"
+        archiving_disabled="true"
+        requested_timeout="608400"
+        num_attachments="1"
+        total_size_of_attachments="382"
+        status="RUNNING"
+        command_id="0"
+        agent_hostname="b.netflix.com"
+        exit_code="-1"
+        process_id="319"
+        check_delay="12000"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/3"
+        resolved="true"
+        api="true"
+    />
+
+    <jobs_applications job_id="0" application_id="0" application_order="0"/>
+    <jobs_applications job_id="0" application_id="2" application_order="1"/>
+    <jobs_applications job_id="0" application_id="3" application_order="2"/>
+</dataset>

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest/deleteUnusedCommands/before.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest/deleteUnusedCommands/before.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<dataset>
+    <commands
+        id="0"
+        created="2020-03-23 01:47:00"
+        updated="2020-03-23 01:59:00"
+        entity_version="0"
+        unique_id="command0"
+        genie_user="tgianos"
+        name="sparksql"
+        version="1.2.3"
+        check_delay="18000"
+        status="INACTIVE"
+    />
+    <commands
+        id="1"
+        created="2020-02-23 01:47:00"
+        updated="2020-02-23 01:59:00"
+        entity_version="0"
+        unique_id="command1"
+        genie_user="tgianos"
+        name="pig_13_prod"
+        version="1.2.3"
+        check_delay="18000"
+        status="ACTIVE"
+    />
+    <commands
+        id="2"
+        created="2020-01-23 01:46:00"
+        updated="2020-01-23 03:12:00"
+        entity_version="0"
+        unique_id="command2"
+        genie_user="mprimi"
+        name="hive_11_prod"
+        version="4.5.6"
+        check_delay="19000"
+        status="INACTIVE"
+    />
+    <commands
+        id="3"
+        created="2019-12-23 01:49:00"
+        updated="2019-12-23 02:59:00"
+        entity_version="0"
+        unique_id="command3"
+        genie_user="tgianos"
+        name="pig_11_prod"
+        version="7.8.9"
+        check_delay="20000"
+        status="DEPRECATED"
+        metadata=
+            "{&quot;key1&quot;: &quot;value1&quot;, &quot;key2&quot;: 65, &quot;key3&quot;: [], &quot;key4&quot;: {}}"
+    />
+    <commands
+        id="4"
+        created="2019-11-23 01:49:00"
+        updated="2019-11-23 02:59:00"
+        entity_version="0"
+        unique_id="command4"
+        genie_user="tgianos"
+        name="oldspark"
+        version="7.8.9"
+        check_delay="20000"
+        status="ACTIVE"
+    />
+    <commands
+        id="5"
+        created="2019-10-23 01:49:00"
+        updated="2019-10-23 02:59:00"
+        entity_version="0"
+        unique_id="command5"
+        genie_user="tgianos"
+        name="olderspark"
+        version="7.8.9"
+        check_delay="20000"
+        status="DEPRECATED"
+    />
+    <commands
+        id="6"
+        created="2020-03-22 01:47:00"
+        updated="2020-03-22 01:59:00"
+        entity_version="0"
+        unique_id="command6"
+        genie_user="tgianos"
+        name="sparksql"
+        version="1.2.3"
+        check_delay="18000"
+        status="INACTIVE"
+    />
+
+    <jobs
+        id="0"
+        created="2020-02-24 01:48:00"
+        updated="2020-02-24 02:59:00"
+        entity_version="1"
+        unique_id="job0"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        archiving_disabled="true"
+        status="SUCCEEDED"
+        command_id="3"
+        requested_id="true"
+        resolved="true"
+        api="true"
+    />
+    <jobs
+        id="1"
+        created="2020-03-23 01:48:00"
+        updated="2020-03-23 02:59:00"
+        entity_version="1"
+        unique_id="job1"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        archiving_disabled="true"
+        status="RUNNING"
+        command_id="1"
+        requested_id="true"
+        resolved="true"
+        api="true"
+    />
+    <jobs
+        id="2"
+        created="2020-01-23 01:48:00"
+        updated="2020-01-23 02:59:00"
+        entity_version="1"
+        unique_id="job2"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        status="KILLED"
+        command_id="2"
+        archiving_disabled="true"
+        requested_id="true"
+        resolved="true"
+        api="true"
+    />
+</dataset>

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest/updateStatusForUnusedCommands/before.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest/updateStatusForUnusedCommands/before.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<dataset>
+    <commands
+        id="0"
+        created="2020-03-23 01:47:00"
+        updated="2020-03-23 01:59:00"
+        entity_version="0"
+        unique_id="command0"
+        genie_user="tgianos"
+        name="sparksql"
+        version="1.2.3"
+        check_delay="18000"
+        status="DEPRECATED"
+    />
+    <commands
+        id="1"
+        created="2020-02-23 01:47:00"
+        updated="2020-02-23 01:59:00"
+        entity_version="0"
+        unique_id="command1"
+        genie_user="tgianos"
+        name="pig_13_prod"
+        version="1.2.3"
+        check_delay="18000"
+        status="ACTIVE"
+    />
+    <commands
+        id="2"
+        created="2020-01-23 01:46:00"
+        updated="2020-01-23 03:12:00"
+        entity_version="0"
+        unique_id="command2"
+        genie_user="amsharma"
+        name="hive_11_prod"
+        version="4.5.6"
+        check_delay="19000"
+        status="ACTIVE"
+    />
+    <commands
+        id="3"
+        created="2019-12-23 01:49:00"
+        updated="2019-12-23 02:59:00"
+        entity_version="0"
+        unique_id="command3"
+        genie_user="tgianos"
+        name="pig_11_prod"
+        version="7.8.9"
+        check_delay="20000"
+        status="DEPRECATED"
+        metadata=
+            "{&quot;key1&quot;: &quot;value1&quot;, &quot;key2&quot;: 65, &quot;key3&quot;: [], &quot;key4&quot;: {}}"
+    />
+    <commands
+        id="4"
+        created="2019-11-23 01:49:00"
+        updated="2019-11-23 02:59:00"
+        entity_version="0"
+        unique_id="command4"
+        genie_user="tgianos"
+        name="oldspark"
+        version="7.8.9"
+        check_delay="20000"
+        status="ACTIVE"
+    />
+    <commands
+        id="5"
+        created="2019-10-23 01:49:00"
+        updated="2019-10-23 02:59:00"
+        entity_version="0"
+        unique_id="command5"
+        genie_user="tgianos"
+        name="olderspark"
+        version="7.8.9"
+        check_delay="20000"
+        status="DEPRECATED"
+    />
+
+    <jobs
+        id="0"
+        created="2020-02-24 01:48:00"
+        updated="2020-02-24 02:59:00"
+        entity_version="1"
+        unique_id="job0"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        archiving_disabled="true"
+        status="SUCCEEDED"
+        command_id="3"
+        requested_id="true"
+        resolved="true"
+        api="true"
+    />
+    <jobs
+        id="1"
+        created="2020-03-23 01:48:00"
+        updated="2020-03-23 02:59:00"
+        entity_version="1"
+        unique_id="job1"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        archiving_disabled="true"
+        status="RUNNING"
+        command_id="1"
+        requested_id="true"
+        resolved="true"
+        api="true"
+    />
+    <jobs
+        id="2"
+        created="2020-01-23 01:48:00"
+        updated="2020-01-23 02:59:00"
+        entity_version="1"
+        unique_id="job2"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        status="KILLED"
+        command_id="1"
+        archiving_disabled="true"
+        requested_id="true"
+        resolved="true"
+        api="true"
+    />
+</dataset>

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImpl.java
@@ -23,6 +23,7 @@ import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.proto.JobKillRegistrationRequest;
 import com.netflix.genie.proto.JobKillRegistrationResponse;
 import com.netflix.genie.proto.JobKillServiceGrpc;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.services.JobKillServiceV4;
 import io.grpc.stub.StreamObserver;
@@ -50,10 +51,10 @@ public class GRpcJobKillServiceImpl
     /**
      * Constructor.
      *
-     * @param jobSearchService Job search service
+     * @param dataServices The {@link DataServices} instance to use
      */
-    public GRpcJobKillServiceImpl(final JobSearchService jobSearchService) {
-        this.jobSearchService = jobSearchService;
+    public GRpcJobKillServiceImpl(final DataServices dataServices) {
+        this.jobSearchService = dataServices.getJobSearchService();
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImpl.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.netflix.genie.common.external.dtos.v4.JobMetadata;
 import com.netflix.genie.web.agent.launchers.AgentLauncher;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.exceptions.checked.AgentLaunchException;
@@ -74,7 +75,7 @@ public class LocalAgentLauncherImpl implements AgentLauncher {
      *
      * @param hostInfo           The {@link GenieWebHostInfo} instance
      * @param rpcInfo            The {@link GenieWebRpcInfo} instance
-     * @param jobSearchService   The {@link JobSearchService} used to get metrics about the jobs on this node
+     * @param dataServices       The {@link DataServices} encapsulation instance to use
      * @param launcherProperties The properties from the configuration that control agent behavior
      * @param executorFactory    A {@link ExecutorFactory} to create {@link org.apache.commons.exec.Executor}
      *                           instances
@@ -83,14 +84,14 @@ public class LocalAgentLauncherImpl implements AgentLauncher {
     public LocalAgentLauncherImpl(
         final GenieWebHostInfo hostInfo,
         final GenieWebRpcInfo rpcInfo,
-        final JobSearchService jobSearchService,
+        final DataServices dataServices,
         final LocalAgentLauncherProperties launcherProperties,
         final ExecutorFactory executorFactory,
         final MeterRegistry registry
     ) {
         this.hostname = hostInfo.getHostname();
         this.rpcPort = rpcInfo.getRpcPort();
-        this.jobSearchService = jobSearchService;
+        this.jobSearchService = dataServices.getJobSearchService();
         this.launcherProperties = launcherProperties;
         this.executorFactory = executorFactory;
         this.registry = registry;

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
@@ -32,6 +32,7 @@ import com.netflix.genie.common.internal.exceptions.unchecked.GenieRuntimeExcept
 import com.netflix.genie.web.agent.inspectors.InspectionReport;
 import com.netflix.genie.web.agent.services.AgentFilterService;
 import com.netflix.genie.web.agent.services.AgentJobService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.dtos.JobSubmission;
 import com.netflix.genie.web.dtos.ResolvedJob;
@@ -73,18 +74,18 @@ public class AgentJobServiceImpl implements AgentJobService {
     /**
      * Constructor.
      *
-     * @param jobPersistenceService The persistence service to use
-     * @param jobResolverService    The specification service to use
-     * @param agentFilterService    The agent filter service to use
-     * @param meterRegistry         The metrics registry to use
+     * @param dataServices       The {@link DataServices} instance to use
+     * @param jobResolverService The specification service to use
+     * @param agentFilterService The agent filter service to use
+     * @param meterRegistry      The metrics registry to use
      */
     public AgentJobServiceImpl(
-        final JobPersistenceService jobPersistenceService,
+        final DataServices dataServices,
         final JobResolverService jobResolverService,
         final AgentFilterService agentFilterService,
         final MeterRegistry meterRegistry
     ) {
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
         this.jobResolverService = jobResolverService;
         this.agentFilterService = agentFilterService;
         this.meterRegistry = meterRegistry;

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/ApplicationRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/ApplicationRestController.java
@@ -33,6 +33,7 @@ import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.ApplicationModelAss
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.CommandModelAssembler;
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.EntityModelAssemblers;
 import com.netflix.genie.web.data.services.ApplicationPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -89,15 +90,15 @@ public class ApplicationRestController {
     /**
      * Constructor.
      *
-     * @param applicationPersistenceService The application configuration service to use.
-     * @param entityModelAssemblers         The encapsulation of all the available V3 resource assemblers
+     * @param dataServices          The {@link DataServices} encapsulation instance to use
+     * @param entityModelAssemblers The encapsulation of all the available V3 resource assemblers
      */
     @Autowired
     public ApplicationRestController(
-        final ApplicationPersistenceService applicationPersistenceService,
+        final DataServices dataServices,
         final EntityModelAssemblers entityModelAssemblers
     ) {
-        this.applicationPersistenceService = applicationPersistenceService;
+        this.applicationPersistenceService = dataServices.getApplicationPersistenceService();
         this.applicationModelAssembler = entityModelAssemblers.getApplicationModelAssembler();
         this.commandModelAssembler = entityModelAssemblers.getCommandModelAssembler();
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/ClusterRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/ClusterRestController.java
@@ -33,6 +33,7 @@ import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.ClusterModelAssembl
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.CommandModelAssembler;
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.EntityModelAssemblers;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -91,15 +92,12 @@ public class ClusterRestController {
     /**
      * Constructor.
      *
-     * @param clusterPersistenceService The cluster configuration service to use.
-     * @param entityModelAssemblers     The encapsulation of all available V3 resource assemblers
+     * @param dataServices          The {@link DataServices} encapsulation instance to use.
+     * @param entityModelAssemblers The encapsulation of all available V3 resource assemblers
      */
     @Autowired
-    public ClusterRestController(
-        final ClusterPersistenceService clusterPersistenceService,
-        final EntityModelAssemblers entityModelAssemblers
-    ) {
-        this.clusterPersistenceService = clusterPersistenceService;
+    public ClusterRestController(final DataServices dataServices, final EntityModelAssemblers entityModelAssemblers) {
+        this.clusterPersistenceService = dataServices.getClusterPersistenceService();
         this.clusterModelAssembler = entityModelAssemblers.getClusterModelAssembler();
         this.commandModelAssembler = entityModelAssemblers.getCommandModelAssembler();
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/CommandRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/CommandRestController.java
@@ -39,6 +39,7 @@ import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.CommandModelAssembl
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.EntityModelAssemblers;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
 import com.netflix.genie.web.data.services.CommandPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -100,18 +101,13 @@ public class CommandRestController {
     /**
      * Constructor.
      *
-     * @param commandPersistenceService The command configuration service to use.
-     * @param clusterPersistenceService The {@link ClusterPersistenceService} implementation to use
-     * @param entityModelAssemblers     The encapsulation of all available V3 resource assemblers
+     * @param dataServices          The {@link DataServices} encapsulation instance to use
+     * @param entityModelAssemblers The encapsulation of all available V3 resource assemblers
      */
     @Autowired
-    public CommandRestController(
-        final CommandPersistenceService commandPersistenceService,
-        final ClusterPersistenceService clusterPersistenceService,
-        final EntityModelAssemblers entityModelAssemblers
-    ) {
-        this.commandPersistenceService = commandPersistenceService;
-        this.clusterPersistenceService = clusterPersistenceService;
+    public CommandRestController(final DataServices dataServices, final EntityModelAssemblers entityModelAssemblers) {
+        this.commandPersistenceService = dataServices.getCommandPersistenceService();
+        this.clusterPersistenceService = dataServices.getClusterPersistenceService();
         this.commandModelAssembler = entityModelAssemblers.getCommandModelAssembler();
         this.applicationModelAssembler = entityModelAssemblers.getApplicationModelAssembler();
         this.clusterModelAssembler = entityModelAssemblers.getClusterModelAssembler();

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
@@ -51,6 +51,7 @@ import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.JobMetadataModelAss
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.JobModelAssembler;
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.JobRequestModelAssembler;
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.JobSearchResultModelAssembler;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.dtos.JobSubmission;
@@ -169,7 +170,7 @@ public class JobRestController {
      * Constructor.
      *
      * @param jobLaunchService          The {@link JobLaunchService} implementation to use
-     * @param jobSearchService          The search service to use
+     * @param dataServices              The {@link DataServices} instance to use
      * @param jobCoordinatorService     The job coordinator service to use.
      * @param entityModelAssemblers     The encapsulation of all the V3 resource assemblers
      * @param genieHostInfo             Information about the host that the Genie process is running on
@@ -177,7 +178,6 @@ public class JobRestController {
      * @param jobDirectoryServerService The service to handle serving back job directory resources
      * @param jobsProperties            All the properties associated with jobs
      * @param registry                  The metrics registry to use
-     * @param jobPersistenceService     Job persistence service
      * @param agentRoutingService       Agent routing service
      * @param environment               The application environment to pull dynamic properties from
      * @param attachmentService         The attachment service to use to save attachments.
@@ -187,7 +187,7 @@ public class JobRestController {
     @SuppressWarnings("checkstyle:parameternumber")
     public JobRestController(
         final JobLaunchService jobLaunchService,
-        final JobSearchService jobSearchService,
+        final DataServices dataServices,
         final JobCoordinatorService jobCoordinatorService,
         final EntityModelAssemblers entityModelAssemblers,
         final GenieHostInfo genieHostInfo,
@@ -195,14 +195,13 @@ public class JobRestController {
         final JobDirectoryServerService jobDirectoryServerService,
         final JobsProperties jobsProperties,
         final MeterRegistry registry,
-        final JobPersistenceService jobPersistenceService,
         final AgentRoutingService agentRoutingService,
         final Environment environment,
         final AttachmentService attachmentService,
         final JobExecutionModeSelector jobExecutionModeSelector
     ) {
         this.jobLaunchService = jobLaunchService;
-        this.jobSearchService = jobSearchService;
+        this.jobSearchService = dataServices.getJobSearchService();
         this.jobCoordinatorService = jobCoordinatorService;
         this.applicationModelAssembler = entityModelAssemblers.getApplicationModelAssembler();
         this.clusterModelAssembler = entityModelAssemblers.getClusterModelAssembler();
@@ -217,7 +216,7 @@ public class JobRestController {
         this.jobDirectoryServerService = jobDirectoryServerService;
         this.jobsProperties = jobsProperties;
         this.agentRoutingService = agentRoutingService;
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
         this.environment = environment;
 
         // TODO: V3 Only. Remove.

--- a/genie-web/src/main/java/com/netflix/genie/web/data/repositories/jpa/JpaCommandRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/repositories/jpa/JpaCommandRepository.java
@@ -16,6 +16,12 @@
 package com.netflix.genie.web.data.repositories.jpa;
 
 import com.netflix.genie.web.data.entities.CommandEntity;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.Set;
 
 /**
  * Command repository.
@@ -23,4 +29,40 @@ import com.netflix.genie.web.data.entities.CommandEntity;
  * @author tgianos
  */
 public interface JpaCommandRepository extends JpaBaseRepository<CommandEntity> {
+
+    /**
+     * The query used to set commands to a given status given input parameters.
+     */
+    String SET_UNUSED_STATUS_QUERY =
+        "UPDATE commands"
+            + " SET status = :desiredStatus"
+            + " WHERE status IN (:currentStatuses)"
+            + " AND created < :commandCreatedThreshold"
+            + " AND id NOT IN ("
+            + "SELECT DISTINCT(command_id)"
+            + " FROM jobs"
+            + " WHERE command_id IS NOT NULL"
+            + " AND created >= :jobCreatedThreshold"
+            + ");";
+
+    /**
+     * Bulk set the status of commands which match the given inputs. Considers whether a command was used in some
+     * period of time till now.
+     *
+     * @param desiredStatus           The new status the matching commands should have
+     * @param commandCreatedThreshold The instant in time which a command must have been created before to be
+     *                                considered for update. Exclusive
+     * @param currentStatuses         The set of current statuses a command must have to be considered for update
+     * @param jobCreatedThreshold     The instant in time after which a command must not have been used in a Genie job
+     *                                for it to be considered for update. Inclusive.
+     * @return The number of commands that were updated by the query
+     */
+    @Query(value = SET_UNUSED_STATUS_QUERY, nativeQuery = true)
+    @Modifying
+    int setUnusedStatus(
+        @Param("desiredStatus") String desiredStatus,
+        @Param("commandCreatedThreshold") Instant commandCreatedThreshold,
+        @Param("currentStatuses") Set<String> currentStatuses,
+        @Param("jobCreatedThreshold") Instant jobCreatedThreshold
+    );
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/ApplicationPersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/ApplicationPersistenceService.java
@@ -33,6 +33,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.Set;
 
 /**
@@ -336,4 +337,16 @@ public interface ApplicationPersistenceService {
         @NotBlank(message = "No application id entered. Unable to get commands.") String id,
         @Nullable Set<CommandStatus> statuses
     ) throws GenieException;
+
+    /**
+     * Delete any unused applications that were created before the given time.
+     * Unused means they aren't linked to any other resources in the Genie system like jobs or commands and therefore
+     * referential integrity is maintained.
+     *
+     * @param createdThreshold The instant in time that any applications had to be created before (exclusive) to be
+     *                         considered for deletion. Presents ability to filter out newly created applications if
+     *                         desired.
+     * @return The number of successfully deleted applications
+     */
+    int deleteUnusedApplicationsCreatedBefore(Instant createdThreshold);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/CommandPersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/CommandPersistenceService.java
@@ -37,6 +37,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -475,4 +476,24 @@ public interface CommandPersistenceService {
      * @return All the {@link Command}'s which matched the {@link Criterion}
      */
     Set<Command> findCommandsMatchingCriterion(@Valid Criterion criterion, boolean addDefaultStatus);
+
+    /**
+     * Update the status of a command to the {@literal desiredStatus} if its status is in {@literal currentStatuses},
+     * it was created before {@literal commandCreatedThreshold} and it hasn't been used in any job that was created
+     * in the Genie system after {@literal jobCreatedThreshold}.
+     *
+     * @param desiredStatus           The new status the matching commands should have
+     * @param commandCreatedThreshold The instant in time which a command must have been created before to be
+     *                                considered for update. Exclusive
+     * @param currentStatuses         The set of current statuses a command must have to be considered for update
+     * @param jobCreatedThreshold     The instant in time after which a command must not have been used in a Genie job
+     *                                for it to be considered for update. Inclusive.
+     * @return The number of commands whose statuses were updated to {@literal desiredStatus}
+     */
+    int updateStatusForUnusedCommands(
+        CommandStatus desiredStatus,
+        Instant commandCreatedThreshold,
+        Set<CommandStatus> currentStatuses,
+        Instant jobCreatedThreshold
+    );
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/CommandPersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/CommandPersistenceService.java
@@ -496,4 +496,15 @@ public interface CommandPersistenceService {
         Set<CommandStatus> currentStatuses,
         Instant jobCreatedThreshold
     );
+
+    /**
+     * Bulk delete commands from the database where their status is in {@literal deleteStatuses} they were created
+     * before {@literal commandCreatedThreshold} and they aren't attached to any jobs still in the database.
+     *
+     * @param deleteStatuses          The set of statuses a command must be in in order to be considered for deletion
+     * @param commandCreatedThreshold The instant in time a command must have been created before to be considered for
+     *                                deletion. Exclusive.
+     * @return The number of commands that were deleted
+     */
+    int deleteUnusedCommands(Set<CommandStatus> deleteStatuses, Instant commandCreatedThreshold);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/DataServices.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/DataServices.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.data.services;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Container class for encapsulating all the various data related services in Genie to ease dependency patterns.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@AllArgsConstructor
+@Getter
+public class DataServices {
+    private final AgentConnectionPersistenceService agentConnectionPersistenceService;
+    private final ApplicationPersistenceService applicationPersistenceService;
+    private final ClusterPersistenceService clusterPersistenceService;
+    private final CommandPersistenceService commandPersistenceService;
+    private final FilePersistenceService filePersistenceService;
+    private final JobPersistenceService jobPersistenceService;
+    private final JobSearchService jobSearchService;
+    private final TagPersistenceService tagPersistenceService;
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaApplicationPersistenceServiceImpl.java
@@ -61,6 +61,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -440,6 +441,15 @@ public class JpaApplicationPersistenceServiceImpl extends JpaBaseService impleme
             .stream()
             .map(EntityDtoConverters::toV4CommandDto)
             .collect(Collectors.toSet());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deleteUnusedApplicationsCreatedBefore(final Instant createdThreshold) {
+        log.info("Attempting to delete unused applications created before {}", createdThreshold);
+        return this.getApplicationRepository().deleteUnusedApplications(createdThreshold);
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImpl.java
@@ -68,6 +68,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -663,6 +664,32 @@ public class JpaCommandPersistenceServiceImpl extends JpaBaseService implements 
             .stream()
             .map(EntityDtoConverters::toV4CommandDto)
             .collect(Collectors.toSet());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int updateStatusForUnusedCommands(
+        final CommandStatus desiredStatus,
+        final Instant commandCreatedThreshold,
+        final Set<CommandStatus> currentStatuses,
+        final Instant jobCreatedThreshold
+    ) {
+        log.info(
+            "Updating any commands with statuses {} "
+                + "that were created before {} and haven't been used in jobs created after {} to new status {}",
+            currentStatuses,
+            commandCreatedThreshold,
+            jobCreatedThreshold,
+            desiredStatus
+        );
+        return this.getCommandRepository().setUnusedStatus(
+            desiredStatus.name(),
+            commandCreatedThreshold,
+            currentStatuses.stream().map(Enum::name).collect(Collectors.toSet()),
+            jobCreatedThreshold
+        );
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImpl.java
@@ -693,6 +693,22 @@ public class JpaCommandPersistenceServiceImpl extends JpaBaseService implements 
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deleteUnusedCommands(final Set<CommandStatus> deleteStatuses, final Instant commandCreatedThreshold) {
+        log.info(
+            "Deleting commands with statuses {} that were created before {}",
+            deleteStatuses,
+            commandCreatedThreshold
+        );
+        return this.getCommandRepository().deleteUnused(
+            deleteStatuses.stream().map(Enum::name).collect(Collectors.toSet()),
+            commandCreatedThreshold
+        );
+    }
+
+    /**
      * Helper method to find a command entity.
      *
      * @param id The id of the command to find

--- a/genie-web/src/main/java/com/netflix/genie/web/events/JobFinishedSNSPublisher.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/events/JobFinishedSNSPublisher.java
@@ -26,6 +26,7 @@ import com.netflix.genie.common.external.dtos.v4.Command;
 import com.netflix.genie.common.external.dtos.v4.JobStatus;
 import com.netflix.genie.common.internal.dtos.v4.FinishedJob;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieInvalidStatusException;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.properties.SNSNotificationsProperties;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -100,21 +101,21 @@ public class JobFinishedSNSPublisher
     /**
      * Constructor.
      *
-     * @param snsClient             Amazon SNS client
-     * @param properties            configuration properties
-     * @param jobPersistenceService job persistence service
-     * @param registry              metrics registry
-     * @param mapper                object mapper
+     * @param snsClient    Amazon SNS client
+     * @param properties   configuration properties
+     * @param dataServices the {@link DataServices} instance to use
+     * @param registry     metrics registry
+     * @param mapper       object mapper
      */
     public JobFinishedSNSPublisher(
         final AmazonSNS snsClient,
         final SNSNotificationsProperties properties,
-        final JobPersistenceService jobPersistenceService,
+        final DataServices dataServices,
         final MeterRegistry registry,
         final ObjectMapper mapper
     ) {
         super(properties, registry, snsClient, mapper);
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/health/LocalAgentLauncherHealthIndicator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/health/LocalAgentLauncherHealthIndicator.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.health;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.LocalAgentLauncherProperties;
 import org.springframework.boot.actuate.health.Health;
@@ -51,16 +52,16 @@ public class LocalAgentLauncherHealthIndicator implements HealthIndicator {
     /**
      * Constructor.
      *
-     * @param jobSearchService   The {@link JobSearchService} implementation to use
+     * @param dataServices       The {@link DataServices} instance to use
      * @param launcherProperties The properties related to local agent launch
      * @param genieHostInfo      The {@link GenieHostInfo} object containing metadata about the current Genie host
      */
     public LocalAgentLauncherHealthIndicator(
-        final JobSearchService jobSearchService,
+        final DataServices dataServices,
         final LocalAgentLauncherProperties launcherProperties,
         final GenieHostInfo genieHostInfo
     ) {
-        this.jobSearchService = jobSearchService;
+        this.jobSearchService = dataServices.getJobSearchService();
         this.launcherProperties = launcherProperties;
         this.hostname = genieHostInfo.getHostname();
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/DatabaseCleanupProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/DatabaseCleanupProperties.java
@@ -44,13 +44,90 @@ public class DatabaseCleanupProperties {
      */
     public static final String ENABLED_PROPERTY = PROPERTY_PREFIX + ".enabled";
 
+    /**
+     * The cron expression for when the cleanup task should occur.
+     */
+    public static final String EXPRESSION_PROPERTY = PROPERTY_PREFIX + ".expression";
+
+    /**
+     * The number of days to retain jobs in the database.
+     */
+    public static final String JOB_RETENTION_PROPERTY = PROPERTY_PREFIX + ".retention";
+
+    /**
+     * The number of job records to delete from the database in a single transaction.
+     * Genie will loop and perform multiple transactions until all jobs older than the retention time are deleted.
+     */
+    public static final String MAX_DELETED_PER_TRANSACTION_PROPERTY = PROPERTY_PREFIX + ".maxDeletedPerTransaction";
+
+    /**
+     * The page size used within each cleanup transaction to iterate through the job records.
+     */
+    public static final String PAGE_SIZE_PROPERTY = PROPERTY_PREFIX + ".pageSize";
+
+    /**
+     * Skip the Jobs table when performing database cleanup.
+     */
+    public static final String SKIP_JOBS_PROPERTY = PROPERTY_PREFIX + ".skipJobsCleanup";
+
+    /**
+     * Skip the Clusters table when performing database cleanup.
+     */
+    public static final String SKIP_CLUSTERS_PROPERTY = PROPERTY_PREFIX + ".skipClustersCleanup";
+
+    /**
+     * Skip the Tags table when performing database cleanup.
+     */
+    public static final String SKIP_TAGS_PROPERTY = PROPERTY_PREFIX + ".skipTagsCleanup";
+
+    /**
+     * Skip the Files table when performing database cleanup.
+     */
+    public static final String SKIP_FILES_PROPERTY = PROPERTY_PREFIX + ".skipFilesCleanup";
+
+    /**
+     * The property key for whether this feature is enabled or not.
+     */
     private boolean enabled;
+
+    /**
+     * The cron expression for when the cleanup task should occur.
+     */
     private String expression = "0 0 0 * * *";
+
+    /**
+     * The number of days to retain jobs in the database.
+     */
     private int retention = 90;
+
+    /**
+     * The number of job records to delete from the database in a single transaction.
+     * Genie will loop and perform multiple transactions until all jobs older than the retention time are deleted.
+     */
     private int maxDeletedPerTransaction = 1_000;
+
+    /**
+     * The page size used within each cleanup transaction to iterate through the job records.
+     */
     private int pageSize = 1_000;
+
+    /**
+     * Skip the Jobs table when performing database cleanup.
+     */
     private boolean skipJobsCleanup;
+
+    /**
+     * Skip the Clusters table when performing database cleanup.
+     */
     private boolean skipClustersCleanup;
+
+    /**
+     * Skip the Tags table when performing database cleanup.
+     */
     private boolean skipTagsCleanup;
+
+    /**
+     * Skip the Files table when performing database cleanup.
+     */
     private boolean skipFilesCleanup;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/DatabaseCleanupProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/DatabaseCleanupProperties.java
@@ -22,6 +22,9 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 /**
  * Properties controlling the behavior of the database cleanup leadership task.
  *
@@ -66,26 +69,6 @@ public class DatabaseCleanupProperties {
     public static final String PAGE_SIZE_PROPERTY = PROPERTY_PREFIX + ".pageSize";
 
     /**
-     * Skip the Jobs table when performing database cleanup.
-     */
-    public static final String SKIP_JOBS_PROPERTY = PROPERTY_PREFIX + ".skipJobsCleanup";
-
-    /**
-     * Skip the Clusters table when performing database cleanup.
-     */
-    public static final String SKIP_CLUSTERS_PROPERTY = PROPERTY_PREFIX + ".skipClustersCleanup";
-
-    /**
-     * Skip the Tags table when performing database cleanup.
-     */
-    public static final String SKIP_TAGS_PROPERTY = PROPERTY_PREFIX + ".skipTagsCleanup";
-
-    /**
-     * Skip the Files table when performing database cleanup.
-     */
-    public static final String SKIP_FILES_PROPERTY = PROPERTY_PREFIX + ".skipFilesCleanup";
-
-    /**
      * The property key for whether this feature is enabled or not.
      */
     private boolean enabled;
@@ -93,7 +76,33 @@ public class DatabaseCleanupProperties {
     /**
      * The cron expression for when the cleanup task should occur.
      */
+    @NotBlank
     private String expression = "0 0 0 * * *";
+
+    /**
+     * Properties related to cleaning up cluster records from the database.
+     */
+    @NotNull
+    private ClusterDatabaseCleanupProperties clusterCleanup = new ClusterDatabaseCleanupProperties();
+
+    /**
+     * Properties related to cleaning up file records from the database.
+     */
+    @NotNull
+    private FileDatabaseCleanupProperties fileCleanup = new FileDatabaseCleanupProperties();
+
+    /**
+     * Properties related to cleaning up job records from the database.
+     */
+    @NotNull
+    private JobDatabaseCleanupProperties jobCleanup = new JobDatabaseCleanupProperties();
+
+    /**
+     * Properties related to cleaning up tag records from the database.
+     */
+    @NotNull
+    private TagDatabaseCleanupProperties tagCleanup = new TagDatabaseCleanupProperties();
+
 
     /**
      * The number of days to retain jobs in the database.
@@ -107,24 +116,145 @@ public class DatabaseCleanupProperties {
     private int maxDeletedPerTransaction = 1_000;
 
     /**
-     * The page size used within each cleanup transaction to iterate through the job records.
+     * Properties related to cleaning up cluster records from the database.
+     *
+     * @author tgianos
+     * @since 4.0.0
      */
-    private int pageSize = 1_000;
+    @Getter
+    @Setter
+    public static class ClusterDatabaseCleanupProperties {
+
+        /**
+         * The prefix for all properties related to cleaning up cluster records from the database.
+         */
+        public static final String CLUSTER_CLEANUP_PROPERTY_PREFIX
+            = DatabaseCleanupProperties.PROPERTY_PREFIX + ".cluster-cleanup";
+
+        /**
+         * Skip the Clusters table when performing database cleanup.
+         */
+        public static final String SKIP_PROPERTY = CLUSTER_CLEANUP_PROPERTY_PREFIX + ".skip";
+
+        /**
+         * Skip the Clusters table when performing database cleanup.
+         */
+        private boolean skip;
+    }
 
     /**
-     * Skip the Jobs table when performing database cleanup.
+     * Properties related to cleaning up file records from the database.
+     *
+     * @author tgianos
+     * @since 4.0.0
      */
-    private boolean skipJobsCleanup;
+    @Getter
+    @Setter
+    public static class FileDatabaseCleanupProperties {
+
+        /**
+         * The prefix for all properties related to cleaning up file records from the database.
+         */
+        public static final String FILE_CLEANUP_PROPERTY_PREFIX
+            = DatabaseCleanupProperties.PROPERTY_PREFIX + ".file-cleanup";
+
+        /**
+         * Skip the Files table when performing database cleanup.
+         */
+        public static final String SKIP_PROPERTY = FILE_CLEANUP_PROPERTY_PREFIX + ".skip";
+
+        /**
+         * Skip the Files table when performing database cleanup.
+         */
+        private boolean skip;
+    }
 
     /**
-     * Skip the Clusters table when performing database cleanup.
+     * Properties related to cleaning up job records from the database.
+     *
+     * @author tgianos
+     * @since 4.0.0
      */
-    private boolean skipClustersCleanup;
+    @Getter
+    @Setter
+    public static class JobDatabaseCleanupProperties {
+
+        /**
+         * The prefix for all properties related to cleaning up job records from the database.
+         */
+        public static final String JOB_CLEANUP_PROPERTY_PREFIX
+            = DatabaseCleanupProperties.PROPERTY_PREFIX + ".job-cleanup";
+
+        /**
+         * Skip the Jobs table when performing database cleanup.
+         */
+        public static final String SKIP_PROPERTY = JOB_CLEANUP_PROPERTY_PREFIX + ".skip";
+
+        /**
+         * The number of days to retain jobs in the database.
+         */
+        public static final String JOB_RETENTION_PROPERTY = JOB_CLEANUP_PROPERTY_PREFIX + ".retention";
+
+        /**
+         * The number of job records to delete from the database in a single transaction.
+         * Genie will loop and perform multiple transactions until all jobs older than the retention time are deleted.
+         */
+        public static final String MAX_DELETED_PER_TRANSACTION_PROPERTY
+            = JOB_CLEANUP_PROPERTY_PREFIX + ".maxDeletedPerTransaction";
+
+        /**
+         * The page size used within each cleanup transaction to iterate through the job records.
+         */
+        public static final String PAGE_SIZE_PROPERTY = JOB_CLEANUP_PROPERTY_PREFIX + ".pageSize";
+
+        /**
+         * Skip the Jobs table when performing database cleanup.
+         */
+        private boolean skip;
+
+        /**
+         * The number of days to retain jobs in the database.
+         */
+        private int retention = 90;
+
+        /**
+         * The number of job records to delete from the database in a single transaction.
+         * Genie will loop and perform multiple transactions until all jobs older than the retention time are deleted.
+         */
+        private int maxDeletedPerTransaction = 1_000;
+
+        /**
+         * The page size used within each cleanup transaction to iterate through the job records.
+         */
+        private int pageSize = 1_000;
+    }
 
     /**
-     * Skip the Tags table when performing database cleanup.
+     * Properties related to cleaning up tag records from the database.
+     *
+     * @author tgianos
+     * @since 4.0.0
      */
-    private boolean skipTagsCleanup;
+    @Getter
+    @Setter
+    public static class TagDatabaseCleanupProperties {
+
+        /**
+         * The prefix for all properties related to cleaning up tag records from the database.
+         */
+        public static final String TAG_CLEANUP_PROPERTY_PREFIX
+            = DatabaseCleanupProperties.PROPERTY_PREFIX + ".tag-cleanup";
+
+        /**
+         * Skip the Tags table when performing database cleanup.
+         */
+        public static final String SKIP_PROPERTY = TAG_CLEANUP_PROPERTY_PREFIX + ".skip";
+
+        /**
+         * Skip the Tags table when performing database cleanup.
+         */
+        private boolean skip;
+    }
 
     /**
      * Skip the Files table when performing database cleanup.

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/ZookeeperLeaderProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/ZookeeperLeaderProperties.java
@@ -28,11 +28,11 @@ import org.springframework.validation.annotation.Validated;
  * @author tgianos
  * @since 3.1.0
  */
-@ConfigurationProperties(prefix = ZookeeperLeadershipProperties.PROPERTY_PREFIX)
+@ConfigurationProperties(prefix = ZookeeperLeaderProperties.PROPERTY_PREFIX)
 @Getter
 @Setter
 @Validated
-public class ZookeeperLeadershipProperties {
+public class ZookeeperLeaderProperties {
 
     /**
      * The property prefix for this group.

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/ArchivedJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/ArchivedJobServiceImpl.java
@@ -24,6 +24,7 @@ import com.netflix.genie.common.external.util.GenieObjectMapper;
 import com.netflix.genie.common.internal.dtos.DirectoryManifest;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieRuntimeException;
 import com.netflix.genie.common.internal.services.JobArchiveService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.dtos.ArchivedJobMetadata;
 import com.netflix.genie.web.exceptions.checked.JobDirectoryManifestNotFoundException;
@@ -75,16 +76,16 @@ public class ArchivedJobServiceImpl implements ArchivedJobService {
     /**
      * Constructor.
      *
-     * @param jobPersistenceService The {@link JobPersistenceService} implementation to use
-     * @param resourceLoader        The {@link ResourceLoader} used to get resources
-     * @param meterRegistry         The {@link MeterRegistry} used to collect metrics
+     * @param dataServices   The {@link DataServices} instance to use
+     * @param resourceLoader The {@link ResourceLoader} used to get resources
+     * @param meterRegistry  The {@link MeterRegistry} used to collect metrics
      */
     public ArchivedJobServiceImpl(
-        final JobPersistenceService jobPersistenceService,
+        final DataServices dataServices,
         final ResourceLoader resourceLoader,
         final MeterRegistry meterRegistry
     ) {
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
         this.resourceLoader = resourceLoader;
         this.meterRegistry = meterRegistry;
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -40,6 +40,7 @@ import com.netflix.genie.common.internal.jobs.JobConstants;
 import com.netflix.genie.web.data.services.ApplicationPersistenceService;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
 import com.netflix.genie.web.data.services.CommandPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.JobsActiveLimitProperties;
@@ -95,39 +96,31 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
     /**
      * Constructor.
      *
-     * @param jobPersistenceService         implementation of job persistence service interface
-     * @param jobKillService                The job kill service to use
-     * @param jobStateService               The service where we report the job state and keep track of
-     *                                      various metrics about jobs currently running
-     * @param jobsProperties                The jobs properties to use
-     * @param applicationPersistenceService Implementation of application service interface
-     * @param jobSearchService              Implementation of job search service
-     * @param clusterPersistenceService     Implementation of cluster service interface
-     * @param commandPersistenceService     Implementation of command service interface
-     * @param jobResolverService            The job specification service to use
-     * @param registry                      The registry
-     * @param hostname                      The name of the host this Genie instance is running on
+     * @param dataServices       The {@link DataServices} encapsulation to use
+     * @param jobKillService     The job kill service to use
+     * @param jobStateService    The service where we report the job state and keep track of
+     *                           various metrics about jobs currently running
+     * @param jobsProperties     The jobs properties to use
+     * @param jobResolverService The job specification service to use
+     * @param registry           The registry
+     * @param hostname           The name of the host this Genie instance is running on
      */
     public JobCoordinatorServiceImpl(
-        @NotNull final JobPersistenceService jobPersistenceService,
+        @NotNull final DataServices dataServices,
         @NotNull final JobKillService jobKillService,
         @NotNull final JobStateService jobStateService,
         @NotNull final JobsProperties jobsProperties,
-        @NotNull final ApplicationPersistenceService applicationPersistenceService,
-        @NotNull final JobSearchService jobSearchService,
-        @NotNull final ClusterPersistenceService clusterPersistenceService,
-        @NotNull final CommandPersistenceService commandPersistenceService,
         @NotNull final JobResolverService jobResolverService,
         @NotNull final MeterRegistry registry,
         @NotBlank final String hostname
     ) {
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
         this.jobKillService = jobKillService;
         this.jobStateService = jobStateService;
-        this.applicationPersistenceService = applicationPersistenceService;
-        this.jobSearchService = jobSearchService;
-        this.clusterPersistenceService = clusterPersistenceService;
-        this.commandPersistenceService = commandPersistenceService;
+        this.applicationPersistenceService = dataServices.getApplicationPersistenceService();
+        this.jobSearchService = dataServices.getJobSearchService();
+        this.clusterPersistenceService = dataServices.getClusterPersistenceService();
+        this.commandPersistenceService = dataServices.getCommandPersistenceService();
         this.jobResolverService = jobResolverService;
         this.jobsProperties = jobsProperties;
         this.hostname = hostname;

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
@@ -30,6 +30,7 @@ import com.netflix.genie.common.internal.dtos.DirectoryManifest;
 import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorService;
 import com.netflix.genie.web.agent.resources.AgentFileProtocolResolver;
 import com.netflix.genie.web.agent.services.AgentFileStreamService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.dtos.ArchivedJobMetadata;
 import com.netflix.genie.web.exceptions.checked.JobDirectoryManifestNotFoundException;
@@ -86,7 +87,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
      * Constructor.
      *
      * @param resourceLoader                     The application resource loader used to get references to resources
-     * @param jobPersistenceService              The job persistence service used to get information about a job
+     * @param dataServices                       The {@link DataServices} instance to use
      * @param agentFileStreamService             The service providing file manifest for active agent jobs
      * @param archivedJobService                 The {@link ArchivedJobService} implementation to use to get archived
      *                                           job data
@@ -96,7 +97,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
      */
     public JobDirectoryServerServiceImpl(
         final ResourceLoader resourceLoader,
-        final JobPersistenceService jobPersistenceService,
+        final DataServices dataServices,
         final AgentFileStreamService agentFileStreamService,
         final ArchivedJobService archivedJobService,
         final MeterRegistry meterRegistry,
@@ -105,7 +106,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
     ) {
         this(
             resourceLoader,
-            jobPersistenceService,
+            dataServices,
             agentFileStreamService,
             archivedJobService,
             new GenieResourceHandler.Factory(),
@@ -121,7 +122,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
     @VisibleForTesting
     JobDirectoryServerServiceImpl(
         final ResourceLoader resourceLoader,
-        final JobPersistenceService jobPersistenceService,
+        final DataServices dataServices,
         final AgentFileStreamService agentFileStreamService,
         final ArchivedJobService archivedJobService,
         final GenieResourceHandler.Factory genieResourceHandlerFactory,
@@ -130,7 +131,7 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
         final JobDirectoryManifestCreatorService jobDirectoryManifestCreatorService
     ) {
         this.resourceLoader = resourceLoader;
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
         this.jobFileService = jobFileService;
         this.agentFileStreamService = agentFileStreamService;
         this.meterRegistry = meterRegistry;

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobKillServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobKillServiceImpl.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.services.impl;
 
 import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.services.JobKillService;
 import com.netflix.genie.web.services.JobKillServiceV4;
@@ -43,19 +44,18 @@ public class JobKillServiceImpl implements JobKillService {
     /**
      * Constructor.
      *
-     * @param jobKillServiceV3      Service to kill V3 jobs.
-     * @param jobKillServiceV4      Service to kill V4 jobs.
-     * @param jobPersistenceService Job persistence service
+     * @param jobKillServiceV3 Service to kill V3 jobs.
+     * @param jobKillServiceV4 Service to kill V4 jobs.
+     * @param dataServices     The {@link DataServices} instance to use
      */
     public JobKillServiceImpl(
         final JobKillServiceV3 jobKillServiceV3,
         final JobKillServiceV4 jobKillServiceV4,
-        final JobPersistenceService jobPersistenceService
-
+        final DataServices dataServices
     ) {
         this.jobKillServiceV3 = jobKillServiceV3;
         this.jobKillServiceV4 = jobKillServiceV4;
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobKillServiceV3.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobKillServiceV3.java
@@ -25,6 +25,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.internal.jobs.JobConstants;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.events.JobFinishedEvent;
@@ -69,7 +70,7 @@ public class JobKillServiceV3 {
      * Constructor.
      *
      * @param hostname              The name of the host this Genie node is running on
-     * @param jobSearchService      The job search service to use to locate job information
+     * @param dataServices          The {@link DataServices} instance to use
      * @param executor              The executor to use to run system processes
      * @param runAsUser             True if jobs are run as the user who submitted the job
      * @param genieEventBus         The system event bus to use
@@ -79,7 +80,7 @@ public class JobKillServiceV3 {
      */
     public JobKillServiceV3(
         @NotBlank final String hostname,
-        @NotNull final JobSearchService jobSearchService,
+        @NotNull final DataServices dataServices,
         @NotNull final Executor executor,
         final boolean runAsUser,
         @NotNull final GenieEventBus genieEventBus,
@@ -88,7 +89,7 @@ public class JobKillServiceV3 {
         @NotNull final ProcessChecker.Factory processCheckerFactory
     ) {
         this.hostname = hostname;
-        this.jobSearchService = jobSearchService;
+        this.jobSearchService = dataServices.getJobSearchService();
         this.executor = executor;
         this.runAsUser = runAsUser;
         this.genieEventBus = genieEventBus;

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import com.netflix.genie.common.external.dtos.v4.JobStatus;
 import com.netflix.genie.common.internal.exceptions.checked.GenieJobResolutionException;
 import com.netflix.genie.web.agent.launchers.AgentLauncher;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.dtos.JobSubmission;
 import com.netflix.genie.web.dtos.ResolvedJob;
@@ -58,18 +59,18 @@ public class JobLaunchServiceImpl implements JobLaunchService {
     /**
      * Constructor.
      *
-     * @param jobPersistenceService {@link JobPersistenceService} implementation to save job data
-     * @param jobResolverService    {@link JobResolverService} implementation used to resolve job details
-     * @param agentLauncher         {@link AgentLauncher} implementation to launch agents
-     * @param registry              {@link MeterRegistry} metrics repository
+     * @param dataServices       The {@link DataServices} instance to use
+     * @param jobResolverService {@link JobResolverService} implementation used to resolve job details
+     * @param agentLauncher      {@link AgentLauncher} implementation to launch agents
+     * @param registry           {@link MeterRegistry} metrics repository
      */
     public JobLaunchServiceImpl(
-        final JobPersistenceService jobPersistenceService,
+        final DataServices dataServices,
         final JobResolverService jobResolverService,
         final AgentLauncher agentLauncher,
         final MeterRegistry registry
     ) {
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
         this.jobResolverService = jobResolverService;
         this.agentLauncher = agentLauncher;
         this.registry = registry;

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobMetricsServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobMetricsServiceImpl.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.services.impl;
 
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.services.JobMetricsService;
 
@@ -37,11 +38,11 @@ public class JobMetricsServiceImpl implements JobMetricsService {
     /**
      * Constructor.
      *
-     * @param jobSearchService The job search service to use.
-     * @param hostname         The name of this host
+     * @param dataServices The {@link DataServices} instance to use.
+     * @param hostname     The name of this host
      */
-    public JobMetricsServiceImpl(@NotNull final JobSearchService jobSearchService, @NotNull final String hostname) {
-        this.jobSearchService = jobSearchService;
+    public JobMetricsServiceImpl(@NotNull final DataServices dataServices, @NotNull final String hostname) {
+        this.jobSearchService = dataServices.getJobSearchService();
         this.hostname = hostname;
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
@@ -40,6 +40,7 @@ import com.netflix.genie.common.internal.jobs.JobConstants;
 import com.netflix.genie.web.data.services.ApplicationPersistenceService;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
 import com.netflix.genie.web.data.services.CommandPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.dtos.ResourceSelectionResult;
@@ -195,31 +196,25 @@ public class JobResolverServiceImpl implements JobResolverService {
     /**
      * Constructor.
      *
-     * @param applicationPersistenceService The {@link ApplicationPersistenceService} to use to manipulate applications
-     * @param clusterPersistenceService     The {@link ClusterPersistenceService} to use to manipulate clusters
-     * @param commandPersistenceService     The {@link CommandPersistenceService} to use to manipulate commands
-     * @param jobPersistenceService         The {@link JobPersistenceService} instance to use
-     * @param clusterSelectors              The {@link ClusterSelector} implementations to use
-     * @param commandSelector               The {@link CommandSelector} implementation to use
-     * @param registry                      The {@link MeterRegistry }metrics repository to use
-     * @param jobsProperties                The properties for running a job set by the user
-     * @param environment                   The Spring application {@link Environment} for dynamic property resolution
+     * @param dataServices     The {@link DataServices} encapsulation instance to use
+     * @param clusterSelectors The {@link ClusterSelector} implementations to use
+     * @param commandSelector  The {@link CommandSelector} implementation to use
+     * @param registry         The {@link MeterRegistry }metrics repository to use
+     * @param jobsProperties   The properties for running a job set by the user
+     * @param environment      The Spring application {@link Environment} for dynamic property resolution
      */
     public JobResolverServiceImpl(
-        final ApplicationPersistenceService applicationPersistenceService,
-        final ClusterPersistenceService clusterPersistenceService,
-        final CommandPersistenceService commandPersistenceService,
-        final JobPersistenceService jobPersistenceService,
+        final DataServices dataServices,
         @NotEmpty final List<ClusterSelector> clusterSelectors,
         final CommandSelector commandSelector, // TODO: For now this is a single value but maybe support List
         final MeterRegistry registry,
         final JobsProperties jobsProperties,
         final Environment environment
     ) {
-        this.applicationPersistenceService = applicationPersistenceService;
-        this.clusterPersistenceService = clusterPersistenceService;
-        this.commandPersistenceService = commandPersistenceService;
-        this.jobPersistenceService = jobPersistenceService;
+        this.applicationPersistenceService = dataServices.getApplicationPersistenceService();
+        this.clusterPersistenceService = dataServices.getClusterPersistenceService();
+        this.commandPersistenceService = dataServices.getCommandPersistenceService();
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
         this.clusterSelectors = clusterSelectors;
         this.commandSelector = commandSelector;
         this.defaultMemory = jobsProperties.getMemory().getDefaultJobMemory();

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/LocalJobRunner.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/LocalJobRunner.java
@@ -27,6 +27,7 @@ import com.netflix.genie.common.external.dtos.v4.Application;
 import com.netflix.genie.common.external.dtos.v4.Cluster;
 import com.netflix.genie.common.external.dtos.v4.Command;
 import com.netflix.genie.common.internal.jobs.JobConstants;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.events.JobFinishedEvent;
@@ -83,20 +84,20 @@ public class LocalJobRunner implements JobSubmitterService {
     /**
      * Constructor create the object.
      *
-     * @param jobPersistenceService Implementation of the job persistence service
-     * @param genieEventBus         The event bus implementation to use
-     * @param workflowTasks         List of all the workflow tasks to be executed
-     * @param genieWorkingDir       Working directory for genie where it creates jobs directories
-     * @param registry              The metrics registry to use
+     * @param dataServices    The {@link DataServices} instance to use
+     * @param genieEventBus   The event bus implementation to use
+     * @param workflowTasks   List of all the workflow tasks to be executed
+     * @param genieWorkingDir Working directory for genie where it creates jobs directories
+     * @param registry        The metrics registry to use
      */
     public LocalJobRunner(
-        @NotNull final JobPersistenceService jobPersistenceService,
+        @NotNull final DataServices dataServices,
         @NonNull final GenieEventBus genieEventBus,
         @NotNull final List<WorkflowTask> workflowTasks,
         @NotNull final Resource genieWorkingDir,
         @NotNull final MeterRegistry registry
     ) {
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
         this.genieEventBus = genieEventBus;
         this.jobWorkflowTasks = workflowTasks;
         this.baseWorkingDirPath = genieWorkingDir;

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/apis/rpc/v4/endpoints/AgentRpcEndpointsAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/apis/rpc/v4/endpoints/AgentRpcEndpointsAutoConfiguration.java
@@ -33,7 +33,7 @@ import com.netflix.genie.web.agent.apis.rpc.v4.endpoints.GRpcPingServiceImpl;
 import com.netflix.genie.web.agent.apis.rpc.v4.endpoints.JobServiceProtoErrorComposer;
 import com.netflix.genie.web.agent.services.AgentJobService;
 import com.netflix.genie.web.agent.services.AgentRoutingService;
-import com.netflix.genie.web.data.services.JobSearchService;
+import com.netflix.genie.web.data.services.DataServices;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -104,7 +104,7 @@ public class AgentRpcEndpointsAutoConfiguration {
      *
      * @param agentRoutingService The {@link AgentRoutingService} implementation to use
      * @param taskScheduler       The {@link TaskScheduler} instance to use
-     * @param registry      The meter registry
+     * @param registry            The meter registry
      * @return A {@link GRpcHeartBeatServiceImpl} instance
      */
     @Bean
@@ -121,13 +121,13 @@ public class AgentRpcEndpointsAutoConfiguration {
      * Provide an implementation of {@link com.netflix.genie.proto.JobKillServiceGrpc.JobKillServiceImplBase}
      * if no other is provided.
      *
-     * @param jobSearchService The {@link JobSearchService} instance to use
+     * @param dataServices The {@link DataServices} instance to use
      * @return A {@link GRpcJobKillServiceImpl} instance
      */
     @Bean
     @ConditionalOnMissingBean(JobKillServiceGrpc.JobKillServiceImplBase.class)
-    public GRpcJobKillServiceImpl gRpcJobKillService(final JobSearchService jobSearchService) {
-        return new GRpcJobKillServiceImpl(jobSearchService);
+    public GRpcJobKillServiceImpl gRpcJobKillService(final DataServices dataServices) {
+        return new GRpcJobKillServiceImpl(dataServices);
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/launchers/AgentLaunchersAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/launchers/AgentLaunchersAutoConfiguration.java
@@ -19,7 +19,7 @@ package com.netflix.genie.web.spring.autoconfigure.agent.launchers;
 
 import com.netflix.genie.web.agent.launchers.AgentLauncher;
 import com.netflix.genie.web.agent.launchers.impl.LocalAgentLauncherImpl;
-import com.netflix.genie.web.data.services.JobSearchService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.introspection.GenieWebHostInfo;
 import com.netflix.genie.web.introspection.GenieWebRpcInfo;
 import com.netflix.genie.web.properties.LocalAgentLauncherProperties;
@@ -61,7 +61,7 @@ public class AgentLaunchersAutoConfiguration {
      *
      * @param genieWebHostInfo   The {@link GenieWebHostInfo} of this instance
      * @param genieWebRpcInfo    The {@link GenieWebRpcInfo} of this instance
-     * @param jobSearchService   The {@link JobSearchService} instance to use
+     * @param dataServices       The {@link DataServices} instance to use
      * @param launcherProperties The properties related to launching an agent locally
      * @param executorFactory    The {@link ExecutorFactory} to use to launch agent processes
      * @param registry           The {@link MeterRegistry} to register metrics
@@ -72,7 +72,7 @@ public class AgentLaunchersAutoConfiguration {
     public LocalAgentLauncherImpl localAgentLauncher(
         final GenieWebHostInfo genieWebHostInfo,
         final GenieWebRpcInfo genieWebRpcInfo,
-        final JobSearchService jobSearchService,
+        final DataServices dataServices,
         final LocalAgentLauncherProperties launcherProperties,
         final ExecutorFactory executorFactory,
         final MeterRegistry registry
@@ -80,7 +80,7 @@ public class AgentLaunchersAutoConfiguration {
         return new LocalAgentLauncherImpl(
             genieWebHostInfo,
             genieWebRpcInfo,
-            jobSearchService,
+            dataServices,
             launcherProperties,
             executorFactory,
             registry

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfiguration.java
@@ -28,7 +28,7 @@ import com.netflix.genie.web.agent.services.impl.AgentJobServiceImpl;
 import com.netflix.genie.web.agent.services.impl.AgentMetricsServiceImpl;
 import com.netflix.genie.web.agent.services.impl.AgentRoutingServiceImpl;
 import com.netflix.genie.web.data.services.AgentConnectionPersistenceService;
-import com.netflix.genie.web.data.services.JobPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.services.JobResolverService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -48,22 +48,22 @@ public class AgentServicesAutoConfiguration {
     /**
      * Get a {@link AgentJobService} instance if there isn't already one.
      *
-     * @param jobPersistenceService The persistence service to use
-     * @param jobResolverService    The specification service to use
-     * @param agentFilterService    The agent filter service to use
-     * @param meterRegistry         The metrics registry to use
+     * @param dataServices       The {@link DataServices} instance to use
+     * @param jobResolverService The specification service to use
+     * @param agentFilterService The agent filter service to use
+     * @param meterRegistry      The metrics registry to use
      * @return An {@link AgentJobServiceImpl} instance.
      */
     @Bean
     @ConditionalOnMissingBean(AgentJobService.class)
     public AgentJobServiceImpl agentJobService(
-        final JobPersistenceService jobPersistenceService,
+        final DataServices dataServices,
         final JobResolverService jobResolverService,
         final AgentFilterService agentFilterService,
         final MeterRegistry meterRegistry
     ) {
         return new AgentJobServiceImpl(
-            jobPersistenceService,
+            dataServices,
             jobResolverService,
             agentFilterService,
             meterRegistry

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/data/DataAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/data/DataAutoConfiguration.java
@@ -29,6 +29,7 @@ import com.netflix.genie.web.data.services.AgentConnectionPersistenceService;
 import com.netflix.genie.web.data.services.ApplicationPersistenceService;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
 import com.netflix.genie.web.data.services.CommandPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.FilePersistenceService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
@@ -249,5 +250,42 @@ public class DataAutoConfiguration {
         final JpaAgentConnectionRepository jpaAgentConnectionRepository
     ) {
         return new JpaAgentConnectionPersistenceServiceImpl(jpaAgentConnectionRepository);
+    }
+
+    /**
+     * Provide a {@link DataServices} instance if one isn't already in the context.
+     *
+     * @param agentConnectionPersistenceService The {@link AgentConnectionPersistenceService} implementation to use
+     * @param applicationPersistenceService     The {@link ApplicationPersistenceService} implementation to use
+     * @param clusterPersistenceService         The {@link ClusterPersistenceService} implementation to use
+     * @param commandPersistenceService         The {@link CommandPersistenceService} implementation to use
+     * @param filePersistenceService            The {@link FilePersistenceService} implementation to use
+     * @param jobPersistenceService             The {@link JobPersistenceService} implementation to use
+     * @param jobSearchService                  The {@link JobSearchService} implementation to use
+     * @param tagPersistenceService             The {@link TagPersistenceService} implementation to use
+     * @return A {@link DataServices} instance
+     */
+    @Bean
+    @ConditionalOnMissingBean(DataServices.class)
+    public DataServices genieDataServices(
+        final AgentConnectionPersistenceService agentConnectionPersistenceService,
+        final ApplicationPersistenceService applicationPersistenceService,
+        final ClusterPersistenceService clusterPersistenceService,
+        final CommandPersistenceService commandPersistenceService,
+        final FilePersistenceService filePersistenceService,
+        final JobPersistenceService jobPersistenceService,
+        final JobSearchService jobSearchService,
+        final TagPersistenceService tagPersistenceService
+    ) {
+        return new DataServices(
+            agentConnectionPersistenceService,
+            applicationPersistenceService,
+            clusterPersistenceService,
+            commandPersistenceService,
+            filePersistenceService,
+            jobPersistenceService,
+            jobSearchService,
+            tagPersistenceService
+        );
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/events/NotificationsAutoConfiguration.java
@@ -21,7 +21,7 @@ import com.amazonaws.services.sns.AmazonSNS;
 import com.netflix.genie.common.external.util.GenieObjectMapper;
 import com.netflix.genie.web.data.observers.PersistedJobStatusObserver;
 import com.netflix.genie.web.data.observers.PersistedJobStatusObserverImpl;
-import com.netflix.genie.web.data.services.JobPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.events.JobFinishedSNSPublisher;
 import com.netflix.genie.web.events.JobNotificationMetricPublisher;
@@ -104,10 +104,10 @@ public class NotificationsAutoConfiguration {
     /**
      * Create a {@link JobFinishedSNSPublisher} unless one exists in the context already.
      *
-     * @param properties            configuration properties
-     * @param registry              the metrics registry
-     * @param snsClient             the Amazon SNS client
-     * @param jobPersistenceService the job persistence service
+     * @param properties   configuration properties
+     * @param registry     the metrics registry
+     * @param snsClient    the Amazon SNS client
+     * @param dataServices The {@link DataServices} instance to use
      * @return a {@link JobFinishedSNSPublisher}
      */
     @Bean
@@ -117,12 +117,12 @@ public class NotificationsAutoConfiguration {
         final SNSNotificationsProperties properties,
         final MeterRegistry registry,
         final AmazonSNS snsClient,
-        final JobPersistenceService jobPersistenceService
+        final DataServices dataServices
     ) {
         return new JobFinishedSNSPublisher(
             snsClient,
             properties,
-            jobPersistenceService,
+            dataServices,
             registry,
             GenieObjectMapper.getMapper()
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/health/HealthAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/health/HealthAutoConfiguration.java
@@ -20,7 +20,7 @@ package com.netflix.genie.web.spring.autoconfigure.health;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.web.agent.launchers.impl.LocalAgentLauncherImpl;
 import com.netflix.genie.web.agent.services.AgentMetricsService;
-import com.netflix.genie.web.data.services.JobSearchService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.health.GenieAgentHealthIndicator;
 import com.netflix.genie.web.health.GenieMemoryHealthIndicator;
 import com.netflix.genie.web.health.LocalAgentLauncherHealthIndicator;
@@ -80,7 +80,7 @@ public class HealthAutoConfiguration {
     /**
      * Provide a health indicator tied to the ability to launch jobs with agents on the local hardware.
      *
-     * @param jobSearchService   The {@link JobSearchService} implementation to use
+     * @param dataServices       The {@link DataServices} instance to use
      * @param launcherProperties The properties related to launching agent jobs locally
      * @param genieHostInfo      The {@link GenieHostInfo} to use
      * @return A {@link LocalAgentLauncherHealthIndicator} instance
@@ -94,10 +94,10 @@ public class HealthAutoConfiguration {
         }
     )
     public LocalAgentLauncherHealthIndicator localAgentLauncherHealthIndicator(
-        final JobSearchService jobSearchService,
+        final DataServices dataServices,
         final LocalAgentLauncherProperties launcherProperties,
         final GenieHostInfo genieHostInfo
     ) {
-        return new LocalAgentLauncherHealthIndicator(jobSearchService, launcherProperties, genieHostInfo);
+        return new LocalAgentLauncherHealthIndicator(dataServices, launcherProperties, genieHostInfo);
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfiguration.java
@@ -25,13 +25,13 @@ import com.netflix.genie.web.properties.ClusterCheckerProperties;
 import com.netflix.genie.web.properties.DatabaseCleanupProperties;
 import com.netflix.genie.web.properties.LeadershipProperties;
 import com.netflix.genie.web.properties.UserMetricsProperties;
-import com.netflix.genie.web.properties.ZookeeperLeadershipProperties;
+import com.netflix.genie.web.properties.ZookeeperLeaderProperties;
 import com.netflix.genie.web.spring.autoconfigure.tasks.TasksAutoConfiguration;
 import com.netflix.genie.web.tasks.leader.AgentJobCleanupTask;
 import com.netflix.genie.web.tasks.leader.ClusterCheckerTask;
 import com.netflix.genie.web.tasks.leader.DatabaseCleanupTask;
-import com.netflix.genie.web.tasks.leader.LeadershipTask;
-import com.netflix.genie.web.tasks.leader.LeadershipTasksCoordinator;
+import com.netflix.genie.web.tasks.leader.LeaderTask;
+import com.netflix.genie.web.tasks.leader.LeaderTasksCoordinator;
 import com.netflix.genie.web.tasks.leader.LocalLeader;
 import com.netflix.genie.web.tasks.leader.UserMetricsTask;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -66,7 +66,7 @@ import java.util.Set;
         DatabaseCleanupProperties.class,
         LeadershipProperties.class,
         UserMetricsProperties.class,
-        ZookeeperLeadershipProperties.class
+        ZookeeperLeaderProperties.class
     }
 )
 @AutoConfigureAfter(
@@ -86,12 +86,12 @@ public class LeaderAutoConfiguration {
      * @return The leader coordinator
      */
     @Bean
-    @ConditionalOnMissingBean(LeadershipTasksCoordinator.class)
-    public LeadershipTasksCoordinator leadershipTasksCoordinator(
+    @ConditionalOnMissingBean(LeaderTasksCoordinator.class)
+    public LeaderTasksCoordinator leaderTasksCoordinator(
         @Qualifier("genieTaskScheduler") final TaskScheduler taskScheduler,
-        final Set<LeadershipTask> tasks
+        final Set<LeaderTask> tasks
     ) {
-        return new LeadershipTasksCoordinator(taskScheduler, tasks);
+        return new LeaderTasksCoordinator(taskScheduler, tasks);
     }
 
     /**
@@ -99,7 +99,7 @@ public class LeaderAutoConfiguration {
      * process within this node for the cluster if Zookeeper is configured.
      *
      * @param client                        The curator framework client to use
-     * @param zookeeperLeadershipProperties The Zookeeper properties to use
+     * @param zookeeperLeaderProperties The Zookeeper properties to use
      * @return The factory bean
      */
     @Bean
@@ -107,11 +107,11 @@ public class LeaderAutoConfiguration {
     @ConditionalOnMissingBean(LeaderInitiatorFactoryBean.class)
     public LeaderInitiatorFactoryBean leaderInitiatorFactory(
         final CuratorFramework client,
-        final ZookeeperLeadershipProperties zookeeperLeadershipProperties
+        final ZookeeperLeaderProperties zookeeperLeaderProperties
     ) {
         final LeaderInitiatorFactoryBean factoryBean = new LeaderInitiatorFactoryBean();
         factoryBean.setClient(client);
-        factoryBean.setPath(zookeeperLeadershipProperties.getPath());
+        factoryBean.setPath(zookeeperLeaderProperties.getPath());
         factoryBean.setRole("cluster");
         return factoryBean;
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfiguration.java
@@ -46,6 +46,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.zookeeper.ZookeeperAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.integration.zookeeper.config.LeaderInitiatorFactoryBean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.client.RestTemplate;
@@ -98,7 +99,7 @@ public class LeaderAutoConfiguration {
      * The leadership initialization factory bean which will create a LeaderInitiator to kick off the leader election
      * process within this node for the cluster if Zookeeper is configured.
      *
-     * @param client                        The curator framework client to use
+     * @param client                    The curator framework client to use
      * @param zookeeperLeaderProperties The Zookeeper properties to use
      * @return The factory bean
      */
@@ -173,6 +174,7 @@ public class LeaderAutoConfiguration {
      * Create a {@link DatabaseCleanupTask} if one is required.
      *
      * @param cleanupProperties The properties to use to configure this task
+     * @param environment       The application {@link Environment} to pull properties from
      * @param dataServices      The {@link DataServices} encapsulation instance to use
      * @param registry          The metrics registry
      * @return The {@link DatabaseCleanupTask} instance to use if the conditions match
@@ -182,11 +184,13 @@ public class LeaderAutoConfiguration {
     @ConditionalOnMissingBean(DatabaseCleanupTask.class)
     public DatabaseCleanupTask databaseCleanupTask(
         final DatabaseCleanupProperties cleanupProperties,
+        final Environment environment,
         final DataServices dataServices,
         final MeterRegistry registry
     ) {
         return new DatabaseCleanupTask(
             cleanupProperties,
+            environment,
             dataServices,
             registry
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/node/NodeAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/node/NodeAutoConfiguration.java
@@ -17,7 +17,7 @@
  */
 package com.netflix.genie.web.spring.autoconfigure.tasks.node;
 
-import com.netflix.genie.web.data.services.JobSearchService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.properties.DiskCleanupProperties;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.tasks.node.DiskCleanupTask;
@@ -51,13 +51,13 @@ public class NodeAutoConfiguration {
     /**
      * If required get a {@link DiskCleanupTask} instance for use.
      *
-     * @param properties       The disk cleanup properties to use.
-     * @param scheduler        The scheduler to use to schedule the cron trigger.
-     * @param jobsDir          The resource representing the location of the job directory
-     * @param jobSearchService The service to find jobs with
-     * @param jobsProperties   The jobs properties to use
-     * @param processExecutor  The process executor to use to delete directories
-     * @param registry         The metrics registry
+     * @param properties      The disk cleanup properties to use.
+     * @param scheduler       The scheduler to use to schedule the cron trigger.
+     * @param jobsDir         The resource representing the location of the job directory
+     * @param dataServices    The {@link DataServices} instance to use
+     * @param jobsProperties  The jobs properties to use
+     * @param processExecutor The process executor to use to delete directories
+     * @param registry        The metrics registry
      * @return The {@link DiskCleanupTask} instance
      * @throws IOException When it is unable to open a file reference to the job directory
      */
@@ -68,7 +68,7 @@ public class NodeAutoConfiguration {
         final DiskCleanupProperties properties,
         @Qualifier("genieTaskScheduler") final TaskScheduler scheduler,
         @Qualifier("jobsDir") final Resource jobsDir,
-        final JobSearchService jobSearchService,
+        final DataServices dataServices,
         final JobsProperties jobsProperties,
         final Executor processExecutor,
         final MeterRegistry registry
@@ -77,7 +77,7 @@ public class NodeAutoConfiguration {
             properties,
             scheduler,
             jobsDir,
-            jobSearchService,
+            dataServices,
             jobsProperties,
             processExecutor,
             registry

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobCompletionService.java
@@ -32,6 +32,7 @@ import com.netflix.genie.common.external.util.GenieObjectMapper;
 import com.netflix.genie.common.internal.exceptions.checked.JobArchiveException;
 import com.netflix.genie.common.internal.jobs.JobConstants;
 import com.netflix.genie.common.internal.services.JobArchiveService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.events.JobFinishedEvent;
@@ -98,19 +99,17 @@ public class JobCompletionService {
     /**
      * Constructor.
      *
-     * @param jobSearchService      An implementation of the job search service.
-     * @param jobPersistenceService An implementation of the job persistence service.
-     * @param jobArchiveService     An implementation of {@link JobArchiveService}
-     * @param genieWorkingDir       The working directory where all job directories are created.
-     * @param mailServiceImpl       An implementation of the mail service.
-     * @param registry              The metrics registry to use
-     * @param jobsProperties        The properties relating to running jobs
-     * @param retryTemplate         Retry template for retrying remote calls
+     * @param dataServices      The {@link DataServices} instance to use
+     * @param jobArchiveService An implementation of {@link JobArchiveService}
+     * @param genieWorkingDir   The working directory where all job directories are created.
+     * @param mailServiceImpl   An implementation of the mail service.
+     * @param registry          The metrics registry to use
+     * @param jobsProperties    The properties relating to running jobs
+     * @param retryTemplate     Retry template for retrying remote calls
      * @throws GenieException if there is a problem
      */
     public JobCompletionService(
-        final JobPersistenceService jobPersistenceService,
-        final JobSearchService jobSearchService,
+        final DataServices dataServices,
         final JobArchiveService jobArchiveService,
         final Resource genieWorkingDir,
         final MailService mailServiceImpl,
@@ -118,8 +117,8 @@ public class JobCompletionService {
         final JobsProperties jobsProperties,
         @NotNull final RetryTemplate retryTemplate
     ) throws GenieException {
-        this.jobPersistenceService = jobPersistenceService;
-        this.jobSearchService = jobSearchService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
+        this.jobSearchService = dataServices.getJobSearchService();
         this.jobArchiveService = jobArchiveService;
         this.mailServiceImpl = mailServiceImpl;
         this.deleteDependencies = jobsProperties.getCleanup().isDeleteDependencies();

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinator.java
@@ -25,6 +25,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.internal.jobs.JobConstants;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.events.JobFinishedEvent;
@@ -76,7 +77,7 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
      * Constructor.
      *
      * @param genieHostInfo         Information about the host the Genie process is currently running on
-     * @param jobSearchService      The search service to use to find jobs
+     * @param dataServices          The {@link DataServices} instance to use
      * @param genieEventBus         The Genie event bus to use for publishing events
      * @param scheduler             The task scheduler to use to register scheduling of job checkers
      * @param registry              The metrics registry
@@ -89,7 +90,7 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
     @Autowired
     public JobMonitoringCoordinator(
         final GenieHostInfo genieHostInfo,
-        final JobSearchService jobSearchService,
+        final DataServices dataServices,
         final GenieEventBus genieEventBus,
         @Qualifier("genieTaskScheduler") final TaskScheduler scheduler,
         final MeterRegistry registry,
@@ -100,7 +101,7 @@ public class JobMonitoringCoordinator extends JobStateServiceImpl {
     ) throws IOException {
         super(jobSubmitterService, scheduler, genieEventBus, registry);
         this.hostname = genieHostInfo.getHostname();
-        this.jobSearchService = jobSearchService;
+        this.jobSearchService = dataServices.getJobSearchService();
         this.jobsDir = jobsDir.getFile();
         this.jobsProperties = jobsProperties;
         this.processCheckerFactory = processCheckerFactory;

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/AgentJobCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/AgentJobCleanupTask.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieException;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.AgentCleanupProperties;
@@ -53,19 +54,17 @@ public class AgentJobCleanupTask extends LeadershipTask {
     /**
      * Constructor.
      *
-     * @param jobSearchService      the job search service
-     * @param jobPersistenceService the job persistence service
-     * @param properties            the task properties
-     * @param registry              the metrics registry
+     * @param dataServices The {@link DataServices} encapsulation instance to use
+     * @param properties   the task properties
+     * @param registry     the metrics registry
      */
     public AgentJobCleanupTask(
-        final JobSearchService jobSearchService,
-        final JobPersistenceService jobPersistenceService,
+        final DataServices dataServices,
         final AgentCleanupProperties properties,
         final MeterRegistry registry
     ) {
-        this.jobSearchService = jobSearchService;
-        this.jobPersistenceService = jobPersistenceService;
+        this.jobSearchService = dataServices.getJobSearchService();
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
         this.properties = properties;
         this.registry = registry;
         this.awolJobDeadlines = Maps.newConcurrentMap();

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/AgentJobCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/AgentJobCleanupTask.java
@@ -41,7 +41,7 @@ import java.util.Set;
  * @since 4.0.0
  */
 @Slf4j
-public class AgentJobCleanupTask extends LeadershipTask {
+public class AgentJobCleanupTask extends LeaderTask {
     private static final String STATUS_MESSAGE = "Agent AWOL for too long";
     private static final String TERMINATED_COUNTER_METRIC_NAME = "genie.jobs.agentDisconnected.terminated.counter";
     private static final String DISCONNECTED_GAUGE_METRIC_NAME = "genie.jobs.agentDisconnected.gauge";

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
@@ -26,6 +26,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.external.util.GenieObjectMapper;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.web.data.services.AgentConnectionPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.ClusterCheckerProperties;
@@ -86,30 +87,26 @@ public class ClusterCheckerTask extends LeadershipTask {
     /**
      * Constructor.
      *
-     * @param genieHostInfo                     Information about the host this Genie process is running on
-     * @param properties                        The properties to use to configure the task
-     * @param jobSearchService                  The job search service to use
-     * @param jobPersistenceService             The job persistence service to use
-     * @param agentConnectionPersistenceService The agent connections persistence service
-     * @param restTemplate                      The rest template for http calls
-     * @param webEndpointProperties             The properties where Spring actuator is running
-     * @param registry                          The spectator registry for getting metrics
+     * @param genieHostInfo         Information about the host this Genie process is running on
+     * @param properties            The properties to use to configure the task
+     * @param dataServices          The {@link DataServices} encapsulation instance to use
+     * @param restTemplate          The rest template for http calls
+     * @param webEndpointProperties The properties where Spring actuator is running
+     * @param registry              The spectator registry for getting metrics
      */
     public ClusterCheckerTask(
         @NotNull final GenieHostInfo genieHostInfo,
         @NotNull final ClusterCheckerProperties properties,
-        @NotNull final JobSearchService jobSearchService,
-        @NotNull final JobPersistenceService jobPersistenceService,
-        @NotNull final AgentConnectionPersistenceService agentConnectionPersistenceService,
+        @NotNull final DataServices dataServices,
         @NotNull final RestTemplate restTemplate,
         @NotNull final WebEndpointProperties webEndpointProperties,
         @NotNull final MeterRegistry registry
     ) {
         this.hostname = genieHostInfo.getHostname();
         this.properties = properties;
-        this.jobSearchService = jobSearchService;
-        this.jobPersistenceService = jobPersistenceService;
-        this.agentConnectionPersistenceService = agentConnectionPersistenceService;
+        this.jobSearchService = dataServices.getJobSearchService();
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
+        this.agentConnectionPersistenceService = dataServices.getAgentConnectionPersistenceService();
         this.restTemplate = restTemplate;
         this.registry = registry;
         this.scheme = this.properties.getScheme() + "://";

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
@@ -63,7 +63,7 @@ import java.util.Set;
  * @since 3.0.0
  */
 @Slf4j
-public class ClusterCheckerTask extends LeadershipTask {
+public class ClusterCheckerTask extends LeaderTask {
     private static final String UNHEALTHY_HOSTS_GAUGE_METRIC_NAME = "genie.tasks.clusterChecker.unhealthyHosts.gauge";
     private static final String BAD_HEALTH_COUNT_METRIC_NAME = "genie.tasks.clusterChecker.failedHealthcheck.counter";
     private static final String BAD_RESPONSE_COUNT_METRIC_NAME = "genie.tasks.clusterChecker.invalidResponse.counter";

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.tasks.leader;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.internal.jobs.JobConstants;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.FilePersistenceService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.TagPersistenceService;
@@ -65,27 +66,21 @@ public class DatabaseCleanupTask extends LeadershipTask {
     /**
      * Constructor.
      *
-     * @param cleanupProperties         The properties to use to configure this task
-     * @param jobPersistenceService     The persistence service to use to cleanup the data store
-     * @param clusterPersistenceService The cluster service to use to delete terminated clusters
-     * @param filePersistenceService    The file service to use to delete unused file references
-     * @param tagPersistenceService     The tag service to use to delete unused tag references
-     * @param registry                  The metrics registry
+     * @param cleanupProperties The properties to use to configure this task
+     * @param dataServices      The {@link DataServices} encapsulation instance to use
+     * @param registry          The metrics registry
      */
     public DatabaseCleanupTask(
         @NotNull final DatabaseCleanupProperties cleanupProperties,
-        @NotNull final JobPersistenceService jobPersistenceService,
-        @NotNull final ClusterPersistenceService clusterPersistenceService,
-        @NotNull final FilePersistenceService filePersistenceService,
-        @NotNull final TagPersistenceService tagPersistenceService,
+        @NotNull final DataServices dataServices,
         @NotNull final MeterRegistry registry
     ) {
         this.registry = registry;
         this.cleanupProperties = cleanupProperties;
-        this.jobPersistenceService = jobPersistenceService;
-        this.clusterPersistenceService = clusterPersistenceService;
-        this.filePersistenceService = filePersistenceService;
-        this.tagPersistenceService = tagPersistenceService;
+        this.jobPersistenceService = dataServices.getJobPersistenceService();
+        this.clusterPersistenceService = dataServices.getClusterPersistenceService();
+        this.filePersistenceService = dataServices.getFilePersistenceService();
+        this.tagPersistenceService = dataServices.getTagPersistenceService();
 
         this.numDeletedJobs = this.registry.gauge(
             "genie.tasks.databaseCleanup.numDeletedJobs.gauge",

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
@@ -174,9 +174,9 @@ public class DatabaseCleanupTask extends LeaderTask {
      */
     private void deleteJobs() {
         final boolean skipJobs = this.environment.getProperty(
-            DatabaseCleanupProperties.SKIP_JOBS_PROPERTY,
+            DatabaseCleanupProperties.JobDatabaseCleanupProperties.SKIP_PROPERTY,
             Boolean.class,
-            this.cleanupProperties.isSkipJobsCleanup()
+            this.cleanupProperties.getJobCleanup().isSkip()
         );
         if (skipJobs) {
             log.info("Skipping job cleanup");
@@ -185,21 +185,21 @@ public class DatabaseCleanupTask extends LeaderTask {
             final Instant midnightUTC = TaskUtils.getMidnightUTC();
             final Instant retentionLimit = midnightUTC.minus(
                 this.environment.getProperty(
-                    DatabaseCleanupProperties.JOB_RETENTION_PROPERTY,
+                    DatabaseCleanupProperties.JobDatabaseCleanupProperties.JOB_RETENTION_PROPERTY,
                     Integer.class,
-                    this.cleanupProperties.getRetention()
+                    this.cleanupProperties.getJobCleanup().getRetention()
                 ),
                 ChronoUnit.DAYS
             );
             final int batchSize = this.environment.getProperty(
-                DatabaseCleanupProperties.MAX_DELETED_PER_TRANSACTION_PROPERTY,
+                DatabaseCleanupProperties.JobDatabaseCleanupProperties.MAX_DELETED_PER_TRANSACTION_PROPERTY,
                 Integer.class,
-                this.cleanupProperties.getMaxDeletedPerTransaction()
+                this.cleanupProperties.getJobCleanup().getMaxDeletedPerTransaction()
             );
             final int pageSize = this.environment.getProperty(
-                DatabaseCleanupProperties.PAGE_SIZE_PROPERTY,
+                DatabaseCleanupProperties.JobDatabaseCleanupProperties.PAGE_SIZE_PROPERTY,
                 Integer.class,
-                this.cleanupProperties.getPageSize()
+                this.cleanupProperties.getJobCleanup().getPageSize()
             );
 
             log.info(
@@ -235,9 +235,9 @@ public class DatabaseCleanupTask extends LeaderTask {
         final Set<Tag> tags = Sets.newHashSet();
         try {
             final boolean skipClusters = this.environment.getProperty(
-                DatabaseCleanupProperties.SKIP_CLUSTERS_PROPERTY,
+                DatabaseCleanupProperties.ClusterDatabaseCleanupProperties.SKIP_PROPERTY,
                 Boolean.class,
-                this.cleanupProperties.isSkipClustersCleanup()
+                this.cleanupProperties.getClusterCleanup().isSkip()
             );
             if (skipClusters) {
                 log.info("Skipping clusters cleanup");
@@ -265,9 +265,9 @@ public class DatabaseCleanupTask extends LeaderTask {
         final Set<Tag> tags = Sets.newHashSet();
         try {
             final boolean skipFiles = this.environment.getProperty(
-                DatabaseCleanupProperties.SKIP_FILES_PROPERTY,
+                DatabaseCleanupProperties.FileDatabaseCleanupProperties.SKIP_PROPERTY,
                 Boolean.class,
-                this.cleanupProperties.isSkipFilesCleanup()
+                this.cleanupProperties.getFileCleanup().isSkip()
             );
             if (skipFiles) {
                 log.info("Skipping files cleanup");
@@ -295,9 +295,9 @@ public class DatabaseCleanupTask extends LeaderTask {
         final Set<Tag> tags = Sets.newHashSet();
         try {
             final boolean skipTags = this.environment.getProperty(
-                DatabaseCleanupProperties.SKIP_TAGS_PROPERTY,
+                DatabaseCleanupProperties.TagDatabaseCleanupProperties.SKIP_PROPERTY,
                 Boolean.class,
-                this.cleanupProperties.isSkipTagsCleanup()
+                this.cleanupProperties.getTagCleanup().isSkip()
             );
             if (skipTags) {
                 log.info("Skipping tags cleanup");

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
@@ -48,7 +48,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @since 3.0.0
  */
 @Slf4j
-public class DatabaseCleanupTask extends LeadershipTask {
+public class DatabaseCleanupTask extends LeaderTask {
 
     private static final String DATABASE_CLEANUP_DURATION_TIMER_NAME = "genie.tasks.databaseCleanup.duration.timer";
     private final DatabaseCleanupProperties cleanupProperties;

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeaderTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeaderTask.java
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
  * @since 3.0.0
  */
 @Slf4j
-public abstract class LeadershipTask extends GenieTask {
+public abstract class LeaderTask extends GenieTask {
 
     /**
      * Any cleanup that needs to be performed when this task is stopped due to leadership being revoked.

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeaderTasksCoordinator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/LeaderTasksCoordinator.java
@@ -39,9 +39,9 @@ import java.util.concurrent.ScheduledFuture;
  * @since 3.0.0
  */
 @Slf4j
-public class LeadershipTasksCoordinator {
+public class LeaderTasksCoordinator {
 
-    private final Set<LeadershipTask> tasks;
+    private final Set<LeaderTask> tasks;
     private final Set<ScheduledFuture<?>> futures;
     private final TaskScheduler taskScheduler;
     private boolean isRunning;
@@ -52,7 +52,7 @@ public class LeadershipTasksCoordinator {
      * @param taskScheduler The task executor to use.
      * @param tasks         The leadership tasks to run
      */
-    public LeadershipTasksCoordinator(final TaskScheduler taskScheduler, final Collection<LeadershipTask> tasks) {
+    public LeaderTasksCoordinator(final TaskScheduler taskScheduler, final Collection<LeaderTask> tasks) {
         this.futures = Sets.newHashSet();
         this.taskScheduler = taskScheduler;
         this.isRunning = false;
@@ -146,6 +146,6 @@ public class LeadershipTasksCoordinator {
 
         // Clear out the tasks
         this.futures.clear();
-        this.tasks.forEach(LeadershipTask::cleanup);
+        this.tasks.forEach(LeaderTask::cleanup);
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/UserMetricsTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/UserMetricsTask.java
@@ -40,7 +40,7 @@ import java.util.Set;
  * @since 4.0.0
  */
 @Slf4j
-public class UserMetricsTask extends LeadershipTask {
+public class UserMetricsTask extends LeaderTask {
 
     private static final String USER_ACTIVE_JOBS_METRIC_NAME = "genie.user.active-jobs.gauge";
     private static final String USER_ACTIVE_MEMORY_METRIC_NAME = "genie.user.active-memory.gauge";

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/UserMetricsTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/UserMetricsTask.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.netflix.genie.common.dto.UserResourcesSummary;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.UserMetricsProperties;
 import com.netflix.genie.web.tasks.GenieTaskScheduleType;
@@ -56,16 +57,16 @@ public class UserMetricsTask extends LeadershipTask {
      * Constructor.
      *
      * @param registry              the metrics registry
-     * @param jobSearchService      the job search service
+     * @param dataServices          The {@link DataServices} instance to use
      * @param userMetricsProperties the properties that configure this task
      */
     public UserMetricsTask(
         final MeterRegistry registry,
-        final JobSearchService jobSearchService,
+        final DataServices dataServices,
         final UserMetricsProperties userMetricsProperties
     ) {
         this.registry = registry;
-        this.jobSearchService = jobSearchService;
+        this.jobSearchService = dataServices.getJobSearchService();
         this.userMetricsProperties = userMetricsProperties;
         this.activeUsersCount = new AtomicDouble(Double.NaN);
 

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/node/DiskCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/node/DiskCleanupTask.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.tasks.node;
 import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.internal.jobs.JobConstants;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.DiskCleanupProperties;
 import com.netflix.genie.web.properties.JobsProperties;
@@ -67,20 +68,20 @@ public class DiskCleanupTask implements Runnable {
     /**
      * Constructor. Schedules this task to be run by the task scheduler.
      *
-     * @param properties       The disk cleanup properties to use.
-     * @param scheduler        The scheduler to use to schedule the cron trigger.
-     * @param jobsDir          The resource representing the location of the job directory
-     * @param jobSearchService The service to find jobs with
-     * @param jobsProperties   The jobs properties to use
-     * @param processExecutor  The process executor to use to delete directories
-     * @param registry         The metrics registry
+     * @param properties      The disk cleanup properties to use.
+     * @param scheduler       The scheduler to use to schedule the cron trigger.
+     * @param jobsDir         The resource representing the location of the job directory
+     * @param dataServices    The {@link DataServices} instance to use
+     * @param jobsProperties  The jobs properties to use
+     * @param processExecutor The process executor to use to delete directories
+     * @param registry        The metrics registry
      * @throws IOException When it is unable to open a file reference to the job directory
      */
     public DiskCleanupTask(
         @NotNull final DiskCleanupProperties properties,
         @NotNull final TaskScheduler scheduler,
         @NotNull final Resource jobsDir,
-        @NotNull final JobSearchService jobSearchService,
+        @NotNull final DataServices dataServices,
         @NotNull final JobsProperties jobsProperties,
         @NotNull final Executor processExecutor,
         @NotNull final MeterRegistry registry
@@ -92,7 +93,7 @@ public class DiskCleanupTask implements Runnable {
 
         this.properties = properties;
         this.jobsDir = jobsDir.getFile();
-        this.jobSearchService = jobSearchService;
+        this.jobSearchService = dataServices.getJobSearchService();
         this.runAsUser = jobsProperties.getUsers().isRunAsUserEnabled();
         this.processExecutor = processExecutor;
 

--- a/genie-web/src/main/resources/genie-web-defaults.yml
+++ b/genie-web/src/main/resources/genie-web-defaults.yml
@@ -93,7 +93,8 @@ genie:
     database-cleanup:
       enabled: true
       expression: 0 0 0 * * *
-      retention: 90
+      job-cleanup:
+        retention: 90
     disk-cleanup:
       enabled: true
       expression: 0 0 0 * * *

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImplSpec.groovy
@@ -21,6 +21,7 @@ import com.netflix.genie.common.dto.JobStatus
 import com.netflix.genie.common.exceptions.GenieServerException
 import com.netflix.genie.proto.JobKillRegistrationRequest
 import com.netflix.genie.proto.JobKillRegistrationResponse
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobSearchService
 import io.grpc.stub.StreamObserver
 import spock.lang.Specification
@@ -43,7 +44,10 @@ class GRpcJobKillServiceImplSpec extends Specification {
         jobId = UUID.randomUUID().toString()
         request = JobKillRegistrationRequest.newBuilder().setJobId(jobId).build()
         response = JobKillRegistrationResponse.newBuilder().build()
-        service = new GRpcJobKillServiceImpl(jobSearchService)
+        def dataServices = Mock(DataServices) {
+            getJobSearchService() >> this.jobSearchService
+        }
+        service = new GRpcJobKillServiceImpl(dataServices)
     }
 
     def "Can kill unfinished jobs and clean up response observer"() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImplSpec.groovy
@@ -20,6 +20,7 @@ package com.netflix.genie.web.agent.launchers.impl
 import com.netflix.genie.common.external.dtos.v4.JobEnvironment
 import com.netflix.genie.common.external.dtos.v4.JobMetadata
 import com.netflix.genie.common.external.dtos.v4.JobSpecification
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobSearchService
 import com.netflix.genie.web.dtos.ResolvedJob
 import com.netflix.genie.web.introspection.GenieWebHostInfo
@@ -58,6 +59,7 @@ class LocalAgentLauncherImplSpec extends Specification {
     LocalAgentLauncherProperties launchProperties
     ExecutorFactory executorFactory
     MeterRegistry meterRegistry
+    DataServices dataServices
 
     LocalAgentLauncherImpl launcher
     String hostname
@@ -89,6 +91,9 @@ class LocalAgentLauncherImplSpec extends Specification {
         this.job = Mock(JobSpecification.ExecutionResource)
         this.executor = Mock(Executor)
         this.additionalEnvironment = [foo: "bar"]
+        this.dataServices = Mock(DataServices) {
+            getJobSearchService() >> this.jobSearchService
+        }
     }
 
     @Unroll
@@ -100,12 +105,12 @@ class LocalAgentLauncherImplSpec extends Specification {
 
         when:
         this.launcher = new LocalAgentLauncherImpl(
-            hostInfo,
-            rpcInfo,
-            jobSearchService,
-            launchProperties,
-            executorFactory,
-            meterRegistry
+            this.hostInfo,
+            this.rpcInfo,
+            this.dataServices,
+            this.launchProperties,
+            this.executorFactory,
+            this.meterRegistry
         )
 
         then:

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
@@ -27,6 +27,7 @@ import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundEx
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobSpecificationNotFoundException
 import com.netflix.genie.web.agent.inspectors.InspectionReport
 import com.netflix.genie.web.agent.services.AgentFilterService
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.dtos.JobSubmission
 import com.netflix.genie.web.dtos.ResolvedJob
@@ -39,10 +40,11 @@ import io.micrometer.core.instrument.Tag
 import spock.lang.Specification
 
 /**
- * Specifications for the {@link com.netflix.genie.web.agent.services.impl.AgentJobServiceImpl} class.
+ * Specifications for the {@link AgentJobServiceImpl} class.
  *
  * @author tgianos
  */
+@SuppressWarnings("GroovyAccessibility")
 class AgentJobServiceImplSpec extends Specification {
 
     public static final String version = "1.2.3"
@@ -61,11 +63,14 @@ class AgentJobServiceImplSpec extends Specification {
         this.agentFilterService = Mock(AgentFilterService)
         this.meterRegistry = Mock(MeterRegistry)
         this.counter = Mock(Counter)
+        def dataServices = Mock(DataServices) {
+            getJobPersistenceService() >> this.jobPersistenceService
+        }
         this.service = new AgentJobServiceImpl(
-            jobPersistenceService,
-            jobSpecificationService,
-            agentFilterService,
-            meterRegistry
+            dataServices,
+            this.jobSpecificationService,
+            this.agentFilterService,
+            this.meterRegistry
         )
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/data/services/DataServicesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/data/services/DataServicesSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.data.services
+
+import spock.lang.Specification
+
+/**
+ * Specifications for the {@link DataServices} class.
+ *
+ * @author tgianos
+ */
+class DataServicesSpec extends Specification {
+
+    def "can build properly"() {
+        def agentConnectionService = Mock(AgentConnectionPersistenceService)
+        def applicationService = Mock(ApplicationPersistenceService)
+        def clusterService = Mock(ClusterPersistenceService)
+        def commandService = Mock(CommandPersistenceService)
+        def fileService = Mock(FilePersistenceService)
+        def jobService = Mock(JobPersistenceService)
+        def jobSearchService = Mock(JobSearchService)
+        def tagService = Mock(TagPersistenceService)
+
+        when:
+        def services = new DataServices(
+            agentConnectionService,
+            applicationService,
+            clusterService,
+            commandService,
+            fileService,
+            jobService,
+            jobSearchService,
+            tagService
+        )
+
+        then:
+        services.getAgentConnectionPersistenceService() == agentConnectionService
+        services.getApplicationPersistenceService() == applicationService
+        services.getClusterPersistenceService() == clusterService
+        services.getCommandPersistenceService() == commandService
+        services.getFilePersistenceService() == fileService
+        services.getJobPersistenceService() == jobService
+        services.getJobSearchService() == jobSearchService
+        services.getTagPersistenceService() == tagService
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/events/JobFinishedSNSPublisherSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/events/JobFinishedSNSPublisherSpec.groovy
@@ -33,6 +33,7 @@ import com.netflix.genie.common.external.dtos.v4.Criterion
 import com.netflix.genie.common.external.dtos.v4.JobStatus
 import com.netflix.genie.common.external.util.GenieObjectMapper
 import com.netflix.genie.common.internal.dtos.v4.FinishedJob
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.properties.SNSNotificationsProperties
 import io.micrometer.core.instrument.Counter
@@ -42,6 +43,7 @@ import spock.lang.Specification
 
 import java.time.Instant
 
+@SuppressWarnings("GroovyAccessibility")
 class JobFinishedSNSPublisherSpec extends Specification {
     Map<String, String> extraKeysMap
     String jobId
@@ -66,12 +68,15 @@ class JobFinishedSNSPublisherSpec extends Specification {
         this.counter = Mock(Counter)
         this.mapper = GenieObjectMapper.getMapper()
         this.event = Mock(JobStateChangeEvent)
+        def dataServices = Mock(DataServices) {
+            getJobPersistenceService() >> this.jobPersistenceService
+        }
         this.publisher = new JobFinishedSNSPublisher(
-            snsClient,
-            snsProperties,
-            jobPersistenceService,
-            registry,
-            mapper
+            this.snsClient,
+            this.snsProperties,
+            dataServices,
+            this.registry,
+            this.mapper
         )
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/health/LocalAgentLauncherHealthIndicatorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/health/LocalAgentLauncherHealthIndicatorSpec.groovy
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.health
 
 import com.netflix.genie.common.internal.util.GenieHostInfo
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobSearchService
 import com.netflix.genie.web.properties.LocalAgentLauncherProperties
 import org.springframework.boot.actuate.health.Status
@@ -36,6 +37,9 @@ class LocalAgentLauncherHealthIndicatorSpec extends Specification {
             getHostname() >> hostname
         }
         def jobSearchService = Mock(JobSearchService)
+        def dataServices = Mock(DataServices) {
+            getJobSearchService() >> jobSearchService
+        }
         def maxTotalJobMemory = 100_003L
         def maxJobMemory = 10_000
         def properties = Mock(LocalAgentLauncherProperties) {
@@ -44,7 +48,7 @@ class LocalAgentLauncherHealthIndicatorSpec extends Specification {
         }
 
         def healthIndicator = new LocalAgentLauncherHealthIndicator(
-            jobSearchService,
+            dataServices,
             properties,
             genieHostInfo
         )

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/ArchivedJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/ArchivedJobServiceImplSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.genie.common.exceptions.GenieNotFoundException
 import com.netflix.genie.common.external.util.GenieObjectMapper
 import com.netflix.genie.common.internal.dtos.DirectoryManifest
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieRuntimeException
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.exceptions.checked.JobDirectoryManifestNotFoundException
 import com.netflix.genie.web.exceptions.checked.JobNotArchivedException
@@ -51,7 +52,10 @@ class ArchivedJobServiceImplSpec extends Specification {
         this.jobPersistenceService = Mock(JobPersistenceService)
         this.resourceLoader = Mock(ResourceLoader)
         this.meterRegistry = new SimpleMeterRegistry()
-        this.service = new ArchivedJobServiceImpl(this.jobPersistenceService, this.resourceLoader, this.meterRegistry)
+        def dataServices = Mock(DataServices) {
+            getJobPersistenceService() >> this.jobPersistenceService
+        }
+        this.service = new ArchivedJobServiceImpl(dataServices, this.resourceLoader, this.meterRegistry)
     }
 
     def "expected exceptions are thrown when conditions exist"() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.genie.common.internal.dtos.DirectoryManifest
 import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorService
 import com.netflix.genie.web.agent.resources.AgentFileProtocolResolver
 import com.netflix.genie.web.agent.services.AgentFileStreamService
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.exceptions.checked.JobDirectoryManifestNotFoundException
 import com.netflix.genie.web.exceptions.checked.JobNotArchivedException
@@ -49,6 +50,7 @@ import java.nio.file.Paths
 /**
  * Specifications for {@link JobDirectoryServerServiceImpl}.
  */
+@SuppressWarnings("GroovyAccessibility")
 class JobDirectoryServerServiceImplSpec extends Specification {
     static final String JOB_ID = "123456"
     static final String REL_PATH = "bar/foo.txt"
@@ -82,9 +84,12 @@ class JobDirectoryServerServiceImplSpec extends Specification {
         this.handler = Mock(JobDirectoryServerServiceImpl.GenieResourceHandler)
         this.jobDirectoryManifestService = Mock(JobDirectoryManifestCreatorService)
         this.archivedJobService = Mock(ArchivedJobService)
+        def dataServices = Mock(DataServices) {
+            getJobPersistenceService() >> this.jobPersistenceService
+        }
         this.service = new JobDirectoryServerServiceImpl(
             this.resourceLoader,
-            this.jobPersistenceService,
+            dataServices,
             this.agentFileStreamService,
             this.archivedJobService,
             this.handlerFactory,

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobKillServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobKillServiceImplSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.genie.web.services.impl
 
 import com.netflix.genie.common.exceptions.GenieServerException
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.services.JobKillServiceV4
 import spock.lang.Specification
@@ -26,7 +27,7 @@ import spock.lang.Specification
 /**
  * Tests for JobKillServiceImpl
  *
- * @author standon* @since 4.0.0
+ * @author standon
  */
 class JobKillServiceImplSpec extends Specification {
     JobKillServiceV3 jobKillServiceV3
@@ -36,11 +37,14 @@ class JobKillServiceImplSpec extends Specification {
     String jobId
 
     void setup() {
-        jobPersistenceService = Mock()
-        jobKillServiceV4 = Mock()
-        jobKillServiceV3 = Mock()
-        jobId = UUID.randomUUID().toString()
-        service = new JobKillServiceImpl(jobKillServiceV3, jobKillServiceV4, jobPersistenceService)
+        this.jobPersistenceService = Mock(JobPersistenceService)
+        this.jobKillServiceV4 = Mock(JobKillServiceV4)
+        this.jobKillServiceV3 = Mock(JobKillServiceV3)
+        this.jobId = UUID.randomUUID().toString()
+        def dataServices = Mock(DataServices) {
+            getJobPersistenceService() >> this.jobPersistenceService
+        }
+        this.service = new JobKillServiceImpl(this.jobKillServiceV3, this.jobKillServiceV4, dataServices)
     }
 
     def "Invoke JobKillServiceV3 for a v3 job"() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobLaunchServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobLaunchServiceImplSpec.groovy
@@ -20,6 +20,7 @@ package com.netflix.genie.web.services.impl
 import com.netflix.genie.common.external.dtos.v4.JobStatus
 import com.netflix.genie.common.internal.exceptions.checked.GenieJobResolutionException
 import com.netflix.genie.web.agent.launchers.AgentLauncher
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.dtos.JobSubmission
 import com.netflix.genie.web.dtos.ResolvedJob
@@ -42,7 +43,10 @@ class JobLaunchServiceImplSpec extends Specification {
         def jobResolverService = Mock(JobResolverService)
         def agentLauncher = Mock(AgentLauncher)
         def registry = new SimpleMeterRegistry()
-        def service = new JobLaunchServiceImpl(jobPersistenceService, jobResolverService, agentLauncher, registry)
+        def dataServices = Mock(DataServices) {
+            getJobPersistenceService() >> jobPersistenceService
+        }
+        def service = new JobLaunchServiceImpl(dataServices, jobResolverService, agentLauncher, registry)
 
         def jobId = UUID.randomUUID().toString()
         def resolvedJob = Mock(ResolvedJob)
@@ -64,7 +68,10 @@ class JobLaunchServiceImplSpec extends Specification {
         def jobResolverService = Mock(JobResolverService)
         def agentLauncher = Mock(AgentLauncher)
         def registry = new SimpleMeterRegistry()
-        def service = new JobLaunchServiceImpl(jobPersistenceService, jobResolverService, agentLauncher, registry)
+        def dataServices = Mock(DataServices) {
+            getJobPersistenceService() >> jobPersistenceService
+        }
+        def service = new JobLaunchServiceImpl(dataServices, jobResolverService, agentLauncher, registry)
 
         def jobId = UUID.randomUUID().toString()
         def resolvedJob = Mock(ResolvedJob)

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
@@ -41,6 +41,7 @@ import com.netflix.genie.common.internal.jobs.JobConstants
 import com.netflix.genie.web.data.services.ApplicationPersistenceService
 import com.netflix.genie.web.data.services.ClusterPersistenceService
 import com.netflix.genie.web.data.services.CommandPersistenceService
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.dtos.ResolvedJob
 import com.netflix.genie.web.dtos.ResourceSelectionResult
@@ -84,11 +85,14 @@ class JobResolverServiceImplSpec extends Specification {
         this.jobService = Mock(JobPersistenceService)
         this.jobsProperties = JobsProperties.getJobsPropertiesDefaults()
         this.environment = Mock(Environment)
+        def dataServices = Mock(DataServices) {
+            getApplicationPersistenceService() >> this.applicationService
+            getClusterPersistenceService() >> this.clusterService
+            getCommandPersistenceService() >> this.commandService
+            getJobPersistenceService() >> this.jobService
+        }
         this.service = new JobResolverServiceImpl(
-            this.applicationService,
-            this.clusterService,
-            this.commandService,
-            this.jobService,
+            dataServices,
             Lists.newArrayList(this.clusterSelector),
             this.commandSelector,
             new SimpleMeterRegistry(),

--- a/genie-web/src/test/groovy/com/netflix/genie/web/tasks/job/JobCompletionServiceSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/tasks/job/JobCompletionServiceSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.genie.common.dto.JobRequest
 import com.netflix.genie.common.dto.JobStatus
 import com.netflix.genie.common.exceptions.GenieServerException
 import com.netflix.genie.common.internal.services.JobArchiveService
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.data.services.JobSearchService
 import com.netflix.genie.web.events.JobFinishedEvent
@@ -51,8 +52,9 @@ import java.util.concurrent.TimeUnit
 /**
  * Unit tests for JobCompletionHandler
  *
- * @author amajumdar* @since 3.0.0
+ * @author amajumdar
  */
+@SuppressWarnings("GroovyAccessibility")
 class JobCompletionServiceSpec extends Specification {
     private static final String NAME = UUID.randomUUID().toString()
     private static final String USER = UUID.randomUUID().toString()
@@ -96,9 +98,12 @@ class JobCompletionServiceSpec extends Specification {
         }
         jobsProperties.cleanup.deleteDependencies = false
         jobsProperties.users.runAsUserEnabled = false
+        def dataServices = Mock(DataServices) {
+            getJobSearchService() >> this.jobSearchService
+            getJobPersistenceService() >> this.jobPersistenceService
+        }
         jobCompletionService = new JobCompletionService(
-            jobPersistenceService,
-            jobSearchService,
+            dataServices,
             jobArchiveService,
             new FileSystemResource("/tmp"),
             mailService,

--- a/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/AgentJobCleanupTaskSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/AgentJobCleanupTaskSpec.groovy
@@ -20,6 +20,7 @@ package com.netflix.genie.web.tasks.leader
 import com.google.common.collect.Sets
 import com.netflix.genie.common.dto.JobStatus
 import com.netflix.genie.common.exceptions.GenieException
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.data.services.JobSearchService
 import com.netflix.genie.web.properties.AgentCleanupProperties
@@ -29,6 +30,7 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import spock.lang.Specification
 
+@SuppressWarnings("GroovyAccessibility")
 class AgentJobCleanupTaskSpec extends Specification {
 
     AgentJobCleanupTask task
@@ -41,14 +43,17 @@ class AgentJobCleanupTaskSpec extends Specification {
     void setup() {
         this.jobSearchService = Mock(JobSearchService)
         this.jobPersistenceService = Mock(JobPersistenceService)
+        def dataServices = Mock(DataServices) {
+            getJobSearchService() >> this.jobSearchService
+            getJobPersistenceService() >> this.jobPersistenceService
+        }
         this.taskProperties = Mock(AgentCleanupProperties)
         this.registry = Mock(MeterRegistry)
         this.counter = Mock(Counter)
         this.task = new AgentJobCleanupTask(
-            jobSearchService,
-            jobPersistenceService,
-            taskProperties,
-            registry
+            dataServices,
+            this.taskProperties,
+            this.registry
         )
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/ClusterCheckerTaskSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/ClusterCheckerTaskSpec.groovy
@@ -22,9 +22,9 @@ import com.netflix.genie.common.dto.Job
 import com.netflix.genie.common.dto.JobExecution
 import com.netflix.genie.common.dto.JobStatus
 import com.netflix.genie.common.exceptions.GenieNotFoundException
-import com.netflix.genie.common.external.util.GenieObjectMapper
 import com.netflix.genie.common.internal.util.GenieHostInfo
 import com.netflix.genie.web.data.services.AgentConnectionPersistenceService
+import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.data.services.JobSearchService
 import com.netflix.genie.web.properties.ClusterCheckerProperties
@@ -39,6 +39,7 @@ import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
 
+@SuppressWarnings("GroovyAccessibility")
 class ClusterCheckerTaskSpec extends Specification {
 
     ClusterCheckerTask task
@@ -51,7 +52,6 @@ class ClusterCheckerTaskSpec extends Specification {
     MeterRegistry meterRegistry
 
     void setup() {
-
         this.hostname = UUID.randomUUID().toString()
         this.properties = Mock(ClusterCheckerProperties) {
             _ * getPort() >> 8080
@@ -71,12 +71,16 @@ class ClusterCheckerTaskSpec extends Specification {
             _ * getBasePath() >> "/actuator"
         }
 
+        def dataServices = Mock(DataServices) {
+            getJobSearchService() >> this.jobSearchService
+            getJobPersistenceService() >> this.jobPersistenceService
+            getAgentConnectionPersistenceService() >> this.agentConnectionPersistenceService
+        }
+
         this.task = new ClusterCheckerTask(
             genieHostInfo,
             this.properties,
-            this.jobSearchService,
-            this.jobPersistenceService,
-            this.agentConnectionPersistenceService,
+            dataServices,
             this.restTemplate,
             serverProperties,
             meterRegistry

--- a/genie-web/src/test/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerTest.java
@@ -36,6 +36,7 @@ import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.JobModelAssembler;
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.JobRequestModelAssembler;
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.JobSearchResultModelAssembler;
 import com.netflix.genie.web.apis.rest.v3.hateoas.assemblers.RootModelAssembler;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.JobsProperties;
@@ -145,9 +146,13 @@ class JobRestControllerTest {
         final Counter counter = Mockito.mock(Counter.class);
         Mockito.when(registry.counter(Mockito.anyString())).thenReturn(counter);
 
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(this.jobSearchService);
+        Mockito.when(dataServices.getJobPersistenceService()).thenReturn(this.jobPersistenceService);
+
         this.controller = new JobRestController(
             Mockito.mock(JobLaunchService.class),
-            this.jobSearchService,
+            dataServices,
             Mockito.mock(JobCoordinatorService.class),
             this.createMockResourceAssembler(),
             new GenieHostInfo(this.hostname),
@@ -155,7 +160,6 @@ class JobRestControllerTest {
             this.jobDirectoryServerService,
             this.jobsProperties,
             registry,
-            this.jobPersistenceService,
             this.agentRoutingService,
             this.environment,
             Mockito.mock(AttachmentService.class),
@@ -860,9 +864,13 @@ class JobRestControllerTest {
         final Counter counter = Mockito.mock(Counter.class);
         Mockito.when(registry.counter(Mockito.anyString())).thenReturn(counter);
 
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(this.jobSearchService);
+        Mockito.when(dataServices.getJobPersistenceService()).thenReturn(this.jobPersistenceService);
+
         final JobRestController jobController = new JobRestController(
             Mockito.mock(JobLaunchService.class),
-            this.jobSearchService,
+            dataServices,
             Mockito.mock(JobCoordinatorService.class),
             this.createMockResourceAssembler(),
             new GenieHostInfo(this.hostname),
@@ -870,7 +878,6 @@ class JobRestControllerTest {
             this.jobDirectoryServerService,
             this.jobsProperties,
             registry,
-            this.jobPersistenceService,
             this.agentRoutingService,
             this.environment,
             Mockito.mock(AttachmentService.class),

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesTest.java
@@ -42,6 +42,11 @@ class DatabaseCleanupPropertiesTest {
     void canGetDefaultValues() {
         Assertions.assertThat(this.properties.isEnabled()).isFalse();
         Assertions.assertThat(this.properties.getExpression()).isEqualTo("0 0 0 * * *");
+        Assertions.assertThat(this.properties.getApplicationCleanup().isSkip()).isFalse();
+        Assertions.assertThat(this.properties.getCommandCleanup().isSkip()).isFalse();
+        Assertions.assertThat(this.properties.getCommandDeactivation().isSkip()).isFalse();
+        Assertions.assertThat(this.properties.getCommandDeactivation().getCommandCreationThreshold()).isEqualTo(60);
+        Assertions.assertThat(this.properties.getCommandDeactivation().getJobCreationThreshold()).isEqualTo(30);
         Assertions.assertThat(this.properties.getJobCleanup().isSkip()).isFalse();
         Assertions.assertThat(this.properties.getJobCleanup().getRetention()).isEqualTo(90);
         Assertions.assertThat(this.properties.getJobCleanup().getMaxDeletedPerTransaction()).isEqualTo(1000);
@@ -107,5 +112,41 @@ class DatabaseCleanupPropertiesTest {
     void caSetSkipFilesCleanup() {
         this.properties.getFileCleanup().setSkip(true);
         Assertions.assertThat(this.properties.getFileCleanup().isSkip()).isTrue();
+    }
+
+    @Test
+    void canSetSkipApplicationsCleanup() {
+        this.properties.getApplicationCleanup().setSkip(true);
+        Assertions.assertThat(this.properties.getApplicationCleanup().isSkip()).isTrue();
+    }
+
+    @Test
+    void canEnableSkipCommandsCleanup() {
+        this.properties.getCommandCleanup().setSkip(true);
+        Assertions.assertThat(this.properties.getCommandCleanup().isSkip()).isTrue();
+    }
+
+    @Test
+    void canEnableSkipCommandDeactivation() {
+        this.properties.getCommandDeactivation().setSkip(true);
+        Assertions.assertThat(this.properties.getCommandDeactivation().isSkip()).isTrue();
+    }
+
+    @Test
+    void canSetCommandDeactivationCommandCreationThreshold() {
+        final int newThreshold = this.properties.getCommandDeactivation().getCommandCreationThreshold() + 1;
+        this.properties.getCommandDeactivation().setCommandCreationThreshold(newThreshold);
+        Assertions
+            .assertThat(this.properties.getCommandDeactivation().getCommandCreationThreshold())
+            .isEqualTo(newThreshold);
+    }
+
+    @Test
+    void canSetCommandDeactivationJobCreationThreshold() {
+        final int newThreshold = this.properties.getCommandDeactivation().getJobCreationThreshold() + 1;
+        this.properties.getCommandDeactivation().setJobCreationThreshold(newThreshold);
+        Assertions
+            .assertThat(this.properties.getCommandDeactivation().getJobCreationThreshold())
+            .isEqualTo(newThreshold);
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesTest.java
@@ -33,42 +33,30 @@ class DatabaseCleanupPropertiesTest {
 
     private DatabaseCleanupProperties properties;
 
-    /**
-     * Setup for tests.
-     */
     @BeforeEach
     void setup() {
         this.properties = new DatabaseCleanupProperties();
     }
 
-    /**
-     * Make sure constructor sets reasonable defaults.
-     */
     @Test
     void canGetDefaultValues() {
         Assertions.assertThat(this.properties.isEnabled()).isFalse();
         Assertions.assertThat(this.properties.getExpression()).isEqualTo("0 0 0 * * *");
-        Assertions.assertThat(this.properties.getRetention()).isEqualTo(90);
-        Assertions.assertThat(this.properties.getMaxDeletedPerTransaction()).isEqualTo(1000);
-        Assertions.assertThat(this.properties.getPageSize()).isEqualTo(1000);
-        Assertions.assertThat(this.properties.isSkipJobsCleanup()).isFalse();
-        Assertions.assertThat(this.properties.isSkipClustersCleanup()).isFalse();
-        Assertions.assertThat(this.properties.isSkipTagsCleanup()).isFalse();
-        Assertions.assertThat(this.properties.isSkipFilesCleanup()).isFalse();
+        Assertions.assertThat(this.properties.getJobCleanup().isSkip()).isFalse();
+        Assertions.assertThat(this.properties.getJobCleanup().getRetention()).isEqualTo(90);
+        Assertions.assertThat(this.properties.getJobCleanup().getMaxDeletedPerTransaction()).isEqualTo(1000);
+        Assertions.assertThat(this.properties.getJobCleanup().getPageSize()).isEqualTo(1000);
+        Assertions.assertThat(this.properties.getClusterCleanup().isSkip()).isFalse();
+        Assertions.assertThat(this.properties.getTagCleanup().isSkip()).isFalse();
+        Assertions.assertThat(this.properties.getFileCleanup().isSkip()).isFalse();
     }
 
-    /**
-     * Make sure can enable.
-     */
     @Test
     void canEnable() {
         this.properties.setEnabled(true);
         Assertions.assertThat(this.properties.isEnabled()).isTrue();
     }
 
-    /**
-     * Make sure can set a new cron expression.
-     */
     @Test
     void canSetExpression() {
         final String expression = UUID.randomUUID().toString();
@@ -76,69 +64,48 @@ class DatabaseCleanupPropertiesTest {
         Assertions.assertThat(this.properties.getExpression()).isEqualTo(expression);
     }
 
-    /**
-     * Make sure can set a new retention time.
-     */
     @Test
-    void canSetRetention() {
+    void canSetJobCleanupRetention() {
         final int retention = 2318;
-        this.properties.setRetention(retention);
-        Assertions.assertThat(this.properties.getRetention()).isEqualTo(retention);
+        this.properties.getJobCleanup().setRetention(retention);
+        Assertions.assertThat(this.properties.getJobCleanup().getRetention()).isEqualTo(retention);
     }
 
-    /**
-     * Make sure can set a max deletion batch size.
-     */
     @Test
-    void canSetMaxDeletedPerTransaction() {
+    void canSetJobCleanupMaxDeletedPerTransaction() {
         final int max = 2318;
-        this.properties.setMaxDeletedPerTransaction(max);
-        Assertions.assertThat(this.properties.getMaxDeletedPerTransaction()).isEqualTo(max);
+        this.properties.getJobCleanup().setMaxDeletedPerTransaction(max);
+        Assertions.assertThat(this.properties.getJobCleanup().getMaxDeletedPerTransaction()).isEqualTo(max);
     }
 
-    /**
-     * Make sure can set a new page size.
-     */
     @Test
-    void canPageSize() {
+    void canSetJobCleanupPageSize() {
         final int size = 2318;
-        this.properties.setPageSize(size);
-        Assertions.assertThat(this.properties.getPageSize()).isEqualTo(size);
+        this.properties.getJobCleanup().setPageSize(size);
+        Assertions.assertThat(this.properties.getJobCleanup().getPageSize()).isEqualTo(size);
     }
 
-    /**
-     * Make sure can enable Jobs entities cleanup.
-     */
     @Test
-    void canEnableJobsCleanup() {
-        this.properties.setSkipJobsCleanup(true);
-        Assertions.assertThat(this.properties.isSkipJobsCleanup()).isTrue();
+    void canSetSkipJobCleanup() {
+        this.properties.getJobCleanup().setSkip(true);
+        Assertions.assertThat(this.properties.getJobCleanup().isSkip()).isTrue();
     }
 
-    /**
-     * Make sure can enable Clusters entities cleanup.
-     */
     @Test
-    void canEnableClustersCleanup() {
-        this.properties.setSkipClustersCleanup(true);
-        Assertions.assertThat(this.properties.isSkipClustersCleanup()).isTrue();
+    void canSetSkipClusterCleanup() {
+        this.properties.getClusterCleanup().setSkip(true);
+        Assertions.assertThat(this.properties.getClusterCleanup().isSkip()).isTrue();
     }
 
-    /**
-     * Make sure can enable Tags entities cleanup.
-     */
     @Test
-    void canEnableTagsCleanup() {
-        this.properties.setSkipTagsCleanup(true);
-        Assertions.assertThat(this.properties.isSkipTagsCleanup()).isTrue();
+    void canSetSkipTagsCleanup() {
+        this.properties.getTagCleanup().setSkip(true);
+        Assertions.assertThat(this.properties.getTagCleanup().isSkip()).isTrue();
     }
 
-    /**
-     * Make sure can enable Files entities cleanup.
-     */
     @Test
-    void canEnableFilesCleanup() {
-        this.properties.setSkipFilesCleanup(true);
-        Assertions.assertThat(this.properties.isSkipFilesCleanup()).isTrue();
+    void caSetSkipFilesCleanup() {
+        this.properties.getFileCleanup().setSkip(true);
+        Assertions.assertThat(this.properties.getFileCleanup().isSkip()).isTrue();
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.UUID;
 
 /**
- * Unit tests for DatabaseCleanupProperties.
+ * Unit tests for {@link DatabaseCleanupProperties}.
  *
  * @author tgianos
  * @since 3.0.0

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
@@ -38,11 +38,15 @@ import com.netflix.genie.common.external.dtos.v4.JobEnvironment;
 import com.netflix.genie.common.external.dtos.v4.JobSpecification;
 import com.netflix.genie.common.internal.exceptions.checked.GenieCheckedException;
 import com.netflix.genie.common.internal.exceptions.checked.GenieJobResolutionException;
+import com.netflix.genie.web.data.services.AgentConnectionPersistenceService;
 import com.netflix.genie.web.data.services.ApplicationPersistenceService;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
 import com.netflix.genie.web.data.services.CommandPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
+import com.netflix.genie.web.data.services.FilePersistenceService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
+import com.netflix.genie.web.data.services.TagPersistenceService;
 import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.services.JobKillService;
@@ -142,15 +146,22 @@ public class JobCoordinatorServiceImplTest {
             )
             .thenReturn(this.setJobEnvironmentTimer);
 
-        this.jobCoordinatorService = new JobCoordinatorServiceImpl(
+        final DataServices dataServices = new DataServices(
+            Mockito.mock(AgentConnectionPersistenceService.class),
+            this.applicationPersistenceService,
+            this.clusterPersistenceService,
+            this.commandPersistenceService,
+            Mockito.mock(FilePersistenceService.class),
             this.jobPersistenceService,
+            this.jobSearchService,
+            Mockito.mock(TagPersistenceService.class)
+        );
+
+        this.jobCoordinatorService = new JobCoordinatorServiceImpl(
+            dataServices,
             this.jobKillService,
             this.jobStateService,
             this.jobsProperties,
-            this.applicationPersistenceService,
-            this.jobSearchService,
-            this.clusterPersistenceService,
-            this.commandPersistenceService,
             this.specificationService,
             this.registry,
             HOST_NAME

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobKillServiceV3Test.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobKillServiceV3Test.java
@@ -24,6 +24,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.external.util.GenieObjectMapper;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.events.JobFinishedEvent;
@@ -68,6 +69,7 @@ public class JobKillServiceV3Test {
     private FileSystemResource genieWorkingDir;
     private ProcessChecker.Factory processCheckerFactory;
     private ProcessChecker processChecker;
+    private DataServices dataServices;
 
     /**
      * Setup for the tests.
@@ -85,9 +87,11 @@ public class JobKillServiceV3Test {
         this.genieEventBus = Mockito.mock(GenieEventBus.class);
         this.processCheckerFactory = Mockito.mock(ProcessChecker.Factory.class);
         this.processChecker = Mockito.mock(ProcessChecker.class);
+        this.dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(this.jobSearchService);
         this.service = new JobKillServiceV3(
             HOSTNAME,
-            this.jobSearchService,
+            this.dataServices,
             this.executor,
             false,
             this.genieEventBus,
@@ -240,7 +244,7 @@ public class JobKillServiceV3Test {
     public void canKillJobRunningAsUser() throws GenieException, IOException {
         this.service = new JobKillServiceV3(
             HOSTNAME,
-            this.jobSearchService,
+            this.dataServices,
             this.executor,
             true,
             this.genieEventBus,

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobMetricsServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobMetricsServiceImplTest.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.services.impl;
 
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.Job;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,7 +46,9 @@ class JobMetricsServiceImplTest {
     @BeforeEach
     void setup() {
         this.jobSearchService = Mockito.mock(JobSearchService.class);
-        this.jobMetricsService = new JobMetricsServiceImpl(this.jobSearchService, this.hostName);
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(this.jobSearchService);
+        this.jobMetricsService = new JobMetricsServiceImpl(dataServices, this.hostName);
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/LocalJobRunnerTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/LocalJobRunnerTest.java
@@ -32,6 +32,7 @@ import com.netflix.genie.common.external.dtos.v4.CommandMetadata;
 import com.netflix.genie.common.external.dtos.v4.CommandStatus;
 import com.netflix.genie.common.external.dtos.v4.ExecutionEnvironment;
 import com.netflix.genie.common.internal.jobs.JobConstants;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.jobs.workflow.WorkflowTask;
@@ -107,8 +108,11 @@ public class LocalJobRunnerTest {
         final MeterRegistry registry = Mockito.mock(MeterRegistry.class);
         Mockito.when(registry.timer(Mockito.anyString())).thenReturn(Mockito.mock(Timer.class));
 
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobPersistenceService()).thenReturn(Mockito.mock(JobPersistenceService.class));
+
         this.jobSubmitterService = new LocalJobRunner(
-            Mockito.mock(JobPersistenceService.class),
+            dataServices,
             genieEventBus,
             jobWorkflowTasks,
             baseWorkingDirResource,

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/apis/rpc/v4/endpoints/AgentRpcEndpointsAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/apis/rpc/v4/endpoints/AgentRpcEndpointsAutoConfigurationTest.java
@@ -31,6 +31,7 @@ import com.netflix.genie.web.agent.apis.rpc.v4.endpoints.GRpcPingServiceImpl;
 import com.netflix.genie.web.agent.apis.rpc.v4.endpoints.JobServiceProtoErrorComposer;
 import com.netflix.genie.web.agent.services.AgentJobService;
 import com.netflix.genie.web.agent.services.AgentRoutingService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.assertj.core.api.Assertions;
@@ -39,7 +40,6 @@ import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
 
 /**
@@ -154,7 +154,6 @@ class AgentRpcEndpointsAutoConfigurationTest {
     /**
      * Mocking needed required beans provided by other configurations.
      */
-    @Configuration
     static class RequiredBeans {
         @Bean
         TaskScheduler genieTaskScheduler() {
@@ -185,12 +184,18 @@ class AgentRpcEndpointsAutoConfigurationTest {
         MeterRegistry meterRegistry() {
             return Mockito.mock(MeterRegistry.class);
         }
+
+        @Bean
+        DataServices genieDataServices(final JobSearchService jobSearchService) {
+            final DataServices dataServices = Mockito.mock(DataServices.class);
+            Mockito.when(dataServices.getJobSearchService()).thenReturn(jobSearchService);
+            return dataServices;
+        }
     }
 
     /**
      * Dummy user configuration.
      */
-    @Configuration
     static class UserConfig {
 
         @Bean(name = "heartBeatServiceTaskScheduler")

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/launchers/AgentLaunchersAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/launchers/AgentLaunchersAutoConfigurationTest.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.spring.autoconfigure.agent.launchers;
 
 import com.netflix.genie.web.agent.launchers.impl.LocalAgentLauncherImpl;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.introspection.GenieWebHostInfo;
 import com.netflix.genie.web.introspection.GenieWebRpcInfo;
@@ -79,6 +80,13 @@ class AgentLaunchersAutoConfigurationTest {
         @Bean
         JobSearchService jobSearchService() {
             return Mockito.mock(JobSearchService.class);
+        }
+
+        @Bean
+        DataServices genieDataServices(final JobSearchService jobSearchService) {
+            final DataServices dataServices = Mockito.mock(DataServices.class);
+            Mockito.when(dataServices.getJobSearchService()).thenReturn(jobSearchService);
+            return dataServices;
         }
 
         @Bean

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/health/HealthAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/health/HealthAutoConfigurationTest.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.spring.autoconfigure.health;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.web.agent.launchers.impl.LocalAgentLauncherImpl;
 import com.netflix.genie.web.agent.services.AgentMetricsService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.health.GenieAgentHealthIndicator;
 import com.netflix.genie.web.health.GenieMemoryHealthIndicator;
@@ -134,6 +135,13 @@ class HealthAutoConfigurationTest {
         @Bean
         GenieHostInfo genieHostInfo() {
             return Mockito.mock(GenieHostInfo.class);
+        }
+
+        @Bean
+        DataServices genieDataServices(final JobSearchService jobSearchService) {
+            final DataServices dataServices = Mockito.mock(DataServices.class);
+            Mockito.when(dataServices.getJobSearchService()).thenReturn(jobSearchService);
+            return dataServices;
         }
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
@@ -19,7 +19,10 @@ package com.netflix.genie.web.spring.autoconfigure.tasks.leader;
 
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.web.data.services.AgentConnectionPersistenceService;
+import com.netflix.genie.web.data.services.ApplicationPersistenceService;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
+import com.netflix.genie.web.data.services.CommandPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.FilePersistenceService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
@@ -286,6 +289,62 @@ class LeaderAutoConfigurationTest {
         @Bean
         AgentConnectionPersistenceService agentConnectionPersistenceService() {
             return Mockito.mock(AgentConnectionPersistenceService.class);
+        }
+
+        /**
+         * Mocked bean.
+         *
+         * @return Mocked bean instance
+         */
+        @Bean
+        ApplicationPersistenceService applicationPersistenceService() {
+            return Mockito.mock(ApplicationPersistenceService.class);
+        }
+
+        /**
+         * Mocked bean.
+         *
+         * @return Mocked bean instance
+         */
+        @Bean
+        CommandPersistenceService commandPersistenceService() {
+            return Mockito.mock(CommandPersistenceService.class);
+        }
+
+        /**
+         * Encapsulation containing mocked instances.
+         *
+         * @param agentConnectionPersistenceService Mocked
+         * @param applicationPersistenceService     Mocked
+         * @param clusterPersistenceService         Mocked
+         * @param commandPersistenceService         Mocked
+         * @param filePersistenceService            Mocked
+         * @param jobPersistenceService             Mocked
+         * @param jobSearchService                  Mocked
+         * @param tagPersistenceService             Mocked
+         * @return {@link DataServices} instance
+         */
+        @Bean
+        DataServices genieDataServices(
+            final AgentConnectionPersistenceService agentConnectionPersistenceService,
+            final ApplicationPersistenceService applicationPersistenceService,
+            final ClusterPersistenceService clusterPersistenceService,
+            final CommandPersistenceService commandPersistenceService,
+            final FilePersistenceService filePersistenceService,
+            final JobPersistenceService jobPersistenceService,
+            final JobSearchService jobSearchService,
+            final TagPersistenceService tagPersistenceService
+        ) {
+            return new DataServices(
+                agentConnectionPersistenceService,
+                applicationPersistenceService,
+                clusterPersistenceService,
+                commandPersistenceService,
+                filePersistenceService,
+                jobPersistenceService,
+                jobSearchService,
+                tagPersistenceService
+            );
         }
     }
 

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
@@ -34,12 +34,12 @@ import com.netflix.genie.web.properties.DatabaseCleanupProperties;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.properties.LeadershipProperties;
 import com.netflix.genie.web.properties.UserMetricsProperties;
-import com.netflix.genie.web.properties.ZookeeperLeadershipProperties;
+import com.netflix.genie.web.properties.ZookeeperLeaderProperties;
 import com.netflix.genie.web.spring.autoconfigure.tasks.TasksAutoConfiguration;
 import com.netflix.genie.web.tasks.leader.AgentJobCleanupTask;
 import com.netflix.genie.web.tasks.leader.ClusterCheckerTask;
 import com.netflix.genie.web.tasks.leader.DatabaseCleanupTask;
-import com.netflix.genie.web.tasks.leader.LeadershipTasksCoordinator;
+import com.netflix.genie.web.tasks.leader.LeaderTasksCoordinator;
 import com.netflix.genie.web.tasks.leader.LocalLeader;
 import com.netflix.genie.web.tasks.leader.UserMetricsTask;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -86,9 +86,9 @@ class LeaderAutoConfigurationTest {
                 Assertions.assertThat(context).hasSingleBean(DatabaseCleanupProperties.class);
                 Assertions.assertThat(context).hasSingleBean(LeadershipProperties.class);
                 Assertions.assertThat(context).hasSingleBean(UserMetricsProperties.class);
-                Assertions.assertThat(context).hasSingleBean(ZookeeperLeadershipProperties.class);
+                Assertions.assertThat(context).hasSingleBean(ZookeeperLeaderProperties.class);
 
-                Assertions.assertThat(context).hasSingleBean(LeadershipTasksCoordinator.class);
+                Assertions.assertThat(context).hasSingleBean(LeaderTasksCoordinator.class);
                 Assertions.assertThat(context).doesNotHaveBean(LeaderInitiatorFactoryBean.class);
                 Assertions.assertThat(context).hasSingleBean(LocalLeader.class);
                 Assertions.assertThat(context).hasSingleBean(ClusterCheckerTask.class);
@@ -119,9 +119,9 @@ class LeaderAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(DatabaseCleanupProperties.class);
                     Assertions.assertThat(context).hasSingleBean(LeadershipProperties.class);
                     Assertions.assertThat(context).hasSingleBean(UserMetricsProperties.class);
-                    Assertions.assertThat(context).hasSingleBean(ZookeeperLeadershipProperties.class);
+                    Assertions.assertThat(context).hasSingleBean(ZookeeperLeaderProperties.class);
 
-                    Assertions.assertThat(context).hasSingleBean(LeadershipTasksCoordinator.class);
+                    Assertions.assertThat(context).hasSingleBean(LeaderTasksCoordinator.class);
                     Assertions.assertThat(context).doesNotHaveBean(LeaderInitiatorFactoryBean.class);
                     Assertions.assertThat(context).hasSingleBean(LocalLeader.class);
                     Assertions.assertThat(context).hasSingleBean(ClusterCheckerTask.class);
@@ -148,9 +148,9 @@ class LeaderAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(DatabaseCleanupProperties.class);
                     Assertions.assertThat(context).hasSingleBean(LeadershipProperties.class);
                     Assertions.assertThat(context).hasSingleBean(UserMetricsProperties.class);
-                    Assertions.assertThat(context).hasSingleBean(ZookeeperLeadershipProperties.class);
+                    Assertions.assertThat(context).hasSingleBean(ZookeeperLeaderProperties.class);
 
-                    Assertions.assertThat(context).hasSingleBean(LeadershipTasksCoordinator.class);
+                    Assertions.assertThat(context).hasSingleBean(LeaderTasksCoordinator.class);
                     Assertions.assertThat(context).hasSingleBean(LeaderInitiatorFactoryBean.class);
                     Assertions.assertThat(context).doesNotHaveBean(LocalLeader.class);
                     Assertions.assertThat(context).hasSingleBean(ClusterCheckerTask.class);

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/node/NodeAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/node/NodeAutoConfigurationTest.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.spring.autoconfigure.tasks.node;
 
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.DiskCleanupProperties;
 import com.netflix.genie.web.properties.JobsProperties;
@@ -152,6 +153,13 @@ class NodeAutoConfigurationTest {
         @Bean
         Executor executor() {
             return Mockito.mock(Executor.class);
+        }
+
+        @Bean
+        DataServices genieDataServices(final JobSearchService jobSearchService) {
+            final DataServices dataServices = Mockito.mock(DataServices.class);
+            Mockito.when(dataServices.getJobSearchService()).thenReturn(jobSearchService);
+            return dataServices;
         }
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/job/JobMonitoringCoordinatorTest.java
@@ -29,6 +29,7 @@ import com.netflix.genie.common.external.dtos.v4.Application;
 import com.netflix.genie.common.external.dtos.v4.Cluster;
 import com.netflix.genie.common.external.dtos.v4.Command;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.events.JobFinishedEvent;
@@ -109,9 +110,12 @@ public class JobMonitoringCoordinatorTest {
         final Resource jobsDir = Mockito.mock(Resource.class);
         Mockito.when(jobsDir.getFile()).thenReturn(jobsFile);
 
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(this.jobSearchService);
+
         this.coordinator = new JobMonitoringCoordinator(
             new GenieHostInfo(HOSTNAME),
-            this.jobSearchService,
+            dataServices,
             this.genieEventBus,
             this.scheduler,
             new SimpleMeterRegistry(),

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskTest.java
@@ -17,8 +17,11 @@
  */
 package com.netflix.genie.web.tasks.leader;
 
+import com.netflix.genie.common.external.dtos.v4.CommandStatus;
 import com.netflix.genie.common.internal.jobs.JobConstants;
+import com.netflix.genie.web.data.services.ApplicationPersistenceService;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
+import com.netflix.genie.web.data.services.CommandPersistenceService;
 import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.FilePersistenceService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
@@ -37,6 +40,7 @@ import org.springframework.scheduling.support.CronTrigger;
 
 import java.time.Instant;
 import java.util.Calendar;
+import java.util.EnumSet;
 
 /**
  * Unit tests for {@link DatabaseCleanupTask}.
@@ -47,11 +51,16 @@ import java.util.Calendar;
 class DatabaseCleanupTaskTest {
 
     private DatabaseCleanupProperties cleanupProperties;
+    private DatabaseCleanupProperties.ApplicationDatabaseCleanupProperties applicationCleanupProperties;
     private DatabaseCleanupProperties.ClusterDatabaseCleanupProperties clusterCleanupProperties;
+    private DatabaseCleanupProperties.CommandDatabaseCleanupProperties commandCleanupProperties;
+    private DatabaseCleanupProperties.CommandDeactivationDatabaseCleanupProperties commandDeactivationProperties;
     private DatabaseCleanupProperties.FileDatabaseCleanupProperties fileCleanupProperties;
     private DatabaseCleanupProperties.JobDatabaseCleanupProperties jobCleanupProperties;
     private DatabaseCleanupProperties.TagDatabaseCleanupProperties tagCleanupProperties;
     private MockEnvironment environment;
+    private ApplicationPersistenceService applicationPersistenceService;
+    private CommandPersistenceService commandPersistenceService;
     private JobPersistenceService jobPersistenceService;
     private ClusterPersistenceService clusterPersistenceService;
     private FilePersistenceService filePersistenceService;
@@ -64,8 +73,16 @@ class DatabaseCleanupTaskTest {
     @BeforeEach
     void setup() {
         this.cleanupProperties = Mockito.mock(DatabaseCleanupProperties.class);
+        this.applicationCleanupProperties
+            = Mockito.mock(DatabaseCleanupProperties.ApplicationDatabaseCleanupProperties.class);
+        Mockito.when(this.cleanupProperties.getApplicationCleanup()).thenReturn(this.applicationCleanupProperties);
         this.clusterCleanupProperties = Mockito.mock(DatabaseCleanupProperties.ClusterDatabaseCleanupProperties.class);
         Mockito.when(this.cleanupProperties.getClusterCleanup()).thenReturn(this.clusterCleanupProperties);
+        this.commandCleanupProperties = Mockito.mock(DatabaseCleanupProperties.CommandDatabaseCleanupProperties.class);
+        Mockito.when(this.cleanupProperties.getCommandCleanup()).thenReturn(this.commandCleanupProperties);
+        this.commandDeactivationProperties
+            = Mockito.mock(DatabaseCleanupProperties.CommandDeactivationDatabaseCleanupProperties.class);
+        Mockito.when(this.cleanupProperties.getCommandDeactivation()).thenReturn(this.commandDeactivationProperties);
         this.fileCleanupProperties = Mockito.mock(DatabaseCleanupProperties.FileDatabaseCleanupProperties.class);
         Mockito.when(this.cleanupProperties.getFileCleanup()).thenReturn(this.fileCleanupProperties);
         this.jobCleanupProperties = Mockito.mock(DatabaseCleanupProperties.JobDatabaseCleanupProperties.class);
@@ -73,11 +90,15 @@ class DatabaseCleanupTaskTest {
         this.tagCleanupProperties = Mockito.mock(DatabaseCleanupProperties.TagDatabaseCleanupProperties.class);
         Mockito.when(this.cleanupProperties.getTagCleanup()).thenReturn(this.tagCleanupProperties);
         this.environment = new MockEnvironment();
+        this.applicationPersistenceService = Mockito.mock(ApplicationPersistenceService.class);
+        this.commandPersistenceService = Mockito.mock(CommandPersistenceService.class);
         this.jobPersistenceService = Mockito.mock(JobPersistenceService.class);
         this.clusterPersistenceService = Mockito.mock(ClusterPersistenceService.class);
         this.filePersistenceService = Mockito.mock(FilePersistenceService.class);
         this.tagPersistenceService = Mockito.mock(TagPersistenceService.class);
         final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getApplicationPersistenceService()).thenReturn(this.applicationPersistenceService);
+        Mockito.when(dataServices.getCommandPersistenceService()).thenReturn(this.commandPersistenceService);
         Mockito.when(dataServices.getClusterPersistenceService()).thenReturn(this.clusterPersistenceService);
         Mockito.when(dataServices.getJobPersistenceService()).thenReturn(this.jobPersistenceService);
         Mockito.when(dataServices.getFilePersistenceService()).thenReturn(this.filePersistenceService);
@@ -128,6 +149,9 @@ class DatabaseCleanupTaskTest {
         Mockito.when(this.jobCleanupProperties.getRetention()).thenReturn(days).thenReturn(negativeDays);
         Mockito.when(this.jobCleanupProperties.getPageSize()).thenReturn(pageSize);
         Mockito.when(this.jobCleanupProperties.getMaxDeletedPerTransaction()).thenReturn(maxDeleted);
+
+        Mockito.when(this.commandDeactivationProperties.getCommandCreationThreshold()).thenReturn(60);
+        Mockito.when(this.commandDeactivationProperties.getJobCreationThreshold()).thenReturn(30);
         final ArgumentCaptor<Instant> argument = ArgumentCaptor.forClass(Instant.class);
 
         final long deletedCount1 = 6L;
@@ -150,6 +174,27 @@ class DatabaseCleanupTaskTest {
         Mockito.when(this.clusterPersistenceService.deleteTerminatedClusters()).thenReturn(1L, 2L);
         Mockito.when(this.filePersistenceService.deleteUnusedFiles(Mockito.any(Instant.class))).thenReturn(3L, 4L);
         Mockito.when(this.tagPersistenceService.deleteUnusedTags(Mockito.any(Instant.class))).thenReturn(5L, 6L);
+        Mockito
+            .when(this.applicationPersistenceService.deleteUnusedApplicationsCreatedBefore(Mockito.any(Instant.class)))
+            .thenReturn(11, 117);
+        Mockito
+            .when(
+                this.commandPersistenceService.updateStatusForUnusedCommands(
+                    Mockito.eq(CommandStatus.INACTIVE),
+                    Mockito.any(Instant.class),
+                    Mockito.eq(EnumSet.of(CommandStatus.DEPRECATED, CommandStatus.ACTIVE)),
+                    Mockito.any(Instant.class)
+                )
+            )
+            .thenReturn(50, 242);
+        Mockito
+            .when(
+                this.commandPersistenceService.deleteUnusedCommands(
+                    Mockito.eq(EnumSet.of(CommandStatus.INACTIVE)),
+                    Mockito.any(Instant.class)
+                )
+            )
+            .thenReturn(11, 81);
 
         // The multiple calendar instances are to protect against running this test when the day flips
         final Calendar before = Calendar.getInstance(JobConstants.UTC);
@@ -176,6 +221,20 @@ class DatabaseCleanupTaskTest {
             Mockito
                 .verify(this.tagPersistenceService, Mockito.times(2))
                 .deleteUnusedTags(Mockito.any(Instant.class));
+            Mockito
+                .verify(this.applicationPersistenceService, Mockito.times(2))
+                .deleteUnusedApplicationsCreatedBefore(Mockito.any(Instant.class));
+            Mockito
+                .verify(this.commandPersistenceService, Mockito.times(2))
+                .deleteUnusedCommands(Mockito.eq(EnumSet.of(CommandStatus.INACTIVE)), Mockito.any(Instant.class));
+            Mockito
+                .verify(this.commandPersistenceService, Mockito.times(2))
+                .updateStatusForUnusedCommands(
+                    Mockito.eq(CommandStatus.INACTIVE),
+                    Mockito.any(Instant.class),
+                    Mockito.eq(EnumSet.of(CommandStatus.DEPRECATED, CommandStatus.ACTIVE)),
+                    Mockito.any(Instant.class)
+                );
         }
     }
 
@@ -211,10 +270,22 @@ class DatabaseCleanupTaskTest {
      */
     @Test
     void skipAll() {
+        this.environment.setProperty(
+            DatabaseCleanupProperties.ApplicationDatabaseCleanupProperties.SKIP_PROPERTY,
+            "true"
+        );
+        this.environment.setProperty(DatabaseCleanupProperties.CommandDatabaseCleanupProperties.SKIP_PROPERTY, "true");
+        this.environment.setProperty(
+            DatabaseCleanupProperties.CommandDeactivationDatabaseCleanupProperties.SKIP_PROPERTY,
+            "true"
+        );
         this.environment.setProperty(DatabaseCleanupProperties.ClusterDatabaseCleanupProperties.SKIP_PROPERTY, "true");
         this.environment.setProperty(DatabaseCleanupProperties.FileDatabaseCleanupProperties.SKIP_PROPERTY, "true");
         this.environment.setProperty(DatabaseCleanupProperties.JobDatabaseCleanupProperties.SKIP_PROPERTY, "true");
         this.environment.setProperty(DatabaseCleanupProperties.TagDatabaseCleanupProperties.SKIP_PROPERTY, "true");
+        Mockito.when(this.applicationCleanupProperties.isSkip()).thenReturn(false);
+        Mockito.when(this.commandCleanupProperties.isSkip()).thenReturn(false);
+        Mockito.when(this.commandDeactivationProperties.isSkip()).thenReturn(false);
         Mockito.when(this.clusterCleanupProperties.isSkip()).thenReturn(false);
         Mockito.when(this.fileCleanupProperties.isSkip()).thenReturn(false);
         Mockito.when(this.tagCleanupProperties.isSkip()).thenReturn(false);
@@ -222,6 +293,20 @@ class DatabaseCleanupTaskTest {
 
         this.task.run();
 
+        Mockito
+            .verify(this.applicationPersistenceService, Mockito.never())
+            .deleteUnusedApplicationsCreatedBefore(Mockito.any(Instant.class));
+        Mockito
+            .verify(this.commandPersistenceService, Mockito.never())
+            .deleteUnusedCommands(Mockito.anySet(), Mockito.any(Instant.class));
+        Mockito
+            .verify(this.commandPersistenceService, Mockito.never())
+            .updateStatusForUnusedCommands(
+                Mockito.any(CommandStatus.class),
+                Mockito.any(Instant.class),
+                Mockito.anySet(),
+                Mockito.any(Instant.class)
+            );
         Mockito
             .verify(this.jobPersistenceService, Mockito.never())
             .deleteBatchOfJobsCreatedBeforeDate(

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskTest.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.tasks.leader;
 
 import com.netflix.genie.common.internal.jobs.JobConstants;
 import com.netflix.genie.web.data.services.ClusterPersistenceService;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.FilePersistenceService;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.TagPersistenceService;
@@ -60,12 +61,14 @@ class DatabaseCleanupTaskTest {
         this.clusterPersistenceService = Mockito.mock(ClusterPersistenceService.class);
         this.filePersistenceService = Mockito.mock(FilePersistenceService.class);
         this.tagPersistenceService = Mockito.mock(TagPersistenceService.class);
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getClusterPersistenceService()).thenReturn(this.clusterPersistenceService);
+        Mockito.when(dataServices.getJobPersistenceService()).thenReturn(this.jobPersistenceService);
+        Mockito.when(dataServices.getFilePersistenceService()).thenReturn(this.filePersistenceService);
+        Mockito.when(dataServices.getTagPersistenceService()).thenReturn(this.tagPersistenceService);
         this.task = new DatabaseCleanupTask(
             this.cleanupProperties,
-            this.jobPersistenceService,
-            this.clusterPersistenceService,
-            this.filePersistenceService,
-            this.tagPersistenceService,
+            dataServices,
             new SimpleMeterRegistry()
         );
     }

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTaskTest.java
@@ -47,6 +47,10 @@ import java.util.Calendar;
 class DatabaseCleanupTaskTest {
 
     private DatabaseCleanupProperties cleanupProperties;
+    private DatabaseCleanupProperties.ClusterDatabaseCleanupProperties clusterCleanupProperties;
+    private DatabaseCleanupProperties.FileDatabaseCleanupProperties fileCleanupProperties;
+    private DatabaseCleanupProperties.JobDatabaseCleanupProperties jobCleanupProperties;
+    private DatabaseCleanupProperties.TagDatabaseCleanupProperties tagCleanupProperties;
     private MockEnvironment environment;
     private JobPersistenceService jobPersistenceService;
     private ClusterPersistenceService clusterPersistenceService;
@@ -60,6 +64,14 @@ class DatabaseCleanupTaskTest {
     @BeforeEach
     void setup() {
         this.cleanupProperties = Mockito.mock(DatabaseCleanupProperties.class);
+        this.clusterCleanupProperties = Mockito.mock(DatabaseCleanupProperties.ClusterDatabaseCleanupProperties.class);
+        Mockito.when(this.cleanupProperties.getClusterCleanup()).thenReturn(this.clusterCleanupProperties);
+        this.fileCleanupProperties = Mockito.mock(DatabaseCleanupProperties.FileDatabaseCleanupProperties.class);
+        Mockito.when(this.cleanupProperties.getFileCleanup()).thenReturn(this.fileCleanupProperties);
+        this.jobCleanupProperties = Mockito.mock(DatabaseCleanupProperties.JobDatabaseCleanupProperties.class);
+        Mockito.when(this.cleanupProperties.getJobCleanup()).thenReturn(this.jobCleanupProperties);
+        this.tagCleanupProperties = Mockito.mock(DatabaseCleanupProperties.TagDatabaseCleanupProperties.class);
+        Mockito.when(this.cleanupProperties.getTagCleanup()).thenReturn(this.tagCleanupProperties);
         this.environment = new MockEnvironment();
         this.jobPersistenceService = Mockito.mock(JobPersistenceService.class);
         this.clusterPersistenceService = Mockito.mock(ClusterPersistenceService.class);
@@ -113,9 +125,9 @@ class DatabaseCleanupTaskTest {
         final int pageSize = 10;
         final int maxDeleted = 10_000;
 
-        Mockito.when(this.cleanupProperties.getRetention()).thenReturn(days).thenReturn(negativeDays);
-        Mockito.when(this.cleanupProperties.getPageSize()).thenReturn(pageSize);
-        Mockito.when(this.cleanupProperties.getMaxDeletedPerTransaction()).thenReturn(maxDeleted);
+        Mockito.when(this.jobCleanupProperties.getRetention()).thenReturn(days).thenReturn(negativeDays);
+        Mockito.when(this.jobCleanupProperties.getPageSize()).thenReturn(pageSize);
+        Mockito.when(this.jobCleanupProperties.getMaxDeletedPerTransaction()).thenReturn(maxDeleted);
         final ArgumentCaptor<Instant> argument = ArgumentCaptor.forClass(Instant.class);
 
         final long deletedCount1 = 6L;
@@ -177,9 +189,9 @@ class DatabaseCleanupTaskTest {
         final int pageSize = 10;
         final int maxDeleted = 10_000;
 
-        Mockito.when(this.cleanupProperties.getRetention()).thenReturn(days).thenReturn(negativeDays);
-        Mockito.when(this.cleanupProperties.getPageSize()).thenReturn(pageSize);
-        Mockito.when(this.cleanupProperties.getMaxDeletedPerTransaction()).thenReturn(maxDeleted);
+        Mockito.when(this.jobCleanupProperties.getRetention()).thenReturn(days).thenReturn(negativeDays);
+        Mockito.when(this.jobCleanupProperties.getPageSize()).thenReturn(pageSize);
+        Mockito.when(this.jobCleanupProperties.getMaxDeletedPerTransaction()).thenReturn(maxDeleted);
 
         Mockito
             .when(
@@ -199,14 +211,14 @@ class DatabaseCleanupTaskTest {
      */
     @Test
     void skipAll() {
-        this.environment.setProperty(DatabaseCleanupProperties.SKIP_JOBS_PROPERTY, "true");
-        this.environment.setProperty(DatabaseCleanupProperties.SKIP_CLUSTERS_PROPERTY, "true");
-        this.environment.setProperty(DatabaseCleanupProperties.SKIP_TAGS_PROPERTY, "true");
-        this.environment.setProperty(DatabaseCleanupProperties.SKIP_FILES_PROPERTY, "true");
-        Mockito.when(this.cleanupProperties.isSkipJobsCleanup()).thenReturn(false);
-        Mockito.when(this.cleanupProperties.isSkipClustersCleanup()).thenReturn(false);
-        Mockito.when(this.cleanupProperties.isSkipTagsCleanup()).thenReturn(false);
-        Mockito.when(this.cleanupProperties.isSkipFilesCleanup()).thenReturn(false);
+        this.environment.setProperty(DatabaseCleanupProperties.ClusterDatabaseCleanupProperties.SKIP_PROPERTY, "true");
+        this.environment.setProperty(DatabaseCleanupProperties.FileDatabaseCleanupProperties.SKIP_PROPERTY, "true");
+        this.environment.setProperty(DatabaseCleanupProperties.JobDatabaseCleanupProperties.SKIP_PROPERTY, "true");
+        this.environment.setProperty(DatabaseCleanupProperties.TagDatabaseCleanupProperties.SKIP_PROPERTY, "true");
+        Mockito.when(this.clusterCleanupProperties.isSkip()).thenReturn(false);
+        Mockito.when(this.fileCleanupProperties.isSkip()).thenReturn(false);
+        Mockito.when(this.tagCleanupProperties.isSkip()).thenReturn(false);
+        Mockito.when(this.jobCleanupProperties.isSkip()).thenReturn(false);
 
         this.task.run();
 

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/LeaderTasksCoordinatorTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/leader/LeaderTasksCoordinatorTest.java
@@ -38,13 +38,13 @@ import java.util.concurrent.ScheduledFuture;
  * @author tgianos
  * @since 3.0.0
  */
-class LeadershipTasksCoordinatorTest {
+class LeaderTasksCoordinatorTest {
 
-    private LeadershipTasksCoordinator coordinator;
+    private LeaderTasksCoordinator coordinator;
     private TaskScheduler scheduler;
-    private LeadershipTask task1;
-    private LeadershipTask task2;
-    private LeadershipTask task3;
+    private LeaderTask task1;
+    private LeaderTask task2;
+    private LeaderTask task3;
 
     /**
      * Setup for the tests.
@@ -52,11 +52,11 @@ class LeadershipTasksCoordinatorTest {
     @BeforeEach
     void setup() {
         this.scheduler = Mockito.mock(TaskScheduler.class);
-        this.task1 = Mockito.mock(LeadershipTask.class);
-        this.task2 = Mockito.mock(LeadershipTask.class);
-        this.task3 = Mockito.mock(LeadershipTask.class);
-        final Set<LeadershipTask> tasks = Sets.newHashSet(this.task1, this.task2, this.task3);
-        this.coordinator = new LeadershipTasksCoordinator(this.scheduler, tasks);
+        this.task1 = Mockito.mock(LeaderTask.class);
+        this.task2 = Mockito.mock(LeaderTask.class);
+        this.task3 = Mockito.mock(LeaderTask.class);
+        final Set<LeaderTask> tasks = Sets.newHashSet(this.task1, this.task2, this.task3);
+        this.coordinator = new LeaderTasksCoordinator(this.scheduler, tasks);
     }
 
     /**

--- a/genie-web/src/test/java/com/netflix/genie/web/tasks/node/DiskCleanupTaskTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/tasks/node/DiskCleanupTaskTest.java
@@ -21,6 +21,7 @@ import com.netflix.genie.common.dto.Job;
 import com.netflix.genie.common.dto.JobStatus;
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieServerException;
+import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobSearchService;
 import com.netflix.genie.web.properties.DiskCleanupProperties;
 import com.netflix.genie.web.properties.JobsProperties;
@@ -71,12 +72,14 @@ public class DiskCleanupTaskTest {
         properties.getUsers().setRunAsUserEnabled(false);
         final Resource jobsDir = Mockito.mock(Resource.class);
         Mockito.when(jobsDir.exists()).thenReturn(false);
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(Mockito.mock(JobSearchService.class));
         Assert.assertNotNull(
             new DiskCleanupTask(
                 new DiskCleanupProperties(),
                 Mockito.mock(TaskScheduler.class),
                 jobsDir,
-                Mockito.mock(JobSearchService.class),
+                dataServices,
                 properties,
                 Mockito.mock(Executor.class),
                 new SimpleMeterRegistry()
@@ -95,12 +98,14 @@ public class DiskCleanupTaskTest {
         final TaskScheduler scheduler = Mockito.mock(TaskScheduler.class);
         final Resource jobsDir = Mockito.mock(Resource.class);
         Mockito.when(jobsDir.exists()).thenReturn(true);
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(Mockito.mock(JobSearchService.class));
         Assert.assertNotNull(
             new DiskCleanupTask(
                 new DiskCleanupProperties(),
                 scheduler,
                 jobsDir,
-                Mockito.mock(JobSearchService.class),
+                dataServices,
                 JobsProperties.getJobsPropertiesDefaults(),
                 Mockito.mock(Executor.class),
                 new SimpleMeterRegistry()
@@ -120,12 +125,14 @@ public class DiskCleanupTaskTest {
         final TaskScheduler scheduler = Mockito.mock(TaskScheduler.class);
         final Resource jobsDir = Mockito.mock(Resource.class);
         Mockito.when(jobsDir.exists()).thenReturn(true);
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(Mockito.mock(JobSearchService.class));
         Assert.assertNotNull(
             new DiskCleanupTask(
                 new DiskCleanupProperties(),
                 scheduler,
                 jobsDir,
-                Mockito.mock(JobSearchService.class),
+                dataServices,
                 JobsProperties.getJobsPropertiesDefaults(),
                 Mockito.mock(Executor.class),
                 new SimpleMeterRegistry()
@@ -147,12 +154,14 @@ public class DiskCleanupTaskTest {
         final TaskScheduler scheduler = Mockito.mock(TaskScheduler.class);
         final Resource jobsDir = Mockito.mock(Resource.class);
         Mockito.when(jobsDir.exists()).thenReturn(true);
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(Mockito.mock(JobSearchService.class));
         Assert.assertNotNull(
             new DiskCleanupTask(
                 new DiskCleanupProperties(),
                 scheduler,
                 jobsDir,
-                Mockito.mock(JobSearchService.class),
+                dataServices,
                 properties,
                 Mockito.mock(Executor.class),
                 new SimpleMeterRegistry()
@@ -212,11 +221,14 @@ public class DiskCleanupTaskTest {
         Mockito.when(jobSearchService.getJob(job4Id)).thenReturn(job4);
         Mockito.when(jobSearchService.getJob(job5Id)).thenThrow(new GenieServerException("blah"));
 
+        final DataServices dataServices = Mockito.mock(DataServices.class);
+        Mockito.when(dataServices.getJobSearchService()).thenReturn(jobSearchService);
+
         final DiskCleanupTask task = new DiskCleanupTask(
             properties,
             scheduler,
             jobDir,
-            jobSearchService,
+            dataServices,
             jobsProperties,
             Mockito.mock(Executor.class),
             new SimpleMeterRegistry()


### PR DESCRIPTION
Primarily adding support for cleaning unused commands and applications from the database similar to how we've done jobs, clusters, files and tags in the past.

Made all database cleanup related properties dynamic to reduce operational burden so clusters don't have to be re-deployed for changes to be picked up.

Additionally technical debt and other improvements found along the way