### PR TITLE
Implement fast and efficient range requests when serving agent files

### DIFF
--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/aws/s3/SimpleStorageRangeResource.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/aws/s3/SimpleStorageRangeResource.java
@@ -1,0 +1,191 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.cloud.aws.core.io.s3.AmazonS3ProxyFactory;
+import org.springframework.cloud.aws.core.io.s3.SimpleStorageResource;
+import org.springframework.core.task.TaskExecutor;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This class extends {@link SimpleStorageResource} in order to efficiently handle range requests.
+ * Rather than fetching the entire object and let the web tier skip, it only downloads the relevant object region and
+ * returns a composite input stream that skips the unrequested bytes.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public final class SimpleStorageRangeResource extends SimpleStorageResource {
+
+    private final AmazonS3 client;
+    private final String bucket;
+    private final String key;
+    private final String versionId;
+    private final Pair<Integer, Integer> range;
+    private final long contentLength;
+
+    SimpleStorageRangeResource(
+        final AmazonS3 client,
+        final String bucket,
+        final String key,
+        final String versionId, final TaskExecutor s3TaskExecutor,
+        final Pair<Integer, Integer> range
+    ) {
+        super(client, bucket, key, s3TaskExecutor, versionId);
+        this.client =  AmazonS3ProxyFactory.createProxy(client);
+        this.bucket = bucket;
+        this.key = key;
+        this.versionId = versionId;
+        this.range = range;
+        try {
+            this.contentLength = super.contentLength();
+        } catch (IOException e) {
+            throw new AmazonS3Exception("Failed to retrieve object range", e);
+        }
+
+        final Integer lower = this.range.getLeft();
+        final Integer upper = this.range.getRight();
+
+        if ((lower != null && upper != null && lower > upper)
+            || (lower != null && lower > contentLength)) {
+            throw new IllegalArgumentException(
+                "Invalid range " + lower + "-" + upper + " for S3 object of size " + contentLength
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InputStream getInputStream() throws IOException {
+
+        // Index of first and last byte to fetch (inclusive)
+        final long rangeStart;
+        final long rangeEnd;
+
+        if (this.range.getLeft() == null && this.range.getRight() == null) {
+            // Full object
+            rangeStart = 0;
+            rangeEnd = Math.max(0, this.contentLength - 1);
+        } else if (this.range.getLeft() == null && this.range.getRight() != null) {
+            // Object suffix
+            rangeStart = Math.max(0, this.contentLength - this.range.getRight());
+            rangeEnd = Math.max(0, this.contentLength - 1);
+        } else if (this.range.getLeft() != null && this.range.getRight() == null) {
+            // From offset to end
+            rangeStart = this.range.getLeft();
+            rangeEnd = Math.max(0, this.contentLength - 1);
+        } else {
+            // Range start and end are provided
+            rangeStart = this.range.getLeft();
+            rangeEnd = Math.min(this.range.getRight(), this.contentLength - 1);
+        }
+
+        log.debug(
+            "Resource {}/{} requested range: {}-{}, actual range: {}-{}",
+            this.bucket,
+            this.key,
+            this.range.getLeft(),
+            this.range.getRight(),
+            rangeStart,
+            rangeEnd
+        );
+
+        final long skipBytes = Math.max(0, rangeStart);
+
+        final InputStream inputStream;
+        if (rangeEnd - rangeStart < 0 || (rangeEnd == 0 && rangeStart == 0)) {
+            inputStream = new EmptyInputStream();
+        } else {
+            final GetObjectRequest getObjectRequest = new GetObjectRequest(this.bucket, this.key)
+                .withRange(rangeStart, rangeEnd)
+                .withVersionId(this.versionId);
+            inputStream = this.client.getObject(getObjectRequest).getObjectContent();
+        }
+
+        return new SkipInputStream(skipBytes, inputStream);
+    }
+
+    /**
+     * An input stream that skips some amount of bytes because they are ignored by the web tier when sending back
+     * the response content.
+     */
+    private static class SkipInputStream extends InputStream {
+        private final InputStream objectRangeInputStream;
+        private long skipBytesLeft;
+
+        SkipInputStream(final long bytesToSkip, final InputStream objectRangeInputStream) {
+            this.objectRangeInputStream = objectRangeInputStream;
+            this.skipBytesLeft = bytesToSkip;
+        }
+
+        @Override
+        public int read() throws IOException {
+            // Overriding other read(...) methods and hoping nobody is using this one directly.
+            throw new NotImplementedException("Not implemented");
+        }
+
+        @Override
+        public int read(final byte[] b, final int off, final int len) throws IOException {
+            if (off < 0 || len < 0 || len > b.length - off) {
+                throw new IndexOutOfBoundsException("Invalid read( b[" + b.length + "], " + off + ", " + len + ")");
+            }
+
+            // Efficiently skip over range of bytes that should be ignored
+            if (this.skipBytesLeft > 0) {
+                final long skippedBytesRead = Math.min(this.skipBytesLeft, len);
+                this.skipBytesLeft -= skippedBytesRead;
+                return Math.toIntExact(skippedBytesRead);
+            }
+
+            return this.objectRangeInputStream.read(b, off, len);
+        }
+
+        @Override
+        public long skip(final long n) throws IOException {
+            long skipped = 0;
+            if (this.skipBytesLeft > 0) {
+                skipped = Math.min(n, this.skipBytesLeft);
+                this.skipBytesLeft -= skipped;
+            }
+
+            if (skipped < n) {
+                skipped += this.objectRangeInputStream.skip(n - skipped);
+            }
+
+            return skipped;
+        }
+    }
+
+    private static class EmptyInputStream extends InputStream {
+        @Override
+        public int read() throws IOException {
+            return -1;
+        }
+    }
+}

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/aws/s3/SimpleStorageRangeResourceSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/aws/s3/SimpleStorageRangeResourceSpec.groovy
@@ -1,0 +1,228 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.aws.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.AmazonS3Exception
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest
+import com.amazonaws.services.s3.model.GetObjectRequest
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.S3Object
+import com.amazonaws.services.s3.model.S3ObjectInputStream
+import org.apache.commons.lang3.tuple.ImmutablePair
+import org.apache.commons.lang3.tuple.Pair
+import org.springframework.core.io.Resource
+import org.springframework.core.task.TaskExecutor
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class SimpleStorageRangeResourceSpec extends Specification {
+
+    String bucket = "some-bucket"
+    String key = "some/object"
+    String version = null
+    AmazonS3 client
+    TaskExecutor taskExecutor
+    ObjectMetadata objectMetadata
+    S3Object object
+    S3ObjectInputStream objectInputStream
+    byte[] data = new byte[1024]
+    Pair<Integer, Integer> nullRange = ImmutablePair.of(null, null)
+
+    void setup() {
+        this.client = Mock(AmazonS3)
+        this.taskExecutor = Mock(TaskExecutor)
+        this.objectMetadata = Mock(ObjectMetadata)
+        this.object = Mock(S3Object)
+        this.objectInputStream = Mock(S3ObjectInputStream)
+
+        new Random().nextBytes(data)
+    }
+
+    @Unroll
+    def "Read entire object (range: #range)"() {
+        setup:
+        byte[] buffer = new byte[512]
+        GetObjectRequest getObjectRequestCapture
+
+        when:
+        SimpleStorageRangeResource resource = new SimpleStorageRangeResource(client, bucket, key, version, taskExecutor, range as Pair<Integer, Integer>)
+        InputStream inputStream = resource.getInputStream()
+
+        then:
+        1 * client.getObjectMetadata(_ as GetObjectMetadataRequest) >> objectMetadata
+        1 * objectMetadata.getContentLength() >> 100
+        1 * client.getObject(_ as GetObjectRequest) >> {
+            args ->
+                getObjectRequestCapture = args[0] as GetObjectRequest
+                return object
+        }
+        1 * object.getObjectContent() >> objectInputStream
+        getObjectRequestCapture != null
+        getObjectRequestCapture.range == [0, 99] as long[]
+        resource != null
+        inputStream != null
+
+        when:
+        inputStream.read(buffer, 0, buffer.size())
+
+        then:
+        1 * this.objectInputStream.read(buffer, 0, buffer.size()) >> 100
+
+        where:
+        range                        | _
+        ImmutablePair.of(null, null) | _
+        ImmutablePair.of(0, 99)      | _
+        ImmutablePair.of(null, 999)  | _
+    }
+
+    @Unroll
+    def "Read object with range #rangeHeader (using skip()? #useSkip)"() {
+        setup:
+        byte[] buffer = new byte[512]
+        GetObjectRequest getObjectRequestCapture
+        long bytesRead
+        int contentLength = 100
+        assert skippedBytes + readBytes == contentLength
+        ImmutablePair<Integer, Integer> range = ImmutablePair.of(rangeStart, rangeEnd)
+
+        when:
+        SimpleStorageRangeResource resource = new SimpleStorageRangeResource(client, bucket, key, version, taskExecutor, range as Pair<Integer, Integer>)
+        InputStream inputStream = resource.getInputStream()
+
+        then:
+        1 * client.getObjectMetadata(_ as GetObjectMetadataRequest) >> objectMetadata
+        1 * objectMetadata.getContentLength() >> contentLength
+        1 * client.getObject(_ as GetObjectRequest) >> {
+            args ->
+                getObjectRequestCapture = args[0] as GetObjectRequest
+                return object
+        }
+        1 * object.getObjectContent() >> objectInputStream
+        getObjectRequestCapture != null
+        getObjectRequestCapture.range == [requestedRangeStart, requestedRangeEnd] as long[]
+        resource != null
+        inputStream != null
+
+        when:
+        if (useSkip) {
+            bytesRead = inputStream.read(buffer, 0, buffer.size())
+        } else {
+            bytesRead = inputStream.skip(requestedRangeStart)
+        }
+
+        then:
+        bytesRead == skippedBytes
+        0 * this.objectInputStream.read(_, _, _)
+
+        when:
+        bytesRead = inputStream.read(buffer, 0, buffer.size())
+
+        then:
+        bytesRead == readBytes
+        1 * this.objectInputStream.read(buffer, 0, buffer.size()) >> (requestedRangeEnd - requestedRangeStart) + 1
+
+        where:
+        rangeHeader    | rangeStart | rangeEnd | requestedRangeStart | requestedRangeEnd | skippedBytes | readBytes | useSkip
+        "bytes=1-99"   | 1          | 99       | 1                   | 99                | 1            | 99        | true
+        "bytes=-10"    | null       | 10       | 90                  | 99                | 90           | 10        | true
+        "bytes=50-"    | 50         | null     | 50                  | 99                | 50           | 50        | true
+        "bytes=99-"    | 99         | null     | 99                  | 99                | 99           | 1         | true
+        "bytes=50-999" | 50         | 999      | 50                  | 99                | 50           | 50        | true
+        "bytes=1-99"   | 1          | 99       | 1                   | 99                | 1            | 99        | false
+        "bytes=-10"    | null       | 10       | 90                  | 99                | 90           | 10        | false
+        "bytes=50-"    | 50         | null     | 50                  | 99                | 50           | 50        | false
+        "bytes=99-"    | 99         | null     | 99                  | 99                | 99           | 1         | false
+        "bytes=50-999" | 50         | 999      | 50                  | 99                | 50           | 50        | false
+    }
+
+    @Unroll
+    def "Invalid range #range"() {
+        def contentLength = 100
+
+        when:
+        new SimpleStorageRangeResource(client, bucket, key, version, taskExecutor, range as Pair<Integer, Integer>)
+
+        then:
+        1 * client.getObjectMetadata(_ as GetObjectMetadataRequest) >> objectMetadata
+        1 * objectMetadata.getContentLength() >> contentLength
+        thrown(IllegalArgumentException)
+
+        where:
+        range                       | _
+        ImmutablePair.of(30, 20)    | _
+        ImmutablePair.of(200, null) | _
+    }
+
+    @Unroll
+    def "Empty range #range"() {
+        byte[] buffer = new byte[512]
+        Resource resource
+        long bytesRead
+
+        when:
+        resource = new SimpleStorageRangeResource(client, bucket, key, version, taskExecutor, range as Pair<Integer, Integer>)
+
+        then:
+        1 * client.getObjectMetadata(_ as GetObjectMetadataRequest) >> objectMetadata
+        1 * objectMetadata.getContentLength() >> contentLength
+        0 * client.getObject(_)
+        resource != null
+
+        when:
+        InputStream inputStream = resource.getInputStream()
+        bytesRead = inputStream.skip(skip)
+
+        then:
+        bytesRead == skip
+
+        when:
+        bytesRead = inputStream.read(buffer, 0, buffer.size())
+
+        then:
+        bytesRead == -1
+
+        where:
+        range                       | contentLength | skip
+        ImmutablePair.of(100, null) | 100           | 100
+        ImmutablePair.of(null, null)| 0             | 0
+    }
+
+    def "Handle metadata error"() {
+        when:
+        new SimpleStorageRangeResource(client, bucket, key, version, taskExecutor, nullRange)
+
+        then:
+        1 * client.getObjectMetadata(_ as GetObjectMetadataRequest) >> objectMetadata
+        1 * objectMetadata.getContentLength() >> {
+            throw new IOException("...")
+        }
+        thrown(AmazonS3Exception)
+    }
+
+    def "Handle content length error"() {
+        when:
+        new SimpleStorageRangeResource(client, bucket, key, version, taskExecutor, nullRange)
+
+        then:
+        1 * client.getObjectMetadata(_ as GetObjectMetadataRequest) >> {
+            throw new AmazonS3Exception("...")
+        }
+        thrown(AmazonS3Exception)
+    }
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentFileStreamService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentFileStreamService.java
@@ -19,7 +19,9 @@ package com.netflix.genie.web.agent.services;
 
 import com.netflix.genie.common.internal.dtos.DirectoryManifest;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpRange;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import java.net.URI;
 import java.nio.file.Path;
@@ -44,9 +46,15 @@ public interface AgentFileStreamService {
      * @param jobId        the job id
      * @param relativePath the relative path in the job directory
      * @param uri          the file uri //TODO redundant
+     * @param range        the list of ranges requested (RFC 7233) or null if no range is specified
      * @return an optional {@link Resource}
      */
-    Optional<AgentFileResource> getResource(@NotBlank String jobId, Path relativePath, URI uri);
+    Optional<AgentFileResource> getResource(
+        @NotBlank String jobId,
+        Path relativePath,
+        URI uri,
+        @Nullable HttpRange range
+    );
 
     /**
      * Returns the manifest for a given job, boxed in an {@link Optional}.

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
@@ -195,8 +195,9 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
             manifest = this.agentFileStreamService.getManifest(jobId).orElseThrow(
                 () -> new GenieServerUnavailableException("Manifest not found for job " + jobId)
             );
+            final String rangeHeader = request.getHeader(HttpHeaders.RANGE);
             try {
-                jobDirRoot = AgentFileProtocolResolver.createUri(jobId, SLASH);
+                jobDirRoot = AgentFileProtocolResolver.createUri(jobId, SLASH, rangeHeader);
             } catch (final URISyntaxException e) {
                 throw new GenieServerException("Failed to construct job directory path", e);
             }
@@ -314,8 +315,10 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
             }
         } else {
             final URI location = jobDirectoryRoot.resolve(entry.getPath());
-            log.debug("Get resource: {}", location);
-            final Resource jobResource = this.resourceLoader.getResource(location.toString());
+            final String locationString = location.toString()
+                + (jobDirectoryRoot.getFragment() != null ? ("#" + jobDirectoryRoot.getFragment()) : "");
+            log.debug("Get resource: {}", locationString);
+            final Resource jobResource = this.resourceLoader.getResource(locationString);
             // Every file really should have a media type but if not use text/plain
             final String mediaType = entry.getMimeType().orElse(MediaType.TEXT_PLAIN_VALUE);
             final ResourceHttpRequestHandler handler = this.genieResourceHandlerFactory.get(mediaType, jobResource);

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobDirectoryServerServiceImpl.java
@@ -44,6 +44,7 @@ import com.netflix.genie.web.services.JobDirectoryServerService;
 import com.netflix.genie.web.services.JobFileService;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.client.utils.URIBuilder;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.HttpHeaders;
@@ -224,8 +225,10 @@ public class JobDirectoryServerServiceImpl implements JobDirectoryServerService 
             log.debug("Routing request to archive");
             try {
                 final ArchivedJobMetadata archivedJobMetadata = this.archivedJobService.getArchivedJobMetadata(jobId);
+                final String rangeHeader = request.getHeader(HttpHeaders.RANGE);
                 manifest = archivedJobMetadata.getManifest();
-                jobDirRoot = archivedJobMetadata.getArchiveBaseUri();
+                final URI baseJobDirRoot = archivedJobMetadata.getArchiveBaseUri();
+                jobDirRoot = new URIBuilder(baseJobDirRoot).setFragment(rangeHeader).build();
             } catch (final JobNotArchivedException e) {
                 throw new GeniePreconditionException("Job outputs were not archived", e);
             } catch (final JobNotFoundException | JobDirectoryManifestNotFoundException e) {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/resources/AgentFileResourceSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/resources/AgentFileResourceSpec.groovy
@@ -18,6 +18,8 @@
 package com.netflix.genie.web.agent.resources
 
 import com.netflix.genie.web.agent.services.AgentFileStreamService
+import org.apache.commons.lang3.tuple.ImmutablePair
+import org.apache.commons.lang3.tuple.Pair
 import spock.lang.Specification
 
 import java.nio.file.Path
@@ -31,7 +33,7 @@ class AgentFileResourceSpec extends Specification {
     Path path = Paths.get("foo/bar.txt")
 
     InputStream inputStream = Mock(InputStream)
-    URI uri = AgentFileProtocolResolver.createUri(jobId, "/" + path)
+    URI uri = AgentFileProtocolResolver.createUri(jobId, "/" + path, null)
     long lastModTime = 1553793121 * 1000
 
     def "Construct for resource"() {


### PR DESCRIPTION
Improve the implementation of range requests when the file is served by a live agent by only streaming the requested bytes, as opposed to sending the entire file then letting the server seek and discard.