### PR TITLE
Implementation of New Algorithm for V4 Resource Resolution

### DIFF
--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -427,6 +427,12 @@ for multiple errors.
 |JobResolverServiceImpl
 |status, exceptionClass, saved
 
+|genie.services.jobResolver.resolveApplications.timer
+|Time taken to retrieve applications information for this task
+|nanoseconds
+|JobResolverServiceImpl
+|status, exceptionClass
+
 |genie.services.jobResolver.resolveCluster.timer
 |Time taken to resolve the cluster to use for a job
 |nanoseconds
@@ -450,12 +456,6 @@ for multiple errors.
 |nanoseconds
 |JobResolverServiceImpl
 |status, commandName, commandId, exceptionClass
-
-|genie.services.jobResolver.selectApplications.timer
-|Time taken to retrieve applications information for this task
-|nanoseconds
-|JobResolverServiceImpl
-|status, exceptionClass
 
 |genie.services.jobResolver.selectCluster.noneFound.counter
 |Number of times the criteria for cluster selection does not match any cluster

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -409,12 +409,6 @@ for multiple errors.
 |JobResolverServiceImpl
 |status, exceptionClass
 
-|genie.services.jobResolver.clusterSelector.counter
-|Counter for cluster selector algorithms invocations
-|count
-|JobResolverServiceImpl
-|class, status, clusterName, clusterId, clusterSelectorClass
-
 |genie.services.jobResolver.generateClusterCriteriaPermutations.timer
 |Time taken to generate all the permutations for cluster criteria between the command options and the job request
 |nanoseconds
@@ -433,23 +427,17 @@ for multiple errors.
 |JobResolverServiceImpl
 |status, exceptionClass
 
+|genie.services.jobResolver.resolveCluster.clusterSelector.counter
+|Counter for cluster selector algorithms invocations
+|count
+|JobResolverServiceImpl
+|class, status, clusterName, clusterId, clusterSelectorClass
+
 |genie.services.jobResolver.resolveCluster.timer
 |Time taken to resolve the cluster to use for a job
 |nanoseconds
 |JobResolverServiceImpl
-|status, clusterName, clusterId, queryCount, criteriaCombinationCount, exceptionClass
-
-|genie.services.jobResolver.resolveCluster.criteriaCombination.count
-|Count of criterion combinations attempted to resolve a cluster for a job
-|count
-|JobResolverServiceImpl
-|
-
-|genie.services.jobResolver.resolveCluster.query.count
-|Count of number of database queries required to resolve a cluster for a job
-|count
-|JobResolverServiceImpl
-|
+|status, clusterName, clusterId, exceptionClass
 
 |genie.services.jobResolver.resolveCommand.timer
 |Time taken to resolve the command to use for a job
@@ -464,7 +452,7 @@ for multiple errors.
 |-
 
 |genie.services.jobResolver.selectCluster.noneSelected.counter
-|Number of times the cluster selection terminated without selecting a cluster
+|Number of times the cluster selection completed without selecting a cluster
 |count
 |JobResolverServiceImpl
 |-

--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -415,6 +415,12 @@ for multiple errors.
 |JobResolverServiceImpl
 |class, status, clusterName, clusterId, clusterSelectorClass
 
+|genie.services.jobResolver.generateClusterCriteriaPermutations.timer
+|Time taken to generate all the permutations for cluster criteria between the command options and the job request
+|nanoseconds
+|JobResolverServiceImpl
+|
+
 |genie.services.jobResolver.resolve.timer
 |Time taken to completely resolve the job
 |nanoseconds

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
@@ -1118,7 +1118,8 @@ public class JobRestControllerIntegrationTest extends RestControllerIntegrationT
                     Matchers.containsString(
                         "No cluster/command combination found for the given criteria. Unable to continue"
                     ),
-                    Matchers.containsString("No cluster selected given criteria for job")
+                    Matchers.containsString("No cluster selected given criteria for job"),
+                    Matchers.containsString("No clusters available to run any candidate command on")
                 )
             )
             .body("stackTrace", Matchers.nullValue());

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/scripts/selectCluster.groovy
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/scripts/selectCluster.groovy
@@ -21,14 +21,16 @@ import com.netflix.genie.common.external.dtos.v4.Cluster
 import com.netflix.genie.common.external.dtos.v4.ClusterMetadata
 import com.netflix.genie.common.external.dtos.v4.ClusterStatus
 import com.netflix.genie.common.external.dtos.v4.JobRequest
