### PR TITLE
Fix handling of failed job resolution in agent/server protocol

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobServiceImpl.java
@@ -303,6 +303,7 @@ class GRpcAgentJobServiceImpl implements AgentJobService {
             case NO_CLUSTER_FOUND:
             case NO_JOB_FOUND:
             case NO_COMMAND_FOUND:
+            case RESOLUTION_FAILED:
                 throw new JobSpecificationResolutionException(
                     "Failed to obtain specification: "
                         + error.getType().name()

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobServiceImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobServiceImplSpec.groovy
@@ -244,6 +244,7 @@ class GRpcAgentJobServiceImplSpec extends Specification {
         JobSpecificationError.Type.NO_CLUSTER_FOUND     | JobSpecificationResolutionException
         JobSpecificationError.Type.NO_JOB_FOUND         | JobSpecificationResolutionException
         JobSpecificationError.Type.NO_COMMAND_FOUND     | JobSpecificationResolutionException
+        JobSpecificationError.Type.RESOLUTION_FAILED    | JobSpecificationResolutionException
         JobSpecificationError.Type.UNKNOWN              | GenieRuntimeException
     }
 
@@ -303,6 +304,7 @@ class GRpcAgentJobServiceImplSpec extends Specification {
         JobSpecificationError.Type.NO_CLUSTER_FOUND     | JobSpecificationResolutionException
         JobSpecificationError.Type.NO_JOB_FOUND         | JobSpecificationResolutionException
         JobSpecificationError.Type.NO_COMMAND_FOUND     | JobSpecificationResolutionException
+        JobSpecificationError.Type.RESOLUTION_FAILED    | JobSpecificationResolutionException
         JobSpecificationError.Type.UNKNOWN              | GenieRuntimeException
     }
 
@@ -379,6 +381,7 @@ class GRpcAgentJobServiceImplSpec extends Specification {
         JobSpecificationError.Type.NO_CLUSTER_FOUND     | JobSpecificationResolutionException
         JobSpecificationError.Type.NO_JOB_FOUND         | JobSpecificationResolutionException
         JobSpecificationError.Type.NO_COMMAND_FOUND     | JobSpecificationResolutionException
+        JobSpecificationError.Type.RESOLUTION_FAILED    | JobSpecificationResolutionException
         JobSpecificationError.Type.UNKNOWN              | GenieRuntimeException
     }
 

--- a/genie-proto/src/main/proto/genie.proto
+++ b/genie-proto/src/main/proto/genie.proto
@@ -177,6 +177,7 @@ message JobSpecificationError {
         NO_JOB_FOUND = 4;
         NO_SPECIFICATION_FOUND = 5;
         INVALID_REQUEST = 6;
+        RESOLUTION_FAILED = 7;
     }
     Type type = 1;
     string message = 2;

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposer.java
@@ -67,6 +67,8 @@ public class JobServiceProtoErrorComposer {
             .put(GenieApplicationNotFoundException.class, JobSpecificationError.Type.NO_APPLICATION_FOUND)
             .put(GenieJobSpecificationNotFoundException.class, JobSpecificationError.Type.NO_SPECIFICATION_FOUND)
             .put(ConstraintViolationException.class, JobSpecificationError.Type.INVALID_REQUEST)
+            .put(GenieJobResolutionException.class, JobSpecificationError.Type.RESOLUTION_FAILED)
+            .put(GeniePreconditionException.class, JobSpecificationError.Type.RESOLUTION_FAILED)
             .build();
 
     private static final Map<Class<? extends Exception>, ClaimJobError.Type> CLAIM_JOB_ERROR_MAP =

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposerSpec.groovy
@@ -98,8 +98,9 @@ class JobServiceProtoErrorComposerSpec extends Specification {
         new GenieJobResolutionException(MESSAGE, new GenieCommandNotFoundException(MESSAGE))          | JobSpecificationError.Type.NO_COMMAND_FOUND
         new GenieJobResolutionException(MESSAGE, new GenieApplicationNotFoundException(MESSAGE))      | JobSpecificationError.Type.NO_APPLICATION_FOUND
         new GenieJobResolutionException(MESSAGE, new GenieJobSpecificationNotFoundException(MESSAGE)) | JobSpecificationError.Type.NO_SPECIFICATION_FOUND
-        new GenieJobResolutionException(MESSAGE)                                                      | JobSpecificationError.Type.UNKNOWN
-        new GenieJobResolutionException(new Throwable(MESSAGE))                                       | JobSpecificationError.Type.UNKNOWN
+        new GenieJobResolutionException(MESSAGE, new GeniePreconditionException(MESSAGE))             | JobSpecificationError.Type.RESOLUTION_FAILED
+        new GenieJobResolutionException(MESSAGE)                                                      | JobSpecificationError.Type.RESOLUTION_FAILED
+        new GenieJobResolutionException(new Throwable(MESSAGE))                                       | JobSpecificationError.Type.RESOLUTION_FAILED
     }
 
     @Unroll


### PR DESCRIPTION
## Bug overview:
When the agent was requesting a job resolution with criteria that cannot be satisfied, the server was not handling the case properly and sending back a generic error (error code `UNKNOWN`).
On the agent side, this was surfaced to the user as a generic exception, i.e.:
`GenieRuntimeException Unhandled error: UNKNOWN: com.netflix.genie.common.exceptions.GeniePreconditionException:No cluster/command combination found for the given criteria. Unable to continue`

## New behavior:
When the specification resolution fails due to unsatisfiable criteria, the server sends a newly introduced error code: `RESOLUTION_FAILED`.
This results in a clearer handling of the error on the agent, and the user message becomes: `JobSpecificationResolutionException: No cluster/command combination found for the given criteria`

## Backward compatibility:
Agent newer than server - No behavior change, the agent surfaces the error same as before.
Server newer than the agent - No behavior change, the agent will fail to recognize the new `RESOLUTION_FAILED` code and treat it as `UNKNOWN`, therefore executing the same codepath as before