### PR TITLE
Expose page and size parameters for job search

### DIFF
--- a/genie-client/src/integTest/java/com/netflix/genie/client/JobClientIntegrationTest.java
+++ b/genie-client/src/integTest/java/com/netflix/genie/client/JobClientIntegrationTest.java
@@ -219,6 +219,7 @@ abstract class JobClientIntegrationTest extends ClusterClientIntegrationTest {
                     null,
                     null,
                     null,
+                    null,
                     null
                 )
             )

--- a/genie-client/src/integTest/java/com/netflix/genie/client/JobClientIntegrationTest.java
+++ b/genie-client/src/integTest/java/com/netflix/genie/client/JobClientIntegrationTest.java
@@ -219,9 +219,6 @@ abstract class JobClientIntegrationTest extends ClusterClientIntegrationTest {
                     null,
                     null,
                     null,
-                    null,
-                    null,
-                    null,
                     null
                 )
             )

--- a/genie-client/src/integTest/java/com/netflix/genie/client/JobClientIntegrationTest.java
+++ b/genie-client/src/integTest/java/com/netflix/genie/client/JobClientIntegrationTest.java
@@ -218,6 +218,10 @@ abstract class JobClientIntegrationTest extends ClusterClientIntegrationTest {
                     null,
                     null,
                     null,
+                    null,
+                    null,
+                    null,
+                    null,
                     null
                 )
             )

--- a/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
@@ -193,7 +193,7 @@ public class JobClient {
     public List<JobSearchResult> getJobs() throws IOException, GenieClientException {
         return this.getJobs(null, null, null, null, null, null,
             null, null, null, null, null, null,
-            null, null, null, null, null, null, null);
+            null, null, null, null);
     }
 
     /**
@@ -233,10 +233,7 @@ public class JobClient {
      * Long,
      * String,
      * String,
-     * Long,
-     * Long,
-     * String,
-     * String
+     * Long
      *)
      */
     @Deprecated
@@ -271,9 +268,6 @@ public class JobClient {
             maxFinished,
             null,
             null,
-            null,
-            null,
-            null,
             null
         );
     }
