### PR TITLE
Add actuator endpoint to force leadership shuffle

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/services/ClusterLeaderService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/ClusterLeaderService.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services;
+
+/**
+ * Service interface for the abstracts the details of leadership within nodes in a Genie cluster.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public interface ClusterLeaderService {
+
+    /**
+     * Stop the service (i.e. renounce leadership and leave the election).
+     */
+    void stop();
+
+    /**
+     * Start the service (i.e. join the the election).
+     */
+    void start();
+
+    /**
+     * Whether or not this node is participating in the cluster leader election.
+     *
+     * @return true if the node is participating in leader election
+     */
+    boolean isRunning();
+
+    /**
+     * Whether or not this node is the current cluster leader.
+     *
+     * @return true if the node is the current cluster leader
+     */
+    boolean isLeader();
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/ClusterLeaderServiceCuratorImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/ClusterLeaderServiceCuratorImpl.java
@@ -1,0 +1,74 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl;
+
+import com.netflix.genie.web.services.ClusterLeaderService;
+import org.springframework.integration.zookeeper.leader.LeaderInitiator;
+
+/**
+ * Implementation of {@link ClusterLeaderService} using Spring's {@link LeaderInitiator} (Zookeeper/Curator based
+ * leader election mechanism).
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class ClusterLeaderServiceCuratorImpl implements ClusterLeaderService {
+
+    private LeaderInitiator leaderInitiator;
+
+    /**
+     * Constructor.
+     *
+     * @param leaderInitiator the leader initiator component
+     */
+    public ClusterLeaderServiceCuratorImpl(final LeaderInitiator leaderInitiator) {
+        this.leaderInitiator = leaderInitiator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void stop() {
+        this.leaderInitiator.stop();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void start() {
+        this.leaderInitiator.start();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunning() {
+        return this.leaderInitiator.isRunning();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isLeader() {
+        return this.leaderInitiator.getContext().isLeader();
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/ClusterLeaderServiceLocalLeaderImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/ClusterLeaderServiceLocalLeaderImpl.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl;
+
+import com.netflix.genie.web.services.ClusterLeaderService;
+import com.netflix.genie.web.tasks.leader.LocalLeader;
+
+/**
+ * Implementation of {@link ClusterLeaderService} using statically configured {@link LocalLeader} module.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class ClusterLeaderServiceLocalLeaderImpl implements ClusterLeaderService {
+    private final LocalLeader localLeader;
+
+    /**
+     * Constructor.
+     *
+     * @param localLeader the local leader module
+     */
+    public ClusterLeaderServiceLocalLeaderImpl(final LocalLeader localLeader) {
+        this.localLeader = localLeader;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void stop() {
+        this.localLeader.stop();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void start() {
+        this.localLeader.start();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunning() {
+        return this.localLeader.isRunning();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isLeader() {
+        return this.localLeader.isLeader();
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/actuators/LeaderElectionActuator.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/actuators/LeaderElectionActuator.java
@@ -1,0 +1,117 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.spring.actuators;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.genie.web.services.ClusterLeaderService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+
+import java.util.Map;
+
+
+/**
+ * An actuator endpoint that exposes leadership status and allows stop/start/restart of the leader election service.
+ * Useful when a specific set of nodes should be given priority to win the leader election (e.g., because they are
+ * running newer code).
+ *
+ * @since 4.0.0
+ * @author mprimi
+ */
+@Endpoint(id = "leaderElection")
+@Slf4j
+public class LeaderElectionActuator {
+
+    /**
+     * Operations that this actuator can perform on the leader service.
+     */
+    public enum Action {
+        /**
+         * Stop the leader election service.
+         */
+        STOP,
+        /**
+         * Start the leader election service.
+         */
+        START,
+        /**
+         * Stop then start the leader election service.
+         */
+        RESTART,
+
+        /**
+         * NOOP action for the purpose of testing unknown actions.
+         */
+        TEST,
+    }
+
+    private static final String RUNNING = "running";
+    private static final String LEADER = "leader";
+    private final ClusterLeaderService clusterLeaderService;
+
+    /**
+     * Constructor.
+     *
+     * @param clusterLeaderService the cluster leader service
+     */
+    public LeaderElectionActuator(final ClusterLeaderService clusterLeaderService) {
+        this.clusterLeaderService = clusterLeaderService;
+    }
+
+    /**
+     * Provides the current leader service status: whether the leader service is running and whether the node is leader.
+     *
+     * @return a map of attributes
+     */
+    @ReadOperation
+    public Map<String, Object> getStatus() {
+        return ImmutableMap.<String, Object>builder()
+            .put(RUNNING, this.clusterLeaderService.isRunning())
+            .put(LEADER, this.clusterLeaderService.isLeader())
+            .build();
+    }
+
+    /**
+     * Forces the node to leave the leader election, then re-join it.
+     *
+     * @param action the action to perform
+     */
+    @WriteOperation
+    public void doAction(final Action action) {
+        switch (action) {
+            case START:
+                log.info("Starting leader election service");
+                this.clusterLeaderService.start();
+                break;
+            case STOP:
+                log.info("Stopping leader election service");
+                this.clusterLeaderService.stop();
+                break;
+            case RESTART:
+                log.info("Restarting leader election service");
+                this.clusterLeaderService.stop();
+                this.clusterLeaderService.start();
+                break;
+            default:
+                log.error("Unknown action: " + action);
+                throw new UnsupportedOperationException("Unknown action: " + action.name());
+        }
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/actuators/package-info.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/actuators/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Actuator endpoints.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.web.spring.actuators;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfiguration.java
@@ -29,6 +29,7 @@ import com.netflix.genie.web.properties.ZookeeperLeaderProperties;
 import com.netflix.genie.web.services.ClusterLeaderService;
 import com.netflix.genie.web.services.impl.ClusterLeaderServiceCuratorImpl;
 import com.netflix.genie.web.services.impl.ClusterLeaderServiceLocalLeaderImpl;
+import com.netflix.genie.web.spring.actuators.LeaderElectionActuator;
 import com.netflix.genie.web.spring.autoconfigure.tasks.TasksAutoConfiguration;
 import com.netflix.genie.web.tasks.leader.AgentJobCleanupTask;
 import com.netflix.genie.web.tasks.leader.ClusterCheckerTask;
@@ -272,5 +273,19 @@ public class LeaderAutoConfiguration {
     @ConditionalOnMissingBean(ClusterLeaderService.class)
     public ClusterLeaderService localClusterLeaderService(final LocalLeader localLeader) {
         return new ClusterLeaderServiceLocalLeaderImpl(localLeader);
+    }
+
+    /**
+     * Create a {@link LeaderElectionActuator} bean if one is not already defined and if
+     * {@link ClusterLeaderService} is available. This bean is an endpoint that gets registered in Spring Actuator.
+     *
+     * @param clusterLeaderService the cluster leader service
+     * @return a {@link LeaderElectionActuator}
+     */
+    @Bean
+    @ConditionalOnBean(ClusterLeaderService.class)
+    @ConditionalOnMissingBean(LeaderElectionActuator.class)
+    public LeaderElectionActuator leaderElectionActuator(final ClusterLeaderService clusterLeaderService) {
+        return new LeaderElectionActuator(clusterLeaderService);
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/ClusterLeaderServiceCuratorImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/ClusterLeaderServiceCuratorImplSpec.groovy
@@ -1,0 +1,71 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl
+
+import com.netflix.genie.web.services.ClusterLeaderService
+import org.springframework.integration.leader.Context
+import org.springframework.integration.zookeeper.leader.LeaderInitiator
+import spock.lang.Specification
+
+class ClusterLeaderServiceCuratorImplSpec extends Specification {
+    LeaderInitiator leaderInitiator
+    ClusterLeaderService service
+
+    void setup() {
+        this.leaderInitiator = Mock(LeaderInitiator)
+        this.service = new ClusterLeaderServiceCuratorImpl(leaderInitiator)
+    }
+
+    def "Start"() {
+        when:
+        this.service.start()
+
+        then:
+        1 * leaderInitiator.start()
+    }
+
+    def "Stop"() {
+        when:
+        this.service.stop()
+
+        then:
+        1 * leaderInitiator.stop()
+    }
+
+    def "isLeader"() {
+        Context context = Mock(Context)
+        when:
+        boolean isLeader = this.service.isLeader()
+
+
+        then:
+        1 * leaderInitiator.getContext() >> context
+        1 * context.isLeader() >> true
+        isLeader
+    }
+
+
+    def "isRunning"() {
+        when:
+        boolean isRunning = this.service.isRunning()
+
+        then:
+        1 * leaderInitiator.isRunning() >> true
+        isRunning
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/ClusterLeaderServiceLocalLeaderImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/ClusterLeaderServiceLocalLeaderImplSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.services.impl
+
+import com.netflix.genie.web.services.ClusterLeaderService
+import com.netflix.genie.web.tasks.leader.LocalLeader
+import spock.lang.Specification
+
+class ClusterLeaderServiceLocalLeaderImplSpec extends Specification {
+    LocalLeader localLeader
+    ClusterLeaderService service
+
+    void setup() {
+        this.localLeader = Mock(LocalLeader)
+        this.service = new ClusterLeaderServiceLocalLeaderImpl(localLeader)
+    }
+
+    def "Start"() {
+        when:
+        this.service.start()
+
+        then:
+        1 * localLeader.start()
+    }
+
+    def "Stop"() {
+        when:
+        this.service.stop()
+
+        then:
+        1 * localLeader.stop()
+    }
+
+    def "isLeader"() {
+        when:
+        boolean isLeader = this.service.isLeader()
+
+        then:
+        1 * localLeader.isLeader() >> true
+        isLeader
+    }
+
+
+    def "isRunning"() {
+        when:
+        boolean isRunning = this.service.isRunning()
+
+        then:
+        1 * localLeader.isRunning() >> true
+        isRunning
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/spring/actuators/LeaderElectionActuatorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/spring/actuators/LeaderElectionActuatorSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.spring.actuators
+
+import com.netflix.genie.web.services.ClusterLeaderService
+import spock.lang.Specification
+
+class LeaderElectionActuatorSpec extends Specification {
+    ClusterLeaderService clusterLeaderService
+    LeaderElectionActuator actuator
+
+    void setup() {
+        this.clusterLeaderService = Mock(ClusterLeaderService)
+        this.actuator = new LeaderElectionActuator(clusterLeaderService)
+    }
+
+    def "Status"() {
+        when:
+        Map<String, Object> status = this.actuator.getStatus()
+
+        then:
+        1 * clusterLeaderService.isRunning() >> running
+        1 * clusterLeaderService.isLeader() >> leader
+        status.get(LeaderElectionActuator.RUNNING) == running
+        status.get(LeaderElectionActuator.LEADER) == leader
+
+        where:
+        running | leader
+        true    | false
+        false   | true
+
+    }
+
+    def "Actions"() {
+        when:
+        this.actuator.doAction(LeaderElectionActuator.Action.START)
+
+        then:
+        1 * clusterLeaderService.start()
+
+        when:
+        this.actuator.doAction(LeaderElectionActuator.Action.STOP)
+
+        then:
+        1 * clusterLeaderService.stop()
+
+        when:
+        this.actuator.doAction(LeaderElectionActuator.Action.RESTART)
+
+        then:
+        1 * clusterLeaderService.stop()
+        1 * clusterLeaderService.start()
+
+        when:
+        this.actuator.doAction(LeaderElectionActuator.Action.TEST)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
@@ -35,6 +35,7 @@ import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.properties.LeadershipProperties;
 import com.netflix.genie.web.properties.UserMetricsProperties;
 import com.netflix.genie.web.properties.ZookeeperLeaderProperties;
+import com.netflix.genie.web.services.ClusterLeaderService;
 import com.netflix.genie.web.spring.autoconfigure.tasks.TasksAutoConfiguration;
 import com.netflix.genie.web.tasks.leader.AgentJobCleanupTask;
 import com.netflix.genie.web.tasks.leader.ClusterCheckerTask;
@@ -92,11 +93,13 @@ class LeaderAutoConfigurationTest {
                 Assertions.assertThat(context).doesNotHaveBean(LeaderInitiatorFactoryBean.class);
                 Assertions.assertThat(context).hasSingleBean(LocalLeader.class);
                 Assertions.assertThat(context).hasSingleBean(ClusterCheckerTask.class);
+                Assertions.assertThat(context).hasSingleBean(ClusterLeaderService.class);
 
                 // Optional beans
                 Assertions.assertThat(context).doesNotHaveBean(DatabaseCleanupTask.class);
                 Assertions.assertThat(context).doesNotHaveBean(UserMetricsTask.class);
                 Assertions.assertThat(context).doesNotHaveBean(AgentJobCleanupTask.class);
+                Assertions.assertThat(context).doesNotHaveBean(LeaderInitiatorFactoryBean.class);
             }
         );
     }
@@ -126,10 +129,13 @@ class LeaderAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(LocalLeader.class);
                     Assertions.assertThat(context).hasSingleBean(ClusterCheckerTask.class);
 
+                    Assertions.assertThat(context).hasSingleBean(ClusterLeaderService.class);
+
                     // Optional beans
                     Assertions.assertThat(context).hasSingleBean(DatabaseCleanupTask.class);
                     Assertions.assertThat(context).hasSingleBean(UserMetricsTask.class);
                     Assertions.assertThat(context).hasSingleBean(AgentJobCleanupTask.class);
+                    Assertions.assertThat(context).doesNotHaveBean(LeaderInitiatorFactoryBean.class);
                 }
             );
     }
@@ -154,6 +160,8 @@ class LeaderAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(LeaderInitiatorFactoryBean.class);
                     Assertions.assertThat(context).doesNotHaveBean(LocalLeader.class);
                     Assertions.assertThat(context).hasSingleBean(ClusterCheckerTask.class);
+
+                    Assertions.assertThat(context).hasSingleBean(ClusterLeaderService.class);
 
                     // Optional beans
                     Assertions.assertThat(context).doesNotHaveBean(DatabaseCleanupTask.class);

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
@@ -36,6 +36,7 @@ import com.netflix.genie.web.properties.LeadershipProperties;
 import com.netflix.genie.web.properties.UserMetricsProperties;
 import com.netflix.genie.web.properties.ZookeeperLeaderProperties;
 import com.netflix.genie.web.services.ClusterLeaderService;
+import com.netflix.genie.web.spring.actuators.LeaderElectionActuator;
 import com.netflix.genie.web.spring.autoconfigure.tasks.TasksAutoConfiguration;
 import com.netflix.genie.web.tasks.leader.AgentJobCleanupTask;
 import com.netflix.genie.web.tasks.leader.ClusterCheckerTask;
@@ -94,6 +95,7 @@ class LeaderAutoConfigurationTest {
                 Assertions.assertThat(context).hasSingleBean(LocalLeader.class);
                 Assertions.assertThat(context).hasSingleBean(ClusterCheckerTask.class);
                 Assertions.assertThat(context).hasSingleBean(ClusterLeaderService.class);
+                Assertions.assertThat(context).hasSingleBean(LeaderElectionActuator.class);
 
                 // Optional beans
                 Assertions.assertThat(context).doesNotHaveBean(DatabaseCleanupTask.class);
@@ -130,6 +132,7 @@ class LeaderAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(ClusterCheckerTask.class);
 
                     Assertions.assertThat(context).hasSingleBean(ClusterLeaderService.class);
+                    Assertions.assertThat(context).hasSingleBean(LeaderElectionActuator.class);
 
                     // Optional beans
                     Assertions.assertThat(context).hasSingleBean(DatabaseCleanupTask.class);
@@ -162,6 +165,7 @@ class LeaderAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(ClusterCheckerTask.class);
 
                     Assertions.assertThat(context).hasSingleBean(ClusterLeaderService.class);
+                    Assertions.assertThat(context).hasSingleBean(LeaderElectionActuator.class);
 
                     // Optional beans
                     Assertions.assertThat(context).doesNotHaveBean(DatabaseCleanupTask.class);


### PR DESCRIPTION
When deploying a new release of Genie, it is sometimes desirable to have one the nodes running the latest version become leader.
The old nodes may have long-running jobs and be around for a while.

The new RejoinLeaderElection actuator addresses this problem by forcing a restart of the leader election service.
In the current (zookeeper based implementation), leadership is awarded in order of arrival.
Therefore any node that receive this command will re-enqueue last, and newly added nodes will be ahead in the queue to become leader.