### PR TITLE
Fix bug where command cluster table not taken into account for command deletion

### DIFF
--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest.java
@@ -1011,7 +1011,7 @@ class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrationTestB
     void testDeleteUnusedCommands() {
         final Instant present = Instant.parse("2020-03-24T00:00:00.000Z");
         final Instant createdThreshold = present.minus(1, ChronoUnit.DAYS);
-        Assertions.assertThat(this.commandRepository.count()).isEqualTo(7);
+        Assertions.assertThat(this.commandRepository.count()).isEqualTo(8);
         Assertions.assertThat(this.commandRepository.existsByUniqueId("command0")).isTrue();
         Assertions.assertThat(this.commandRepository.existsByUniqueId("command1")).isTrue();
         Assertions.assertThat(this.commandRepository.existsByUniqueId("command2")).isTrue();
@@ -1019,6 +1019,7 @@ class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrationTestB
         Assertions.assertThat(this.commandRepository.existsByUniqueId("command4")).isTrue();
         Assertions.assertThat(this.commandRepository.existsByUniqueId("command5")).isTrue();
         Assertions.assertThat(this.commandRepository.existsByUniqueId("command6")).isTrue();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command7")).isTrue();
         Assertions.assertThat(
             this.service.deleteUnusedCommands(
                 EnumSet.of(CommandStatus.INACTIVE, CommandStatus.DEPRECATED),
@@ -1032,6 +1033,7 @@ class JpaCommandPersistenceServiceImplIntegrationTest extends DBIntegrationTestB
         Assertions.assertThat(this.commandRepository.existsByUniqueId("command4")).isTrue();
         Assertions.assertThat(this.commandRepository.existsByUniqueId("command5")).isFalse();
         Assertions.assertThat(this.commandRepository.existsByUniqueId("command6")).isFalse();
+        Assertions.assertThat(this.commandRepository.existsByUniqueId("command7")).isTrue();
     }
 
     private Command createTestCommand(

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest/deleteUnusedCommands/before.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImplIntegrationTest/deleteUnusedCommands/before.xml
@@ -101,6 +101,35 @@
         check_delay="18000"
         status="INACTIVE"
     />
+    <commands
+        id="7"
+        created="2020-03-22 01:47:00"
+        updated="2020-03-22 01:59:00"
+        entity_version="0"
+        unique_id="command7"
+        genie_user="tgianos"
+        name="sparksql"
+        version="1.2.3"
+        check_delay="18000"
+        status="INACTIVE"
+    />
+
+    <clusters
+        id="0"
+        created="2020-03-22 01:49:00"
+        updated="2020-03-22 02:59:00"
+        entity_version="0"
+        unique_id="cluster0"
+        genie_user="tgianos"
+        name="h2prod"
+        version="2.4.0"
+        status="UP"
+    />
+    <clusters_commands
+        cluster_id="0"
+        command_id="7"
+        command_order="0"
+    />
 
     <jobs
         id="0"

--- a/genie-web/src/main/java/com/netflix/genie/web/data/repositories/jpa/JpaCommandRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/repositories/jpa/JpaCommandRepository.java
@@ -57,7 +57,8 @@ public interface JpaCommandRepository extends JpaBaseRepository<CommandEntity> {
             + "SELECT DISTINCT(command_id)"
             + " FROM jobs"
             + " WHERE command_id IS NOT NULL"
-            + ");";
+            + ")"
+            + " AND id NOT IN (SELECT DISTINCT(command_id) FROM clusters_commands);";
 
     /**
      * Bulk set the status of commands which match the given inputs. Considers whether a command was used in some


### PR DESCRIPTION
Forgot to factor in the `clusters_commands` table when considering which commands to delete. This caused referential integrity failure when run on real data.
This table is going to be deleted once V4 resource selection migration is completed so it slipped my mind to include it in the original query. This will have to be ripped out again once we remove that table.