### PR TITLE
Bug: forward stdin to command at launch

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/JobSetupServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/JobSetupServiceImpl.java
@@ -695,7 +695,7 @@ class JobSetupServiceImpl implements JobSetupService {
             sb
                 .append("# Launch the command")
                 .append(NEWLINE)
-                .append(this.commandLine).append(" &").append(NEWLINE)
+                .append(this.commandLine).append(" <&0 &").append(NEWLINE)
                 .append("wait %1").append(NEWLINE)
                 .append("exit $?").append(NEWLINE)
                 .append(NEWLINE);

--- a/genie-agent/src/test/resources/JobSetupServiceImplSpec_run1.test.sh
+++ b/genie-agent/src/test/resources/JobSetupServiceImplSpec_run1.test.sh
@@ -105,7 +105,7 @@ exec 2>&7 7>&-
 env | sort > ${__GENIE_ENVIRONMENT_DUMP_FILE}
 
 # Launch the command
-presto -v --exec 'select * from table limit 1' &
+presto -v --exec 'select * from table limit 1' <&0 &
 wait %1
 exit $?
 

--- a/genie-agent/src/test/resources/JobSetupServiceImplSpec_run2.test.sh
+++ b/genie-agent/src/test/resources/JobSetupServiceImplSpec_run2.test.sh
@@ -100,7 +100,7 @@ exec 2>&7 7>&-
 env | sort > ${__GENIE_ENVIRONMENT_DUMP_FILE}
 
 # Launch the command
-presto -v --exec 'select * from table limit 10' &
+presto -v --exec 'select * from table limit 10' <&0 &
 wait %1
 exit $?
 

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/runsh-agent.txt
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/runsh-agent.txt
@@ -135,7 +135,7 @@ exec 2>&7 7>&-
 env | sort > ${__GENIE_ENVIRONMENT_DUMP_FILE}
 
 # Launch the command
-/bin/bash -c 'sleep 1 && echo hello world' &
+/bin/bash -c 'sleep 1 && echo hello world' <&0 &
 wait %1
 exit $?
 


### PR DESCRIPTION
The recent change of logic to better handle signals (PR #1020) did not take into account interactive commands.
After this change, any command that tried to read from stdin, would immediately find EOF.

Update the run script so that the bash process stdin is forwarded to the actual running command.