### PR TITLE
Fix inconsistent javax.validation constraints on interface implementations

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/ScriptClusterSelectorImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/ScriptClusterSelectorImpl.java
@@ -74,18 +74,18 @@ public class ScriptClusterSelectorImpl implements ClusterSelector {
      */
     @Override
     public ResourceSelectionResult<Cluster> select(
-        @NotEmpty final Set<@Valid Cluster> clusters,
+        @NotEmpty final Set<@Valid Cluster> resources,
         @Valid final JobRequest jobRequest,
         @NotBlank final String jobId
     ) throws ResourceSelectionException {
         final long selectStart = System.nanoTime();
-        log.debug("Called to select cluster from {} for job {}", clusters, jobId);
+        log.debug("Called to select cluster from {} for job {}", resources, jobId);
         final Set<Tag> tags = Sets.newHashSet();
         final ResourceSelectionResult.Builder<Cluster> builder = new ResourceSelectionResult.Builder<>(this.getClass());
 
         try {
             final ResourceSelectorScriptResult<Cluster> result
-                = this.clusterSelectorManagedScript.selectResource(clusters, jobRequest, jobId);
+                = this.clusterSelectorManagedScript.selectResource(resources, jobRequest, jobId);
             MetricsUtils.addSuccessTags(tags);
 
             final Optional<Cluster> clusterOptional = result.getResource();

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/ScriptCommandSelectorImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/ScriptCommandSelectorImpl.java
@@ -32,6 +32,7 @@ import io.micrometer.core.instrument.Tag;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import java.util.Optional;
 import java.util.Set;
@@ -72,18 +73,18 @@ public class ScriptCommandSelectorImpl implements CommandSelector {
      */
     @Override
     public ResourceSelectionResult<Command> select(
-        @NotEmpty final Set<@Valid Command> commands,
+        @NotEmpty final Set<@Valid Command> resources,
         @Valid final JobRequest jobRequest,
-        @NotEmpty final String jobId
+        @NotBlank final String jobId
     ) throws ResourceSelectionException {
         final long selectStart = System.nanoTime();
-        log.debug("Called to select a command from {} for job {}", commands, jobId);
+        log.debug("Called to select a command from {} for job {}", resources, jobId);
         final Set<Tag> tags = Sets.newHashSet();
         final ResourceSelectionResult.Builder<Command> builder = new ResourceSelectionResult.Builder<>(this.getClass());
 
         try {
             final ResourceSelectorScriptResult<Command> result
-                = this.commandSelectorManagedScript.selectResource(commands, jobRequest, jobId);
+                = this.commandSelectorManagedScript.selectResource(resources, jobRequest, jobId);
             MetricsUtils.addSuccessTags(tags);
 
             final Optional<Command> commandOptional = result.getResource();


### PR DESCRIPTION
Unfortunately there was an inconsistency where one implementation marked a field @NotEmpty instead of @NotBlank. This caused runtime exception:
```javax.validation.ConstraintDeclarationException: HV000151: A method overriding another method must not redefine the parameter constraint configuration, but method ScriptCommandSelectorImpl#select(Set, JobRequest, String) redefines the configuration of ResourceSelector#select(Set, JobRequest, String)```

Because integration tests don't yet use this path it wasn't caught in testing.