+import com.netflix.genie.web.selectors.ClusterSelectionContext
 
 import java.time.Instant
 
 def binding = this.getBinding()
 
-String jobId = GroovyScriptUtils.getJobId(binding)
-JobRequest jobRequest = GroovyScriptUtils.getJobRequest(binding)
-Set<Cluster> clusters = GroovyScriptUtils.getClusters(binding)
+ClusterSelectionContext context = GroovyScriptUtils.getClusterSelectionContext(binding)
+String jobId = context.getJobId()
+JobRequest jobRequest = context.getJobRequest()
+Set<Cluster> clusters = context.getClusters()
 
 Cluster selectedCluster = null
 String rationale = null

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/scripts/selectCommand.groovy
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/scripts/selectCommand.groovy
@@ -21,14 +21,16 @@ import com.netflix.genie.common.external.dtos.v4.Command
 import com.netflix.genie.common.external.dtos.v4.CommandMetadata
 import com.netflix.genie.common.external.dtos.v4.CommandStatus
 import com.netflix.genie.common.external.dtos.v4.JobRequest
+import com.netflix.genie.web.selectors.CommandSelectionContext
 
 import java.time.Instant
 
 def binding = this.getBinding()
 
-String jobId = GroovyScriptUtils.getJobId(binding)
-JobRequest jobRequest = GroovyScriptUtils.getJobRequest(binding)
-Set<Command> commands = GroovyScriptUtils.getCommands(binding)
+CommandSelectionContext context = GroovyScriptUtils.getCommandSelectionContext(binding)
+String jobId = context.getJobId()
+JobRequest jobRequest = context.getJobRequest()
+Set<Command> commands = context.getResources()
 
 Command selectedCommand = null
 String rationale = null

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
@@ -351,6 +351,17 @@ public interface PersistenceService {
      * @return All the {@link Cluster}'s which matched the {@link Criterion}
      */
     Set<Cluster> findClustersMatchingCriterion(@Valid Criterion criterion, boolean addDefaultStatus);
+
+    /**
+     * Find all the {@link Cluster}'s that match any of the given {@link Criterion}.
+     *
+     * @param criteria         The set of {@link Criterion} supplied that a cluster needs to completely match at least
+     *                         one of to be returned
+     * @param addDefaultStatus {@literal true} if the a default status should be added to the supplied
+     *                         {@link Criterion} if the supplied criterion doesn't already have a status
+     * @return All the {@link Cluster}'s which matched the {@link Criterion}
+     */
+    Set<Cluster> findClustersMatchingAnyCriterion(@NotEmpty Set<@Valid Criterion> criteria, boolean addDefaultStatus);
     //endregion
 
     //region Command APIs

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/queries/specifications/JpaSpecificationUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/queries/specifications/JpaSpecificationUtils.java
@@ -26,8 +26,8 @@ import com.netflix.genie.web.data.services.impl.jpa.entities.TagEntity_;
 import com.netflix.genie.web.data.services.impl.jpa.entities.UniqueIdEntity;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.persistence.criteria.AbstractQuery;
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Predicate;
@@ -114,7 +114,7 @@ public final class JpaSpecificationUtils {
 
     static <E extends BaseEntity> Predicate createCriterionPredicate(
         final Root<E> root,
-        final CriteriaQuery<?> cq,
+        final AbstractQuery<?> cq,
         final CriteriaBuilder cb,
         final SingularAttribute<UniqueIdEntity, String> uniqueIdAttribute,
         final SingularAttribute<BaseEntity, String> nameAttribute,

--- a/genie-web/src/main/java/com/netflix/genie/web/scripts/ClusterSelectorManagedScript.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/scripts/ClusterSelectorManagedScript.java
@@ -84,6 +84,8 @@ public class ClusterSelectorManagedScript extends ResourceSelectorScript<Cluster
         final ClusterSelectionContext context
     ) {
         super.addParametersForScript(parameters, context);
+
+        // TODO: Remove once internal scripts migrate to use context directly
         parameters.put(CLUSTERS_BINDING, context.getClusters());
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/scripts/CommandSelectorManagedScript.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/scripts/CommandSelectorManagedScript.java
@@ -18,14 +18,13 @@
 package com.netflix.genie.web.scripts;
 
 import com.netflix.genie.common.external.dtos.v4.Command;
-import com.netflix.genie.common.external.dtos.v4.JobRequest;
 import com.netflix.genie.web.exceptions.checked.ResourceSelectionException;
 import com.netflix.genie.web.properties.CommandSelectorManagedScriptProperties;
+import com.netflix.genie.web.selectors.CommandSelectionContext;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * An extension of {@link ResourceSelectorScript} which from a set of commands and the original job request will
@@ -35,7 +34,7 @@ import java.util.Set;
  * @since 4.0.0
  */
 @Slf4j
-public class CommandSelectorManagedScript extends ResourceSelectorScript<Command> {
+public class CommandSelectorManagedScript extends ResourceSelectorScript<Command, CommandSelectionContext> {
 
     static final String COMMANDS_BINDING = "commandsParameter";
 
@@ -59,13 +58,15 @@ public class CommandSelectorManagedScript extends ResourceSelectorScript<Command
      */
     @Override
     public ResourceSelectorScriptResult<Command> selectResource(
-        final Set<Command> resources,
-        final JobRequest jobRequest,
-        final String jobId
+        final CommandSelectionContext context
     ) throws ResourceSelectionException {
-        log.debug("Called to attempt to select a command from {} for job {}", resources, jobId);
+        log.debug(
+            "Called to attempt to select a command from {} for job {}",
+            context.getResources(),
+            context.getJobId()
+        );
 
-        return super.selectResource(resources, jobRequest, jobId);
+        return super.selectResource(context);
     }
 
     /**
@@ -74,10 +75,9 @@ public class CommandSelectorManagedScript extends ResourceSelectorScript<Command
     @Override
     protected void addParametersForScript(
         final Map<String, Object> parameters,
-        final Set<Command> resources,
-        final JobRequest jobRequest
+        final CommandSelectionContext context
     ) {
-        super.addParametersForScript(parameters, resources, jobRequest);
-        parameters.put(COMMANDS_BINDING, resources);
+        super.addParametersForScript(parameters, context);
+        parameters.put(COMMANDS_BINDING, context.getResources());
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/scripts/CommandSelectorManagedScript.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/scripts/CommandSelectorManagedScript.java
@@ -78,6 +78,8 @@ public class CommandSelectorManagedScript extends ResourceSelectorScript<Command
         final CommandSelectionContext context
     ) {
         super.addParametersForScript(parameters, context);
+
+        // TODO: Remove once internal scripts migrate to use context directly
         parameters.put(COMMANDS_BINDING, context.getResources());
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/scripts/GroovyScriptUtils.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/scripts/GroovyScriptUtils.java
@@ -20,6 +20,8 @@ package com.netflix.genie.web.scripts;
 import com.netflix.genie.common.external.dtos.v4.Cluster;
 import com.netflix.genie.common.external.dtos.v4.Command;
 import com.netflix.genie.common.external.dtos.v4.JobRequest;
+import com.netflix.genie.web.selectors.ClusterSelectionContext;
+import com.netflix.genie.web.selectors.CommandSelectionContext;
 import groovy.lang.Binding;
 
 import java.util.Set;
@@ -35,12 +37,43 @@ public final class GroovyScriptUtils {
     }
 
     /**
+     * Given the {@link Binding} that a script has attempt to extract the command selection context.
+     *
+     * @param binding The {@link Binding} for the script
+     * @return The {@link CommandSelectionContext} instance
+     * @throws IllegalArgumentException If there is no context parameter for the script or it is not a
+     *                                  {@link CommandSelectionContext}
+     */
+    public static CommandSelectionContext getCommandSelectionContext(
+        final Binding binding
+    ) throws IllegalArgumentException {
+        return getObjectVariable(binding, ResourceSelectorScript.CONTEXT_BINDING, CommandSelectionContext.class);
+    }
+
+    /**
+     * Given the {@link Binding} that a script has attempt to extract the cluster selection context.
+     *
+     * @param binding The {@link Binding} for the script
+     * @return The {@link ClusterSelectionContext} instance
+     * @throws IllegalArgumentException If there is no context parameter for the script or it is not a
+     *                                  {@link ClusterSelectionContext}
+     */
+    public static ClusterSelectionContext getClusterSelectionContext(
+        final Binding binding
+    ) throws IllegalArgumentException {
+        return getObjectVariable(binding, ResourceSelectorScript.CONTEXT_BINDING, ClusterSelectionContext.class);
+    }
+
+    /**
      * Given the {@link Binding} that a script has attempt to extract the job id parameter.
      *
      * @param binding The {@link Binding} for the script
      * @return The job id
      * @throws IllegalArgumentException If there is no job id parameter for the script or it is not a String
+     * @deprecated Use {@link #getClusterSelectionContext(Binding)} or {@link #getCommandSelectionContext(Binding)}
+     * instead
      */
+    @Deprecated
     public static String getJobId(final Binding binding) throws IllegalArgumentException {
         return getObjectVariable(binding, ResourceSelectorScript.JOB_ID_BINDING, String.class);
     }
@@ -52,7 +85,10 @@ public final class GroovyScriptUtils {
      * @return The {@link JobRequest}
      * @throws IllegalArgumentException If there is no job request parameter for the script or it is not a
      *                                  {@link JobRequest}
+     * @deprecated Use {@link #getClusterSelectionContext(Binding)} or {@link #getCommandSelectionContext(Binding)}
+     * instead
      */
+    @Deprecated
     public static JobRequest getJobRequest(final Binding binding) throws IllegalArgumentException {
         return getObjectVariable(binding, ResourceSelectorScript.JOB_REQUEST_BINDING, JobRequest.class);
     }
@@ -64,7 +100,10 @@ public final class GroovyScriptUtils {
      * @return The set of {@link Cluster}'s
      * @throws IllegalArgumentException If there is no clusters parameter, it isn't a set, is empty or doesn't contain
      *                                  all {@link Cluster} instances
+     * @deprecated Use {@link #getClusterSelectionContext(Binding)} or {@link #getCommandSelectionContext(Binding)}
+     * instead
      */
+    @Deprecated
     public static Set<Cluster> getClusters(final Binding binding) throws IllegalArgumentException {
         return getSetVariable(binding, ClusterSelectorManagedScript.CLUSTERS_BINDING, Cluster.class);
     }
@@ -76,7 +115,10 @@ public final class GroovyScriptUtils {
      * @return The set of {@link Command}'s
      * @throws IllegalArgumentException If there is no commands parameter, it isn't a set, is empty or doesn't contain
      *                                  all {@link Command} instances
+     * @deprecated Use {@link #getClusterSelectionContext(Binding)} or {@link #getCommandSelectionContext(Binding)}
+     * instead
      */
+    @Deprecated
     public static Set<Command> getCommands(final Binding binding) throws IllegalArgumentException {
         return getSetVariable(binding, CommandSelectorManagedScript.COMMANDS_BINDING, Command.class);
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/scripts/ResourceSelectorScript.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/scripts/ResourceSelectorScript.java
@@ -42,6 +42,7 @@ public class ResourceSelectorScript<R, C extends ResourceSelectionContext<R>> ex
 
     static final String JOB_REQUEST_BINDING = "jobRequestParameter";
     static final String JOB_ID_BINDING = "jobIdParameter";
+    static final String CONTEXT_BINDING = "contextParameter";
 
     /**
      * Constructor.
@@ -97,13 +98,15 @@ public class ResourceSelectorScript<R, C extends ResourceSelectionContext<R>> ex
     }
 
     /**
-     * Add any implementation specific parameters to the map of parameters to send to the script. The job request
-     * will already have been added under {@literal jobRequestParameter}.
+     * Add any implementation specific parameters to the map of parameters to send to the script.
      *
      * @param parameters The existing set of parameters for implementations to add to
      * @param context    The selection context
      */
     protected void addParametersForScript(final Map<String, Object> parameters, final C context) {
+        parameters.put(CONTEXT_BINDING, context);
+
+        // TODO: Remove once internal scripts migrate to use context directly
         parameters.put(JOB_REQUEST_BINDING, context.getJobRequest());
         parameters.put(JOB_ID_BINDING, context.getJobId());
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/ClusterSelectionContext.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/ClusterSelectionContext.java
@@ -1,0 +1,87 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.selectors;
+
+import com.google.common.collect.ImmutableSet;
+import com.netflix.genie.common.external.dtos.v4.Cluster;
+import com.netflix.genie.common.external.dtos.v4.Command;
+import com.netflix.genie.common.external.dtos.v4.JobRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+import javax.annotation.Nullable;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Extension of {@link ResourceSelectionContext} to include specific data useful in cluster selection.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Getter
+@ToString(callSuper = true, doNotUseGetters = true)
+public class ClusterSelectionContext extends ResourceSelectionContext<Cluster> {
+
+    private final Command command;
+    private final Set<Cluster> clusters;
+
+    /**
+     * Constructor.
+     *
+     * @param jobId      The id of the job which the command is being selected for
+     * @param jobRequest The job request the user originally made
+     * @param apiJob     Whether the job was submitted via the API or from Agent CLI
+     * @param command    The command which was already selected (if there was one)
+     * @param clusters   The clusters to choose from
+     */
+    public ClusterSelectionContext(
+        @NotEmpty final String jobId,
+        @NotNull final JobRequest jobRequest,
+        final boolean apiJob,
+        @Nullable @Valid final Command command,
+        @NotEmpty final Set<@Valid Cluster> clusters
+    ) {
+        super(jobId, jobRequest, apiJob);
+        this.command = command;
+        this.clusters = ImmutableSet.copyOf(clusters);
+    }
+
+    /**
+     * Get the command which was already selected for the job if there was one.
+     * <p>
+     * This is currently returning an optional due to the support for v3 and v4 algorithms. Once v4 is the only
+     * resource selection algorithm command will no longer be optional.
+     *
+     * @return The {@link Command} wrapped in an {@link Optional}
+     */
+    public Optional<Command> getCommand() {
+        return Optional.ofNullable(this.command);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<Cluster> getResources() {
+        return this.clusters;
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/ClusterSelector.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/ClusterSelector.java
@@ -30,5 +30,5 @@ import org.springframework.validation.annotation.Validated;
  * @since 2.0.0
  */
 @Validated
-public interface ClusterSelector extends ResourceSelector<Cluster> {
+public interface ClusterSelector extends ResourceSelector<Cluster, ClusterSelectionContext> {
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/CommandSelectionContext.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/CommandSelectionContext.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.selectors;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.genie.common.external.dtos.v4.Cluster;
+import com.netflix.genie.common.external.dtos.v4.Command;
+import com.netflix.genie.common.external.dtos.v4.JobRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Extension of {@link ResourceSelectionContext} to include specific data useful in command selection.
+ *
+ * @author tgianos
+ * @since 4.0.0
+ */
+@Getter
+@ToString(callSuper = true, doNotUseGetters = true)
+public class CommandSelectionContext extends ResourceSelectionContext<Command> {
+
+    private final Map<Command, Set<Cluster>> commandToClusters;
+
+    /**
+     * Constructor.
+     *
+     * @param jobId             The id of the job which the command is being selected for
+     * @param jobRequest        The job request the user originally made
+     * @param apiJob            Whether the job was submitted via the API or from Agent CLI
+     * @param commandToClusters The map of command candidates to their respective clusters candidates
+     */
+    public CommandSelectionContext(
+        @NotBlank final String jobId,
+        @NotNull final JobRequest jobRequest,
+        final boolean apiJob,
+        @NotEmpty final Map<@Valid Command, @NotEmpty Set<@Valid Cluster>> commandToClusters
+    ) {
+        super(jobId, jobRequest, apiJob);
+        this.commandToClusters = ImmutableMap.copyOf(commandToClusters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<Command> getResources() {
+        return this.commandToClusters.keySet();
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/CommandSelectionContext.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/CommandSelectionContext.java
@@ -55,7 +55,7 @@ public class CommandSelectionContext extends ResourceSelectionContext<Command> {
         @NotBlank final String jobId,
         @NotNull final JobRequest jobRequest,
         final boolean apiJob,
-        @NotEmpty final Map<@Valid Command, @NotEmpty Set<@Valid Cluster>> commandToClusters
+        @NotEmpty final Map<@Valid Command, /* temporarily @NotEmpty */ Set<@Valid Cluster>> commandToClusters
     ) {
         super(jobId, jobRequest, apiJob);
         this.commandToClusters = ImmutableMap.copyOf(commandToClusters);

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/CommandSelectionContext.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/CommandSelectionContext.java
@@ -55,7 +55,7 @@ public class CommandSelectionContext extends ResourceSelectionContext<Command> {
         @NotBlank final String jobId,
         @NotNull final JobRequest jobRequest,
         final boolean apiJob,
-        @NotEmpty final Map<@Valid Command, /* temporarily @NotEmpty */ Set<@Valid Cluster>> commandToClusters
+        @NotEmpty final Map<@Valid Command, @NotEmpty Set<@Valid Cluster>> commandToClusters
     ) {
         super(jobId, jobRequest, apiJob);
         this.commandToClusters = ImmutableMap.copyOf(commandToClusters);

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/CommandSelector.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/CommandSelector.java
@@ -29,5 +29,5 @@ import org.springframework.validation.annotation.Validated;
  * @since 4.0.0
  */
 @Validated
-public interface CommandSelector extends ResourceSelector<Command> {
+public interface CommandSelector extends ResourceSelector<Command, CommandSelectionContext> {
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/ResourceSelectionContext.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/ResourceSelectionContext.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.selectors;
+
+import com.netflix.genie.common.external.dtos.v4.JobRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+
+/**
+ * Context object for encapsulating state into the selectors.
+ *
+ * @param <R> The type of resource this context is meant to help select
+ * @author tgianos
+ * @since 4.0.0
+ */
+@RequiredArgsConstructor
+@Getter
+@ToString(doNotUseGetters = true)
+public abstract class ResourceSelectionContext<R> {
+    @NotBlank
+    private final String jobId;
+    @NotNull
+    private final JobRequest jobRequest;
+    private final boolean apiJob;
+
+    /**
+     * Return the {@link Set} of distinct resources that a selector is meant to chose from.
+     *
+     * @return The resources
+     */
+    public abstract Set<R> getResources();
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/ResourceSelector.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/ResourceSelector.java
@@ -17,40 +17,31 @@
  */
 package com.netflix.genie.web.selectors;
 
-import com.netflix.genie.common.external.dtos.v4.JobRequest;
 import com.netflix.genie.web.dtos.ResourceSelectionResult;
 import com.netflix.genie.web.exceptions.checked.ResourceSelectionException;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
-import java.util.Set;
 
 /**
  * Generic interface for a selector which selects a resource from a set of resources for a given job request.
  *
  * @param <R> The type of resource this selector is selecting
+ * @param <C> The type of context which this selector will accept. Must extend {@link ResourceSelectionContext}
  * @author tgianos
  * @since 4.0.0
  */
 @Validated
-public interface ResourceSelector<R> {
+public interface ResourceSelector<R, C extends ResourceSelectionContext<R>> {
 
     /**
      * Select a resource from the given set of resources if possible.
      *
-     * @param resources  A set of resources which matched the user supplied criterion to chose from
-     * @param jobRequest The job user's original job request
-     * @param jobId      The unique id the job has or will have within the Genie system
+     * @param context The context specific for this resource selection
      * @return The a {@link ResourceSelectionResult} instance which contains information about the result of this
      * invocation
      * @throws ResourceSelectionException When the underlying implementation can't successfully come to a selection
      *                                    decision
      */
-    ResourceSelectionResult<R> select(
-        @NotEmpty Set<@Valid R> resources,
-        @Valid JobRequest jobRequest,
-        @NotBlank String jobId
-    ) throws ResourceSelectionException;
+    ResourceSelectionResult<R> select(@Valid C context) throws ResourceSelectionException;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/RandomClusterSelectorImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/RandomClusterSelectorImpl.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.selectors.impl;
 
 import com.netflix.genie.common.external.dtos.v4.Cluster;
+import com.netflix.genie.web.selectors.ClusterSelectionContext;
 import com.netflix.genie.web.selectors.ClusterSelector;
 
 /**
@@ -27,5 +28,7 @@ import com.netflix.genie.web.selectors.ClusterSelector;
  * @author tgianos
  * @since 2.0.0
  */
-public class RandomClusterSelectorImpl extends RandomResourceSelector<Cluster> implements ClusterSelector {
+public class RandomClusterSelectorImpl
+    extends RandomResourceSelector<Cluster, ClusterSelectionContext>
+    implements ClusterSelector {
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/RandomCommandSelectorImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/RandomCommandSelectorImpl.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.selectors.impl;
 
 import com.netflix.genie.common.external.dtos.v4.Command;
+import com.netflix.genie.web.selectors.CommandSelectionContext;
 import com.netflix.genie.web.selectors.CommandSelector;
 
 /**
@@ -27,5 +28,7 @@ import com.netflix.genie.web.selectors.CommandSelector;
  * @author tgianos
  * @since 4.0.0
  */
-public class RandomCommandSelectorImpl extends RandomResourceSelector<Command> implements CommandSelector {
+public class RandomCommandSelectorImpl
+    extends RandomResourceSelector<Command, CommandSelectionContext>
+    implements CommandSelector {
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/RandomResourceSelector.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/selectors/impl/RandomResourceSelector.java
@@ -17,30 +17,29 @@
  */
 package com.netflix.genie.web.selectors.impl;
 
-import com.netflix.genie.common.external.dtos.v4.JobRequest;
 import com.netflix.genie.web.dtos.ResourceSelectionResult;
 import com.netflix.genie.web.exceptions.checked.ResourceSelectionException;
+import com.netflix.genie.web.selectors.ResourceSelectionContext;
 import com.netflix.genie.web.selectors.ResourceSelector;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Random;
-import java.util.Set;
 
 /**
  * A base class for any selector which desires to select a random element from a collection of elements.
  *
  * @param <R> The type of resource the collection has
+ * @param <C> The type of context which this selector will accept. Must extend {@link ResourceSelectionContext}
  * @author tgianos
  * @since 4.0.0
  */
 @Slf4j
-class RandomResourceSelector<R> implements ResourceSelector<R> {
+class RandomResourceSelector<R, C extends ResourceSelectionContext<R>> implements ResourceSelector<R, C> {
 
     static final String SELECTION_RATIONALE = "Selected randomly";
     private final Random random = new Random();
@@ -49,16 +48,12 @@ class RandomResourceSelector<R> implements ResourceSelector<R> {
      * {@inheritDoc}
      */
     @Override
-    public ResourceSelectionResult<R> select(
-        @NotEmpty final Set<@Valid R> resources,
-        @Valid final JobRequest jobRequest,
-        @NotBlank final String jobId
-    ) throws ResourceSelectionException {
-        log.debug("Called to select for job {}", jobId);
+    public ResourceSelectionResult<R> select(@Valid final C context) throws ResourceSelectionException {
+        log.debug("Called to select for job {}", context.getJobId());
         final ResourceSelectionResult.Builder<R> builder = new ResourceSelectionResult.Builder<>(this.getClass());
 
         try {
-            final R selectedResource = this.randomlySelect(resources);
+            final R selectedResource = this.randomlySelect(context.getResources());
             return builder.withSelectionRationale(SELECTION_RATIONALE).withSelectedResource(selectedResource).build();
         } catch (final Exception e) {
             throw new ResourceSelectionException(e);

--- a/genie-web/src/test/groovy/com/netflix/genie/web/scripts/GroovyScriptUtilsSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/scripts/GroovyScriptUtilsSpec.groovy
@@ -24,6 +24,8 @@ import com.netflix.genie.common.external.dtos.v4.Command
 import com.netflix.genie.common.external.dtos.v4.ExecutionResourceCriteria
 import com.netflix.genie.common.external.dtos.v4.JobMetadata
 import com.netflix.genie.common.external.dtos.v4.JobRequest
+import com.netflix.genie.web.selectors.ClusterSelectionContext
+import com.netflix.genie.web.selectors.CommandSelectionContext
 import spock.lang.Specification
 
 /**
@@ -37,6 +39,66 @@ class GroovyScriptUtilsSpec extends Specification {
 
     def setup() {
         this.scriptBinding = new Binding()
+    }
+
+    def "Can get command selection context"() {
+        when:
+        GroovyScriptUtils.getCommandSelectionContext(this.scriptBinding)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        this.scriptBinding.setVariable(ResourceSelectorScript.CONTEXT_BINDING, 1)
+        GroovyScriptUtils.getCommandSelectionContext(this.scriptBinding)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        def expectedContext = new CommandSelectionContext(
+            UUID.randomUUID().toString(),
+            Mock(JobRequest),
+            true,
+            [
+                (Mock(Command)): Sets.newHashSet(Mock(Cluster)),
+                (Mock(Command)): Sets.newHashSet(Mock(Cluster), Mock(Cluster))
+            ]
+        )
+        this.scriptBinding.setVariable(ResourceSelectorScript.CONTEXT_BINDING, expectedContext)
+        def context = GroovyScriptUtils.getCommandSelectionContext(this.scriptBinding)
+
+        then:
+        context == expectedContext
+    }
+
+    def "Can get cluster selection context"() {
+        when:
+        GroovyScriptUtils.getClusterSelectionContext(this.scriptBinding)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        this.scriptBinding.setVariable(ResourceSelectorScript.CONTEXT_BINDING, 1)
+        GroovyScriptUtils.getClusterSelectionContext(this.scriptBinding)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        def expectedContext = new ClusterSelectionContext(
+            UUID.randomUUID().toString(),
+            Mock(JobRequest),
+            true,
+            Mock(Command),
+            Sets.newHashSet(Mock(Cluster))
+        )
+        this.scriptBinding.setVariable(ResourceSelectorScript.CONTEXT_BINDING, expectedContext)
+        def context = GroovyScriptUtils.getClusterSelectionContext(this.scriptBinding)
+
+        then:
+        context == expectedContext
     }
 
     def "Can get job id"() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/selectors/ClusterSelectionContextSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/selectors/ClusterSelectionContextSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.selectors
+
+
+import com.google.common.collect.ImmutableSet
+import com.netflix.genie.common.external.dtos.v4.Cluster
+import com.netflix.genie.common.external.dtos.v4.Command
+import com.netflix.genie.common.external.dtos.v4.JobRequest
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link ClusterSelectionContext}.
+ *
+ * @author tgianos
+ */
+class ClusterSelectionContextSpec extends Specification {
+
+    def "is immutable bean"() {
+        def jobId = UUID.randomUUID().toString()
+        def jobRequest = Mock(JobRequest)
+        def cluster0 = Mock(Cluster)
+        def cluster1 = Mock(Cluster)
+        def cluster2 = Mock(Cluster)
+        def command = Mock(Command)
+        def clusters = ImmutableSet.of(cluster0, cluster1, cluster2)
+
+        when:
+        def context = new ClusterSelectionContext(jobId, jobRequest, true, null, clusters)
+
+        then:
+        noExceptionThrown()
+        context.getJobId() == jobId
+        context.getJobRequest() == jobRequest
+        context.isApiJob()
+        !context.getCommand().isPresent()
+        context.getClusters() == clusters
+        context.getResources() == clusters
+
+        when:
+        context.toString()
+
+        then:
+        noExceptionThrown()
+
+        when:
+        context = new ClusterSelectionContext(jobId, jobRequest, true, command, clusters)
+
+        then:
+        noExceptionThrown()
+        context.getJobId() == jobId
+        context.getJobRequest() == jobRequest
+        context.isApiJob()
+        context.getCommand().orElse(null) == command
+        context.getClusters() == clusters
+        context.getResources() == clusters
+
+        when:
+        context.toString()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/selectors/CommandSelectionContextSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/selectors/CommandSelectionContextSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.selectors
+
+import com.google.common.collect.ImmutableMap
+import com.google.common.collect.ImmutableSet
+import com.netflix.genie.common.external.dtos.v4.Cluster
+import com.netflix.genie.common.external.dtos.v4.Command
+import com.netflix.genie.common.external.dtos.v4.JobRequest
+import spock.lang.Specification
+
+/**
+ * Specifications for {@link CommandSelectionContext}.
+ *
+ * @author tgianos
+ */
+class CommandSelectionContextSpec extends Specification {
+
+    def "is immutable bean"() {
+        def jobId = UUID.randomUUID().toString()
+        def jobRequest = Mock(JobRequest)
+        def cluster0 = Mock(Cluster)
+        def cluster1 = Mock(Cluster)
+        def cluster2 = Mock(Cluster)
+        Map<Command, Set<Cluster>> commandToClusters = ImmutableMap.of(
+            Mock(Command),
+            ImmutableSet.of(cluster0, cluster1, cluster2)
+        )
+
+        when:
+        def context = new CommandSelectionContext(jobId, jobRequest, true, commandToClusters)
+
+        then:
+        noExceptionThrown()
+        context.getJobId() == jobId
+        context.getJobRequest() == jobRequest
+        context.isApiJob()
+        context.getCommandToClusters() == commandToClusters
+        context.getResources() == commandToClusters.keySet()
+
+        when:
+        context.toString()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobResolverServiceImplSpec.groovy
@@ -1092,6 +1092,7 @@ class JobResolverServiceImplSpec extends Specification {
         noExceptionThrown()
     }
 
+    //region Helper Methods
     private static Cluster createCluster(String id) {
         return createCluster(id, null)
     }
@@ -1177,4 +1178,5 @@ class JobResolverServiceImplSpec extends Specification {
                 .build()
         )
     }
+    //endregion
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
After internal testing determined some gaps in the previous implementation of a V4 resource resolution algorithm additional design and discussion went into a new algorithm to fill those gaps. This PR contains that implementation as well as a bunch of improvements/supporting work to hopefully make the system easier to modify going forward.

Algorithm Steps (simplified a bit):

1. Take `command criterion` from user` job request` and query database for all possible matching commands (candidate commands)
2. Take `cluster criteria` from `job request` and `cluster criteria` from each `command` candidate and create uber query which finds ALL clusters that match at least one of the resulting merged criterion (merged meaning combining a job and command cluster criterion)
3. Iterate through commands from step 1 and evaluate job/command cluster criterion against resulting set of clusters from step 2. Filter out any commands that don't match any clusters. Save resulting cluster set for each command in map command -> Set<Cluster>
4. Pass `set<command>`, `jobRequest`, `jobId`, `map<command<set<Cluster>>`  to command selector which will return single command
5. Using command result pass previously computed `Set<Cluster>` to cluster selector to select single cluster
6. Save results and run job