### PR TITLE
Fix issue where too long status messages caused entire job status update to fail

### DIFF
--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessages.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessages.java
@@ -188,6 +188,12 @@ public final class JobStatusMessages {
     public static final String FAILED_AGENT_CONFIGURATION = "Failed to configure execution";
 
     /**
+     * Could not resolve the job.
+     */
+    public static final String FAILED_TO_RESOLVE_JOB
+        = "Failed to resolve job given original request and available resources";
+
+    /**
      * Private constructor, this class is not meant to be instantiated.
      */
     private JobStatusMessages() {

--- a/genie-web/src/main/java/com/netflix/genie/web/aspects/DataServiceRetryAspect.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/aspects/DataServiceRetryAspect.java
@@ -113,7 +113,7 @@ public class DataServiceRetryAspect implements Ordered {
         ) {
             throw e;
         } catch (Throwable e) {
-            throw new GenieRuntimeException("Failed to execute data service method", e);
+            throw new GenieRuntimeException("Failed to execute data service method due to " + e.getMessage(), e);
         }
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.services.impl;
 
 import com.google.common.collect.Sets;
+import com.netflix.genie.common.dto.JobStatusMessages;
 import com.netflix.genie.common.external.dtos.v4.JobStatus;
 import com.netflix.genie.common.internal.exceptions.checked.GenieJobResolutionException;
 import com.netflix.genie.web.agent.launchers.AgentLauncher;
@@ -113,7 +114,7 @@ public class JobLaunchServiceImpl implements JobLaunchService {
                     jobId,
                     JobStatus.RESERVED,
                     JobStatus.FAILED,
-                    t.getMessage()
+                    JobStatusMessages.FAILED_TO_RESOLVE_JOB // TODO: Move somewhere not in genie-common
                 );
                 throw t; // Caught below for metrics gathering
             }

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
@@ -184,7 +184,7 @@ public class JobCoordinatorServiceImplTest {
                 .verify(this.registry, Mockito.times(1))
                 .timer(
                     JobCoordinatorServiceImpl.OVERALL_COORDINATION_TIMER_NAME,
-                    MetricsUtils.newFailureTagsSetForException(new GeniePreconditionException("test"))
+                    MetricsUtils.newFailureTagsSetForException(new GenieJobResolutionException())
                 );
         }
     }


### PR DESCRIPTION
As status messages aren't super critical better to truncate the message than allow job to be stuck in an inaccurate state.