### PR TITLE
Fix missing updates to job archive status

### DIFF
--- a/genie-common-external/src/main/java/com/netflix/genie/common/external/dtos/v4/ArchiveStatus.java
+++ b/genie-common-external/src/main/java/com/netflix/genie/common/external/dtos/v4/ArchiveStatus.java
@@ -46,6 +46,12 @@ public enum ArchiveStatus {
     DISABLED,
 
     /**
+     * No files were archived because no files were created.
+     * i.e., job never reached the point where a directory is created.
+     */
+    NO_FILES,
+
+    /**
      * Archive status is unknown.
      */
     UNKNOWN,

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
@@ -19,6 +19,7 @@ package com.netflix.genie.web.services.impl;
 
 import com.google.common.collect.Sets;
 import com.netflix.genie.common.dto.JobStatusMessages;
+import com.netflix.genie.common.external.dtos.v4.ArchiveStatus;
 import com.netflix.genie.common.external.dtos.v4.JobStatus;
 import com.netflix.genie.common.internal.exceptions.checked.GenieJobResolutionException;
 import com.netflix.genie.web.agent.launchers.AgentLauncher;
@@ -116,6 +117,7 @@ public class JobLaunchServiceImpl implements JobLaunchService {
                     JobStatus.FAILED,
                     JobStatusMessages.FAILED_TO_RESOLVE_JOB // TODO: Move somewhere not in genie-common
                 );
+                this.persistenceService.updateJobArchiveStatus(jobId, ArchiveStatus.NO_FILES);
                 throw t; // Caught below for metrics gathering
             }
 
@@ -140,6 +142,7 @@ public class JobLaunchServiceImpl implements JobLaunchService {
             } catch (final AgentLaunchException e) {
                 // TODO: this could fail as well
                 this.persistenceService.updateJobStatus(jobId, JobStatus.ACCEPTED, JobStatus.FAILED, e.getMessage());
+                this.persistenceService.updateJobArchiveStatus(jobId, ArchiveStatus.NO_FILES);
                 // TODO: How will we get the ID back to the user? Should we add it to an exception? We don't get
                 //       We don't get the ID until after saveJobSubmission so if that fails we'd still return nothing
                 //       Probably need multiple exceptions to be thrown from this API (if we go with checked)

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobLaunchServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/JobLaunchServiceImplSpec.groovy
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.web.services.impl
 
+import com.netflix.genie.common.external.dtos.v4.ArchiveStatus
 import com.netflix.genie.common.external.dtos.v4.JobStatus
 import com.netflix.genie.common.internal.exceptions.checked.GenieJobResolutionException
 import com.netflix.genie.web.agent.launchers.AgentLauncher
@@ -87,6 +88,7 @@ class JobLaunchServiceImplSpec extends Specification {
         }
         0 * jobResolverService.resolveJob(_ as String)
         0 * persistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String)
+        0 * persistenceService.updateJobArchiveStatus(_, _)
         0 * agentLauncher.launchAgent(_ as ResolvedJob)
         thrown(IllegalStateException)
 
@@ -99,6 +101,7 @@ class JobLaunchServiceImplSpec extends Specification {
         }
         0 * jobResolverService.resolveJob(_ as String)
         0 * persistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String)
+        0 * persistenceService.updateJobArchiveStatus(_, _)
         0 * agentLauncher.launchAgent(_ as ResolvedJob)
         thrown(IdAlreadyExistsException)
 
@@ -111,6 +114,7 @@ class JobLaunchServiceImplSpec extends Specification {
         }
         0 * jobResolverService.resolveJob(_ as String)
         0 * persistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String)
+        0 * persistenceService.updateJobArchiveStatus(_, _)
         0 * agentLauncher.launchAgent(_ as ResolvedJob)
         thrown(SaveAttachmentException)
 
@@ -123,6 +127,7 @@ class JobLaunchServiceImplSpec extends Specification {
             throw new GenieJobResolutionException("fail")
         }
         1 * persistenceService.updateJobStatus(jobId, JobStatus.RESERVED, JobStatus.FAILED, _ as String)
