### PR TITLE
Ensure agent resolves local hostname same as web

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/AgentMetadataImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/AgentMetadataImpl.java
@@ -46,9 +46,34 @@ public class AgentMetadataImpl implements AgentMetadata {
      * Constructor.
      */
     public AgentMetadataImpl() {
-        this.agentVersion = getAgentVersionOrFallback();
-        this.agentHostName = getAgentHostNameOrFallback();
-        this.agentPid = getAgentPidOrFallback();
+        this(
+            getAgentVersionOrFallback(),
+            getAgentHostNameOrFallback(),
+            getAgentPidOrFallback()
+        );
+    }
+
+    /**
+     * Constructor with pre-resolved hostname.
+     *
+     * @param hostname The hostname
+     */
+    public AgentMetadataImpl(final String hostname) {
+        this(
+            getAgentVersionOrFallback(),
+            hostname,
+            getAgentPidOrFallback()
+        );
+    }
+
+    private AgentMetadataImpl(
+        final String agentVersion,
+        final String agentHostName,
+        final String agentPid
+    ) {
+        this.agentVersion = agentVersion;
+        this.agentHostName = agentHostName;
+        this.agentPid = agentPid;
     }
 
     private static String getAgentVersionOrFallback() {

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/AgentMetadataImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/AgentMetadataImplSpec.groovy
@@ -21,13 +21,26 @@ import org.apache.commons.lang3.StringUtils
 import spock.lang.Specification
 
 class AgentMetadataImplSpec extends Specification {
-    def "Construct"() {
+    def "Construct without arguments"() {
         when:
-        AgentMetadata agentMetadata = new AgentMetadataImpl();
+        AgentMetadata agentMetadata = new AgentMetadataImpl()
 
         then:
         !StringUtils.isBlank(agentMetadata.getAgentVersion())
         !StringUtils.isBlank(agentMetadata.getAgentHostName())
+        !StringUtils.isBlank(agentMetadata.getAgentPid())
+    }
+
+    def "Construct with hostname"() {
+        setup:
+        String hostname = UUID.randomUUID().toString()
+
+        when:
+        AgentMetadata agentMetadata = new AgentMetadataImpl(hostname)
+
+        then:
+        !StringUtils.isBlank(agentMetadata.getAgentVersion())
+        agentMetadata.getAgentHostName() == hostname
         !StringUtils.isBlank(agentMetadata.getAgentPid())
     }
 }

--- a/genie-agent/src/test/java/com/netflix/genie/agent/spring/autoconfigure/AgentAutoConfigurationTest.java
+++ b/genie-agent/src/test/java/com/netflix/genie/agent/spring/autoconfigure/AgentAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package com.netflix.genie.agent.spring.autoconfigure;
 
 import com.netflix.genie.agent.AgentMetadataImpl;
 import com.netflix.genie.agent.utils.locks.impl.FileLockFactory;
+import com.netflix.genie.common.internal.util.GenieHostInfo;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -47,6 +48,7 @@ public class AgentAutoConfigurationTest {
     public void expectedBeansExist() {
         this.contextRunner.run(
             context -> {
+                Assertions.assertThat(context).hasSingleBean(GenieHostInfo.class);
                 Assertions.assertThat(context).hasSingleBean(AgentMetadataImpl.class);
                 Assertions.assertThat(context).hasSingleBean(FileLockFactory.class);
                 Assertions

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/util/HostnameUtil.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/util/HostnameUtil.java
@@ -1,0 +1,57 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.util;
+
+import com.amazonaws.util.EC2MetadataUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.cloud.aws.context.support.env.AwsCloudEnvironmentCheckUtils;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Static utility class to determine the local hostname.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class HostnameUtil {
+
+    /**
+     * Get the local hostname string.
+     * This implementation actually return an IP address string.
+     *
+     * @return a hostname string
+     * @throws UnknownHostException if hostname resolution fails
+     */
+    public static String getHostname() throws UnknownHostException {
+        final String hostname;
+        if (AwsCloudEnvironmentCheckUtils.isRunningOnCloudEnvironment()) {
+            hostname = EC2MetadataUtils.getPrivateIpAddress();
+        } else {
+            // Fallback if not on AWS
+            hostname = InetAddress.getLocalHost().getCanonicalHostName();
+        }
+
+        if (StringUtils.isBlank(hostname)) {
+            throw new IllegalStateException("Unable to create a Genie Host Info instance as hostname is blank");
+        }
+
+        return hostname;
+    }
+}

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/util/HostnameUtilSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/util/HostnameUtilSpec.groovy
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.util
+
+import org.apache.commons.lang3.StringUtils
+import spock.lang.Specification
+
+class HostnameUtilSpec extends Specification {
+    def "GetHostname"() {
+        expect:
+        StringUtils.isNotBlank(HostnameUtil.getHostname())
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/introspection/IntrospectionAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/introspection/IntrospectionAutoConfiguration.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.spring.autoconfigure.introspection;
 
 import com.amazonaws.util.EC2MetadataUtils;
+import com.netflix.genie.common.internal.util.HostnameUtil;
 import com.netflix.genie.web.agent.apis.rpc.servers.GRpcServerUtils;
 import com.netflix.genie.web.introspection.GenieWebHostInfo;
 import com.netflix.genie.web.introspection.GenieWebRpcInfo;
@@ -59,18 +60,7 @@ public class IntrospectionAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(GenieWebHostInfo.class)
     public GenieWebHostInfo genieHostInfo() throws UnknownHostException {
-        final String hostname;
-        if (AwsCloudEnvironmentCheckUtils.isRunningOnCloudEnvironment()) {
-            hostname = EC2MetadataUtils.getPrivateIpAddress();
-        } else {
-            // Fallback if not on AWS
-            hostname = InetAddress.getLocalHost().getCanonicalHostName();
-        }
-
-        if (StringUtils.isBlank(hostname)) {
-            throw new IllegalStateException("Unable to create a Genie Host Info instance as hostname is blank");
-        }
-
+        final String hostname = HostnameUtil.getHostname();
         return new GenieWebHostInfo(hostname);
     }
 


### PR DESCRIPTION
During this transition period in which agent jobs are launched on the same host as the genie node receiving the request, some components assume that server and agent resolve their hostname in the same way.
This assumption is for example used to calculate memory usage on that host.

This commit changes agent hostname resolution to match the server.