### PR TITLE
Set transaction isolation level to read committed for updating unused command statuses

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/jpa/JpaCommandPersistenceServiceImpl.java
@@ -58,6 +58,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Nullable;
@@ -670,6 +671,7 @@ public class JpaCommandPersistenceServiceImpl extends JpaBaseService implements 
      * {@inheritDoc}
      */
     @Override
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public int updateStatusForUnusedCommands(
         final CommandStatus desiredStatus,
         final Instant commandCreatedThreshold,


### PR DESCRIPTION
The update with default transaction isolation level (repeatable read) was causing the db to become unresponsive while the update was happening due to how mysql deals with update queries with scans and locking.
See:
https://dev.mysql.com/doc/refman/5.7/en/innodb-locks-set.html

By lowering the transaction isolation level for the update command to read committed it will only lock rows that match the update where condition and unlock those that don't.
See:
https://dev.mysql.com/doc/refman/5.7/en/innodb-transaction-isolation-levels.html

This will slightly lower the consistency but given how this query is intended to update things that haven't been used in a long time it shouldn't pose any large risk in practice while providing the benefit that the system stays performant while this update is happening in the background.