### PR TITLE
File transfers from agent return random bytes

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
@@ -410,7 +410,7 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
         private void sendChunk() throws IOException {
 
             if (this.watermark < this.endOffset - 1) {
-                // Reset mark before reading!
+                // Reset mark before reading into the buffer
                 readBuffer.rewind();
 
                 final int bytesRead;
@@ -418,6 +418,9 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
                     channel.position(this.watermark);
                     bytesRead = channel.read(readBuffer);
                 }
+
+                // Reset mark again before copying data out
+                readBuffer.rewind();
 
                 final AgentFileMessage chunkMessage = AgentFileMessage.newBuilder()
                     .setStreamId(this.streamId)


### PR DESCRIPTION
[This recent change](https://github.com/Netflix/genie/commit/86a35d831b299bae5121673b7c2c200fe616a8f8#diff-940e18974ceae4a15af1275a9378170dR413) introduced a serious regression where sometimes the agent-streamed job files consist of random bytes.

Also improve gRPC random stream cancellation we sometime observe.