### PR TITLE
Agent Runtime Config

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/ExecutionAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/ExecutionAutoConfiguration.java
@@ -32,12 +32,13 @@ import com.netflix.genie.agent.execution.statemachine.ExecutionStage;
 import com.netflix.genie.agent.execution.statemachine.JobExecutionStateMachine;
 import com.netflix.genie.agent.execution.statemachine.JobExecutionStateMachineImpl;
 import com.netflix.genie.agent.execution.statemachine.States;
+import com.netflix.genie.agent.execution.statemachine.listeners.ConsoleLogListener;
 import com.netflix.genie.agent.execution.statemachine.listeners.JobExecutionListener;
 import com.netflix.genie.agent.execution.statemachine.listeners.LoggingListener;
-import com.netflix.genie.agent.execution.statemachine.listeners.ConsoleLogListener;
 import com.netflix.genie.agent.execution.statemachine.stages.ArchiveJobOutputsStage;
 import com.netflix.genie.agent.execution.statemachine.stages.ClaimJobStage;
 import com.netflix.genie.agent.execution.statemachine.stages.CleanupJobDirectoryStage;
+import com.netflix.genie.agent.execution.statemachine.stages.ConfigureAgentStage;
 import com.netflix.genie.agent.execution.statemachine.stages.ConfigureExecutionStage;
 import com.netflix.genie.agent.execution.statemachine.stages.CreateJobDirectoryStage;
 import com.netflix.genie.agent.execution.statemachine.stages.CreateJobScriptStage;
