### PR TITLE
Bug: S3 file not found produces error 500

### DIFF
--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/aws/s3/S3ProtocolResolver.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/aws/s3/S3ProtocolResolver.java
@@ -29,6 +29,7 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.task.TaskExecutor;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.net.URI;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -113,14 +114,19 @@ public class S3ProtocolResolver implements ProtocolResolver {
 
         // TODO: This implementation from Spring Cloud AWS always wraps the passed in client with a proxy that follows
         //       redirects. I'm not sure if we want that or not. Probably ok for now but maybe revisit later?
-        return new SimpleStorageRangeResource(
-            client,
-            s3URI.getBucket(),
-            normalizedKey,
-            s3URI.getVersionId(),
-            this.s3TaskExecutor,
-            range
-        );
+        try {
+            return new SimpleStorageRangeResource(
+                client,
+                s3URI.getBucket(),
+                normalizedKey,
+                s3URI.getVersionId(),
+                this.s3TaskExecutor,
+                range
+            );
+        } catch (IOException e) {
+            log.error("Failed to create S3 resource: " + location + ": " + e.getMessage());
+            return null;
+        }
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/ArchivedJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/ArchivedJobServiceImpl.java
@@ -149,7 +149,7 @@ public class ArchivedJobServiceImpl implements ArchivedJobService {
             }
 
             final Resource manifestResource = this.resourceLoader.getResource(manifestLocation.toString());
-            if (!manifestResource.exists()) {
+            if (manifestResource == null || !manifestResource.exists()) {
                 throw new JobDirectoryManifestNotFoundException(
                     "No job directory manifest exists at " + manifestLocation
                 );


### PR DESCRIPTION
The recently introduced support for ranges of S3 resources introduced a regression that would make the REST API return error 500 for a non-existent S3 resource.
The correct response code is 404.
This commit addresses this by returning a valid S3 resource that returns false if exist() is called.