### PR TITLE
Revise logic for routing file requests to agent

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentRoutingService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentRoutingService.java
@@ -62,4 +62,11 @@ public interface AgentRoutingService {
      */
     void handleClientDisconnected(@NotBlank String jobId);
 
+    /**
+     * Whether the agent executing a given job is currently connected.
+     *
+     * @param jobId the job id
+     * @return true if an agent running the job is connected
+     */
+    boolean isAgentConnected(String jobId);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentRoutingServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentRoutingServiceImpl.java
@@ -87,4 +87,12 @@ public class AgentRoutingServiceImpl implements AgentRoutingService {
         log.info("Agent executing job {} disconnected", jobId);
         this.agentConnectionPersistenceService.removeAgentConnection(jobId, genieHostInfo.getHostname());
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAgentConnected(final String jobId) {
+        return getHostnameForAgentConnection(jobId).isPresent();
+    }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
@@ -695,7 +695,10 @@ public class JobRestController {
 
         // if forwarded from isn't null it's already been forwarded to this node. Assume data is on this node.
         // if the job is finished all file serving is done from the archive it doesn't need to be forwarded anywhere
-        if (jobStatus.isActive() && this.jobsProperties.getForwarding().isEnabled() && forwardedFrom == null) {
+        final boolean activeV3job = !isV4 && jobStatus.isActive();
+        final boolean activeV4job = isV4 && agentRoutingService.isAgentConnected(id);
+        final boolean shouldForward = activeV3job || activeV4job;
+        if (shouldForward && this.jobsProperties.getForwarding().isEnabled() && forwardedFrom == null) {
             final String jobHostname = this.getJobOwnerHostname(id, isV4);
             if (!this.hostname.equals(jobHostname)) {
                 log.info("Job {} is not run on this node. Forwarding to {}", id, jobHostname);

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfiguration.java
@@ -24,6 +24,7 @@ import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorSer
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.web.agent.launchers.AgentLauncher;
 import com.netflix.genie.web.agent.services.AgentFileStreamService;
+import com.netflix.genie.web.agent.services.AgentRoutingService;
 import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.jobs.workflow.WorkflowTask;
@@ -422,6 +423,7 @@ public class ServicesAutoConfiguration {
      * @param jobFileService                     The service responsible for managing the job working directory on disk
      *                                           for V3 Jobs
      * @param jobDirectoryManifestCreatorService The job directory manifest service
+     * @param agentRoutingService                The agent routing service
      * @return An instance of {@link JobDirectoryServerServiceImpl}
      */
     @Bean
@@ -433,7 +435,8 @@ public class ServicesAutoConfiguration {
         final ArchivedJobService archivedJobService,
         final MeterRegistry meterRegistry,
         final JobFileService jobFileService,
-        final JobDirectoryManifestCreatorService jobDirectoryManifestCreatorService
+        final JobDirectoryManifestCreatorService jobDirectoryManifestCreatorService,
+        final AgentRoutingService agentRoutingService
     ) {
         return new JobDirectoryServerServiceImpl(
             resourceLoader,
@@ -442,7 +445,8 @@ public class ServicesAutoConfiguration {
             archivedJobService,
             meterRegistry,
             jobFileService,
-            jobDirectoryManifestCreatorService
+            jobDirectoryManifestCreatorService,
+            agentRoutingService
         );
     }
 

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentRoutingServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentRoutingServiceImplSpec.groovy
@@ -119,4 +119,19 @@ class AgentRoutingServiceImplSpec extends Specification {
         1 * genieHostInfo.getHostname() >> HOSTNAME
         1 * persistenceService.removeAgentConnection(jobId, HOSTNAME)
     }
+
+    def "isAgentConnected"() {
+        boolean connected;
+        when:
+        connected = service.isAgentConnected(jobId)
+
+        then:
+        1 * persistenceService.lookupAgentConnectionServer(jobId) >> Optional.ofNullable(server)
+        connected == expectedConnected
+
+        where:
+        server    | expectedConnected
+        null      | false
+        "1.2.3.4" | true
+    }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImplSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.genie.common.internal.dtos.DirectoryManifest
 import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorService
 import com.netflix.genie.web.agent.resources.AgentFileProtocolResolver
 import com.netflix.genie.web.agent.services.AgentFileStreamService
+import com.netflix.genie.web.agent.services.AgentRoutingService
 import com.netflix.genie.web.data.services.DataServices
 import com.netflix.genie.web.data.services.JobPersistenceService
 import com.netflix.genie.web.exceptions.checked.JobDirectoryManifestNotFoundException
@@ -73,6 +74,7 @@ class JobDirectoryServerServiceImplSpec extends Specification {
     JobDirectoryServerServiceImpl.GenieResourceHandler handler
     JobDirectoryManifestCreatorService jobDirectoryManifestService
     ArchivedJobService archivedJobService
+    AgentRoutingService agentRoutingService
 
     void setup() {
         this.resourceLoader = Mock(ResourceLoader)
@@ -84,6 +86,7 @@ class JobDirectoryServerServiceImplSpec extends Specification {
         this.handler = Mock(JobDirectoryServerServiceImpl.GenieResourceHandler)
         this.jobDirectoryManifestService = Mock(JobDirectoryManifestCreatorService)
         this.archivedJobService = Mock(ArchivedJobService)
+        this.agentRoutingService = Mock(AgentRoutingService)
         def dataServices = Mock(DataServices) {
             getJobPersistenceService() >> this.jobPersistenceService
         }
@@ -95,7 +98,8 @@ class JobDirectoryServerServiceImplSpec extends Specification {
             this.handlerFactory,
             this.meterRegistry,
             this.jobFileService,
-            this.jobDirectoryManifestService
+            this.jobDirectoryManifestService,
+            this.agentRoutingService
         )
 
         this.request = Mock(HttpServletRequest)
@@ -134,6 +138,7 @@ class JobDirectoryServerServiceImplSpec extends Specification {
         then:
         1 * this.jobPersistenceService.getJobStatus(JOB_ID) >> JobStatus.RUNNING
         1 * this.jobPersistenceService.isV4(JOB_ID) >> true
+        1 * this.agentRoutingService.isAgentConnectionLocal(JOB_ID) >> true
         1 * this.agentFileStreamService.getManifest(JOB_ID) >> Optional.empty()
         thrown(GenieServerUnavailableException)
 
@@ -145,6 +150,7 @@ class JobDirectoryServerServiceImplSpec extends Specification {
         then:
         1 * this.jobPersistenceService.getJobStatus(JOB_ID) >> JobStatus.RUNNING
         1 * this.jobPersistenceService.isV4(JOB_ID) >> true
+        1 * this.agentRoutingService.isAgentConnectionLocal(JOB_ID) >> true
         1 * this.agentFileStreamService.getManifest(JOB_ID) >> Optional.of(this.manifest)
         1 * this.manifest.getEntry(REL_PATH) >> Optional.empty()
         thrown(GenieNotFoundException)
@@ -155,6 +161,7 @@ class JobDirectoryServerServiceImplSpec extends Specification {
         then:
         1 * this.jobPersistenceService.getJobStatus(JOB_ID) >> JobStatus.RUNNING
         1 * this.jobPersistenceService.isV4(JOB_ID) >> true
+        1 * this.agentRoutingService.isAgentConnectionLocal(JOB_ID) >> true
         1 * this.agentFileStreamService.getManifest(JOB_ID) >> Optional.of(this.manifest)
         1 * this.manifest.getEntry(REL_PATH) >> Optional.of(this.manifestEntry)
         1 * this.manifestEntry.isDirectory() >> false

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/services/ServicesAutoConfigurationTest.java
@@ -19,7 +19,10 @@ package com.netflix.genie.web.spring.autoconfigure.services;
 
 import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.external.util.GenieObjectMapper;
+import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorService;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
+import com.netflix.genie.web.agent.services.AgentFileStreamService;
+import com.netflix.genie.web.agent.services.AgentRoutingService;
 import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.JobPersistenceService;
 import com.netflix.genie.web.data.services.JobSearchService;
@@ -35,7 +38,9 @@ import com.netflix.genie.web.properties.JobsMaxProperties;
 import com.netflix.genie.web.properties.JobsMemoryProperties;
 import com.netflix.genie.web.properties.JobsProperties;
 import com.netflix.genie.web.properties.JobsUsersProperties;
+import com.netflix.genie.web.services.ArchivedJobService;
 import com.netflix.genie.web.services.FileTransferFactory;
+import com.netflix.genie.web.services.JobFileService;
 import com.netflix.genie.web.services.JobKillService;
 import com.netflix.genie.web.services.JobKillServiceV4;
 import com.netflix.genie.web.services.JobResolverService;
@@ -53,6 +58,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -207,6 +213,25 @@ public class ServicesAutoConfigurationTest {
                 Mockito.mock(JobResolverService.class),
                 Mockito.mock(MeterRegistry.class),
                 new GenieHostInfo(UUID.randomUUID().toString())
+            )
+        );
+    }
+
+    /**
+     * Can get the bean for Job Directory Server Service.
+     */
+    @Test
+    public void canGetJobDirectoryServerServiceBean() {
+        Assert.assertNotNull(
+            this.servicesAutoConfiguration.jobDirectoryServerService(
+                Mockito.mock(ResourceLoader.class),
+                Mockito.mock(DataServices.class),
+                Mockito.mock(AgentFileStreamService.class),
+                Mockito.mock(ArchivedJobService.class),
+                Mockito.mock(MeterRegistry.class),
+                Mockito.mock(JobFileService.class),
+                Mockito.mock(JobDirectoryManifestCreatorService.class),
+                Mockito.mock(AgentRoutingService.class)
             )
         );
     }


### PR DESCRIPTION
Rather then rely on 'active' job status, request the files from the agent as long as the agent is connected.
This ensures files can be served while the agent is in the process of archiving (after having already marked the job completed).