@@ -159,6 +160,23 @@ public class ExecutionAutoConfiguration {
     @ConditionalOnMissingBean(HandshakeStage.class)
     HandshakeStage handshakeStage(final AgentJobService agentJobService) {
         return new HandshakeStage(agentJobService);
+    }
+
+    /**
+     * Create a {@link ConfigureAgentStage} bean if one is not already defined.
+     *
+     * @param agentJobService     the agent job service
+     */
+    @Bean
+    @Lazy
+    @Order(25)
+    @ConditionalOnMissingBean(ConfigureAgentStage.class)
+    ConfigureAgentStage configureAgentStage(
+        final AgentJobService agentJobService
+    ) {
+        return new ConfigureAgentStage(
+            agentJobService
+        );
     }
 
     /**

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/ExecutionAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/ExecutionAutoConfiguration.java
@@ -62,8 +62,10 @@ import com.netflix.genie.agent.execution.statemachine.stages.StopFileServiceStag
 import com.netflix.genie.agent.execution.statemachine.stages.StopHeartbeatServiceStage;
 import com.netflix.genie.agent.execution.statemachine.stages.StopKillServiceStage;
 import com.netflix.genie.agent.execution.statemachine.stages.WaitJobCompletionStage;
+import com.netflix.genie.agent.properties.AgentProperties;
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -80,6 +82,11 @@ import java.util.List;
  * @since 4.0.0
  */
 @Configuration
+@EnableConfigurationProperties(
+    {
+        AgentProperties.class
+    }
+)
 public class ExecutionAutoConfiguration {
 
     /**
@@ -114,9 +121,8 @@ public class ExecutionAutoConfiguration {
     @Bean
     @Lazy
     @ConditionalOnMissingBean
-    ExecutionContext executionContext(
-    ) {
-        return new ExecutionContext();
+    ExecutionContext executionContext(final AgentProperties agentProperties) {
+        return new ExecutionContext(agentProperties);
     }
 
     @Bean

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/exceptions/ConfigureException.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/exceptions/ConfigureException.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.execution.exceptions;
+
+/**
+ * Failure to obtain configuration properties from server.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class ConfigureException extends Exception {
+
+    /**
+     * Constructor with message.
+     *
+     * @param message a message
+     */
+    public ConfigureException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor with message and cause.
+     *
+     * @param message a message
+     * @param cause   a cause
+     */
+    public ConfigureException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/AgentJobService.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/AgentJobService.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.agent.execution.services;
 
 import com.netflix.genie.agent.execution.exceptions.ChangeJobStatusException;
+import com.netflix.genie.agent.execution.exceptions.ConfigureException;
 import com.netflix.genie.agent.execution.exceptions.HandshakeException;
 import com.netflix.genie.agent.execution.exceptions.JobIdUnavailableException;
 import com.netflix.genie.agent.execution.exceptions.JobReservationException;
@@ -30,6 +31,7 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import java.util.Map;
 
 /**
  * Agent side job specification service for resolving and retrieving job specifications from the server.
@@ -50,6 +52,17 @@ public interface AgentJobService {
     void handshake(
         @Valid AgentClientMetadata agentClientMetadata
     ) throws HandshakeException;
+
+    /**
+     * Obtain server-provided configuration properties.
+     *
+     * @param agentClientMetadata metadata about the client making this request
+     * @throws ConfigureException if the server properties cannot be obtained
+     * @return a map of properties
+     */
+    Map<String, String> configure(
+        @Valid AgentClientMetadata agentClientMetadata
+    ) throws ConfigureException;
 
     /**
      * Request a given job id to be reserved for this job, send along the job details, to be persisted by the server.

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/KillServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/KillServiceImpl.java
@@ -20,10 +20,9 @@ package com.netflix.genie.agent.execution.services.impl;
 import com.netflix.genie.agent.cli.ExitCode;
 import com.netflix.genie.agent.cli.logging.ConsoleLog;
 import com.netflix.genie.agent.execution.services.KillService;
+import com.netflix.genie.agent.properties.AgentProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-
-import java.time.Duration;
 
 /**
  * Implementation of {@link KillService}.
@@ -34,32 +33,32 @@ import java.time.Duration;
 @Slf4j
 class KillServiceImpl implements KillService {
 
-    private static final Duration DEFAULT_DELAY = Duration.ofMinutes(10); //TODO: Make configurable
     private static final Runnable DEFAULT_ACTION = () -> System.exit(ExitCode.EXEC_ABORTED.getCode());
     private static final String EMERGENCY_TERMINATION_THREAD_NAME = "emergency-shutdown";
 
     private final ApplicationEventPublisher applicationEventPublisher;
     private final Thread emergencyTerminationThread;
+    private final AgentProperties agentProperties;
 
-    KillServiceImpl(final ApplicationEventPublisher applicationEventPublisher) {
+    KillServiceImpl(final ApplicationEventPublisher applicationEventPublisher, final AgentProperties agentProperties) {
         this(
             applicationEventPublisher,
-            DEFAULT_ACTION,
-            DEFAULT_DELAY
+            agentProperties, DEFAULT_ACTION
         );
     }
 
     KillServiceImpl(
         final ApplicationEventPublisher applicationEventPublisher,
-        final Runnable emergencyTerminationAction,
-        final Duration emergencyTerminationDelay
+        final AgentProperties agentProperties,
+        final Runnable emergencyTerminationAction
     ) {
         this.applicationEventPublisher = applicationEventPublisher;
+        this.agentProperties = agentProperties;
         this.emergencyTerminationThread = new Thread(
             () -> {
                 log.debug("Emergency shutdown countdown started");
                 try {
-                    Thread.sleep(emergencyTerminationDelay.toMillis());
+                    Thread.sleep(this.agentProperties.getEmergencyShutdownDelay().toMillis());
                 } catch (InterruptedException e) {
                     log.warn("Interrupted during delayed emergency countdown");
                 }

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/ServicesAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/ServicesAutoConfiguration.java
@@ -22,6 +22,7 @@ import com.netflix.genie.agent.execution.services.DownloadService;
 import com.netflix.genie.agent.execution.services.FetchingCacheService;
 import com.netflix.genie.agent.execution.services.JobSetupService;
 import com.netflix.genie.agent.execution.services.KillService;
+import com.netflix.genie.agent.properties.AgentProperties;
 import com.netflix.genie.agent.utils.locks.impl.FileLockFactory;
 import com.netflix.genie.common.internal.configs.AwsAutoConfiguration;
 import lombok.extern.slf4j.Slf4j;
@@ -93,13 +94,17 @@ public class ServicesAutoConfiguration {
      * Provide a lazy {@link KillService} bean if one hasn't already been defined.
      *
      * @param applicationEventPublisher The Spring event publisher to use
+     * @param agentProperties           The agent properties
      * @return A {@link KillServiceImpl} instance
      */
     @Bean
     @Lazy
     @ConditionalOnMissingBean(KillService.class)
-    public KillService killService(final ApplicationEventPublisher applicationEventPublisher) {
-        return new KillServiceImpl(applicationEventPublisher);
+    public KillService killService(
+        final ApplicationEventPublisher applicationEventPublisher,
+        final AgentProperties agentProperties
+    ) {
+        return new KillServiceImpl(applicationEventPublisher, agentProperties);
     }
 
     /**

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
@@ -20,6 +20,7 @@ package com.netflix.genie.agent.execution.services.impl.grpc;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
 import com.netflix.genie.agent.execution.services.AgentFileStreamService;
+import com.netflix.genie.agent.properties.FileStreamServiceProperties;
 import com.netflix.genie.common.internal.dtos.v4.converters.JobDirectoryManifestProtoConverter;
 import com.netflix.genie.common.internal.exceptions.checked.GenieConversionException;
 import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorService;
@@ -66,19 +67,17 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @Slf4j
 public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
-    private static final boolean ENABLE_COMPRESSION = true; //TODO make configurable
-    private static final int MAX_DATA_CHUNK_SIZE = 1024 * 1024; //TODO make configurable
-    private static final int MAX_CONCURRENT_TRANSMIT_STREAMS = 5;  //TODO make configurable
-    private static final long DRAIN_TASK_TIMEOUT = 15_000; //TODO make configurable
 
     private final FileStreamServiceGrpc.FileStreamServiceStub fileStreamServiceStub;
     private final TaskScheduler taskScheduler;
     private final ExponentialBackOffTrigger trigger;
+    private final FileStreamServiceProperties properties;
     private final JobDirectoryManifestProtoConverter manifestProtoConverter;
     private final StreamObserver<ServerControlMessage> responseObserver;
     private final Semaphore concurrentTransfersSemaphore;
     private final Set<FileTransfer> activeFileTransfers;
     private final JobDirectoryManifestCreatorService jobDirectoryManifestCreatorService;
+    private final int maxStreams;
 
     private StreamObserver<AgentManifestMessage> controlStreamObserver;
     private String jobId;
@@ -90,20 +89,19 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
         final FileStreamServiceGrpc.FileStreamServiceStub fileStreamServiceStub,
         final TaskScheduler taskScheduler,
         final JobDirectoryManifestProtoConverter manifestProtoConverter,
-        final JobDirectoryManifestCreatorService jobDirectoryManifestCreatorService
+        final JobDirectoryManifestCreatorService jobDirectoryManifestCreatorService,
+        final FileStreamServiceProperties properties
     ) {
         this.fileStreamServiceStub = fileStreamServiceStub;
         this.taskScheduler = taskScheduler;
         this.manifestProtoConverter = manifestProtoConverter;
         this.jobDirectoryManifestCreatorService = jobDirectoryManifestCreatorService;
-        this.trigger = new ExponentialBackOffTrigger(
-            ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_EXECUTION_BEGIN,
-            1000, //TODO make configurable
-            10000, //TODO make configurable
-            1.1f //TODO make configurable
-        );
+        this.properties = properties;
+
+        this.trigger = new ExponentialBackOffTrigger(properties.getErrorBackOff());
         this.responseObserver = new ServerControlStreamObserver(this);
-        this.concurrentTransfersSemaphore = new Semaphore(MAX_CONCURRENT_TRANSMIT_STREAMS);
+        this.maxStreams = properties.getMaxConcurrentStreams();
+        this.concurrentTransfersSemaphore = new Semaphore(this.maxStreams);
         this.activeFileTransfers = Sets.newConcurrentHashSet();
     }
 
@@ -169,7 +167,7 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
         // This ensures no new transfers will be started.
         // If the task completes successfully, it also guarantees there are no in-progress transfers.
         final Runnable drainTask = () -> {
-            while (acquiredPermitsCount.get() < MAX_CONCURRENT_TRANSMIT_STREAMS) {
+            while (acquiredPermitsCount.get() < this.maxStreams) {
                 try {
                     if (this.concurrentTransfersSemaphore.tryAcquire(1, TimeUnit.SECONDS)) {
                         acquiredPermitsCount.incrementAndGet();
@@ -184,12 +182,12 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
         // Submit the task for immediate execution, but do not wait more than a fixed amount of time
         final ScheduledFuture<?> drainTaskFuture = taskScheduler.schedule(drainTask, Instant.now());
         try {
-            drainTaskFuture.get(DRAIN_TASK_TIMEOUT, TimeUnit.MILLISECONDS);
+            drainTaskFuture.get(this.properties.getDrainTimeout().toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             log.warn("Failed to wait for in-flight transfers to complete", e);
         }
 
-        final int ongoingTransfers = MAX_CONCURRENT_TRANSMIT_STREAMS - acquiredPermitsCount.get();
+        final int ongoingTransfers = this.maxStreams - acquiredPermitsCount.get();
         if (ongoingTransfers > 0) {
             log.warn("{} file transfers are still active after waiting for completion", ongoingTransfers);
         }
@@ -214,7 +212,8 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
             if (this.controlStreamObserver == null) {
                 this.controlStreamObserver = fileStreamServiceStub.sync(this.responseObserver);
                 if (this.controlStreamObserver instanceof ClientCallStreamObserver) {
-                    ((ClientCallStreamObserver) this.controlStreamObserver).setMessageCompression(ENABLE_COMPRESSION);
+                    ((ClientCallStreamObserver) this.controlStreamObserver)
+                        .setMessageCompression(this.properties.isEnableCompression());
                 }
             }
 
@@ -275,7 +274,14 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
             return;
         }
 
-        final FileTransfer fileTransfer = new FileTransfer(this, streamId, absolutePath, startOffset, endOffset);
+        final FileTransfer fileTransfer = new FileTransfer(
+            this,
+            streamId,
+            absolutePath,
+            startOffset,
+            endOffset,
+            properties.getDataChunkMaxSize().toBytes()
+        );
         this.activeFileTransfers.add(fileTransfer);
         fileTransfer.start();
     }
@@ -334,7 +340,8 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
             final String streamId,
             final Path absolutePath,
             final int startOffset,
-            final int endOffset
+            final int endOffset,
+            final long maxChunkSize
         ) {
             this.gRpcAgentFileStreamService = gRpcAgentFileStreamService;
             this.streamId = streamId;
@@ -343,7 +350,7 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
             this.endOffset = endOffset;
             this.outboundStreamObserver = this.gRpcAgentFileStreamService.fileStreamServiceStub.transmit(this);
             this.watermark = startOffset;
-            this.readBuffer = ByteBuffer.allocate(GRpcAgentFileStreamServiceImpl.MAX_DATA_CHUNK_SIZE);
+            this.readBuffer = ByteBuffer.allocate(Math.toIntExact(maxChunkSize));
         }
 
         void start() {

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
@@ -112,6 +112,7 @@ public class GRpcServicesAutoConfiguration {
      * @param taskScheduler                      The task scheduler to use
      * @param jobDirectoryManifestProtoConverter The converter to serialize manifests into messages
      * @param jobDirectoryManifestCreatorService The job directory manifest service
+     * @param agentProperties                    The agent properties
      * @return A {@link AgentFileStreamService} instance
      */
     @Bean
@@ -121,13 +122,15 @@ public class GRpcServicesAutoConfiguration {
         final FileStreamServiceGrpc.FileStreamServiceStub fileStreamServiceStub,
         @Qualifier("sharedAgentTaskScheduler") final TaskScheduler taskScheduler,
         final JobDirectoryManifestProtoConverter jobDirectoryManifestProtoConverter,
-        final JobDirectoryManifestCreatorService jobDirectoryManifestCreatorService
+        final JobDirectoryManifestCreatorService jobDirectoryManifestCreatorService,
+        final AgentProperties agentProperties
     ) {
         return new GRpcAgentFileStreamServiceImpl(
             fileStreamServiceStub,
             taskScheduler,
             jobDirectoryManifestProtoConverter,
-            jobDirectoryManifestCreatorService
+            jobDirectoryManifestCreatorService,
+            agentProperties.getFileStreamService()
         );
     }
 }

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
@@ -81,6 +81,7 @@ public class GRpcServicesAutoConfiguration {
      * @param jobKillServiceFutureStub The future stub to use for the service communication with the server
      * @param killService              The kill service to use to terminate this agent gracefully
      * @param taskScheduler            The task scheduler to use
+     * @param agentProperties          The agent properties
      * @return A {@link GRpcAgentJobKillServiceImpl} instance
      */
     @Bean
@@ -89,9 +90,15 @@ public class GRpcServicesAutoConfiguration {
     public AgentJobKillService agentJobKillService(
         final JobKillServiceGrpc.JobKillServiceFutureStub jobKillServiceFutureStub,
         final KillService killService,
-        @Qualifier("sharedAgentTaskScheduler") final TaskScheduler taskScheduler
+        @Qualifier("sharedAgentTaskScheduler") final TaskScheduler taskScheduler,
+        final AgentProperties agentProperties
     ) {
-        return new GRpcAgentJobKillServiceImpl(jobKillServiceFutureStub, killService, taskScheduler);
+        return new GRpcAgentJobKillServiceImpl(
+            jobKillServiceFutureStub,
+            killService,
+            taskScheduler,
+            agentProperties.getJobKillService()
+        );
     }
 
     /**

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
@@ -22,6 +22,7 @@ import com.netflix.genie.agent.execution.services.AgentHeartBeatService;
 import com.netflix.genie.agent.execution.services.AgentJobKillService;
 import com.netflix.genie.agent.execution.services.AgentJobService;
 import com.netflix.genie.agent.execution.services.KillService;
+import com.netflix.genie.agent.properties.AgentProperties;
 import com.netflix.genie.common.internal.dtos.v4.converters.JobDirectoryManifestProtoConverter;
 import com.netflix.genie.common.internal.dtos.v4.converters.JobServiceProtoConverter;
 import com.netflix.genie.common.internal.services.JobDirectoryManifestCreatorService;
@@ -31,6 +32,7 @@ import com.netflix.genie.proto.JobKillServiceGrpc;
 import com.netflix.genie.proto.JobServiceGrpc;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -43,6 +45,11 @@ import org.springframework.scheduling.TaskScheduler;
  * @since 4.0.0
  */
 @Configuration
+@EnableConfigurationProperties(
+    {
+        AgentProperties.class
+    }
+)
 public class GRpcServicesAutoConfiguration {
 
     /**

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcServicesAutoConfiguration.java
@@ -57,6 +57,7 @@ public class GRpcServicesAutoConfiguration {
      *
      * @param heartBeatServiceStub The heart beat service stub to use
      * @param taskScheduler        The task scheduler to use
+     * @param agentProperties      The agent properties
      * @return A {@link GrpcAgentHeartBeatServiceImpl} instance
      */
     @Bean
@@ -64,9 +65,14 @@ public class GRpcServicesAutoConfiguration {
     @ConditionalOnMissingBean(AgentHeartBeatService.class)
     public AgentHeartBeatService agentHeartBeatService(
         final HeartBeatServiceGrpc.HeartBeatServiceStub heartBeatServiceStub,
-        @Qualifier("heartBeatServiceTaskScheduler") final TaskScheduler taskScheduler
+        @Qualifier("heartBeatServiceTaskScheduler") final TaskScheduler taskScheduler,
+        final AgentProperties agentProperties
     ) {
-        return new GrpcAgentHeartBeatServiceImpl(heartBeatServiceStub, taskScheduler);
+        return new GrpcAgentHeartBeatServiceImpl(
+            heartBeatServiceStub,
+            taskScheduler,
+            agentProperties.getHeartBeatService()
+        );
     }
 
     /**

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/ExecutionContext.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/ExecutionContext.java
@@ -30,6 +30,7 @@ import com.netflix.genie.agent.execution.statemachine.stages.LaunchJobStage;
 import com.netflix.genie.agent.execution.statemachine.stages.ObtainJobSpecificationStage;
 import com.netflix.genie.agent.execution.statemachine.stages.ReserveJobIdStage;
 import com.netflix.genie.agent.execution.statemachine.stages.WaitJobCompletionStage;
+import com.netflix.genie.agent.properties.AgentProperties;
 import com.netflix.genie.common.external.dtos.v4.AgentClientMetadata;
 import com.netflix.genie.common.external.dtos.v4.AgentJobRequest;
 import com.netflix.genie.common.external.dtos.v4.JobSpecification;
@@ -64,6 +65,12 @@ public class ExecutionContext {
      * List of all exception thrown by state transitions.
      */
     private final List<TransitionExceptionRecord> transitionExceptionRecords = Lists.newArrayList();
+
+    /**
+     * Agent properties.
+     */
+    private final AgentProperties agentProperties;
+
     /**
      * Agent client metadata sent to the server in certain requests.
      * Present if {@link InitializeAgentStage} ran successfully.
@@ -167,6 +174,15 @@ public class ExecutionContext {
      * The message to attach to when the job status is updated.
      */
     private String nextJobStatusMessage;
+
+    /**
+     * Constructor.
+     *
+     * @param agentProperties The agent properties
+     */
+    public ExecutionContext(final AgentProperties agentProperties) {
+        this.agentProperties = agentProperties;
+    }
 
     /**
      * Record an execution exception, even if it is retryable.

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/States.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/States.java
@@ -46,6 +46,11 @@ public enum States {
     HANDSHAKE(3, true, JobStatusMessages.FAILED_AGENT_SERVER_HANDSHAKE),
 
     /**
+     * Configure the agent based on server-provided values.
+     */
+    CONFIGURE_AGENT(1, true),
+
+    /**
      * Configure the execution based on command-line arguments.
      */
     CONFIGURE_EXECUTION(0, true, JobStatusMessages.FAILED_AGENT_CONFIGURATION),

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/stages/ConfigureAgentStage.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/stages/ConfigureAgentStage.java
@@ -1,0 +1,90 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.execution.statemachine.stages;
+
+import com.netflix.genie.agent.execution.exceptions.ConfigureException;
+import com.netflix.genie.agent.execution.services.AgentJobService;
+import com.netflix.genie.agent.execution.statemachine.ExecutionContext;
+import com.netflix.genie.agent.execution.statemachine.ExecutionStage;
+import com.netflix.genie.agent.execution.statemachine.FatalJobExecutionException;
+import com.netflix.genie.agent.execution.statemachine.RetryableJobExecutionException;
+import com.netflix.genie.agent.execution.statemachine.States;
+import com.netflix.genie.agent.properties.AgentProperties;
+import com.netflix.genie.common.external.dtos.v4.AgentClientMetadata;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import java.util.Map;
+
+/**
+ * Configures the agent with server-provided runtime parameters that are independent of the job.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public class ConfigureAgentStage extends ExecutionStage {
+
+    private final AgentJobService agentJobService;
+
+    /**
+     * Constructor.
+     *
+     * @param agentJobService the agent job service
+     */
+    public ConfigureAgentStage(
+        final AgentJobService agentJobService
+    ) {
+        super(States.CONFIGURE_AGENT);
+        this.agentJobService = agentJobService;
+    }
+
+    @Override
+    protected void attemptStageAction(
+        final ExecutionContext executionContext
+    ) throws RetryableJobExecutionException, FatalJobExecutionException {
+
+        final AgentClientMetadata agentClientMetadata = executionContext.getAgentClientMetadata();
+        final AgentProperties agentProperties = executionContext.getAgentProperties();
+
+        // Obtain server-provided properties
+        final Map<String, String> serverPropertiesMap;
+        try {
+            serverPropertiesMap = this.agentJobService.configure(agentClientMetadata);
+        } catch (ConfigureException e) {
+            throw new RetryableJobExecutionException("Failed to obtain configuration", e);
+        }
+
+        for (final Map.Entry<String, String> entry : serverPropertiesMap.entrySet()) {
+            log.info("Received property {}={}", entry.getKey(), entry.getValue());
+        }
+
+        // Bind properties received
+        final ConfigurationPropertySource serverPropertiesSource =
+            new MapConfigurationPropertySource(serverPropertiesMap);
+
+        new Binder(serverPropertiesSource)
+            .bind(
+                AgentProperties.PREFIX,
+                Bindable.ofInstance(agentProperties)
+            );
+    }
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/properties/AgentProperties.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/properties/AgentProperties.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Root properties class for agent.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@ConfigurationProperties(prefix = AgentProperties.PREFIX)
+@Getter
+@Setter
+public class AgentProperties {
+    /**
+     * Properties prefix.
+     */
+    public static final String PREFIX = "genie.agent.runtime";
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/properties/AgentProperties.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/properties/AgentProperties.java
@@ -39,4 +39,5 @@ public class AgentProperties {
     public static final String PREFIX = "genie.agent.runtime";
 
     private Duration emergencyShutdownDelay = Duration.ofMinutes(5);
+    private FileStreamServiceProperties fileStreamService = new FileStreamServiceProperties();
 }

--- a/genie-agent/src/main/java/com/netflix/genie/agent/properties/AgentProperties.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/properties/AgentProperties.java
@@ -39,6 +39,7 @@ public class AgentProperties {
     public static final String PREFIX = "genie.agent.runtime";
 
     private Duration emergencyShutdownDelay = Duration.ofMinutes(5);
+    private Duration forceManifestRefreshTimeout = Duration.ofSeconds(5);
     private FileStreamServiceProperties fileStreamService = new FileStreamServiceProperties();
     private HeartBeatServiceProperties heartBeatService = new HeartBeatServiceProperties();
     private JobKillServiceProperties jobKillService = new JobKillServiceProperties();

--- a/genie-agent/src/main/java/com/netflix/genie/agent/properties/AgentProperties.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/properties/AgentProperties.java
@@ -21,6 +21,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 /**
  * Root properties class for agent.
  *
@@ -35,4 +37,6 @@ public class AgentProperties {
      * Properties prefix.
      */
     public static final String PREFIX = "genie.agent.runtime";
+
+    private Duration emergencyShutdownDelay = Duration.ofMinutes(5);
 }

--- a/genie-agent/src/main/java/com/netflix/genie/agent/properties/FileStreamServiceProperties.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/properties/FileStreamServiceProperties.java
@@ -1,0 +1,48 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.properties;
+
+import com.netflix.genie.agent.execution.services.AgentFileStreamService;
+import com.netflix.genie.common.internal.properties.ExponentialBackOffTriggerProperties;
+import com.netflix.genie.common.internal.util.ExponentialBackOffTrigger;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.util.unit.DataSize;
+
+import java.time.Duration;
+
+/**
+ * Properties for {@link AgentFileStreamService}.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Getter
+@Setter
+public class FileStreamServiceProperties {
+    private ExponentialBackOffTriggerProperties errorBackOff = new ExponentialBackOffTriggerProperties(
+        ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_EXECUTION_BEGIN,
+        Duration.ofSeconds(1),
+        Duration.ofSeconds(10),
+        1.1f
+    );
+    private boolean enableCompression = true;
+    private DataSize dataChunkMaxSize = DataSize.ofMegabytes(1);
+    private int maxConcurrentStreams = 5;
+    private Duration drainTimeout = Duration.ofSeconds(15);
+}

--- a/genie-agent/src/main/java/com/netflix/genie/agent/properties/HeartBeatServiceProperties.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/properties/HeartBeatServiceProperties.java
@@ -19,26 +19,18 @@ package com.netflix.genie.agent.properties;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;
 
 /**
- * Root properties class for agent.
+ * Properties for {@link com.netflix.genie.agent.execution.services.AgentHeartBeatService}.
  *
  * @author mprimi
  * @since 4.0.0
  */
-@ConfigurationProperties(prefix = AgentProperties.PREFIX)
 @Getter
 @Setter
-public class AgentProperties {
-    /**
-     * Properties prefix.
-     */
-    public static final String PREFIX = "genie.agent.runtime";
-
-    private Duration emergencyShutdownDelay = Duration.ofMinutes(5);
-    private FileStreamServiceProperties fileStreamService = new FileStreamServiceProperties();
-    private HeartBeatServiceProperties heartBeatService = new HeartBeatServiceProperties();
+public class HeartBeatServiceProperties {
+    private Duration interval = Duration.ofSeconds(2);
+    private Duration errorRetryDelay = Duration.ofSeconds(1);
 }

--- a/genie-agent/src/main/java/com/netflix/genie/agent/properties/JobKillServiceProperties.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/properties/JobKillServiceProperties.java
@@ -17,29 +17,26 @@
  */
 package com.netflix.genie.agent.properties;
 
+import com.netflix.genie.common.internal.properties.ExponentialBackOffTriggerProperties;
+import com.netflix.genie.common.internal.util.ExponentialBackOffTrigger;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;
 
 /**
- * Root properties class for agent.
+ * Properties for {@link com.netflix.genie.agent.execution.services.AgentJobKillService}.
  *
  * @author mprimi
  * @since 4.0.0
  */
-@ConfigurationProperties(prefix = AgentProperties.PREFIX)
 @Getter
 @Setter
-public class AgentProperties {
-    /**
-     * Properties prefix.
-     */
-    public static final String PREFIX = "genie.agent.runtime";
-
-    private Duration emergencyShutdownDelay = Duration.ofMinutes(5);
-    private FileStreamServiceProperties fileStreamService = new FileStreamServiceProperties();
-    private HeartBeatServiceProperties heartBeatService = new HeartBeatServiceProperties();
-    private JobKillServiceProperties jobKillService = new JobKillServiceProperties();
+public class JobKillServiceProperties {
+    private ExponentialBackOffTriggerProperties responseCheckBackOff = new ExponentialBackOffTriggerProperties(
+        ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_EXECUTION_COMPLETION,
+        Duration.ofMillis(500),
+        Duration.ofSeconds(5),
+        1.2f
+    );
 }

--- a/genie-agent/src/main/java/com/netflix/genie/agent/properties/package-info.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/properties/package-info.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/**
+ * Agent properties.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@ParametersAreNonnullByDefault
+package com.netflix.genie.agent.properties;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/genie-agent/src/main/java/com/netflix/genie/agent/spring/autoconfigure/AgentAutoConfiguration.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/spring/autoconfigure/AgentAutoConfiguration.java
@@ -19,10 +19,12 @@ package com.netflix.genie.agent.spring.autoconfigure;
 
 import com.netflix.genie.agent.AgentMetadata;
 import com.netflix.genie.agent.AgentMetadataImpl;
+import com.netflix.genie.agent.properties.AgentProperties;
 import com.netflix.genie.agent.utils.locks.impl.FileLockFactory;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.common.internal.util.HostnameUtil;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -40,6 +42,11 @@ import java.net.UnknownHostException;
  * @since 4.0.0
  */
 @Configuration
+@EnableConfigurationProperties(
+    {
+        AgentProperties.class
+    }
+)
 public class AgentAutoConfiguration {
 
     /**

--- a/genie-agent/src/main/resources/genie-agent-defaults.yml
+++ b/genie-agent/src/main/resources/genie-agent-defaults.yml
@@ -36,6 +36,9 @@ genie:
           - '.*/temp'
         directory-traversal-reject-patterns:
           - '.*/genie/.*/dependencies'
+  agent:
+    runtime:
+      emergency-shutdown-delay: 5m
 
 spring:
   banner:

--- a/genie-agent/src/main/resources/genie-agent-defaults.yml
+++ b/genie-agent/src/main/resources/genie-agent-defaults.yml
@@ -52,6 +52,12 @@ genie:
       heart-beat-service:
         interval: 2s
         error-retry-delay: 1s
+      job-kill-service:
+        response-check-back-off:
+          delay-type: FROM_PREVIOUS_EXECUTION_COMPLETION
+          min-delay: 500ms
+          max-delay: 5s
+          factor: 1.2
 
 spring:
   banner:

--- a/genie-agent/src/main/resources/genie-agent-defaults.yml
+++ b/genie-agent/src/main/resources/genie-agent-defaults.yml
@@ -39,6 +39,7 @@ genie:
   agent:
     runtime:
       emergency-shutdown-delay: 5m
+      force-manifest-refresh-timeout: 5s
       file-stream-service:
         error-back-off:
           delay-type: FROM_PREVIOUS_EXECUTION_BEGIN

--- a/genie-agent/src/main/resources/genie-agent-defaults.yml
+++ b/genie-agent/src/main/resources/genie-agent-defaults.yml
@@ -39,6 +39,16 @@ genie:
   agent:
     runtime:
       emergency-shutdown-delay: 5m
+      file-stream-service:
+        error-back-off:
+          delay-type: FROM_PREVIOUS_EXECUTION_BEGIN
+          min-delay: 1s
+          max-delay: 10s
+          factor: 1.1
+        enable-compression: true
+        data-chunk-max-size: 1MB
+        max-concurrent-streams: 5
+        drain-timeout: 15s
 
 spring:
   banner:

--- a/genie-agent/src/main/resources/genie-agent-defaults.yml
+++ b/genie-agent/src/main/resources/genie-agent-defaults.yml
@@ -49,6 +49,9 @@ genie:
         data-chunk-max-size: 1MB
         max-concurrent-streams: 5
         drain-timeout: 15s
+      heart-beat-service:
+        interval: 2s
+        error-retry-delay: 1s
 
 spring:
   banner:

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/exceptions/AgentExecutionExceptionsSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/exceptions/AgentExecutionExceptionsSpec.groovy
@@ -52,6 +52,7 @@ class AgentExecutionExceptionsSpec extends Specification {
         JobReservationException.class             | true
         ChangeJobStatusException.class            | true
         HandshakeException.class                  | true
+        ConfigureException.class                  | true
         InvalidStateException.class               | false
     }
 }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/KillServiceImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/KillServiceImplSpec.groovy
@@ -18,7 +18,7 @@
 package com.netflix.genie.agent.execution.services.impl
 
 import com.netflix.genie.agent.execution.services.KillService
-import com.netflix.genie.agent.execution.services.impl.KillServiceImpl
+import com.netflix.genie.agent.properties.AgentProperties
 import org.springframework.context.ApplicationEventPublisher
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -28,11 +28,13 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class KillServiceImplSpec extends Specification {
     ApplicationEventPublisher applicationEventPublisher
+    AgentProperties agentProperties
     KillService service
 
     void setup() {
+        agentProperties = new AgentProperties()
         applicationEventPublisher = Mock(ApplicationEventPublisher)
-        service = new KillServiceImpl(applicationEventPublisher)
+        service = new KillServiceImpl(applicationEventPublisher, agentProperties)
     }
 
     @Unroll
@@ -60,9 +62,10 @@ class KillServiceImplSpec extends Specification {
         AtomicBoolean emergencyTerminationExecuted = new AtomicBoolean(false)
         service = new KillServiceImpl(
             applicationEventPublisher,
-            { -> emergencyTerminationExecuted.set(true) },
-            Duration.ofMillis(10)
+            agentProperties,
+            { -> emergencyTerminationExecuted.set(true) }
         )
+        agentProperties.setEmergencyShutdownDelay(Duration.ofMillis(1))
 
         when:
         service.kill(KillService.KillSource.SYSTEM_SIGNAL)

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobKillServiceImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobKillServiceImplSpec.groovy
@@ -18,12 +18,11 @@
 package com.netflix.genie.agent.execution.services.impl.grpc
 
 import com.netflix.genie.agent.execution.services.KillService
+import com.netflix.genie.agent.properties.JobKillServiceProperties
 import com.netflix.genie.common.internal.util.ExponentialBackOffTrigger
 import com.netflix.genie.proto.JobKillRegistrationRequest
 import com.netflix.genie.proto.JobKillRegistrationResponse
 import com.netflix.genie.proto.JobKillServiceGrpc
-import io.grpc.Status
-import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
 import io.grpc.testing.GrpcServerRule
 import org.junit.Rule
@@ -44,6 +43,7 @@ class GRpcAgentJobKillServiceImplSpec extends Specification {
     TaskScheduler taskScheduler
     ScheduledFuture<?> periodicTaskScheduledFuture
     JobKillServiceGrpc.JobKillServiceImplBase server
+    JobKillServiceProperties serviceProperties
 
     void setup() {
         this.server = Mock(JobKillServiceGrpc.JobKillServiceImplBase)
@@ -53,7 +53,8 @@ class GRpcAgentJobKillServiceImplSpec extends Specification {
         this.killService = Mock(KillService)
         this.taskScheduler = Mock(TaskScheduler)
         this.periodicTaskScheduledFuture = Mock(ScheduledFuture)
-        this.service = new GRpcAgentJobKillServiceImpl(client, killService, taskScheduler)
+        this.serviceProperties = new JobKillServiceProperties()
+        this.service = new GRpcAgentJobKillServiceImpl(client, killService, taskScheduler, serviceProperties)
     }
 
     void cleanup() {

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GrpcAgentHeartBeatServiceImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GrpcAgentHeartBeatServiceImplSpec.groovy
@@ -17,12 +17,13 @@
  */
 package com.netflix.genie.agent.execution.services.impl.grpc
 
+import com.google.common.collect.Lists
+import com.netflix.genie.agent.properties.HeartBeatServiceProperties
 import com.netflix.genie.proto.AgentHeartBeat
 import com.netflix.genie.proto.HeartBeatServiceGrpc
 import com.netflix.genie.proto.ServerHeartBeat
 import io.grpc.stub.StreamObserver
 import io.grpc.testing.GrpcServerRule
-import org.assertj.core.util.Lists
 import org.junit.Rule
 import org.springframework.scheduling.TaskScheduler
 import spock.lang.Specification
@@ -39,6 +40,7 @@ class GrpcAgentHeartBeatServiceImplSpec extends Specification {
     TaskScheduler taskScheduler
     ScheduledFuture heartBeatFuture
     GrpcAgentHeartBeatServiceImpl service
+    HeartBeatServiceProperties serviceProperties = new HeartBeatServiceProperties()
 
     StreamObserver<ServerHeartBeat> currentResponseObserver
     StreamObserver<AgentHeartBeat> currentRequestObserver
@@ -50,7 +52,7 @@ class GrpcAgentHeartBeatServiceImplSpec extends Specification {
         this.heartBeatFuture = Mock(ScheduledFuture)
         this.grpcServerRule.getServiceRegistry().addService(new TestService())
         this.client = HeartBeatServiceGrpc.newStub(grpcServerRule.getChannel())
-        this.service = new GrpcAgentHeartBeatServiceImpl(client, taskScheduler)
+        this.service = new GrpcAgentHeartBeatServiceImpl(client, taskScheduler, serviceProperties)
         this.heartbeatsReceived.clear()
     }
 
@@ -80,7 +82,7 @@ class GrpcAgentHeartBeatServiceImplSpec extends Specification {
         service.start(jobId)
 
         then:
-        1 * taskScheduler.scheduleAtFixedRate(_ as Runnable, _ as Long) >> {
+        1 * taskScheduler.scheduleAtFixedRate(_ as Runnable, serviceProperties.getInterval()) >> {
             args ->
                 sendHeartBeatsRunnable = args[0] as Runnable
                 return heartBeatFuture

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/ExecutionContextSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/ExecutionContextSpec.groovy
@@ -20,6 +20,7 @@ package com.netflix.genie.agent.execution.statemachine
 
 import com.netflix.genie.agent.execution.CleanupStrategy
 import com.netflix.genie.agent.execution.process.JobProcessResult
+import com.netflix.genie.agent.properties.AgentProperties
 import com.netflix.genie.common.external.dtos.v4.AgentClientMetadata
 import com.netflix.genie.common.external.dtos.v4.AgentJobRequest
 import com.netflix.genie.common.external.dtos.v4.JobSpecification
@@ -40,8 +41,8 @@ class ExecutionContextSpec extends Specification {
         JobProcessResult jobProcessResult = Mock(JobProcessResult)
         Exception retryableException = new RetryableJobExecutionException("...", null)
         Exception fatalException = new FatalJobExecutionException(States.CREATE_JOB_DIRECTORY, "...", new IOException())
-        ExecutionContext executionContext = new ExecutionContext()
-
+        AgentProperties agentProperties = Mock(AgentProperties)
+        ExecutionContext executionContext = new ExecutionContext(agentProperties)
 
         expect:
         executionContext.getAgentClientMetadata() == null
@@ -66,6 +67,7 @@ class ExecutionContextSpec extends Specification {
         executionContext.getCleanupStrategy() == CleanupStrategy.DEFAULT_STRATEGY
         executionContext.getNextJobStatus() == JobStatus.INVALID
         executionContext.getNextJobStatusMessage() == null
+        executionContext.getAgentProperties() != null
 
         when:
         executionContext.setAgentClientMetadata(agentClientMetadata)
@@ -89,7 +91,6 @@ class ExecutionContextSpec extends Specification {
         executionContext.setCleanupStrategy(CleanupStrategy.FULL_CLEANUP)
         executionContext.setNextJobStatus(JobStatus.RUNNING)
         executionContext.setNextJobStatusMessage("Job running")
-
 
         then:
         executionContext.getAgentClientMetadata() == agentClientMetadata
@@ -117,6 +118,5 @@ class ExecutionContextSpec extends Specification {
         executionContext.getCleanupStrategy() == CleanupStrategy.FULL_CLEANUP
         executionContext.getNextJobStatus() == JobStatus.RUNNING
         executionContext.getNextJobStatusMessage() == "Job running"
-
     }
 }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/stages/ConfigureAgentStageSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/stages/ConfigureAgentStageSpec.groovy
@@ -1,0 +1,107 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.execution.statemachine.stages
+
+import com.netflix.genie.agent.cli.ArgumentDelegates
+import com.netflix.genie.agent.cli.JobRequestConverter
+import com.netflix.genie.agent.execution.CleanupStrategy
+import com.netflix.genie.agent.execution.exceptions.ConfigureException
+import com.netflix.genie.agent.execution.services.AgentJobService
+import com.netflix.genie.agent.execution.statemachine.ExecutionContext
+import com.netflix.genie.agent.execution.statemachine.ExecutionStage
+import com.netflix.genie.agent.execution.statemachine.FatalJobExecutionException
+import com.netflix.genie.agent.execution.statemachine.RetryableJobExecutionException
+import com.netflix.genie.agent.properties.AgentProperties
+import com.netflix.genie.common.external.dtos.v4.AgentClientMetadata
+import com.netflix.genie.common.external.dtos.v4.AgentJobRequest
+import spock.lang.Specification
+
+import java.time.Duration
+
+class ConfigureAgentStageSpec extends Specification {
+    ExecutionStage stage
+    ExecutionContext executionContext
+    AgentJobService agentJobService
+    AgentClientMetadata agentClientMetadata
+    AgentProperties agentProperties
+
+    void setup() {
+        this.agentClientMetadata = Mock(AgentClientMetadata)
+        this.executionContext = Mock(ExecutionContext)
+        this.agentJobService = Mock(AgentJobService)
+        this.agentProperties = new AgentProperties()
+        this.stage = new ConfigureAgentStage(
+            agentJobService
+        )
+    }
+
+    def "Attempt transition -- no server values does not override/wipe defaults"() {
+        def killMaxDelayValue = agentProperties.getJobKillService().getResponseCheckBackOff().getMaxDelay()
+        def emergencyShutdownDelayValue = agentProperties.getEmergencyShutdownDelay()
+
+        when:
+        stage.attemptStageAction(executionContext)
+
+        then:
+        1 * executionContext.getAgentClientMetadata() >> agentClientMetadata
+        1 * executionContext.getAgentProperties() >> agentProperties
+        1 * agentJobService.configure(agentClientMetadata) >> [:]
+
+        expect:
+        agentProperties.getJobKillService().getResponseCheckBackOff().getMaxDelay() == killMaxDelayValue
+        agentProperties.getEmergencyShutdownDelay() == emergencyShutdownDelayValue
+    }
+
+    def "Attempt transition -- server values does override defaults, unknown properties are ignored"() {
+        def killMaxDelayValue = agentProperties.getJobKillService().getResponseCheckBackOff().getMaxDelay()
+        def emergencyShutdownDelayValue = agentProperties.getEmergencyShutdownDelay()
+        def heartbeatInterval = agentProperties.getHeartBeatService().getInterval()
+
+        when:
+        stage.attemptStageAction(executionContext)
+
+        then:
+        1 * executionContext.getAgentClientMetadata() >> agentClientMetadata
+        1 * executionContext.getAgentProperties() >> agentProperties
+        1 * agentJobService.configure(agentClientMetadata) >> [
+            'genie.agent.runtime.heart-beat-service.interval': '10s',
+            'foo.bar': 'blah',
+        ]
+
+        expect:
+        agentProperties.getJobKillService().getResponseCheckBackOff().getMaxDelay() == killMaxDelayValue
+        agentProperties.getEmergencyShutdownDelay() == emergencyShutdownDelayValue
+        agentProperties.getHeartBeatService().getInterval() != heartbeatInterval
+        agentProperties.getHeartBeatService().getInterval() == Duration.ofSeconds(10)
+    }
+
+
+    def "Attempt transition -- handle service exception"() {
+        Exception configureException = new ConfigureException("...")
+
+        when:
+        stage.attemptStageAction(executionContext)
+
+        then:
+        1 * executionContext.getAgentClientMetadata() >> agentClientMetadata
+        1 * executionContext.getAgentProperties() >> agentProperties
+        1 * agentJobService.configure(agentClientMetadata) >> { throw configureException }
+        def e = thrown(RetryableJobExecutionException)
+        e.getCause() == configureException
+    }
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/stages/RefreshManifestStageSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/stages/RefreshManifestStageSpec.groovy
@@ -21,8 +21,10 @@ import com.netflix.genie.agent.execution.services.AgentFileStreamService
 import com.netflix.genie.agent.execution.statemachine.ExecutionContext
 import com.netflix.genie.agent.execution.statemachine.ExecutionStage
 import com.netflix.genie.agent.execution.statemachine.States
+import com.netflix.genie.agent.properties.AgentProperties
 import spock.lang.Specification
 import spock.lang.Unroll
+import sun.management.Agent
 
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.ScheduledFuture
@@ -33,10 +35,12 @@ class RefreshManifestStageSpec extends Specification {
 
     ExecutionContext executionContext
     ScheduledFuture<?> future
+    AgentProperties agentProperties
 
     void setup() {
         this.agentFileService = Mock(AgentFileStreamService)
         this.executionContext = Mock(ExecutionContext)
+        this.agentProperties = new AgentProperties()
         this.future = Mock(ScheduledFuture)
     }
 
@@ -50,6 +54,7 @@ class RefreshManifestStageSpec extends Specification {
         then:
         1 * executionContext.getJobDirectory() >> Mock(File)
         1 * agentFileService.forceServerSync() >> Optional.<ScheduledFuture<?>>of(future)
+        1 * executionContext.getAgentProperties() >> agentProperties
         1 * future.get(_, _)
 
         when:
@@ -83,6 +88,7 @@ class RefreshManifestStageSpec extends Specification {
         then:
         1 * executionContext.getJobDirectory() >> Mock(File)
         1 * agentFileService.forceServerSync() >> Optional.<ScheduledFuture<?>>of(future)
+        1 * executionContext.getAgentProperties() >> agentProperties
         1 * future.get(_, _) >> { throw exception }
 
         where:

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
@@ -34,18 +34,22 @@ class AgentPropertiesSpec extends Specification {
         agentProperties.getEmergencyShutdownDelay() == Duration.ofMinutes(5)
         agentProperties.getFileStreamService() != null
         agentProperties.getHeartBeatService() != null
+        agentProperties.getJobKillService() != null
 
         when:
         def fileStreamServiceProps = Mock(FileStreamServiceProperties)
         def heartBeatServiceProps = Mock(HeartBeatServiceProperties)
+        def jobKillServiceProps = Mock(JobKillServiceProperties)
 
         agentProperties.setEmergencyShutdownDelay(Duration.ofMinutes(5))
         agentProperties.setFileStreamService(fileStreamServiceProps)
         agentProperties.setHeartBeatService(heartBeatServiceProps)
+        agentProperties.setJobKillService(jobKillServiceProps)
 
         then:
         agentProperties.getEmergencyShutdownDelay() == Duration.ofMinutes(5)
         agentProperties.getFileStreamService() == fileStreamServiceProps
         agentProperties.getHeartBeatService() == heartBeatServiceProps
+        agentProperties.getJobKillService() == jobKillServiceProps
     }
 }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.properties
+
+import spock.lang.Specification
+
+class AgentPropertiesSpec extends Specification {
+
+    AgentProperties agentProperties
+
+    void setup() {
+        agentProperties = new AgentProperties()
+    }
+
+    def "defaults, getters setters"() {
+
+    }
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
@@ -19,6 +19,8 @@ package com.netflix.genie.agent.properties
 
 import spock.lang.Specification
 
+import java.time.Duration
+
 class AgentPropertiesSpec extends Specification {
 
     AgentProperties agentProperties
@@ -28,6 +30,13 @@ class AgentPropertiesSpec extends Specification {
     }
 
     def "defaults, getters setters"() {
+        expect:
+        agentProperties.getEmergencyShutdownDelay() == Duration.ofMinutes(5)
 
+        when:
+        agentProperties.setEmergencyShutdownDelay(Duration.ofMinutes(5))
+
+        then:
+        agentProperties.getEmergencyShutdownDelay() == Duration.ofMinutes(5)
     }
 }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
@@ -33,14 +33,19 @@ class AgentPropertiesSpec extends Specification {
         expect:
         agentProperties.getEmergencyShutdownDelay() == Duration.ofMinutes(5)
         agentProperties.getFileStreamService() != null
+        agentProperties.getHeartBeatService() != null
 
         when:
         def fileStreamServiceProps = Mock(FileStreamServiceProperties)
+        def heartBeatServiceProps = Mock(HeartBeatServiceProperties)
+
         agentProperties.setEmergencyShutdownDelay(Duration.ofMinutes(5))
         agentProperties.setFileStreamService(fileStreamServiceProps)
+        agentProperties.setHeartBeatService(heartBeatServiceProps)
 
         then:
         agentProperties.getEmergencyShutdownDelay() == Duration.ofMinutes(5)
         agentProperties.getFileStreamService() == fileStreamServiceProps
+        agentProperties.getHeartBeatService() == heartBeatServiceProps
     }
 }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/AgentPropertiesSpec.groovy
@@ -32,11 +32,15 @@ class AgentPropertiesSpec extends Specification {
     def "defaults, getters setters"() {
         expect:
         agentProperties.getEmergencyShutdownDelay() == Duration.ofMinutes(5)
+        agentProperties.getFileStreamService() != null
 
         when:
+        def fileStreamServiceProps = Mock(FileStreamServiceProperties)
         agentProperties.setEmergencyShutdownDelay(Duration.ofMinutes(5))
+        agentProperties.setFileStreamService(fileStreamServiceProps)
 
         then:
         agentProperties.getEmergencyShutdownDelay() == Duration.ofMinutes(5)
+        agentProperties.getFileStreamService() == fileStreamServiceProps
     }
 }

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/FileStreamServicePropertiesSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/FileStreamServicePropertiesSpec.groovy
@@ -1,0 +1,63 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.properties
+
+import com.netflix.genie.common.internal.properties.ExponentialBackOffTriggerProperties
+import com.netflix.genie.common.internal.util.ExponentialBackOffTrigger
+import org.springframework.util.unit.DataSize
+import spock.lang.Specification
+
+import java.time.Duration
+
+class FileStreamServicePropertiesSpec extends Specification {
+
+    def "Defaults, setters, getters"() {
+        setup:
+        FileStreamServiceProperties props = new FileStreamServiceProperties()
+
+        expect:
+        props.getErrorBackOff().getDelayType() == ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_EXECUTION_BEGIN
+        props.getErrorBackOff().getMinDelay() == Duration.ofSeconds(1)
+        props.getErrorBackOff().getMaxDelay() == Duration.ofSeconds(10)
+        props.getErrorBackOff().getFactor() == 1.1f
+        props.isEnableCompression()
+        props.getDataChunkMaxSize() == DataSize.ofMegabytes(1)
+        props.getMaxConcurrentStreams() == 5
+        props.getDrainTimeout() == Duration.ofSeconds(15)
+
+        when:
+        def newErrorBackOff = new ExponentialBackOffTriggerProperties(
+            ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_EXECUTION_COMPLETION,
+            Duration.ofSeconds(3),
+            Duration.ofSeconds(5),
+            1.5f
+        )
+        props.setErrorBackOff(newErrorBackOff)
+        props.setEnableCompression(false)
+        props.setDataChunkMaxSize(DataSize.ofKilobytes(512))
+        props.setMaxConcurrentStreams(10)
+        props.setDrainTimeout(Duration.ofSeconds(20))
+
+        then:
+        props.getErrorBackOff() == newErrorBackOff
+        !props.isEnableCompression()
+        props.getDataChunkMaxSize() == DataSize.ofKilobytes(512)
+        props.getMaxConcurrentStreams() == 10
+        props.getDrainTimeout() == Duration.ofSeconds(20)
+    }
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/HeartBeatServicePropertiesSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/HeartBeatServicePropertiesSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.properties
+
+import spock.lang.Specification
+
+import java.time.Duration
+
+class HeartBeatServicePropertiesSpec extends Specification {
+
+    def "Defaults, setters, getters"() {
+        setup:
+        HeartBeatServiceProperties props = new HeartBeatServiceProperties()
+
+        expect:
+        props.getInterval() == Duration.ofSeconds(2)
+        props.getErrorRetryDelay() == Duration.ofSeconds(1)
+
+        when:
+        props.setInterval(Duration.ofSeconds(1))
+        props.setErrorRetryDelay(Duration.ofSeconds(5))
+
+        then:
+        props.getInterval() == Duration.ofSeconds(1)
+        props.getErrorRetryDelay() == Duration.ofSeconds(5)
+    }
+}

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/JobKillServicePropertiesSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/properties/JobKillServicePropertiesSpec.groovy
@@ -1,0 +1,50 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.agent.properties
+
+import com.netflix.genie.common.internal.properties.ExponentialBackOffTriggerProperties
+import com.netflix.genie.common.internal.util.ExponentialBackOffTrigger
+import spock.lang.Specification
+
+import java.time.Duration
+
+class JobKillServicePropertiesSpec extends Specification {
+
+    def "Defaults, setters, getters"() {
+        setup:
+        JobKillServiceProperties props = new JobKillServiceProperties()
+
+        expect:
+        props.getResponseCheckBackOff().getDelayType() == ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_EXECUTION_COMPLETION
+        props.getResponseCheckBackOff().getMinDelay() == Duration.ofMillis(500)
+        props.getResponseCheckBackOff().getMaxDelay() == Duration.ofSeconds(5)
+        props.getResponseCheckBackOff().getFactor() == 1.2f
+
+        when:
+        def newResponseCheckBackOff = new ExponentialBackOffTriggerProperties(
+            ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_EXECUTION_BEGIN,
+            Duration.ofSeconds(3),
+            Duration.ofSeconds(5),
+            1.5f
+        )
+        props.setResponseCheckBackOff(newResponseCheckBackOff)
+
+        then:
+        props.getResponseCheckBackOff() == newResponseCheckBackOff
+    }
+}

--- a/genie-agent/src/test/java/com/netflix/genie/agent/execution/ExecutionAutoConfigurationTest.java
+++ b/genie-agent/src/test/java/com/netflix/genie/agent/execution/ExecutionAutoConfigurationTest.java
@@ -32,11 +32,12 @@ import com.netflix.genie.agent.execution.services.JobSetupService;
 import com.netflix.genie.agent.execution.statemachine.ExecutionContext;
 import com.netflix.genie.agent.execution.statemachine.ExecutionStage;
 import com.netflix.genie.agent.execution.statemachine.JobExecutionStateMachine;
-import com.netflix.genie.agent.execution.statemachine.listeners.LoggingListener;
 import com.netflix.genie.agent.execution.statemachine.listeners.ConsoleLogListener;
+import com.netflix.genie.agent.execution.statemachine.listeners.LoggingListener;
 import com.netflix.genie.agent.execution.statemachine.stages.ArchiveJobOutputsStage;
 import com.netflix.genie.agent.execution.statemachine.stages.ClaimJobStage;
 import com.netflix.genie.agent.execution.statemachine.stages.CleanupJobDirectoryStage;
+import com.netflix.genie.agent.execution.statemachine.stages.ConfigureAgentStage;
 import com.netflix.genie.agent.execution.statemachine.stages.ConfigureExecutionStage;
 import com.netflix.genie.agent.execution.statemachine.stages.CreateJobDirectoryStage;
 import com.netflix.genie.agent.execution.statemachine.stages.CreateJobScriptStage;
@@ -92,6 +93,7 @@ class ExecutionAutoConfigurationTest {
         ArchiveJobOutputsStage.class,
         ClaimJobStage.class,
         CleanupJobDirectoryStage.class,
+        ConfigureAgentStage.class,
         ConfigureExecutionStage.class,
         CreateJobDirectoryStage.class,
         CreateJobScriptStage.class,

--- a/genie-agent/src/test/java/com/netflix/genie/agent/execution/ExecutionAutoConfigurationTest.java
+++ b/genie-agent/src/test/java/com/netflix/genie/agent/execution/ExecutionAutoConfigurationTest.java
@@ -61,6 +61,7 @@ import com.netflix.genie.agent.execution.statemachine.stages.StopFileServiceStag
 import com.netflix.genie.agent.execution.statemachine.stages.StopHeartbeatServiceStage;
 import com.netflix.genie.agent.execution.statemachine.stages.StopKillServiceStage;
 import com.netflix.genie.agent.execution.statemachine.stages.WaitJobCompletionStage;
+import com.netflix.genie.agent.properties.AgentProperties;
 import com.netflix.genie.common.internal.services.JobArchiveService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -131,6 +132,7 @@ class ExecutionAutoConfigurationTest {
                 Assertions.assertThat(context).hasSingleBean(ConsoleLogListener.class);
                 Assertions.assertThat(context).hasSingleBean(ExecutionContext.class);
                 Assertions.assertThat(context).hasSingleBean(JobExecutionStateMachine.class);
+                Assertions.assertThat(context).hasSingleBean(AgentProperties.class);
                 uniqueExecutionStages.forEach(
                     stageClass ->
                         Assertions.assertThat(context).hasSingleBean(stageClass)

--- a/genie-agent/src/test/java/com/netflix/genie/agent/spring/autoconfigure/AgentAutoConfigurationTest.java
+++ b/genie-agent/src/test/java/com/netflix/genie/agent/spring/autoconfigure/AgentAutoConfigurationTest.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.agent.spring.autoconfigure;
 
 import com.netflix.genie.agent.AgentMetadataImpl;
+import com.netflix.genie.agent.properties.AgentProperties;
 import com.netflix.genie.agent.utils.locks.impl.FileLockFactory;
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import org.assertj.core.api.Assertions;
@@ -65,6 +66,7 @@ public class AgentAutoConfigurationTest {
                     .assertThat(context)
                     .getBean("heartBeatServiceTaskScheduler")
                     .isOfAnyClassIn(ThreadPoolTaskScheduler.class);
+                Assertions.assertThat(context).hasSingleBean(AgentProperties.class);
             }
         );
     }

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dtos/v4/converters/JobServiceProtoConverter.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dtos/v4/converters/JobServiceProtoConverter.java
@@ -38,6 +38,7 @@ import com.netflix.genie.proto.AgentConfig;
 import com.netflix.genie.proto.AgentMetadata;
 import com.netflix.genie.proto.ChangeJobStatusRequest;
 import com.netflix.genie.proto.ClaimJobRequest;
+import com.netflix.genie.proto.ConfigureRequest;
 import com.netflix.genie.proto.DryRunJobSpecificationRequest;
 import com.netflix.genie.proto.ExecutionResource;
 import com.netflix.genie.proto.HandshakeRequest;
@@ -282,6 +283,23 @@ public class JobServiceProtoConverter {
         final AgentClientMetadata agentClientMetadata
     ) throws GenieConversionException {
         return HandshakeRequest.newBuilder()
+            .setAgentMetadata(
+                toAgentMetadataProto(agentClientMetadata)
+            )
+            .build();
+    }
+
+    /**
+     * Convert parameters into ConfigureRequest for the server.
+     *
+     * @param agentClientMetadata agent client metadata
+     * @return a {@link ConfigureRequest}
+     * @throws GenieConversionException if the inputs are invalid
+     */
+    public ConfigureRequest toConfigureRequestProto(
+        final AgentClientMetadata agentClientMetadata
+    ) throws GenieConversionException {
+        return ConfigureRequest.newBuilder()
             .setAgentMetadata(
                 toAgentMetadataProto(agentClientMetadata)
             )

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/properties/ExponentialBackOffTriggerProperties.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/properties/ExponentialBackOffTriggerProperties.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.properties;
+
+import com.netflix.genie.common.internal.util.ExponentialBackOffTrigger;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Duration;
+
+/**
+ * Properties for {@link com.netflix.genie.common.internal.util.ExponentialBackOffTrigger} used in various places.
+ *
+ * Notice this class is not tagged as {@link org.springframework.boot.context.properties.ConfigurationProperties}
+ * since it's not a root property class.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ExponentialBackOffTriggerProperties {
+    private ExponentialBackOffTrigger.DelayType delayType =
+        ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_EXECUTION_COMPLETION;
+    private Duration minDelay = Duration.ofMillis(100);
+    private Duration maxDelay = Duration.ofSeconds(3);
+    private float factor = 1.2f;
+}

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/util/ExponentialBackOffTrigger.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/util/ExponentialBackOffTrigger.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.common.internal.util;
 
+import com.netflix.genie.common.internal.properties.ExponentialBackOffTriggerProperties;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.TriggerContext;
 
@@ -40,6 +41,23 @@ public class ExponentialBackOffTrigger implements Trigger {
     private final long maxDelay;
     private final float factor;
     private long currentDelay;
+
+    /**
+     * Constructor with properties.
+     * Loads all values during construction. I.e. does not respond to subsequent changes to property values dynamically.
+     *
+     * @param properties the properties
+     */
+    public ExponentialBackOffTrigger(
+        final ExponentialBackOffTriggerProperties properties
+    ) {
+        this(
+            properties.getDelayType(),
+            properties.getMinDelay().toMillis(),
+            properties.getMaxDelay().toMillis(),
+            properties.getFactor()
+        );
+    }
 
     /**
      * Constructor.

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dtos/v4/converters/JobServiceProtoConverterSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dtos/v4/converters/JobServiceProtoConverterSpec.groovy
@@ -33,6 +33,7 @@ import com.netflix.genie.common.external.dtos.v4.JobStatus
 import com.netflix.genie.common.external.util.GenieObjectMapper
 import com.netflix.genie.proto.AgentConfig
 import com.netflix.genie.proto.AgentMetadata
+import com.netflix.genie.proto.ConfigureRequest
 import com.netflix.genie.proto.DryRunJobSpecificationRequest
 import com.netflix.genie.proto.ExecutionResource
 import com.netflix.genie.proto.HandshakeRequest
@@ -405,6 +406,20 @@ class JobServiceProtoConverterSpec extends Specification {
 
         then:
         AgentMetadata agentMetadata = handshakeRequest.getAgentMetadata()
+        agentMetadata != null
+        agentMetadata.getAgentHostname() == agentHostname
+        agentMetadata.getAgentVersion() == agentVersion
+        agentMetadata.getAgentPid() == agentPid
+    }
+
+    def "Can convert AgentClientMetadata to ConfigureRequest"() {
+        AgentClientMetadata agentClientMetadata = createAgentClientMetadata()
+
+        when:
+        ConfigureRequest configureRequest = converter.toConfigureRequestProto(agentClientMetadata)
+
+        then:
+        AgentMetadata agentMetadata = configureRequest.getAgentMetadata()
         agentMetadata != null
         agentMetadata.getAgentHostname() == agentHostname
         agentMetadata.getAgentVersion() == agentVersion

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/properties/ExponentialBackOffTriggerPropertiesSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/properties/ExponentialBackOffTriggerPropertiesSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.properties
+
+import com.netflix.genie.common.internal.util.ExponentialBackOffTrigger
+import spock.lang.Specification
+
+import java.time.Duration
+
+class ExponentialBackOffTriggerPropertiesSpec extends Specification {
+    ExponentialBackOffTriggerProperties props
+
+    void setup() {
+        this.props = new ExponentialBackOffTriggerProperties()
+    }
+
+    def "defaults, setters, getters"() {
+        expect:
+        props.getDelayType() == ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_EXECUTION_COMPLETION
+        props.getMinDelay() == Duration.ofMillis(100)
+        props.getMaxDelay() == Duration.ofSeconds(3)
+        props.getFactor() == 1.2f
+
+        when:
+        props.setDelayType(ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_SCHEDULING)
+        props.setMinDelay(Duration.ofMinutes(1))
+        props.setMaxDelay(Duration.ofMinutes(5))
+        props.setFactor(1.5f)
+
+        then:
+
+        props.getDelayType() == ExponentialBackOffTrigger.DelayType.FROM_PREVIOUS_SCHEDULING
+        props.getMinDelay() == Duration.ofMinutes(1)
+        props.getMaxDelay() == Duration.ofMinutes(5)
+        props.getFactor() == 1.5f
+    }
+}

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/util/ExponentialBackOffTriggerSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/util/ExponentialBackOffTriggerSpec.groovy
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.common.internal.util
 
+import com.netflix.genie.common.internal.properties.ExponentialBackOffTriggerProperties
 import org.springframework.scheduling.TriggerContext
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -139,5 +140,15 @@ class ExponentialBackOffTriggerSpec extends Specification {
         10  | 9   | 2.0f
         10  | 100 | -2.0f
         10  | 100 | 0.0f
+    }
+
+    def "Construct with properties"() {
+        def triggerProperties = new ExponentialBackOffTriggerProperties()
+
+        when:
+        new ExponentialBackOffTrigger(triggerProperties)
+
+        then:
+        noExceptionThrown()
     }
 }

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -1,5 +1,7 @@
 == Properties
 
+== Genie Web
+
 This section describes the various properties that can be set to control the behavior of your Genie node and cluster.
 For more information on Spring properties you should see the
 http://docs.spring.io/spring-boot/docs/{springBootVersion}/reference/htmlsingle/[Spring Boot] reference documentation and the http://cloud.spring.io/spring-cloud-static/{springCloudVersion}/[Spring Cloud] documentation.
@@ -821,5 +823,102 @@ See https://cloud.spring.io/spring-cloud-aws/[Spring Cloud AWS] for more informa
 |spring.datasource.hikari.data-source-properties.userServerPrepStatements
 |https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration[MySQL Tuning]
 |true
+
+|===
+
+== Genie Agent
+
+This section describes the various properties that can be set to control the behavior of the Genie agent.
+
+Unless otherwise noted, properties are loaded from the standard sources (defaults, profiles, other files).
+The server also has a chance to override them during the 'Agent Configuration' execution stage.
+
+=== Default Properties
+
+==== Genie Properties
+
+
+|===
+|Property |Description |Default Value | Notes
+
+| `genie.agent.runtime.emergency-shutdown-delay`
+| Time allowed to the agent to shut down cleanly (archive, cleanup, ...) before the JVM is forcefully shut down
+| 5m
+|
+
+| `genie.agent.runtime.force-manifest-refresh-timeout`
+| Maximum time block when trying to forcefully push a manifest update
+| 5s
+|
+
+| `genie.agent.runtime.file-stream-service.error-back-off.delay-type`
+| Scheduling policy for backoff in case of error during file streaming
+| FROM_PREVIOUS_EXECUTION_BEGIN
+|
+
+| `genie.agent.runtime.file-stream-service.error-back-off.min-delay`
+| Minimum delay before another attempt during file streaming
+| 1s
+|
+
+| `genie.agent.runtime.file-stream-service.error-back-off.max-delay`
+| Maximum delay before another attempt during file streaming
+| 10s
+|
+
+| `genie.agent.runtime.file-stream-service.error-back-off.factor`
+| Multiplication factor for retry delay before another attempt during file streaming
+| 1.1
+|
+
+| `genie.agent.runtime.file-stream-service.enable-compression`
+| Wether to enable compression when transmitting file chunks to the server
+| true
+|
+
+| `genie.agent.runtime.file-stream-service.data-chunk-max-size`
+| Max size of a file chunk sent to the server
+| 1MB
+|
+
+| `genie.agent.runtime.file-stream-service.max-concurrent-streams`
+| Maximum number of files transmitted concurrently to the server
+| 5
+|
+
+| `genie.agent.runtime.file-stream-service.drain-timeout`
+| Maximum time a file transfer is allowed to complete before it is terminated during agent shutdown
+| 15s
+| Should be lower then `genie.agent.runtime.emergency-shutdown-delay`
+
+| `genie.agent.runtime.heart-beat-service.interval`
+| Interval between heartbeats
+| 2s
+|
+
+| `genie.agent.runtime.heart-beat-service.error-retry-delay`
+| Interval to wait before re-establishing the heartbeat stream
+| 1s
+|
+
+| `genie.agent.runtime.job-kill-service.response-check-back-off.delay-type`
+| Scheduling policy for backoff in case of error during kill request
+| FROM_PREVIOUS_EXECUTION_COMPLETION
+|
+
+| `genie.agent.runtime.job-kill-service.response-check-back-off.min-delay`
+| Minimum delay before another attempt during kill request
+| 500ms
+|
+
+| `genie.agent.runtime.job-kill-service.response-check-back-off.max-delay`
+| Maximium delay before another attempt during kill request
+| 5s
+|
+
+| `genie.agent.runtime.job-kill-service.response-check-back-off.factor`
+| Multiplication factor for retry delay before another attempt during kill request
+| 1.2
+|
 
 |===

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -15,6 +15,21 @@ Whereas static properties values are bound during application startup and do not
 |===
 |Property |Description |Default Value |Dynamic
 
+|genie.agent.configuration.agent-properties-filter-pattern
+|Regular expression applied to filter server properties that are forwarded to the agent
+|^genie\.agent\.runtime\..*
+|no
+
+|genie.agent.configuration.cache-expiration-interval
+|Interval after which the agent properties cache is considered stale and re-calculated
+|1m
+|no
+
+|genie.agent.configuration.cache-refresh-interval
+|Interval for after which the agent properties cache is forcefully refreshed in case of no access
+|5m
+|no
+
 |genie.agent.filter.enabled
 |If set to `true`, enables the built-in agent filter service. The filter behavior is controlled by other active `genie.agent.filter.*` properties.
 |
@@ -84,6 +99,11 @@ https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-featu
 |Whether to launch the agent subprocess as the user specified in the job request
 |false
 |no
+
+|genie.agent.runtime.*
+|Properties with this prefix are forwarded to each agent during startup
+|
+|yes
 
 |genie.aws.credentials.role
 |The AWS role ARN to assume when connecting to S3. If this is set Genie will create a credentials provider that will

--- a/genie-proto/src/main/proto/genie.proto
+++ b/genie-proto/src/main/proto/genie.proto
@@ -44,6 +44,7 @@ message PongResponse {
 //--------------------------------------------------------------------
 service JobService {
     rpc handshake (HandshakeRequest) returns (HandshakeResponse);
+    rpc configure (ConfigureRequest) returns (ConfigureResponse);
     rpc reserveJobId (ReserveJobIdRequest) returns (ReserveJobIdResponse);
     rpc resolveJobSpecification (JobSpecificationRequest) returns (JobSpecificationResponse);
     rpc getJobSpecification (JobSpecificationRequest) returns (JobSpecificationResponse);
@@ -242,6 +243,12 @@ message ChangeJobStatusError {
 message ChangeJobStatusResponse {
     bool successful = 1;
     ChangeJobStatusError error = 2;
+}
+
+message ConfigureRequest {
+}
+
+message ConfigureResponse {
 }
 
 //--------------------------------------------------------------------

--- a/genie-proto/src/main/proto/genie.proto
+++ b/genie-proto/src/main/proto/genie.proto
@@ -246,9 +246,11 @@ message ChangeJobStatusResponse {
 }
 
 message ConfigureRequest {
+    AgentMetadata agent_metadata = 1;
 }
 
 message ConfigureResponse {
+    map<string, string> properties = 1;
 }
 
 //--------------------------------------------------------------------

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobServiceImpl.java
@@ -26,6 +26,8 @@ import com.netflix.genie.proto.ChangeJobStatusRequest;
 import com.netflix.genie.proto.ChangeJobStatusResponse;
 import com.netflix.genie.proto.ClaimJobRequest;
 import com.netflix.genie.proto.ClaimJobResponse;
+import com.netflix.genie.proto.ConfigureRequest;
+import com.netflix.genie.proto.ConfigureResponse;
 import com.netflix.genie.proto.DryRunJobSpecificationRequest;
 import com.netflix.genie.proto.HandshakeRequest;
 import com.netflix.genie.proto.HandshakeResponse;
@@ -98,6 +100,22 @@ public class GRpcJobServiceImpl extends JobServiceGrpc.JobServiceImplBase {
             responseObserver.onNext(protoErrorComposer.toProtoHandshakeResponse(e));
         }
 
+        responseObserver.onCompleted();
+    }
+
+    /**
+     * This API provides runtime configuration to the agent (example: timeouts, parallelism, etc.).
+     *
+     * @param request          The agent request
+     * @param responseObserver To send the response
+     */
+    @Override
+    public void configure(
+        final ConfigureRequest request,
+        final StreamObserver<ConfigureResponse> responseObserver
+    ) {
+        // TODO currently NOOP, sends back an empty message
+        responseObserver.onNext(ConfigureResponse.newBuilder().build());
         responseObserver.onCompleted();
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposer.java
@@ -34,6 +34,7 @@ import com.netflix.genie.proto.ChangeJobStatusError;
 import com.netflix.genie.proto.ChangeJobStatusResponse;
 import com.netflix.genie.proto.ClaimJobError;
 import com.netflix.genie.proto.ClaimJobResponse;
+import com.netflix.genie.proto.ConfigureResponse;
 import com.netflix.genie.proto.HandshakeResponse;
 import com.netflix.genie.proto.JobSpecificationError;
 import com.netflix.genie.proto.JobSpecificationResponse;
@@ -198,6 +199,18 @@ public class JobServiceProtoErrorComposer {
         return HandshakeResponse.newBuilder()
             .setMessage(getMessage(e))
             .setType(getErrorType(e, HANDSHAKE_ERROR_MAP, HandshakeResponse.Type.SERVER_ERROR))
+            .build();
+    }
+
+    /**
+     * Build a {@link ConfigureResponse} out of the given {@link Exception}.
+     * Because the configuration is optional, send back an empty message.
+     *
+     * @param e The server exception
+     * @return The response
+     */
+    ConfigureResponse toProtoConfigureResponse(final Exception e) {
+        return ConfigureResponse.newBuilder()
             .build();
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentConfigurationService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentConfigurationService.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.agent.services;
+
+import java.util.Map;
+
+/**
+ * Service that provides agent runtime configuration (i.e. independent of the job being executed).
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public interface AgentConfigurationService {
+
+    /**
+     * Produce a list of properties to be sent down to the agents running jobs.
+     *
+     * @return a map of properties and values
+     */
+    Map<String, String> getAgentProperties();
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentJobService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentJobService.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import java.util.Map;
 
 /**
  * A Service to collect the logic for implementing calls from the Agent when a job is launched via the CLI.
@@ -52,6 +53,15 @@ public interface AgentJobService {
      * @throws ConstraintViolationException If the arguments fail validation
      */
     void handshake(@Valid AgentClientMetadata agentMetadata);
+
+    /**
+     * Provide configuration properties for an agent that is beginning to execute a job.
+     *
+     * @param agentMetadata The metadata about the agent starting to run a given job
+     * @throws ConstraintViolationException If the arguments fail validation
+     * @return a map of properties for the agent
+     */
+    Map<String, String> getAgentProperties(@Valid AgentClientMetadata agentMetadata);
 
     /**
      * Reserve a job id and persist job details in the database based on the supplied {@link JobRequest}.

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentConfigurationServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentConfigurationServiceImpl.java
@@ -1,0 +1,138 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.agent.services.impl;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import com.netflix.genie.web.agent.services.AgentConfigurationService;
+import com.netflix.genie.web.properties.AgentConfigurationProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.PropertySources;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * This implementation of {@link AgentConfigurationService} forwards properties set on the server that match a given
+ * set of regular expressions, plus any additional ones specified in configuration.
+ * It utilizes a cache to avoid recomputing the set of properties and values for every request.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public class AgentConfigurationServiceImpl implements AgentConfigurationService {
+
+    private static final String AGENT_PROPERTIES_CACHE_KEY = "agent-properties";
+
+    private final AgentConfigurationProperties agentConfigurationProperties;
+    private final Environment environment;
+    private final Pattern agentPropertiesPattern;
+    private final LoadingCache<String, Map<String, String>> cache;
+
+    /**
+     * Constructor.
+     *
+     * @param agentConfigurationProperties the properties
+     * @param environment the environment
+     */
+    public AgentConfigurationServiceImpl(
+        final AgentConfigurationProperties agentConfigurationProperties,
+        final Environment environment
+    ) {
+        this.agentConfigurationProperties = agentConfigurationProperties;
+        this.environment = environment;
+
+        this.agentPropertiesPattern = Pattern.compile(
+            this.agentConfigurationProperties.getAgentPropertiesFilterPattern(),
+            Pattern.CASE_INSENSITIVE
+        );
+
+        // Use a cache to re-compute agent properties periodically, rather than for every request.
+        this.cache = Caffeine
+            .newBuilder()
+            .expireAfterWrite(this.agentConfigurationProperties.getCacheExpirationInterval())
+            .refreshAfterWrite(this.agentConfigurationProperties.getCacheRefreshInterval())
+            .initialCapacity(1)
+            .build(this::loadProperties);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> getAgentProperties() {
+        return this.cache.get(AGENT_PROPERTIES_CACHE_KEY);
+    }
+
+
+    private Map<String, String> loadProperties(@NonNull final String propertiesKey) {
+        if (AGENT_PROPERTIES_CACHE_KEY.equals(propertiesKey)) {
+            return reloadAgentProperties();
+        }
+        throw new IllegalArgumentException("Unknown key to load: " + propertiesKey);
+    }
+
+    private Map<String, String> reloadAgentProperties() {
+        // Obtain properties sources from environment
+        final PropertySources propertySources;
+        if (environment instanceof ConfigurableEnvironment) {
+            propertySources = ((ConfigurableEnvironment) environment).getPropertySources();
+        } else {
+            propertySources = new StandardEnvironment().getPropertySources();
+        }
+
+        // Create set of all properties that match the filter pattern
+        final Set<String> filteredPropertyNames = Sets.newHashSet();
+        for (final PropertySource<?> propertySource : propertySources) {
+            if (propertySource instanceof EnumerablePropertySource) {
+                for (final String propertyName : ((EnumerablePropertySource<?>) propertySource).getPropertyNames()) {
+                    if (agentPropertiesPattern.matcher(propertyName).matches()) {
+                        log.debug("Adding matching property: {}", propertyName);
+                        filteredPropertyNames.add(propertyName);
+                    } else {
+                        log.debug("Ignoring property: {}", propertyName);
+                    }
+                }
+            }
+        }
+
+        // Create immutable properties map
+        final ImmutableMap.Builder<String, String> propertiesMapBuilder = ImmutableMap.builder();
+        for (final String propertyName : filteredPropertyNames) {
+            final String propertyValue = environment.getProperty(propertyName);
+            if (StringUtils.isBlank(propertyValue)) {
+                log.debug("Skipping blank value property: {}", propertyName);
+            } else {
+                propertiesMapBuilder.put(propertyName, propertyValue);
+            }
+        }
+
+        return propertiesMapBuilder.build();
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.agent.services.impl;
 
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.external.dtos.v4.AgentClientMetadata;
 import com.netflix.genie.common.external.dtos.v4.JobRequest;
@@ -50,6 +51,7 @@ import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -122,6 +124,17 @@ public class AgentJobServiceImpl implements AgentJobService {
             throw new GenieAgentRejectedException("Agent rejected: " + report.getMessage());
         }
 
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> getAgentProperties(
+        @Valid final AgentClientMetadata agentClientMetadata
+    ) {
+        // TODO: currently NOOP. Implement.
+        return Maps.newHashMap();
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
@@ -69,7 +69,6 @@ public class AgentJobServiceImpl implements AgentJobService {
     private static final String GET_AGENT_PROPERTIES_COUNTER_METRIC_NAME
         = AGENT_JOB_SERVICE_METRIC_PREFIX + "getAgentProperties.counter";
     private static final String AGENT_VERSION_METRIC_TAG_NAME = "agentVersion";
-    private static final String AGENT_HOST_METRIC_TAG_NAME = "agentHost";
     private static final String HANDSHAKE_DECISION_METRIC_TAG_NAME = "handshakeDecision";
     private final PersistenceService persistenceService;
     private final JobResolverService jobResolverService;
@@ -108,8 +107,7 @@ public class AgentJobServiceImpl implements AgentJobService {
     ) throws GenieAgentRejectedException {
 
         final HashSet<Tag> tags = Sets.newHashSet(
-            Tag.of(AGENT_VERSION_METRIC_TAG_NAME, agentClientMetadata.getVersion().orElse("null")),
-            Tag.of(AGENT_HOST_METRIC_TAG_NAME, agentClientMetadata.getHostname().orElse("null"))
+            Tag.of(AGENT_VERSION_METRIC_TAG_NAME, agentClientMetadata.getVersion().orElse("null"))
         );
 
         final InspectionReport report;
@@ -139,8 +137,7 @@ public class AgentJobServiceImpl implements AgentJobService {
         @Valid final AgentClientMetadata agentClientMetadata
     ) {
         final HashSet<Tag> tags = Sets.newHashSet(
-            Tag.of(AGENT_VERSION_METRIC_TAG_NAME, agentClientMetadata.getVersion().orElse("null")),
-            Tag.of(AGENT_HOST_METRIC_TAG_NAME, agentClientMetadata.getHostname().orElse("null"))
+            Tag.of(AGENT_VERSION_METRIC_TAG_NAME, agentClientMetadata.getVersion().orElse("null"))
         );
 
         try {

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/AgentConfigurationProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/AgentConfigurationProperties.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import com.netflix.genie.web.agent.services.AgentConfigurationService;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Properties for {@link AgentConfigurationService}.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@ConfigurationProperties(prefix = AgentConfigurationProperties.PREFIX)
+@Getter
+@Setter
+public class AgentConfigurationProperties {
+    /**
+     * Properties prefix.
+     */
+    static final String PREFIX = "genie.agent.configuration";
+
+    private String agentPropertiesFilterPattern = "^genie\\.agent\\.runtime\\..*";
+    private Duration cacheExpirationInterval = Duration.ofMinutes(1);
+    private Duration cacheRefreshInterval = Duration.ofMinutes(5);
+}

--- a/genie-web/src/main/resources/genie-web-defaults.yml
+++ b/genie-web/src/main/resources/genie-web-defaults.yml
@@ -27,6 +27,11 @@ cloud:
       auto: false
 
 genie:
+  agent:
+    configuration:
+      agent-properties-filter-pattern: ^genie\.agent\.runtime\..*
+      cache-expiration-interval: 1m
+      cache-refresh-interval: 5m
   file:
     cache:
       location: file://${java.io.tmpdir}genie/cache

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobServiceImplSpec.groovy
@@ -32,6 +32,8 @@ import com.netflix.genie.proto.ChangeJobStatusRequest
 import com.netflix.genie.proto.ChangeJobStatusResponse
 import com.netflix.genie.proto.ClaimJobRequest
 import com.netflix.genie.proto.ClaimJobResponse
+import com.netflix.genie.proto.ConfigureRequest
+import com.netflix.genie.proto.ConfigureResponse
 import com.netflix.genie.proto.DryRunJobSpecificationRequest
 import com.netflix.genie.proto.HandshakeRequest
 import com.netflix.genie.proto.HandshakeResponse
@@ -56,6 +58,7 @@ class GRpcJobServiceImplSpec extends Specification {
     AgentJobService agentJobService
     GRpcJobServiceImpl gRpcJobService
     StreamObserver<HandshakeResponse> handshakeResponseObserver
+    StreamObserver<ConfigureResponse> configureResponseObserver
     StreamObserver<ReserveJobIdResponse> reserveJobIdResponseObserver
     StreamObserver<JobSpecificationResponse> jobSpecificationResponseObserver
     StreamObserver<ClaimJobResponse> claimJobResponseObserver
@@ -69,6 +72,7 @@ class GRpcJobServiceImplSpec extends Specification {
         this.agentJobService = Mock(AgentJobService)
         this.gRpcJobService = new GRpcJobServiceImpl(agentJobService, jobServiceProtoConverter, errorMessageComposer)
         this.handshakeResponseObserver = Mock(StreamObserver)
+        this.configureResponseObserver = Mock(StreamObserver)
         this.reserveJobIdResponseObserver = Mock(StreamObserver)
         this.jobSpecificationResponseObserver = Mock(StreamObserver)
         this.claimJobResponseObserver = Mock(StreamObserver)
@@ -118,6 +122,21 @@ class GRpcJobServiceImplSpec extends Specification {
             args -> assert response == args[0]
         }
         1 * handshakeResponseObserver.onCompleted()
+    }
+
+    def "Configure -- successful"() {
+        ConfigureRequest request = ConfigureRequest.newBuilder().build()
+        ConfigureResponse responseCapture
+
+        when:
+        gRpcJobService.configure(request, configureResponseObserver)
+
+        then:
+        1 * configureResponseObserver.onNext(_ as ConfigureResponse) >> {
+            args -> responseCapture = args[0]
+        }
+        1 * configureResponseObserver.onCompleted()
+        responseCapture != null
     }
 
     def "Reserve job id -- successful"() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobServiceImplSpec.groovy
@@ -17,7 +17,7 @@
  */
 package com.netflix.genie.web.agent.apis.rpc.v4.endpoints
 
-
+import com.google.common.collect.Maps
 import com.netflix.genie.common.external.dtos.v4.AgentClientMetadata
 import com.netflix.genie.common.external.dtos.v4.JobRequest
 import com.netflix.genie.common.external.dtos.v4.JobSpecification
@@ -125,18 +125,25 @@ class GRpcJobServiceImplSpec extends Specification {
     }
 
     def "Configure -- successful"() {
+        AgentMetadata agentMetadata = AgentMetadata.newBuilder().build()
+        AgentClientMetadata agentClientMetadata = Mock(AgentClientMetadata)
         ConfigureRequest request = ConfigureRequest.newBuilder().build()
+        Map<String, String> agentProperties = Maps.newHashMap()
+        agentProperties.put("foo", "bar")
         ConfigureResponse responseCapture
 
         when:
         gRpcJobService.configure(request, configureResponseObserver)
 
         then:
+        1 * jobServiceProtoConverter.toAgentClientMetadataDto(agentMetadata) >> agentClientMetadata
+        1 * agentJobService.getAgentProperties(agentClientMetadata) >> agentProperties
         1 * configureResponseObserver.onNext(_ as ConfigureResponse) >> {
             args -> responseCapture = args[0]
         }
         1 * configureResponseObserver.onCompleted()
         responseCapture != null
+        responseCapture.getPropertiesMap().get("foo") == "bar"
     }
 
     def "Reserve job id -- successful"() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposerSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposerSpec.groovy
@@ -33,6 +33,7 @@ import com.netflix.genie.proto.ChangeJobStatusError
 import com.netflix.genie.proto.ChangeJobStatusResponse
 import com.netflix.genie.proto.ClaimJobError
 import com.netflix.genie.proto.ClaimJobResponse
+import com.netflix.genie.proto.ConfigureResponse
 import com.netflix.genie.proto.HandshakeResponse
 import com.netflix.genie.proto.JobSpecificationError
 import com.netflix.genie.proto.JobSpecificationResponse
@@ -160,5 +161,18 @@ class JobServiceProtoErrorComposerSpec extends Specification {
         new GenieAgentRejectedException(MESSAGE)       | HandshakeResponse.Type.REJECTED
         new ConstraintViolationException(MESSAGE, cvs) | HandshakeResponse.Type.INVALID_REQUEST
         new RuntimeException(MESSAGE)                  | HandshakeResponse.Type.SERVER_ERROR
+    }
+
+    @Unroll
+    def "ToProtoConfigureResponse for #exception.class.getSimpleName()"() {
+        when:
+        ConfigureResponse response = errorComposer.toProtoConfigureResponse(exception)
+
+        then:
+        response.getPropertiesMap().isEmpty()
+
+        where:
+        exception                                      | _
+        new RuntimeException(MESSAGE)                  | _
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentConfigurationServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentConfigurationServiceImplSpec.groovy
@@ -1,0 +1,108 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.agent.services.impl
+
+import com.netflix.genie.web.agent.services.AgentConfigurationService
+import com.netflix.genie.web.properties.AgentConfigurationProperties
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.Environment
+import org.springframework.core.env.MapPropertySource
+import org.springframework.core.env.MutablePropertySources
+import spock.lang.Specification
+
+class AgentConfigurationServiceImplSpec extends Specification {
+    AgentConfigurationProperties props
+    ConfigurableEnvironment env
+    MutablePropertySources propertySources
+
+    void setup() {
+        this.props = new AgentConfigurationProperties()
+        this.env = Mock(ConfigurableEnvironment)
+        this.propertySources = new MutablePropertySources()
+    }
+
+    def "Result is cached"() {
+        AgentConfigurationService service = new AgentConfigurationServiceImpl(props, env)
+
+        then:
+
+        when:
+        Map<String, String> agentProperties = service.getAgentProperties()
+
+        then:
+        1 * env.getPropertySources() >> propertySources
+        agentProperties.isEmpty()
+
+        when:
+        service.getAgentProperties()
+
+        then:
+        0 * env.getPropertySources() >> propertySources
+    }
+
+    def "Fallback to standard environment during load"() {
+        Environment env = Mock(Environment)
+
+        when:
+        AgentConfigurationService service = new AgentConfigurationServiceImpl(props, env)
+        Map<String, String> agentProperties = service.getAgentProperties()
+
+        then:
+        _ * env.getProperty(_ as String) >> UUID.randomUUID().toString()
+        agentProperties != null
+    }
+
+    def "Iterate through property sources with custom filter and some blank values"() {
+        props.setAgentPropertiesFilterPattern("^agent\\..*")
+
+        def map1 = [
+            'agent.foo': "...",
+            'agent.bar': "...",
+            'server.foo': "...",
+            'server.bar': "...",
+            'agent.null': "...",
+            'agent.empty': "...",
+        ]
+        def map2 = [
+            'agent.foo': "...",
+            'genie.agent.foo': "...",
+            'genie.agent.bar': "...",
+        ]
+
+        def expectedProperties = [
+            'agent.foo': "Foo",
+            'agent.bar': "Bar",
+        ]
+
+        def propertySources = new MutablePropertySources()
+        propertySources.addFirst(new MapPropertySource("map1", map1))
+        propertySources.addFirst(new MapPropertySource("map2", map2))
+
+        when:
+        AgentConfigurationService service = new AgentConfigurationServiceImpl(props, env)
+        Map<String, String> agentProperties = service.getAgentProperties()
+
+        then:
+        1 * env.getPropertySources() >> propertySources
+        1 * env.getProperty("agent.foo") >> "Foo"
+        1 * env.getProperty("agent.bar") >> "Bar"
+        1 * env.getProperty("agent.null") >> null
+        1 * env.getProperty("agent.empty") >> " "
+        agentProperties == expectedProperties
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
@@ -85,7 +85,6 @@ class AgentJobServiceImplSpec extends Specification {
         Set<Tag> expectedTags = Sets.newHashSet(
             Tag.of(AgentJobServiceImpl.HANDSHAKE_DECISION_METRIC_TAG_NAME, InspectionReport.Decision.ACCEPT.name()),
             Tag.of(AgentJobServiceImpl.AGENT_VERSION_METRIC_TAG_NAME, version),
-            Tag.of(AgentJobServiceImpl.AGENT_HOST_METRIC_TAG_NAME, hostname),
             MetricsUtils.SUCCESS_STATUS_TAG
         )
 
@@ -94,7 +93,6 @@ class AgentJobServiceImplSpec extends Specification {
 
         then:
         1 * agentClientMetadata.getVersion() >> Optional.of(version)
-        1 * agentClientMetadata.getHostname() >> Optional.of(hostname)
         1 * agentFilterService.inspectAgentMetadata(agentClientMetadata) >> inspectionReport
         2 * inspectionReport.getDecision() >> InspectionReport.Decision.ACCEPT
         0 * inspectionReport.getMessage()
@@ -113,7 +111,6 @@ class AgentJobServiceImplSpec extends Specification {
         Set<Tag> expectedTags = Sets.newHashSet(
             Tag.of(AgentJobServiceImpl.HANDSHAKE_DECISION_METRIC_TAG_NAME, InspectionReport.Decision.REJECT.name()),
             Tag.of(AgentJobServiceImpl.AGENT_VERSION_METRIC_TAG_NAME, version),
-            Tag.of(AgentJobServiceImpl.AGENT_HOST_METRIC_TAG_NAME, hostname),
             MetricsUtils.SUCCESS_STATUS_TAG
         )
 
@@ -122,7 +119,6 @@ class AgentJobServiceImplSpec extends Specification {
 
         then:
         1 * agentClientMetadata.getVersion() >> Optional.of(version)
-        1 * agentClientMetadata.getHostname() >> Optional.of(hostname)
         1 * agentFilterService.inspectAgentMetadata(agentClientMetadata) >> inspectionReport
         2 * inspectionReport.getDecision() >> InspectionReport.Decision.REJECT
         1 * inspectionReport.getMessage() >> message
@@ -141,7 +137,6 @@ class AgentJobServiceImplSpec extends Specification {
         def exception = new RuntimeException("...")
         Set<Tag> expectedTags = Sets.newHashSet(
             Tag.of(AgentJobServiceImpl.AGENT_VERSION_METRIC_TAG_NAME, version),
-            Tag.of(AgentJobServiceImpl.AGENT_HOST_METRIC_TAG_NAME, hostname),
             MetricsUtils.FAILURE_STATUS_TAG,
             Tag.of(MetricsConstants.TagKeys.EXCEPTION_CLASS, exception.getClass().getCanonicalName())
         )
@@ -152,7 +147,6 @@ class AgentJobServiceImplSpec extends Specification {
         then:
         thrown(exception.class)
         1 * agentClientMetadata.getVersion() >> Optional.of(version)
-        1 * agentClientMetadata.getHostname() >> Optional.of(hostname)
         1 * agentFilterService.inspectAgentMetadata(agentClientMetadata) >> { throw exception }
         1 * meterRegistry.counter("genie.services.agentJob.handshake.counter", _ as Set<Tag>) >> {
             args ->
@@ -166,7 +160,6 @@ class AgentJobServiceImplSpec extends Specification {
         def agentClientMetadata = Mock(AgentClientMetadata)
         Set<Tag> expectedTags = Sets.newHashSet(
             Tag.of(AgentJobServiceImpl.AGENT_VERSION_METRIC_TAG_NAME, version),
-            Tag.of(AgentJobServiceImpl.AGENT_HOST_METRIC_TAG_NAME, hostname),
             MetricsUtils.SUCCESS_STATUS_TAG
         )
 
@@ -181,7 +174,6 @@ class AgentJobServiceImplSpec extends Specification {
                 return counter
         }
         1 * agentClientMetadata.getVersion() >> Optional.of(version)
-        1 * agentClientMetadata.getHostname() >> Optional.of(hostname)
         1 * counter.increment()
         propertiesMap != null
     }
@@ -192,7 +184,6 @@ class AgentJobServiceImplSpec extends Specification {
         def exception = new RuntimeException("...")
         Set<Tag> expectedTags = Sets.newHashSet(
             Tag.of(AgentJobServiceImpl.AGENT_VERSION_METRIC_TAG_NAME, version),
-            Tag.of(AgentJobServiceImpl.AGENT_HOST_METRIC_TAG_NAME, hostname)
         )
         MetricsUtils.addFailureTagsWithException(expectedTags, exception)
 
@@ -207,7 +198,6 @@ class AgentJobServiceImplSpec extends Specification {
                 return counter
         }
         1 * agentClientMetadata.getVersion() >> Optional.of(version)
-        1 * agentClientMetadata.getHostname() >> Optional.of(hostname)
         1 * counter.increment()
         thrown(RuntimeException)
     }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/services/impl/AgentJobServiceImplSpec.groovy
@@ -158,6 +158,17 @@ class AgentJobServiceImplSpec extends Specification {
         1 * counter.increment()
     }
 
+    def "Can get agent properties"() {
+        def agentClientMetadata = Mock(AgentClientMetadata)
+
+        when:
+        Map<String, String> propertiesMap = service.getAgentProperties(agentClientMetadata)
+
+        then:
+        propertiesMap != null
+        propertiesMap.isEmpty()
+    }
+
     def "Can reserve job id"() {
         def jobRequest = Mock(JobRequest)
         def agentClientMetadata = Mock(AgentClientMetadata)

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentConfigurationPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentConfigurationPropertiesSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties
+
+import spock.lang.Specification
+
+import java.time.Duration
+
+class AgentConfigurationPropertiesSpec extends Specification {
+
+    def "Defaults, getters, setters"() {
+        AgentConfigurationProperties props = new AgentConfigurationProperties()
+
+        expect:
+        props.getAgentPropertiesFilterPattern() == "^genie\\.agent\\.runtime\\..*"
+        props.getCacheExpirationInterval() == Duration.ofMinutes(1)
+        props.getCacheRefreshInterval() == Duration.ofMinutes(5)
+
+        when:
+        props.setAgentPropertiesFilterPattern("^agent\\..*")
+        props.setCacheExpirationInterval(Duration.ofMinutes(10))
+        props.setCacheRefreshInterval(Duration.ofMinutes(20))
+
+        then:
+        props.getAgentPropertiesFilterPattern() == "^agent\\..*"
+        props.getCacheExpirationInterval() == Duration.ofMinutes(10)
+        props.getCacheRefreshInterval() == Duration.ofMinutes(20)
+
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.spring.autoconfigure.agent.services;
 
 import com.netflix.genie.common.internal.util.GenieHostInfo;
 import com.netflix.genie.web.agent.inspectors.AgentMetadataInspector;
+import com.netflix.genie.web.agent.services.AgentConfigurationService;
 import com.netflix.genie.web.agent.services.AgentConnectionTrackingService;
 import com.netflix.genie.web.agent.services.AgentFilterService;
 import com.netflix.genie.web.agent.services.AgentJobService;
@@ -26,6 +27,7 @@ import com.netflix.genie.web.agent.services.AgentRoutingService;
 import com.netflix.genie.web.agent.services.impl.AgentRoutingServiceCuratorDiscoveryImpl;
 import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.PersistenceService;
+import com.netflix.genie.web.properties.AgentConfigurationProperties;
 import com.netflix.genie.web.services.JobResolverService;
 import com.netflix.genie.web.spring.autoconfigure.agent.apis.rpc.v4.endpoints.AgentRpcEndpointsAutoConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -71,6 +73,8 @@ class AgentServicesAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(AgentJobService.class);
                     Assertions.assertThat(context).hasSingleBean(AgentConnectionTrackingService.class);
                     Assertions.assertThat(context).hasSingleBean(AgentFilterService.class);
+                    Assertions.assertThat(context).hasSingleBean(AgentConfigurationProperties.class);
+                    Assertions.assertThat(context).hasSingleBean(AgentConfigurationService.class);
                 }
             );
     }
@@ -89,6 +93,8 @@ class AgentServicesAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(AgentConnectionTrackingService.class);
                     Assertions.assertThat(context).hasSingleBean(AgentRoutingService.class);
                     Assertions.assertThat(context).hasSingleBean(AgentFilterService.class);
+                    Assertions.assertThat(context).hasSingleBean(AgentConfigurationProperties.class);
+                    Assertions.assertThat(context).hasSingleBean(AgentConfigurationService.class);
                 }
             );
     }


### PR DESCRIPTION
Allow the server to override some agent runtime configuration.
For example, slow down the rate of heartbeat if the server is under excessive load.
But could also be used to remotely turn off agent features or perform A/B experiments.

 * Remove hardcoded configuration in Agent with Properties classes
 * Create protocol to retrieve properties overrides from the server
 * Introduce new execution stage that binds server-provided values into loaded ones