@@ -297,9 +291,6 @@ public class JobClient {
      * @param grouping         The grouping the job should be a member of
      * @param groupingInstance The grouping instance the job should be a member of
      * @param page             The page offset of the results
-     * @param size             The size of page results
-     * @param sort             The column to sort the results on
-     * @param direction        The sorting direction, ASC or DESC
      * @return A list of jobs.
      * @throws GenieClientException If the response received is not 2xx.
      * @throws IOException          For Network and other IO issues.
@@ -321,10 +312,7 @@ public class JobClient {
         @Nullable final Long maxFinished,
         @Nullable final String grouping,
         @Nullable final String groupingInstance,
-        @Nullable final Long page,
-        @Nullable final Long size,
-        @Nullable final String sort,
-        @Nullable final String direction
+        @Nullable final Long page
     ) throws IOException, GenieClientException {
         return GenieClientUtils.parseSearchResultsResponse(
             this.jobService.getJobs(
@@ -343,10 +331,7 @@ public class JobClient {
                 maxFinished,
                 grouping,
                 groupingInstance,
-                page,
-                size,
-                sort,
-                direction
+                page
             ).execute(),
             "jobSearchResultList",
             JobSearchResult.class

--- a/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
@@ -193,7 +193,7 @@ public class JobClient {
     public List<JobSearchResult> getJobs() throws IOException, GenieClientException {
         return this.getJobs(null, null, null, null, null, null,
             null, null, null, null, null, null,
-            null, null, null, null);
+            null, null, null, null, null);
     }
 
     /**
@@ -233,6 +233,7 @@ public class JobClient {
      * Long,
      * String,
      * String,
+     * Long,
      * Long
      *)
      */
@@ -268,6 +269,7 @@ public class JobClient {
             maxFinished,
             null,
             null,
+            null,
             null
         );
     }
@@ -291,6 +293,7 @@ public class JobClient {
      * @param grouping         The grouping the job should be a member of
      * @param groupingInstance The grouping instance the job should be a member of
      * @param page             The page offset of the results
+     * @param size             The size of page results
      * @return A list of jobs.
      * @throws GenieClientException If the response received is not 2xx.
      * @throws IOException          For Network and other IO issues.
@@ -312,7 +315,8 @@ public class JobClient {
         @Nullable final Long maxFinished,
         @Nullable final String grouping,
         @Nullable final String groupingInstance,
-        @Nullable final Long page
+        @Nullable final Long page,
+        @Nullable final Long size
     ) throws IOException, GenieClientException {
         return GenieClientUtils.parseSearchResultsResponse(
             this.jobService.getJobs(
@@ -331,7 +335,8 @@ public class JobClient {
                 maxFinished,
                 grouping,
                 groupingInstance,
-                page
+                page,
+                size
             ).execute(),
             "jobSearchResultList",
             JobSearchResult.class

--- a/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
@@ -233,8 +233,8 @@ public class JobClient {
      * Long,
      * String,
      * String,
-     * Long,
-     * Long
+     * Integer,
+     * Integer
      *)
      */
     @Deprecated
@@ -315,8 +315,8 @@ public class JobClient {
         @Nullable final Long maxFinished,
         @Nullable final String grouping,
         @Nullable final String groupingInstance,
-        @Nullable final Long page,
-        @Nullable final Long size
+        @Nullable final Integer page,
+        @Nullable final Integer size
     ) throws IOException, GenieClientException {
         return GenieClientUtils.parseSearchResultsResponse(
             this.jobService.getJobs(

--- a/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
@@ -191,7 +191,9 @@ public class JobClient {
      * @throws IOException          For Network and other IO issues.
      */
     public List<JobSearchResult> getJobs() throws IOException, GenieClientException {
-        return this.getJobs(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        return this.getJobs(null, null, null, null, null, null,
+            null, null, null, null, null, null,
+            null, null, null, null, null, null, null);
     }
 
     /**
@@ -230,6 +232,10 @@ public class JobClient {
      * Long,
      * Long,
      * String,
+     * String,
+     * Long,
+     * Long,
+     * String,
      * String
      *)
      */
@@ -264,6 +270,10 @@ public class JobClient {
             minFinished,
             maxFinished,
             null,
+            null,
+            null,
+            null,
+            null,
             null
         );
     }
@@ -286,10 +296,15 @@ public class JobClient {
      * @param maxFinished      The time which the job had to finish before in order to be returned (exclusive)
      * @param grouping         The grouping the job should be a member of
      * @param groupingInstance The grouping instance the job should be a member of
+     * @param page             The page offset of the results
+     * @param size             The size of page results
+     * @param sort             The column to sort the results on
+     * @param direction        The sorting direction, ASC or DESC
      * @return A list of jobs.
      * @throws GenieClientException If the response received is not 2xx.
      * @throws IOException          For Network and other IO issues.
      */
+    @SuppressWarnings("checkstyle:ParameterNumber")
     public List<JobSearchResult> getJobs(
         @Nullable final String id,
         @Nullable final String name,
@@ -305,7 +320,11 @@ public class JobClient {
         @Nullable final Long minFinished,
         @Nullable final Long maxFinished,
         @Nullable final String grouping,
-        @Nullable final String groupingInstance
+        @Nullable final String groupingInstance,
+        @Nullable final Long page,
+        @Nullable final Long size,
+        @Nullable final String sort,
+        @Nullable final String direction
     ) throws IOException, GenieClientException {
         return GenieClientUtils.parseSearchResultsResponse(
             this.jobService.getJobs(
@@ -323,7 +342,11 @@ public class JobClient {
                 minFinished,
                 maxFinished,
                 grouping,
-                groupingInstance
+                groupingInstance,
+                page,
+                size,
+                sort,
+                direction
             ).execute(),
             "jobSearchResultList",
             JobSearchResult.class

--- a/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/JobClient.java
@@ -292,8 +292,8 @@ public class JobClient {
      * @param maxFinished      The time which the job had to finish before in order to be returned (exclusive)
      * @param grouping         The grouping the job should be a member of
      * @param groupingInstance The grouping instance the job should be a member of
-     * @param page             The page offset of the results
-     * @param size             The size of page results
+     * @param page             The page offset of the search results
+     * @param size             The number of search results per page
      * @return A list of jobs.
      * @throws GenieClientException If the response received is not 2xx.
      * @throws IOException          For Network and other IO issues.

--- a/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
@@ -95,9 +95,6 @@ public interface JobService {
      * @param grouping         The grouping the job should be a member of
      * @param groupingInstance The grouping instance the job should be a member of
      * @param page             The page offset of the results
-     * @param size             The size of page results
-     * @param sort             The column to sort the results on
-     * @param direction        The sorting direction, ASC or DESC
      * @return A callable object.
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -118,10 +115,7 @@ public interface JobService {
         @Query("maxFinished") Long maxFinished,
         @Query("grouping") String grouping,
         @Query("groupingInstance") String groupingInstance,
-        @Query("page") Long page,
-        @Query("size") Long size,
-        @Query("sort") String sort,
-        @Query("direction") String direction
+        @Query("page") Long page
     );
 
     /**

--- a/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
@@ -116,8 +116,8 @@ public interface JobService {
         @Query("maxFinished") Long maxFinished,
         @Query("grouping") String grouping,
         @Query("groupingInstance") String groupingInstance,
-        @Query("page") Long page,
-        @Query("size") Long size
+        @Query("page") Integer page,
+        @Query("size") Integer size
     );
 
     /**

--- a/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
@@ -95,6 +95,7 @@ public interface JobService {
      * @param grouping         The grouping the job should be a member of
      * @param groupingInstance The grouping instance the job should be a member of
      * @param page             The page offset of the results
+     * @param size             The size of page results
      * @return A callable object.
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -115,7 +116,8 @@ public interface JobService {
         @Query("maxFinished") Long maxFinished,
         @Query("grouping") String grouping,
         @Query("groupingInstance") String groupingInstance,
-        @Query("page") Long page
+        @Query("page") Long page,
+        @Query("size") Long size
     );
 
     /**

--- a/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
@@ -94,8 +94,8 @@ public interface JobService {
      * @param maxFinished      The time which the job had to finish before in order to be returned (exclusive)
      * @param grouping         The grouping the job should be a member of
      * @param groupingInstance The grouping instance the job should be a member of
-     * @param page             The page offset of the results
-     * @param size             The size of page results
+     * @param page             The page offset of the search results
+     * @param size             The number of search results per page
      * @return A callable object.
      */
     @SuppressWarnings("checkstyle:ParameterNumber")

--- a/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/apis/JobService.java
@@ -94,8 +94,13 @@ public interface JobService {
      * @param maxFinished      The time which the job had to finish before in order to be returned (exclusive)
      * @param grouping         The grouping the job should be a member of
      * @param groupingInstance The grouping instance the job should be a member of
+     * @param page             The page offset of the results
+     * @param size             The size of page results
+     * @param sort             The column to sort the results on
+     * @param direction        The sorting direction, ASC or DESC
      * @return A callable object.
      */
+    @SuppressWarnings("checkstyle:ParameterNumber")
     @GET(JOBS_URL_SUFFIX)
     Call<JsonNode> getJobs(
         @Query("id") String id,
@@ -112,7 +117,11 @@ public interface JobService {
         @Query("minFinished") Long minFinished,
         @Query("maxFinished") Long maxFinished,
         @Query("grouping") String grouping,
-        @Query("groupingInstance") String groupingInstance
+        @Query("groupingInstance") String groupingInstance,
+        @Query("page") Long page,
+        @Query("size") Long size,
+        @Query("sort") String sort,
+        @Query("direction") String direction
     );
 
     /**


### PR DESCRIPTION
Currently, the getJobs method doesn't expose the page and the search results size parameter in the client library. As a result we can only fetch the first 10 search results. There is no way to request additional search results using the client library. The API supports retrieving additional search results using the page and the size parameters. 

This pull request change exposes those parameters in the getJobs method so that users can retrieve all the results.