### PR TITLE
Fix Demo documentation script paths

### DIFF
--- a/genie-demo/src/docs/asciidoc/index.adoc
+++ b/genie-demo/src/docs/asciidoc/index.adoc
@@ -227,8 +227,8 @@ stdout
 ... `./run_hadoop_job.py test`
 ... `./run_yarn_job.py test`
 ... `./run_hdfs_job.py test`
-... `./run_spark_submit_job sla 2.1.3`
-... `./run_presto_job`
+... `./run_spark_submit_job.py sla 2.1.3`
+... `./run_presto_job.py`
 .. Replace `test` with, `sla` to run the jobs against the Prod cluster
 .. If any of the Docker container crashes, you may need to increase the default memory available in the Docker preferences.
 The current default for a fresh install is 2GB, which is not sufficient for this demo.


### PR DESCRIPTION
- Add missing '.py' path to spark and presto job scripts