### PR TITLE
Update genie-app docker image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -443,6 +443,25 @@ gitPublishPush {
  * Docker Tasks
  **********************************/
 
+ext.isDockerRunning = {
+    def dummyOutputStream = new OutputStream() {
+        @Override
+        void write(int b) {}
+    }
+    // See: https://docs.docker.com/config/daemon/#check-whether-docker-is-running
+    def dockerRunning = exec {
+        executable "docker"
+        args "info"
+        ignoreExitValue true
+        standardOutput dummyOutputStream
+        errorOutput dummyOutputStream
+    }
+    if (dockerRunning.exitValue != 0) {
+        println("Docker not running.")
+    }
+    return dockerRunning.exitValue == 0
+}
+
 ext.getDockerTags = { String appName, String projectVersion ->
     def tags = ["netflixoss/${appName}:${projectVersion}"]
     if (!projectVersion.contains("SNAPSHOT") && !projectVersion.contains("-rc.")) {
@@ -457,15 +476,24 @@ ext.getDockerTags = { String appName, String projectVersion ->
 }
 
 task dockerLogout(type: Exec, group: "Docker", description: "Logout of docker hub") {
+    onlyIf {
+        rootProject.ext.isDockerRunning()
+    }
     commandLine "docker", "logout"
 }
 
 task dockerLogin(type: Exec, group: "Docker", description: "Login to docker hub using DOCKER_USER and DOCKER_PASSWORD environment variables") {
+    onlyIf {
+        rootProject.ext.isDockerRunning()
+    }
     dependsOn tasks.dockerLogout
     commandLine "docker", "login", "-u", System.getenv("DOCKER_USER"), "-p", System.getenv("DOCKER_PASSWORD")
 }
 
 task dockerBuildAllImages(group: "Docker", description: "Container task for all docker image builds") {
+    onlyIf {
+        rootProject.ext.isDockerRunning()
+    }
     dependsOn ":genie-app:dockerBuildAppImage"
     dependsOn ":genie-demo:dockerBuildApacheImage"
     dependsOn ":genie-demo:dockerBuildClientImage"

--- a/genie-app/build.gradle
+++ b/genie-app/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: "org.springframework.boot"
 
+configurations {
+    genieAgent
+}
+
 dependencies {
     /*******************************
      * Implementation Dependencies
@@ -24,6 +28,12 @@ dependencies {
 
     testImplementation(project(":genie-test"))
     testImplementation(project(":genie-test-web"))
+
+    /*******************************
+     * Agent Dependencies
+     *******************************/
+
+    genieAgent(project(path: ":genie-agent-app", configuration: "agentBootJar"))
 }
 
 bootJar {
@@ -41,27 +51,33 @@ springBoot {
 def dockerDir = new File(project.buildDir, "/docker")
 
 task dockerCreateInputDir(type: Copy, group: "Docker", description: "Stage all the necessary files docker image") {
-    dependsOn tasks.jar, tasks.bootJar
+    dependsOn tasks.jar, tasks.bootJar, project.findProject(":genie-agent-app").tasks.bootJar
     from tasks.jar
     from new File(project.projectDir, "src/main/docker/Dockerfile")
+    from "${configurations.genieAgent.asPath}"
     into dockerDir
 }
 
 task dockerBuildAppImage(type: Exec, group: "Docker", description: "Build docker image for the Genie App") {
+    onlyIf {
+        rootProject.ext.isDockerRunning()
+    }
+    inputs.dir(dockerDir)
     dependsOn tasks.dockerCreateInputDir
     workingDir dockerDir
 
-    def appName = tasks.jar.getArchiveBaseName().get()
+    def serverName = tasks.jar.getArchiveBaseName().get()
+    def agentName = project.findProject(":genie-agent-app").tasks.jar.getArchiveBaseName().get()
 
     def commandArgs = new ArrayList<>()
     commandArgs.add("docker")
     commandArgs.add("build")
     commandArgs.add("--force-rm")
     commandArgs.add("--build-arg")
-    commandArgs.add("JAR_NAME=${appName}")
+    commandArgs.add("SERVER_JAR=${serverName}-${project.version}.jar")
     commandArgs.add("--build-arg")
-    commandArgs.add("VERSION=${project.version}")
-    for (String tag : rootProject.ext.getDockerTags(appName, project.version.toString())) {
+    commandArgs.add("AGENT_JAR=${agentName}-${project.version}.jar")
+    for (String tag : rootProject.ext.getDockerTags(serverName, project.version.toString())) {
         commandArgs.add("-t")
         commandArgs.add(tag)
     }
@@ -73,7 +89,7 @@ task dockerBuildAppImage(type: Exec, group: "Docker", description: "Build docker
 task dockerPush(group: "Docker", description: "Push the built docker app image to Docker Hub") {
     dependsOn parent.tasks.dockerLogin, tasks.dockerBuildAppImage
     onlyIf {
-        System.env."CI"
+        System.env."CI" && rootProject.ext.isDockerRunning()
     }
     doLast {
         def appName = tasks.jar.archiveBaseName.get()

--- a/genie-app/src/main/docker/Dockerfile
+++ b/genie-app/src/main/docker/Dockerfile
@@ -2,9 +2,19 @@ from openjdk:8-jre
 MAINTAINER NetflixOSS <netflixoss@netflix.com>
 EXPOSE 8080
 VOLUME /tmp
-RUN apt-get update && apt-get install -y --no-install-recommends procps
-ARG JAR_NAME
-ARG VERSION
-ADD ${JAR_NAME}-${VERSION}.jar /usr/local/bin/genie.jar
-RUN sh -c "touch /usr/local/bin/genie.jar"
-ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/usr/local/bin/genie.jar"]
+ARG SERVER_JAR
+ARG AGENT_JAR
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends procps && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+COPY ${SERVER_JAR} /usr/local/bin/genie-server.jar
+COPY ${AGENT_JAR} /usr/local/bin/genie-agent.jar
+ENTRYPOINT ["java", \
+            "-Djava.security.egd=file:/dev/./urandom", \
+            "-Dgenie.agent.launcher.local.agent-jar-path=/usr/local/bin/genie-agent.jar", \
+            "-Dgenie.jobs.agent-execution.agent-probability=1.0", \
+            "-Dgenie.services.job-resolver.v4-probability=1.0", \
+            "-jar", \
+            "/usr/local/bin/genie-server.jar" \
+            ]

--- a/genie-client/src/integTest/java/com/netflix/genie/client/GenieClientIntegrationTestBase.java
+++ b/genie-client/src/integTest/java/com/netflix/genie/client/GenieClientIntegrationTestBase.java
@@ -53,11 +53,19 @@ import java.util.UUID;
 )
 abstract class GenieClientIntegrationTestBase {
 
-    // TODO: Move this to latest.candidate or latest.snapshot once new tagging is established OR
-    //       figure out a good way to build the container for the current commit locally and use that if we desire
-    //       testing same version to same version rather than for compatibility
+    // TODO: Move this to latest.candidate after it's released
+    // Note: Attempt made to make this use the version currently under build however the gradle compiler avoidance
+    //       doesn't work right and generates new images every test / build run. This leaves a lot of orphaned
+    //       layers on the developers machine which takes up a lot of space. Not currently worth the gain.
+    //       Also passing in environment variable from gradle file wasn't being picked up properly in IDE tests for some
+    //       reason. For now just leave it hardcoded as the `latest` tags float anyway. This does become problem
+    //       for making builds repeatable on tags long term though so it might be better to just periodically update
+    //       a static tagged image if we can't get local docker images to reproduce without disk usage overhead.
+    // TODO: Improve genie-app image packaging to leverage unpacked (application plugin) based agent so that startup
+    //       is faster as in agent mode the tests are much slower than embedded. Also once we move to boot 2.3 we can
+    //       leverage their layered jars to produce less changing images.
     @Container
-    private static final GenericContainer GENIE = new GenericContainer("netflixoss/genie-app:4.0.0-rc.56")
+    private static final GenericContainer GENIE = new GenericContainer("netflixoss/genie-app:latest.snapshot")
         .waitingFor(Wait.forHttp("/admin/health").forStatusCode(200).withStartupTimeout(Duration.ofMinutes(1L)))
         .withExposedPorts(8080);
 

--- a/genie-demo/build.gradle
+++ b/genie-demo/build.gradle
@@ -17,6 +17,9 @@ def apacheImageName = "genie-demo-apache"
 def clientImageName = "genie-demo-client"
 
 task dockerBuildApacheImage(type: Exec, group: "Docker", description: "Build docker image for demo apache") {
+    onlyIf {
+        rootProject.ext.isDockerRunning()
+    }
     workingDir new File(project.projectDir, "/src/main/docker/apache")
 
     def commandArgs = new ArrayList<>()
@@ -33,6 +36,9 @@ task dockerBuildApacheImage(type: Exec, group: "Docker", description: "Build doc
 }
 
 task dockerBuildClientImage(type: Exec, group: "Docker", description: "Build docker image for demo client") {
+    onlyIf {
+        rootProject.ext.isDockerRunning()
+    }
     workingDir new File(project.projectDir, "/src/main/docker/client")
 
     def commandArgs = new ArrayList<>()
@@ -51,7 +57,7 @@ task dockerBuildClientImage(type: Exec, group: "Docker", description: "Build doc
 task dockerPush(group: "Docker", description: "Push the demo docker images to docker hub") {
     dependsOn parent.tasks.dockerLogin, tasks.dockerBuildApacheImage, tasks.dockerBuildClientImage
     onlyIf {
-        System.env."CI"
+        System.env."CI" && rootProject.ext.isDockerRunning()
     }
     doLast {
         for (String tag : rootProject.ext.getDockerTags(apacheImageName, project.version.toString())) {

--- a/genie-ui/build.gradle
+++ b/genie-ui/build.gradle
@@ -44,14 +44,14 @@ node {
 }
 
 task bundle(type: NpmTask) {
-    inputs.files(fileTree("node_modules"))
-    inputs.files(fileTree("src/main/web"))
+    inputs.dir("${projectDir}/node_modules")
+    inputs.dir("${projectDir}/src/main/web")
     inputs.file("npm-shrinkwrap.json")
     inputs.file("package.json")
     inputs.file("server.js")
     inputs.file("webpack.config.js")
 
-    outputs.dir file("${project.buildDir}/web/bundle")
+    outputs.dir("${project.buildDir}/web/bundle")
 
     dependsOn npmInstall
     args = ["run", "build"]


### PR DESCRIPTION
- Include `genie-agent` in `genie-app` image for new execution mode support
- Add some protection to tasks in case docker isn't actually running on a machine they're skipped
- Add todo notes
- Make client integration tests use `latest.snapshot` so that once v3 resolution algorithm is removed it still works
- Make genie-app use both major V4 features (agent, resource resolution) via property flags until they become defaults. Make sure client is exercising latest server features.
- Improve layering of genie-app image