+        1 * persistenceService.updateJobArchiveStatus(jobId, ArchiveStatus.NO_FILES)
         0 * persistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String)
         0 * agentLauncher.launchAgent(_ as ResolvedJob)
         thrown(GenieJobResolutionException)
@@ -136,6 +141,7 @@ class JobLaunchServiceImplSpec extends Specification {
         1 * persistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String) >> {
             throw new RuntimeException("fail")
         }
+        0 * persistenceService.updateJobArchiveStatus(_, _)
         0 * agentLauncher.launchAgent(_ as ResolvedJob)
         thrown(AgentLaunchException)
 
@@ -150,6 +156,7 @@ class JobLaunchServiceImplSpec extends Specification {
             throw new AgentLaunchException("that didn't work")
         }
         1 * persistenceService.updateJobStatus(jobId, JobStatus.ACCEPTED, JobStatus.FAILED, _ as String)
+        1 * persistenceService.updateJobArchiveStatus(jobId, ArchiveStatus.NO_FILES)
         thrown(AgentLaunchException)
 
         when:
@@ -159,6 +166,7 @@ class JobLaunchServiceImplSpec extends Specification {
         1 * persistenceService.saveJobSubmission(jobSubmission) >> jobId
         1 * jobResolverService.resolveJob(jobId) >> resolvedJob
         1 * persistenceService.updateJobStatus(jobId, JobStatus.RESOLVED, JobStatus.ACCEPTED, _ as String) >> { throw new NotFoundException() }
+        0 * persistenceService.updateJobArchiveStatus(_, _)
         0 * agentLauncher.launchAgent(_ as ResolvedJob)
         0 * persistenceService.updateJobStatus(jobId, JobStatus.ACCEPTED, JobStatus.FAILED, _ as String)
         thrown(AgentLaunchException)

--- a/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImplTest.java
@@ -31,6 +31,7 @@ import com.netflix.genie.common.exceptions.GenieServerException;
 import com.netflix.genie.common.exceptions.GenieServerUnavailableException;
 import com.netflix.genie.common.exceptions.GenieUserLimitExceededException;
 import com.netflix.genie.common.external.dtos.v4.Application;
+import com.netflix.genie.common.external.dtos.v4.ArchiveStatus;
 import com.netflix.genie.common.external.dtos.v4.Cluster;
 import com.netflix.genie.common.external.dtos.v4.Command;
 import com.netflix.genie.common.external.dtos.v4.ExecutionEnvironment;
@@ -534,6 +535,10 @@ public class JobCoordinatorServiceImplTest {
                 .updateJobStatus(Mockito.eq(JOB_1_ID), Mockito.eq(JobStatus.FAILED), Mockito.anyString());
 
             Mockito
+                .verify(this.persistenceService, Mockito.times(1))
+                .updateJobArchiveStatus(Mockito.eq(JOB_1_ID), Mockito.eq(ArchiveStatus.NO_FILES));
+
+            Mockito
                 .verify(this.coordinationTimer, Mockito.times(1))
                 .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));
             Mockito
@@ -901,7 +906,9 @@ public class JobCoordinatorServiceImplTest {
             Mockito
                 .verify(this.persistenceService, Mockito.times(1))
                 .updateJobStatus(Mockito.eq(JOB_1_ID), Mockito.eq(JobStatus.FAILED), Mockito.any());
-
+            Mockito
+                .verify(this.persistenceService, Mockito.times(1))
+                .updateJobArchiveStatus(Mockito.eq(JOB_1_ID), Mockito.eq(ArchiveStatus.NO_FILES));
             Mockito
                 .verify(this.coordinationTimer, Mockito.times(1))
                 .record(Mockito.anyLong(), Mockito.eq(TimeUnit.NANOSECONDS));


### PR DESCRIPTION
 - Certain execution paths (for example, job that fails to resolve) were not updating the archive status, leaving it in PENDING state.
 - Also add a new ArchiveStatus value: NO_LOGS