### PR TITLE
Changes to enable compilation with either Java 8 or Java 11 JDK

### DIFF
--- a/genie-agent/build.gradle
+++ b/genie-agent/build.gradle
@@ -84,6 +84,12 @@ jar {
     }
 }
 
+javadoc {
+    // Lombok problems with no fix in sight
+    // https://stackoverflow.com/questions/59062830/unable-to-generate-javadoc-on-lombok-setters-getters-with-onmethod-attribute
+    failOnError false
+}
+
 processResources {
     filesMatching("**/*.txt") {
         filter ReplaceTokens, tokens: [

--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
@@ -31,6 +31,7 @@ import com.netflix.genie.proto.FileStreamServiceGrpc;
 import com.netflix.genie.proto.ServerAckMessage;
 import com.netflix.genie.proto.ServerControlMessage;
 import com.netflix.genie.proto.ServerFileRequestMessage;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.Context;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.StreamObserver;
@@ -414,6 +415,10 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
             }
         }
 
+        @SuppressFBWarnings(
+            value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+            justification = "https://github.com/spotbugs/spotbugs/issues/756"
+        )
         private void sendChunk() throws IOException {
 
             if (this.watermark < this.endOffset - 1) {

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/stages/RefreshManifestStageSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/statemachine/stages/RefreshManifestStageSpec.groovy
@@ -24,7 +24,6 @@ import com.netflix.genie.agent.execution.statemachine.States
 import com.netflix.genie.agent.properties.AgentProperties
 import spock.lang.Specification
 import spock.lang.Unroll
-import sun.management.Agent
 
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.ScheduledFuture
@@ -53,7 +52,7 @@ class RefreshManifestStageSpec extends Specification {
 
         then:
         1 * executionContext.getJobDirectory() >> Mock(File)
-        1 * agentFileService.forceServerSync() >> Optional.<ScheduledFuture<?>>of(future)
+        1 * agentFileService.forceServerSync() >> Optional.<ScheduledFuture<?>> of(future)
         1 * executionContext.getAgentProperties() >> agentProperties
         1 * future.get(_, _)
 
@@ -87,7 +86,7 @@ class RefreshManifestStageSpec extends Specification {
 
         then:
         1 * executionContext.getJobDirectory() >> Mock(File)
-        1 * agentFileService.forceServerSync() >> Optional.<ScheduledFuture<?>>of(future)
+        1 * agentFileService.forceServerSync() >> Optional.<ScheduledFuture<?>> of(future)
         1 * executionContext.getAgentProperties() >> agentProperties
         1 * future.get(_, _) >> { throw exception }
 

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dtos/DirectoryManifest.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dtos/DirectoryManifest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -396,6 +397,10 @@ public class DirectoryManifest {
             }
         }
 
+        @SuppressFBWarnings(
+            value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+            justification = "https://github.com/spotbugs/spotbugs/issues/756"
+        )
         private ManifestEntry buildEntry(
             final Path entry,
             final BasicFileAttributes attributes,

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dtos/v4/converters/DtoConvertersSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dtos/v4/converters/DtoConvertersSpec.groovy
@@ -1425,4 +1425,54 @@ class DtoConvertersSpec extends Specification {
         " "                          | _
         UUID.randomUUID().toString() | _
     }
+
+    @Unroll
+    def "Can convert command cluster criterion #v3 to #v4"() {
+        expect:
+        DtoConverters.toV4CommandClusterCriterion(v3) == v4
+
+        where:
+        v3           | v4
+        new Criterion.Builder()
+            .withId("hi")
+            .withName("bye")
+            .withVersion("1.2.3")
+            .withStatus(ClusterStatus.OUT_OF_SERVICE.name())
+            .withTags(["one", "two", "three"] as Set)
+            .build() | new Criterion.Builder()
+            .withId("hi")
+            .withName("bye")
+            .withVersion("1.2.3")
+            .withStatus(ClusterStatus.OUT_OF_SERVICE.name())
+            .withTags(["one", "two", "three"] as Set)
+            .build()
+
+        new Criterion.Builder()
+            .withId(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .withVersion("1.2.3")
+            .withStatus(ClusterStatus.UP.name())
+            .withTags(
+                [
+                    "one",
+                    "two",
+                    "three",
+                    DtoConverters.GENIE_ID_PREFIX + "456",
+                    DtoConverters.GENIE_NAME_PREFIX + "prod"
+                ] as Set
+            )
+            .build() | new Criterion.Builder()
+            .withId("456")
+            .withName("prod")
+            .withVersion("1.2.3")
+            .withStatus(ClusterStatus.UP.name())
+            .withTags(
+                [
+                    "one",
+                    "two",
+                    "three"
+                ] as Set
+            )
+            .build()
+    }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/DiskJobFileServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/DiskJobFileServiceImpl.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.services.impl;
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.internal.dtos.v4.files.JobFileState;
 import com.netflix.genie.web.services.JobFileService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -115,6 +116,10 @@ public class DiskJobFileServiceImpl implements JobFileService {
      * {@inheritDoc}
      */
     @Override
+    @SuppressFBWarnings(
+        value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+        justification = "https://github.com/spotbugs/spotbugs/issues/756"
+    )
     // TODO: We should be careful about how large the byte[] is. Perhaps we should have precondition to protect memory
     //       or we should wrap calls to this in something that chunks it off an input stream or just take this in as
     //       input stream


### PR DESCRIPTION
Minor differences in the two JDKs caused issues with spotbugs and javadoc so there are a couple of fixes in here that makes it so that even though the project still targets Java 8 byte code you can at least use Java 11 as your default JDK if you so chose

Additional second commit addresses bug in conversion of criterion objects sent in as cluster criteria to the V3 command API