### PR TITLE
Separate timeouts for starting vs. disconnected agent jobs

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/ExecutionAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/ExecutionAutoConfiguration.java
@@ -450,6 +450,20 @@ public class ExecutionAutoConfiguration {
         return new LogExecutionErrorsStage();
     }
 
+
+    /**
+     * Create a {@link CleanupJobDirectoryStage} bean if one is not already defined.
+     *
+     * @param jobSetupService the job setup service
+     */
+    @Bean
+    @Lazy
+    @Order(220)
+    @ConditionalOnMissingBean(CleanupJobDirectoryStage.class)
+    CleanupJobDirectoryStage cleanupJobDirectoryStage(final JobSetupService jobSetupService) {
+        return new CleanupJobDirectoryStage(jobSetupService);
+    }
+
     /**
      * Create a {@link ArchiveJobOutputsStage} bean if one is not already defined.
      *
@@ -457,7 +471,7 @@ public class ExecutionAutoConfiguration {
      */
     @Bean
     @Lazy
-    @Order(220)
+    @Order(230)
     @ConditionalOnMissingBean(ArchiveJobOutputsStage.class)
     ArchiveJobOutputsStage archiveJobOutputsStage(final JobArchiveService jobArchiveService) {
         return new ArchiveJobOutputsStage(jobArchiveService);
@@ -470,7 +484,7 @@ public class ExecutionAutoConfiguration {
      */
     @Bean
     @Lazy
-    @Order(230)
+    @Order(240)
     @ConditionalOnMissingBean(StopHeartbeatServiceStage.class)
     StopHeartbeatServiceStage stopHeartbeatServiceStage(final AgentHeartBeatService heartbeatService) {
         return new StopHeartbeatServiceStage(heartbeatService);
@@ -483,23 +497,10 @@ public class ExecutionAutoConfiguration {
      */
     @Bean
     @Lazy
-    @Order(240)
+    @Order(250)
     @ConditionalOnMissingBean(StopFileServiceStage.class)
     StopFileServiceStage stopFileServiceStage(final AgentFileStreamService agentFileStreamService) {
         return new StopFileServiceStage(agentFileStreamService);
-    }
-
-    /**
-     * Create a {@link CleanupJobDirectoryStage} bean if one is not already defined.
-     *
-     * @param jobSetupService the job setup service
-     */
-    @Bean
-    @Lazy
-    @Order(250)
-    @ConditionalOnMissingBean(CleanupJobDirectoryStage.class)
-    CleanupJobDirectoryStage cleanupJobDirectoryStage(final JobSetupService jobSetupService) {
-        return new CleanupJobDirectoryStage(jobSetupService);
     }
 
     /**

--- a/genie-common-external/src/main/java/com/netflix/genie/common/external/dtos/v4/JobStatus.java
+++ b/genie-common-external/src/main/java/com/netflix/genie/common/external/dtos/v4/JobStatus.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.common.external.dtos.v4;
 
+import com.google.common.collect.Sets;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -90,6 +91,10 @@ public enum JobStatus {
         Arrays.stream(JobStatus.values()).filter(JobStatus::isClaimable).collect(Collectors.toSet())
     );
 
+    private static final Set<JobStatus> BEFORE_CLAIMED_STATUSES = Collections.unmodifiableSet(
+        Sets.newHashSet(RESERVED, RESOLVED, ACCEPTED)
+    );
+
     private final boolean active;
     private final boolean resolvable;
     private final boolean claimable;
@@ -116,6 +121,15 @@ public enum JobStatus {
      */
     public static Set<JobStatus> getActiveStatuses() {
         return ACTIVE_STATUSES;
+    }
+
+    /**
+     * Get an unmodifiable set of all the statuses that come before CLAIMED.
+     *
+     * @return Unmodifiable set of all statuses
+     */
+    public static Set<JobStatus> getStatusesBeforeClaimed() {
+        return BEFORE_CLAIMED_STATUSES;
     }
 
     /**

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -425,13 +425,18 @@ of 2.0
 |true
 |no
 
+|genie.tasks.agent-cleanup.launchTimeLimit
+|How long a job can stay in ACCEPTED state, waiting for the agent to claim it, before the job is marked failed, in milliseconds
+|240000
+|no
+
 |genie.tasks.agent-cleanup.refreshInterval
 |How often the AWOL agent tasks executed, in milliseconds
 |10000
 |no
 
-|genie.tasks.agent-cleanup.timeLimit
-|How long of a leeway to give a job after it agent disconnected and before the job is marked failed, in milliseconds
+|genie.tasks.agent-cleanup.reconnectTimeLimit
+|How long of a leeway to give a job after its agent disconnected and before the job is marked failed, in milliseconds
 |120000
 |no
 

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsIntegrationTest.java
@@ -1189,6 +1189,16 @@ class JpaPersistenceServiceImplJobsIntegrationTest extends JpaPersistenceService
             .containsExactlyInAnyOrder(AGENT_JOB_1, AGENT_JOB_2);
     }
 
+    @Test
+    @DatabaseSetup("persistence/jobs/unclaimed.xml")
+    void canGetUnclaimedAgentJobs() {
+
+        Assertions
+            .assertThat(this.service.getUnclaimedAgentJobs())
+            .hasSize(2)
+            .containsExactlyInAnyOrder(AGENT_JOB_1, AGENT_JOB_2);
+    }
+
     private void validateJobRequest(final com.netflix.genie.common.dto.JobRequest savedJobRequest) {
         Assertions.assertThat(savedJobRequest.getId()).isPresent().contains(UNIQUE_ID);
         Assertions.assertThat(savedJobRequest.getName()).isEqualTo(NAME);

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/impl/jpa/persistence/jobs/unclaimed.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/impl/jpa/persistence/jobs/unclaimed.xml
@@ -1,0 +1,843 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2016 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<dataset>
+    <files
+        id="1"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/hadoop/config/file"
+    />
+    <files
+        id="2"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/other/hadoop/config/file"
+    />
+    <files
+        id="3"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="hadoop.jar"
+    />
+    <files
+        id="4"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/spark/config/file"
+    />
+    <files
+        id="5"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/other/spark/config/file"
+    />
+    <files
+        id="6"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="spark.jar"
+    />
+    <files
+        id="7"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/spark2/config/file"
+    />
+    <files
+        id="8"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/other/spark2/config/file"
+    />
+    <files
+        id="9"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="spark2.jar"
+    />
+    <files
+        id="10"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/config/file"
+    />
+    <files
+        id="11"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/other/config/file"
+    />
+
+    <tags
+        id="1"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:app1"
+    />
+    <tags
+        id="2"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.name:hadoop"
+    />
+    <tags
+        id="3"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="type:hadoop"
+    />
+    <tags
+        id="4"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:app2"
+    />
+    <tags
+        id="5"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.name:spark"
+    />
+    <tags
+        id="6"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="type:spark"
+    />
+    <tags
+        id="7"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:app3"
+    />
+    <tags
+        id="8"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:command1"
+    />
+    <tags
+        id="9"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:cluster1"
+    />
+    <tags
+        id="10"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.name:h2query"
+    />
+    <tags
+        id="11"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="sched:adhoc"
+    />
+    <tags
+        id="12"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="type:yarn"
+    />
+    <tags
+        id="13"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="sla"
+    />
+    <tags
+        id="14"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="yarn"
+    />
+    <tags
+        id="15"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="adhoc"
+    />
+    <tags
+        id="16"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="ver:1.6.0"
+    />
+    <tags
+        id="17"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="sched:sla"
+    />
+
+    <applications
+        id="1"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:40:00"
+        entity_version="0"
+        unique_id="app1"
+        genie_user="tgianos"
+        name="hadoop"
+        version="4.5.6"
+        status="ACTIVE"
+        type="hadoop"
+    />
+    <applications_configs
+        application_id="1"
+        file_id="1"
+    />
+    <applications_configs
+        application_id="1"
+        file_id="2"
+    />
+    <applications_dependencies
+        application_id="1"
+        file_id="2"
+    />
+    <applications_tags
+        application_id="1"
+        tag_id="1"
+    />
+    <applications_tags
+        application_id="1"
+        tag_id="2"
+    />
+    <applications_tags
+        application_id="1"
+        tag_id="3"
+    />
+
+    <applications
+        id="2"
+        created="2016-03-21 01:45:00"
+        updated="2016-03-21 01:50:00"
+        entity_version="0"
+        unique_id="app2"
+        genie_user="tgianos"
+        name="spark"
+        version="1.6.0"
+        status="ACTIVE"
+        type="spark"
+    />
+    <applications_configs
+        application_id="2"
+        file_id="4"
+    />
+    <applications_configs
+        application_id="2"
+        file_id="5"
+    />
+    <applications_dependencies
+        application_id="2"
+        file_id="6"
+    />
+    <applications_tags
+        application_id="2"
+        tag_id="4"
+    />
+    <applications_tags
+        application_id="2"
+        tag_id="5"
+    />
+    <applications_tags
+        application_id="2"
+        tag_id="6"
+    />
+
+    <applications
+        id="3"
+        created="2016-03-21 01:55:00"
+        updated="2016-03-21 02:00:00"
+        entity_version="0"
+        unique_id="app3"
+        genie_user="tgianos"
+        name="spark"
+        version="2.0.0"
+        status="ACTIVE"
+        type="spark"
+    />
+    <applications_configs
+        application_id="3"
+        file_id="7"
+    />
+    <applications_configs
+        application_id="3"
+        file_id="8"
+    />
+    <applications_dependencies
+        application_id="3"
+        file_id="9"
+    />
+    <applications_tags
+        application_id="3"
+        tag_id="7"
+    />
+    <applications_tags
+        application_id="3"
+        tag_id="5"
+    />
+    <applications_tags
+        application_id="3"
+        tag_id="6"
+    />
+
+    <commands
+        id="1"
+        created="2016-03-21 01:47:00"
+        updated="2016-03-21 01:59:00"
+        entity_version="0"
+        unique_id="command1"
+        genie_user="tgianos"
+        name="spark"
+        version="1.6.0"
+        check_delay="10000"
+        status="ACTIVE"
+    />
+
+    <commands_tags
+        command_id="1"
+        tag_id="8"
+    />
+    <commands_tags
+        command_id="1"
+        tag_id="5"
+    />
+
+    <command_executable_arguments
+        command_id="1"
+        argument="spark"
+        argument_order="0"
+    />
+
+    <commands_applications command_id="1" application_id="1" application_order="0"/>
+    <commands_applications command_id="1" application_id="2" application_order="1"/>
+
+    <clusters
+        id="1"
+        created="2016-03-21 01:49:00"
+        updated="2016-03-21 02:59:00"
+        entity_version="0"
+        unique_id="cluster1"
+        genie_user="tgianos"
+        name="h2query"
+        version="2.4.0"
+        status="UP"
+    />
+    <clusters_configs
+        cluster_id="1"
+        file_id="10"
+    />
+    <clusters_configs
+        cluster_id="1"
+        file_id="11"
+    />
+
+    <clusters_commands
+        cluster_id="1"
+        command_id="1"
+        command_order="0"
+    />
+
+    <criteria
+        id="0"
+        name="spark"
+    />
+    <criteria_tags
+        criterion_id="0"
+        tag_id="6"
+    />
+    <criteria_tags
+        criterion_id="0"
+        tag_id="16"
+    />
+    <jobs
+        id="1"
+        created="2015-08-11 01:48:00"
+        updated="2015-08-11 02:59:00"
+        entity_version="1"
+        unique_id="job1"
+        genie_user="tgianos"
+        name="testSparkJob"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="1"
+        requested_memory="1560"
+        archiving_disabled="true"
+        requested_timeout="608400"
+        num_attachments="2"
+        total_size_of_attachments="38083"
+        status="SUCCEEDED"
+        cluster_id="1"
+        command_id="1"
+        agent_hostname="a.netflix.com"
+        exit_code="0"
+        process_id="317"
+        check_delay="10000"
+        timeout_used="608400"
+        grouping="job1Grouping"
+        grouping_instance="job1GroupingInstance"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/1"
+        resolved="true"
+        v4="false"
+        cluster_name="h2query"
+        command_name="spark"
+    />
+    <job_command_arguments
+        job_id="1"
+        argument="-f"
+        argument_order="0"
+    />
+    <job_command_arguments
+        job_id="1"
+        argument="query.q"
+        argument_order="1"
+    />
+    <job_requested_applications
+        job_id="1"
+        application_id="app1"
+        application_order="0"
+    />
+    <job_requested_applications
+        job_id="1"
+        application_id="app3"
+        application_order="1"
+    />
+    <criteria
+        id="1"
+        unique_id="cluster1"
+        name="h2query"
+    />
+    <criteria_tags
+        criterion_id="1"
+        tag_id="13"
+    />
+    <criteria_tags
+        criterion_id="1"
+        tag_id="14"
+    />
+    <jobs_cluster_criteria
+        job_id="1"
+        criterion_id="1"
+        priority_order="0"
+    />
+    <criteria
+        id="2"
+    />
+    <criteria_tags
+        criterion_id="2"
+        tag_id="13"
+    />
+    <criteria_tags
+        criterion_id="2"
+        tag_id="15"
+    />
+    <jobs_cluster_criteria
+        job_id="1"
+        criterion_id="2"
+        priority_order="1"
+    />
+
+    <jobs_applications job_id="1" application_id="1" application_order="0"/>
+    <jobs_applications job_id="1" application_id="3" application_order="1"/>
+
+    <criteria
+        id="3"
+    />
+    <criteria_tags
+        criterion_id="3"
+        tag_id="6"
+    />
+    <jobs
+        id="2"
+        created="2015-08-12 01:48:00"
+        updated="2015-08-12 02:59:00"
+        entity_version="1"
+        unique_id="job2"
+        genie_user="tgianos"
+        name="testSparkJob1"
+        version="2.4"
+        command_criterion="3"
+        requested_cpu="2"
+        requested_memory="2048"
+        memory_used="2048"
+        archiving_disabled="false"
+        requested_timeout="608400"
+        num_attachments="3"
+        total_size_of_attachments="38082233"
+        status="ACCEPTED"
+        cluster_id="1"
+        command_id="1"
+        agent_hostname="a.netflix.com"
+        exit_code="-1"
+        process_id="318"
+        check_delay="11000"
+        timeout_used="608400"
+        grouping="job2Grouping"
+        grouping_instance="job2GroupingInstance"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/2"
+        resolved="true"
+        v4="false"
+        cluster_name="h2query"
+        command_name="spark"
+    />
+    <job_command_arguments
+        job_id="2"
+        argument="-f"
+        argument_order="0"
+    />
+    <job_command_arguments
+        job_id="2"
+        argument="spark.jar"
+        argument_order="1"
+    />
+    <criteria
+        id="4"
+    />
+    <criteria_tags
+        criterion_id="4"
+        tag_id="17"
+    />
+    <criteria_tags
+        criterion_id="4"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="2"
+        criterion_id="4"
+        priority_order="0"
+    />
+    <criteria
+        id="5"
+    />
+    <criteria_tags
+        criterion_id="5"
+        tag_id="11"
+    />
+    <criteria_tags
+        criterion_id="5"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="2"
+        criterion_id="5"
+        priority_order="1"
+    />
+
+    <jobs_applications job_id="2" application_id="1" application_order="0"/>
+    <jobs_applications job_id="2" application_id="2" application_order="1"/>
+
+    <criteria
+        id="6"
+    />
+    <criteria_tags
+        criterion_id="6"
+        tag_id="6"
+    />
+    <jobs
+        id="3"
+        created="2016-02-24 01:48:00"
+        updated="2016-02-24 02:59:00"
+        entity_version="1"
+        unique_id="agentJob0"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        command_criterion="6"
+        requested_cpu="2"
+        requested_memory="2048"
+        memory_used="2048"
+        archiving_disabled="true"
+        requested_timeout="608400"
+        num_attachments="1"
+        total_size_of_attachments="382"
+        status="FAILED"
+        cluster_id="1"
+        command_id="1"
+        agent_hostname="b.netflix.com"
+        exit_code="-1"
+        process_id="319"
+        check_delay="12000"
+        timeout_used="608400"
+        grouping="job3Grouping"
+        grouping_instance="job3GroupingInstance"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/3"
+        resolved="true"
+        v4="true"
+        cluster_name="h2query"
+        command_name="spark"
+    />
+    <job_command_arguments
+        job_id="3"
+        argument="-f"
+        argument_order="0"
+    />
+    <job_command_arguments
+        job_id="3"
+        argument="spark.jar"
+        argument_order="1"
+    />
+    <criteria
+        id="7"
+    />
+    <criteria_tags
+        criterion_id="7"
+        tag_id="17"
+    />
+    <criteria_tags
+        criterion_id="7"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="3"
+        criterion_id="7"
+        priority_order="0"
+    />
+    <criteria
+        id="8"
+    />
+    <criteria_tags
+        criterion_id="8"
+        tag_id="11"
+    />
+    <criteria_tags
+        criterion_id="8"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="3"
+        criterion_id="8"
+        priority_order="1"
+    />
+
+    <jobs_applications job_id="3" application_id="1" application_order="0"/>
+    <jobs_applications job_id="3" application_id="2" application_order="1"/>
+
+    <criteria
+        id="9"
+    />
+    <criteria_tags
+        criterion_id="9"
+        tag_id="6"
+    />
+    <jobs
+        id="4"
+        created="2016-02-24 01:48:00"
+        updated="2016-02-24 02:59:00"
+        entity_version="1"
+        unique_id="agentJob1"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        command_criterion="9"
+        requested_cpu="2"
+        requested_memory="2048"
+        memory_used="2048"
+        archiving_disabled="true"
+        requested_timeout="608400"
+        num_attachments="1"
+        total_size_of_attachments="382"
+        status="RESERVED"
+        cluster_id="1"
+        command_id="1"
+        agent_hostname="agent.netflix.com"
+        exit_code="-1"
+        process_id="319"
+        check_delay="12000"
+        timeout_used="608400"
+        grouping="agentJob1Grouping"
+        grouping_instance="agentJob1GroupingInstance"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/13"
+        resolved="true"
+        v4="true"
+        cluster_name="h2query"
+        command_name="spark"
+    />
+    <job_command_arguments
+        job_id="4"
+        argument="-f"
+        argument_order="0"
+    />
+    <job_command_arguments
+        job_id="4"
+        argument="spark.jar"
+        argument_order="1"
+    />
+    <criteria
+        id="10"
+    />
+    <criteria_tags
+        criterion_id="10"
+        tag_id="17"
+    />
+    <criteria_tags
+        criterion_id="10"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="4"
+        criterion_id="10"
+        priority_order="0"
+    />
+    <criteria
+        id="11"
+    />
+    <criteria_tags
+        criterion_id="11"
+        tag_id="11"
+    />
+    <criteria_tags
+        criterion_id="11"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="4"
+        criterion_id="11"
+        priority_order="1"
+    />
+
+    <jobs_applications job_id="4" application_id="1" application_order="0"/>
+    <jobs_applications job_id="4" application_id="2" application_order="1"/>
+
+    <criteria
+        id="12"
+    />
+    <criteria_tags
+        criterion_id="12"
+        tag_id="6"
+    />
+    <jobs
+        id="5"
+        created="2016-02-24 01:48:00"
+        updated="2016-02-24 02:59:00"
+        entity_version="1"
+        unique_id="agentJob2"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        command_criterion="12"
+        requested_cpu="2"
+        requested_memory="2048"
+        memory_used="2048"
+        archiving_disabled="true"
+        requested_timeout="608400"
+        num_attachments="1"
+        total_size_of_attachments="382"
+        status="ACCEPTED"
+        cluster_id="1"
+        command_id="1"
+        agent_hostname="agent.netflix.com"
+        exit_code="-1"
+        process_id="319"
+        check_delay="12000"
+        timeout_used="608400"
+        grouping="agentJob2Grouping"
+        grouping_instance="agentJob2GroupingInstance"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/13"
+        resolved="true"
+        v4="true"
+        cluster_name="h2query"
+        command_name="spark"
+    />
+    <job_command_arguments
+        job_id="5"
+        argument="-f"
+        argument_order="0"
+    />
+    <job_command_arguments
+        job_id="5"
+        argument="spark.jar"
+        argument_order="1"
+    />
+    <criteria
+        id="13"
+    />
+    <criteria_tags
+        criterion_id="13"
+        tag_id="17"
+    />
+    <criteria_tags
+        criterion_id="13"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="5"
+        criterion_id="13"
+        priority_order="0"
+    />
+    <criteria
+        id="14"
+    />
+    <criteria_tags
+        criterion_id="14"
+        tag_id="11"
+    />
+    <criteria_tags
+        criterion_id="14"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="5"
+        criterion_id="14"
+        priority_order="1"
+    />
+
+    <jobs_applications job_id="5" application_id="1" application_order="0"/>
+    <jobs_applications job_id="5" application_id="2" application_order="1"/>
+
+    <agent_connections
+        created="2016-02-24 01:48:00"
+        updated="2016-02-24 02:59:00"
+        entity_version="1"
+        job_id="agentJob2"
+        server_hostname="b.netflix.com"
+    />
+
+</dataset>

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
@@ -1042,6 +1042,13 @@ public interface PersistenceService {
      * @return The list of job ids
      */
     Set<String> getActiveAgentJobs();
+
+    /**
+     * Get the set of agent jobs in that have not reached CLAIMED state.
+     *
+     * @return The list of job ids
+     */
+    Set<String> getUnclaimedAgentJobs();
     //endregion
     //endregion
 

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
@@ -187,6 +187,16 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
         .collect(Collectors.toSet());
 
     /**
+     * The a set containing statuses that come before CLAIMED.
+     */
+    @VisibleForTesting
+    static final Set<String> UNCLAIMED_STATUS_SET = JobStatus
+        .getStatusesBeforeClaimed()
+        .stream()
+        .map(Enum::name)
+        .collect(Collectors.toSet());
+
+    /**
      * The set of job statuses which are considered to be using memory on a Genie node.
      */
     @VisibleForTesting
@@ -1933,6 +1943,19 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
     public Set<String> getActiveAgentJobs() {
         log.debug("[getActiveAgentJobs] Called");
         return this.jobRepository.getAgentJobIdsWithStatusIn(ACTIVE_STATUS_SET)
+            .stream()
+            .map(UniqueIdProjection::getUniqueId)
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Set<String> getUnclaimedAgentJobs() {
+        log.debug("[getUnclaimedAgentJobs] Called");
+        return this.jobRepository.getAgentJobIdsWithStatusIn(UNCLAIMED_STATUS_SET)
             .stream()
             .map(UniqueIdProjection::getUniqueId)
             .collect(Collectors.toSet());

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/AgentCleanupProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/AgentCleanupProperties.java
@@ -22,6 +22,8 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import java.time.Duration;
+
 /**
  * Properties related to cleaning up jobs associated to AWOL/MIA agents.
  *
@@ -46,9 +48,9 @@ public class AgentCleanupProperties {
 
     private boolean enabled = true;
 
-    private long refreshInterval = 10_000;
+    private Duration refreshInterval = Duration.ofSeconds(10);
 
-    private long reconnectTimeLimit = 120_000;
+    private Duration reconnectTimeLimit = Duration.ofMinutes(2);
 
-    private long launchTimeLimit = 240_000;
+    private Duration launchTimeLimit = Duration.ofMinutes(4);
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/AgentCleanupProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/AgentCleanupProperties.java
@@ -48,5 +48,7 @@ public class AgentCleanupProperties {
 
     private long refreshInterval = 10_000;
 
-    private long timeLimit = 120_000;
+    private long reconnectTimeLimit = 120_000;
+
+    private long launchTimeLimit = 240_000;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/AgentJobCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/AgentJobCleanupTask.java
@@ -116,8 +116,8 @@ public class AgentJobCleanupTask extends LeaderTask {
             final Instant awolJobFirstSeen = entry.getValue();
 
             final boolean jobWasClaimed = !acceptedAgentJobIds.contains(awolJobId);
-            final Instant claimDeadline = awolJobFirstSeen.plusMillis(this.properties.getLaunchTimeLimit());
-            final Instant reconnectDeadline = awolJobFirstSeen.plusMillis(this.properties.getReconnectTimeLimit());
+            final Instant claimDeadline = awolJobFirstSeen.plus(this.properties.getLaunchTimeLimit());
+            final Instant reconnectDeadline = awolJobFirstSeen.plus(this.properties.getReconnectTimeLimit());
 
             if (!jobWasClaimed && now.isBefore(claimDeadline)) {
                 log.debug("Job {} agent still pending agent start/claim", awolJobId);
@@ -176,7 +176,7 @@ public class AgentJobCleanupTask extends LeaderTask {
      */
     @Override
     public long getFixedRate() {
-        return properties.getRefreshInterval();
+        return properties.getRefreshInterval().toMillis();
     }
 
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentCleanupPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentCleanupPropertiesSpec.groovy
@@ -26,17 +26,20 @@ class AgentCleanupPropertiesSpec extends Specification {
 
         expect:
         properties.getRefreshInterval() == 10000L
-        properties.getTimeLimit() == 120000L
+        properties.getReconnectTimeLimit() == 120000L
+        properties.getLaunchTimeLimit() == 240000L
         properties.isEnabled()
 
         when:
         properties.setRefreshInterval(1000)
-        properties.setTimeLimit(2000)
+        properties.setReconnectTimeLimit(2000)
+        properties.setLaunchTimeLimit(3000)
         properties.setEnabled(false)
 
         then:
         properties.getRefreshInterval() == 1000L
-        properties.getTimeLimit() == 2000L
+        properties.getReconnectTimeLimit() == 2000L
+        properties.getLaunchTimeLimit() == 3000L
         !properties.isEnabled()
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentCleanupPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentCleanupPropertiesSpec.groovy
@@ -19,27 +19,30 @@ package com.netflix.genie.web.properties
 
 import spock.lang.Specification
 
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
 class AgentCleanupPropertiesSpec extends Specification {
     def "testDefaultsSettersAndGetters"() {
         setup:
         AgentCleanupProperties properties = new AgentCleanupProperties()
 
         expect:
-        properties.getRefreshInterval() == 10000L
-        properties.getReconnectTimeLimit() == 120000L
-        properties.getLaunchTimeLimit() == 240000L
+        properties.getRefreshInterval() == Duration.of(10, ChronoUnit.SECONDS)
+        properties.getReconnectTimeLimit() == Duration.of(2, ChronoUnit.MINUTES)
+        properties.getLaunchTimeLimit() == Duration.of(4, ChronoUnit.MINUTES)
         properties.isEnabled()
 
         when:
-        properties.setRefreshInterval(1000)
-        properties.setReconnectTimeLimit(2000)
-        properties.setLaunchTimeLimit(3000)
+        properties.setRefreshInterval(Duration.of(1, ChronoUnit.MINUTES))
+        properties.setReconnectTimeLimit(Duration.of(2, ChronoUnit.MINUTES))
+        properties.setLaunchTimeLimit(Duration.of(3, ChronoUnit.MINUTES))
         properties.setEnabled(false)
 
         then:
-        properties.getRefreshInterval() == 1000L
-        properties.getReconnectTimeLimit() == 2000L
-        properties.getLaunchTimeLimit() == 3000L
+        properties.getRefreshInterval() == Duration.of(1, ChronoUnit.MINUTES)
+        properties.getReconnectTimeLimit() == Duration.of(2, ChronoUnit.MINUTES)
+        properties.getLaunchTimeLimit() == Duration.of(3, ChronoUnit.MINUTES)
         !properties.isEnabled()
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/AgentJobCleanupTaskSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/AgentJobCleanupTaskSpec.groovy
@@ -79,7 +79,7 @@ class AgentJobCleanupTaskSpec extends Specification {
         1 * agentRoutingService.isAgentConnected("j2") >> false
         1 * agentRoutingService.isAgentConnected("j3") >> true
         1 * agentRoutingService.isAgentConnected("j4") >> true
-        2 * taskProperties.getTimeLimit() >> -1 // Make sure it's past deadline next iteration
+        0 * taskProperties.getTimeLimit()
 
         when:
         task.run()
@@ -87,7 +87,7 @@ class AgentJobCleanupTaskSpec extends Specification {
         then:
         1 * persistenceService.getActiveAgentJobs() >> Sets.newHashSet("j1", "j2", "j3", "j4")
         4 * agentRoutingService.isAgentConnected(_) >> false
-        2 * taskProperties.getTimeLimit() >> 1_000_000L // Make sure it not expiring
+        2 * taskProperties.getTimeLimit() >> -1 // Make sure they look expired
         1 * persistenceService.setJobCompletionInformation("j1", -1, JobStatus.FAILED, AgentJobCleanupTask.STATUS_MESSAGE, null, null)
         1 * persistenceService.setJobCompletionInformation("j2", -1, JobStatus.FAILED, AgentJobCleanupTask.STATUS_MESSAGE, null, null) >> {
             throw e
@@ -103,6 +103,7 @@ class AgentJobCleanupTaskSpec extends Specification {
         1 * persistenceService.getActiveAgentJobs() >> Sets.newHashSet("j3", "j4")
         1 * agentRoutingService.isAgentConnected("j3") >> false
         1 * agentRoutingService.isAgentConnected("j4") >> true
+        1 * taskProperties.getTimeLimit() >> 10_000 // Make sure it's not expired
         0 * persistenceService._
 
         when:

--- a/genie-web/src/test/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsTest.java
@@ -1192,4 +1192,36 @@ class JpaPersistenceServiceImplJobsTest {
             .assertThat(this.persistenceService.getActiveAgentJobs())
             .isEqualTo(Sets.newHashSet());
     }
+
+    @Test
+    void canGetUnclaimedAgentJobs() {
+        final String jobId1 = UUID.randomUUID().toString();
+        final String jobId2 = UUID.randomUUID().toString();
+
+        final UniqueIdProjection job1 = Mockito.mock(UniqueIdProjection.class);
+        final UniqueIdProjection job2 = Mockito.mock(UniqueIdProjection.class);
+
+        Mockito.when(job1.getUniqueId()).thenReturn(jobId1);
+        Mockito.when(job2.getUniqueId()).thenReturn(jobId2);
+
+        Mockito
+            .when(this.jobRepository.getAgentJobIdsWithStatusIn(JpaPersistenceServiceImpl.UNCLAIMED_STATUS_SET))
+            .thenReturn(Sets.newHashSet(job1, job2));
+
+        Assertions
+            .assertThat(this.persistenceService.getUnclaimedAgentJobs())
+            .isEqualTo(Sets.newHashSet(jobId1, jobId2));
+    }
+
+    @Test
+    void canGetUnclaimedAgentJobsWhenEmpty() {
+
+        Mockito
+            .when(this.jobRepository.getAgentJobIdsWithStatusIn(JpaPersistenceServiceImpl.UNCLAIMED_STATUS_SET))
+            .thenReturn(Sets.newHashSet());
+
+        Assertions
+            .assertThat(this.persistenceService.getUnclaimedAgentJobs())
+            .isEqualTo(Sets.newHashSet());
+    }
 }


### PR DESCRIPTION
Separate the two cases of
 * Agent not yet started (job in unclaimed state)
 * Agent started then disconnected (job in active/claimed state)
and allow setting different timeout values for the two.