### PR TITLE
Add leader task ArchiveStatusCleanup

### DIFF
--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -185,6 +185,12 @@ It will have to be added if one is desired otherwise metrics are just published 
 |AgentJobCleanupTask
 |status, exceptionClass
 
+|genie.jobs.archiveStatus.cleanup.counter
+|Counter of jobs whose archive status was left in PENDING state after execution completed
+|count
+|ArchiveStatusCleanupTask
+|status, exceptionClass
+
 |genie.jobs.clusters.selectors.script.select.timer
 |Time taken by the loaded script to select a cluster among the one passed as input
 |nanoseconds
@@ -473,6 +479,12 @@ for multiple errors.
 |The time taken to fetch the metadata of an archived job if it isn't already cached
 |nanoseconds
 |ArchivedJobServiceImpl
+|status, exceptionClass
+
+|genie.tasks.archiveStatusCleanup.timer
+|Time taken to execute the cleanup task
+|nanoseconds
+|ArchiveStatusCleanupTask
 |status, exceptionClass
 
 |genie.tasks.clusterChecker.connectionsReaped.counter

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -507,6 +507,21 @@ of 2.0
 |120000
 |no
 
+|genie.tasks.archive-status-cleanup.enabled
+|Whether to enable the task that detects jobs whose archive status was left in PENDING state
+|true
+|no
+
+|genie.tasks.archive-status-cleanup.check-interval
+|How often the archive status tasks executed
+|10s
+|no
+
+|genie.tasks.archive-status-cleanup.gracePeriod
+|How much time since the final status update to give to jobs before marking the status as UNKNOWN
+|2m
+|no
+
 |genie.tasks.cluster-checker.healthIndicatorsToIgnore
 |The health indicator groups from the actuator /health endpoint to ignore when determining if a node is lost or not as
 a comma separated list

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/impl/jpa/persistence/jobs/archive_status.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/impl/jpa/persistence/jobs/archive_status.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<dataset>
+
+    <commands
+        id="1"
+        created="2016-03-21 01:47:00"
+        updated="2016-03-21 01:59:00"
+        entity_version="0"
+        unique_id="command1"
+        genie_user="tgianos"
+        name="spark"
+        version="1.6.0"
+        check_delay="10000"
+        status="ACTIVE"
+    />
+
+    <command_executable_arguments
+        command_id="1"
+        argument="spark"
+        argument_order="0"
+    />
+
+    <clusters
+        id="1"
+        created="2016-03-21 01:49:00"
+        updated="2016-03-21 02:59:00"
+        entity_version="0"
+        unique_id="cluster1"
+        genie_user="tgianos"
+        name="h2query"
+        version="2.4.0"
+        status="UP"
+    />
+
+    <criteria
+        id="0"
+        name="spark"
+    />
+
+    <!-- Should match with the right threshold -->
+    <jobs
+        id="1"
+        created="2020-01-01 00:00:00"
+        updated="2020-01-01 00:00:00"
+        entity_version="1"
+        unique_id="agentJob1"
+        genie_user="tgianos"
+        name="testSparkJob"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="1"
+        requested_memory="1560"
+        requested_timeout="608400"
+        status="SUCCEEDED"
+        cluster_id="1"
+        command_id="1"
+        check_delay="10000"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/1"
+        resolved="true"
+        v4="true"
+        cluster_name="h2query"
+        command_name="spark"
+        api="true"
+        archive_status="PENDING"
+    />
+
+    <!-- Should match with the right threshold -->
+    <jobs
+        id="2"
+        created="2020-01-01 00:00:00"
+        updated="2020-01-01 00:00:00"
+        entity_version="1"
+        unique_id="agentJob2"
+        genie_user="tgianos"
+        name="testSparkJob"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="1"
+        requested_memory="1560"
+        requested_timeout="608400"
+        status="FAILED"
+        cluster_id="1"
+        command_id="1"
+        check_delay="10000"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/1"
+        resolved="true"
+        v4="true"
+        cluster_name="h2query"
+        command_name="spark"
+        api="true"
+        archive_status="PENDING"
+    />
+
+    <!-- Not "v4"-->
+    <jobs
+        id="3"
+        created="2020-01-01 00:00:00"
+        updated="2020-01-01 00:00:00"
+        entity_version="1"
+        unique_id="NotAgentJob1"
+        genie_user="tgianos"
+        name="testSparkJob"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="1"
+        requested_memory="1560"
+        requested_timeout="608400"
+        status="SUCCEEDED"
+        cluster_id="1"
+        command_id="1"
+        check_delay="10000"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/1"
+        resolved="true"
+        v4="false"
+        cluster_name="h2query"
+        command_name="spark"
+        api="true"
+        archive_status="PENDING"
+    />
+
+    <!-- Not in final state -->
+    <jobs
+        id="4"
+        created="2020-01-01 00:00:00"
+        updated="2020-01-01 00:00:00"
+        entity_version="1"
+        unique_id="InitJob"
+        genie_user="tgianos"
+        name="testSparkJob"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="1"
+        requested_memory="1560"
+        requested_timeout="608400"
+        status="INIT"
+        cluster_id="1"
+        command_id="1"
+        check_delay="10000"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/1"
+        resolved="true"
+        v4="true"
+        cluster_name="h2query"
+        command_name="spark"
+        api="true"
+        archive_status="PENDING"
+    />
+
+    <!-- Not in final state -->
+    <jobs
+        id="5"
+        created="2020-01-01 00:00:00"
+        updated="2020-01-01 00:00:00"
+        entity_version="1"
+        unique_id="RunningJob"
+        genie_user="tgianos"
+        name="testSparkJob"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="1"
+        requested_memory="1560"
+        requested_timeout="608400"
+        status="RUNNING"
+        cluster_id="1"
+        command_id="1"
+        check_delay="10000"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/1"
+        resolved="true"
+        v4="true"
+        cluster_name="h2query"
+        command_name="spark"
+        api="true"
+        archive_status="PENDING"
+    />
+    <!-- Not pending -->
+    <jobs
+        id="6"
+        created="2020-01-01 00:00:00"
+        updated="2020-01-01 00:00:00"
+        entity_version="1"
+        unique_id="ArchivedJob"
+        genie_user="tgianos"
+        name="testSparkJob"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="1"
+        requested_memory="1560"
+        requested_timeout="608400"
+        status="SUCCEEDED"
+        cluster_id="1"
+        command_id="1"
+        check_delay="10000"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/1"
+        resolved="true"
+        v4="true"
+        cluster_name="h2query"
+        command_name="spark"
+        api="true"
+        archive_status="ARCHIVED"
+    />
+
+</dataset>

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
@@ -970,6 +970,21 @@ public interface PersistenceService {
      * @return A {@link JobInfoAggregate} containing the metadata information
      */
     JobInfoAggregate getHostJobInformation(@NotBlank String hostname);
+
+    /**
+     * Get the set of jobs (agent only) whose state is in {@code statuses} and archive status is in
+     * {@code archiveStatuses} and last updated before {@code updated}.
+     *
+     * @param statuses        the set of job statuses
+     * @param archiveStatuses the set of job archive statuses
+     * @param updated         the threshold of last update
+     * @return a set of job ids
+     */
+    Set<String> getJobsWithStatusAndArchiveStatusUpdatedBefore(
+        @NotEmpty Set<JobStatus> statuses,
+        @NotEmpty Set<ArchiveStatus> archiveStatuses,
+        @NotNull Instant updated
+    );
     //endregion
     //endregion
 

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
@@ -2212,6 +2212,29 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
         log.debug("[getHostJobInformation] Called for hostname {}", hostname);
         return this.jobRepository.getHostJobInfo(hostname, ACTIVE_STATUS_SET, USING_MEMORY_JOB_SET);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Set<String> getJobsWithStatusAndArchiveStatusUpdatedBefore(
+        @NotEmpty final Set<JobStatus> statuses,
+        @NotEmpty final Set<ArchiveStatus> archiveStatuses,
+        @NotNull final Instant updated
+    ) {
+        log.debug(
+            "[getJobsWithStatusAndArchiveStatusUpdatedBefore] Called with statuses {}, archiveStatuses {}, updated {}",
+            statuses,
+            archiveStatuses,
+            updated
+        );
+        return this.jobRepository.getJobsWithStatusAndArchiveStatusUpdatedBefore(
+            statuses.stream().map(JobStatus::name).collect(Collectors.toSet()),
+            archiveStatuses.stream().map(ArchiveStatus::name).collect(Collectors.toSet()),
+            updated
+        );
+    }
     //endregion
     //endregion
 

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaJobRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaJobRepository.java
@@ -155,7 +155,7 @@ public interface JpaJobRepository extends JpaBaseRepository<JobEntity> {
      * Only jobs running on Genie servers are considered (i.e. no Agent jobs)
      *
      * @param statuses The set of statuses a job has to be in to be considered
-     * @param api Whether the job was submitted through the api ({@literal true}) or agent cli ({@literal false})
+     * @param api      Whether the job was submitted through the api ({@literal true}) or agent cli ({@literal false})
      * @return The user resource aggregates
      */
     @Query(
@@ -182,6 +182,28 @@ public interface JpaJobRepository extends JpaBaseRepository<JobEntity> {
             + " AND j.v4 = TRUE"
     )
     Set<String> getAgentJobIdsWithStatusIn(@Param("statuses") @NotEmpty Set<String> statuses);
+
+    /**
+     * Find agent jobs in the given set of job and archive states that were marked finished before a given threshold.
+     *
+     * @param statuses        the job statuses filter
+     * @param archiveStatuses the job archive statuses filter
+     * @param updateThreshold select jobs last updated before this threshold
+     * @return a set of job ids
+     */
+    @Query(
+        "SELECT j.uniqueId"
+            + " FROM JobEntity j"
+            + " WHERE j.status IN (:statuses)"
+            + " AND j.archiveStatus IN (:archiveStatuses)"
+            + " AND j.updated < :updatedThreshold"
+            + " AND j.v4 = TRUE"
+    )
+    Set<String> getJobsWithStatusAndArchiveStatusUpdatedBefore(
+        @Param("statuses") @NotEmpty Set<String> statuses,
+        @Param("archiveStatuses") @NotEmpty Set<String> archiveStatuses,
+        @Param("updatedThreshold") Instant updateThreshold
+    );
 
     /**
      * Get only the status of a job.

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/ArchiveStatusCleanupProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/ArchiveStatusCleanupProperties.java
@@ -1,0 +1,54 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+
+/**
+ * Properties related to cleaning up jobs archive status.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@ConfigurationProperties(prefix = ArchiveStatusCleanupProperties.PROPERTY_PREFIX)
+@Getter
+@Setter
+@Validated
+public class ArchiveStatusCleanupProperties {
+
+    /**
+     * The property prefix for all properties in this group.
+     */
+    public static final String PROPERTY_PREFIX = "genie.tasks.archive-status-cleanup";
+
+    /**
+     * Determines whether the {@link com.netflix.genie.web.tasks.leader.ArchiveStatusCleanupTask} is active.
+     */
+    public static final String ENABLED_PROPERTY = PROPERTY_PREFIX + ".enabled";
+
+    private boolean enabled = true;
+
+    private Duration checkInterval = Duration.ofSeconds(10);
+
+    private Duration gracePeriod = Duration.ofMinutes(2);
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfiguration.java
@@ -22,6 +22,7 @@ import com.netflix.genie.web.agent.services.AgentRoutingService;
 import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.properties.AgentCleanupProperties;
+import com.netflix.genie.web.properties.ArchiveStatusCleanupProperties;
 import com.netflix.genie.web.properties.ClusterCheckerProperties;
 import com.netflix.genie.web.properties.DatabaseCleanupProperties;
 import com.netflix.genie.web.properties.LeadershipProperties;
@@ -33,6 +34,7 @@ import com.netflix.genie.web.spring.actuators.LeaderElectionActuator;
 import com.netflix.genie.web.spring.autoconfigure.ZookeeperAutoConfiguration;
 import com.netflix.genie.web.spring.autoconfigure.tasks.TasksAutoConfiguration;
 import com.netflix.genie.web.tasks.leader.AgentJobCleanupTask;
+import com.netflix.genie.web.tasks.leader.ArchiveStatusCleanupTask;
 import com.netflix.genie.web.tasks.leader.ClusterCheckerTask;
 import com.netflix.genie.web.tasks.leader.DatabaseCleanupTask;
 import com.netflix.genie.web.tasks.leader.LeaderTask;
@@ -66,6 +68,7 @@ import java.util.Set;
 @EnableConfigurationProperties(
     {
         AgentCleanupProperties.class,
+        ArchiveStatusCleanupProperties.class,
         ClusterCheckerProperties.class,
         DatabaseCleanupProperties.class,
         LeadershipProperties.class,
@@ -200,6 +203,32 @@ public class LeaderAutoConfiguration {
             agentCleanupProperties,
             registry,
             agentRoutingService
+        );
+    }
+
+    /**
+     * If required, get a {@link ArchiveStatusCleanupTask} instance for use.
+     *
+     * @param dataServices                   The {@link DataServices} encapsulation instance to use
+     * @param agentRoutingService            the agent routing service
+     * @param archiveStatusCleanupProperties the archive status cleanup properties
+     * @param registry                       the metrics registry
+     * @return a {@link AgentJobCleanupTask}
+     */
+    @Bean
+    @ConditionalOnProperty(value = ArchiveStatusCleanupProperties.ENABLED_PROPERTY, havingValue = "true")
+    @ConditionalOnMissingBean(ArchiveStatusCleanupTask.class)
+    public ArchiveStatusCleanupTask archiveStatusCleanupTask(
+        final DataServices dataServices,
+        final AgentRoutingService agentRoutingService,
+        final ArchiveStatusCleanupProperties archiveStatusCleanupProperties,
+        final MeterRegistry registry
+    ) {
+        return new ArchiveStatusCleanupTask(
+            dataServices,
+            agentRoutingService,
+            archiveStatusCleanupProperties,
+            registry
         );
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ArchiveStatusCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ArchiveStatusCleanupTask.java
@@ -1,0 +1,146 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.tasks.leader;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.netflix.genie.common.external.dtos.v4.ArchiveStatus;
+import com.netflix.genie.common.external.dtos.v4.JobStatus;
+import com.netflix.genie.web.agent.services.AgentRoutingService;
+import com.netflix.genie.web.data.services.DataServices;
+import com.netflix.genie.web.data.services.PersistenceService;
+import com.netflix.genie.web.exceptions.checked.NotFoundException;
+import com.netflix.genie.web.properties.ArchiveStatusCleanupProperties;
+import com.netflix.genie.web.tasks.GenieTaskScheduleType;
+import com.netflix.genie.web.util.MetricsUtils;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Leader task that find jobs whose archival status was left in 'PENDING' state.
+ * This can for example happen if the agent fails to update the server after successfully archiving.
+ * The logic is summarized as:
+ * If a job finished running more than N minutes ago, and the agent is disconnected and the archive status is PENDING,
+ * then set the archive status to UNKNOWN.
+ * This task ignores non-agent jobs because {@link ClusterCheckerTask} handles them already.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@Slf4j
+public class ArchiveStatusCleanupTask extends LeaderTask {
+
+    private static final String CLEAR_ARCHIVE_STATUS_COUNTER_NAME = "genie.jobs.archiveStatus.cleanup.counter";
+    private static final String CLEAR_ARCHIVE_STATUS_TIMER_NAME = "genie.tasks.archiveStatusCleanup.timer";
+    private static final Set<ArchiveStatus> PENDING_STATUS_SET = ImmutableSet.of(ArchiveStatus.PENDING);
+    private final PersistenceService persistenceService;
+    private final AgentRoutingService agentRoutingService;
+    private final ArchiveStatusCleanupProperties properties;
+    private final MeterRegistry registry;
+
+    /**
+     * Constructor.
+     *
+     * @param dataServices        data services
+     * @param agentRoutingService agent routing service
+     * @param properties          task properties
+     * @param registry            metrics registry
+     */
+    public ArchiveStatusCleanupTask(
+        final DataServices dataServices,
+        final AgentRoutingService agentRoutingService,
+        final ArchiveStatusCleanupProperties properties,
+        final MeterRegistry registry
+    ) {
+        this.persistenceService = dataServices.getPersistenceService();
+        this.agentRoutingService = agentRoutingService;
+        this.properties = properties;
+        this.registry = registry;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void run() {
+        final Set<Tag> tags = Sets.newHashSet();
+        final long start = System.nanoTime();
+        try {
+            final Instant updatedThreshold = Instant.now().minus(this.properties.getGracePeriod());
+            final Set<String> jobIds = this.persistenceService.getJobsWithStatusAndArchiveStatusUpdatedBefore(
+                    JobStatus.getFinishedStatuses(),
+                    PENDING_STATUS_SET,
+                    updatedThreshold
+                );
+            if (!jobIds.isEmpty()) {
+                log.debug("Found {} finished jobs with PENDING archive status", jobIds.size());
+                this.clearJobsArchiveStatus(jobIds);
+            }
+            MetricsUtils.addSuccessTags(tags);
+        } catch (Exception e) {
+            MetricsUtils.addFailureTagsWithException(tags, e);
+            log.error("Archive status cleanup task failed with exception: {}", e.getMessage(), e);
+        } finally {
+            final long taskDuration = System.nanoTime() - start;
+            registry.timer(CLEAR_ARCHIVE_STATUS_TIMER_NAME, tags).record(taskDuration, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private void clearJobsArchiveStatus(final Set<String> jobIds) {
+
+        for (final String jobId : jobIds) {
+            if (this.agentRoutingService.isAgentConnected(jobId)) {
+                log.debug("Agent for job {} is still connected and probably archiving", jobId);
+            } else {
+                log.warn("Marking job {} archive status to UNKNOWN", jobId);
+                final Set<Tag> tags = Sets.newHashSet();
+
+                try {
+                    this.persistenceService.updateJobArchiveStatus(jobId, ArchiveStatus.UNKNOWN);
+                    MetricsUtils.addSuccessTags(tags);
+                } catch (NotFoundException e) {
+                    log.error("Tried to update a job that does not exist: {}", jobId);
+                    MetricsUtils.addFailureTagsWithException(tags, e);
+                } finally {
+                    registry.counter(CLEAR_ARCHIVE_STATUS_COUNTER_NAME, tags).increment();
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GenieTaskScheduleType getScheduleType() {
+        return GenieTaskScheduleType.FIXED_RATE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getFixedRate() {
+        return this.properties.getCheckInterval().toMillis();
+    }
+}

--- a/genie-web/src/main/resources/genie-web-defaults.yml
+++ b/genie-web/src/main/resources/genie-web-defaults.yml
@@ -97,6 +97,8 @@ genie:
   tasks:
     agent-cleanup:
       enabled: true
+    archive-status-cleanup:
+      enabled: true
     cluster-checker:
       scheme: http
       port: 8080

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/ArchiveStatusCleanupPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/ArchiveStatusCleanupPropertiesSpec.groovy
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties
+
+import spock.lang.Specification
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+class ArchiveStatusCleanupPropertiesSpec extends Specification {
+    def "testDefaultsSettersAndGetters"() {
+        setup:
+        ArchiveStatusCleanupProperties properties = new ArchiveStatusCleanupProperties()
+
+        expect:
+        properties.getCheckInterval() == Duration.of(10, ChronoUnit.SECONDS)
+        properties.getGracePeriod() == Duration.of(2, ChronoUnit.MINUTES)
+        properties.isEnabled()
+
+        when:
+        properties.setCheckInterval(Duration.of(1, ChronoUnit.MINUTES))
+        properties.setGracePeriod(Duration.of(2, ChronoUnit.MINUTES))
+        properties.setEnabled(false)
+
+        then:
+        properties.getCheckInterval() == Duration.of(1, ChronoUnit.MINUTES)
+        properties.getGracePeriod() == Duration.of(2, ChronoUnit.MINUTES)
+        !properties.isEnabled()
+    }
+}

--- a/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/ArchiveStatusCleanupTaskSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/ArchiveStatusCleanupTaskSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.tasks.leader
+
+import com.google.common.collect.Sets
+import com.netflix.genie.common.external.dtos.v4.ArchiveStatus
+import com.netflix.genie.common.external.dtos.v4.JobStatus
+import com.netflix.genie.web.agent.services.AgentRoutingService
+import com.netflix.genie.web.data.services.DataServices
+import com.netflix.genie.web.data.services.PersistenceService
+import com.netflix.genie.web.exceptions.checked.NotFoundException
+import com.netflix.genie.web.properties.ArchiveStatusCleanupProperties
+import com.netflix.genie.web.tasks.GenieTaskScheduleType
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import spock.lang.Specification
+
+import java.time.Instant
+
+class ArchiveStatusCleanupTaskSpec extends Specification {
+
+    DataServices dataServices
+    AgentRoutingService agentRoutingService
+    PersistenceService persistenceServiceMock
+    ArchiveStatusCleanupProperties props
+    MeterRegistry registry
+    ArchiveStatusCleanupTask task
+
+    void setup() {
+        this.persistenceServiceMock = Mock(PersistenceService)
+        this.dataServices = Mock(DataServices) {
+            getPersistenceService() >> persistenceServiceMock
+        }
+        this.agentRoutingService = Mock(AgentRoutingService)
+        this.props = new ArchiveStatusCleanupProperties()
+        this.registry = new SimpleMeterRegistry()
+        this.task = new ArchiveStatusCleanupTask(
+            dataServices,
+            agentRoutingService,
+            props,
+            registry
+        )
+    }
+
+    def "Run"() {
+        when:
+        task.run()
+
+        then:
+        1 * persistenceServiceMock.getJobsWithStatusAndArchiveStatusUpdatedBefore(_ as Set, _ as Set, _ as Instant) >> {
+            Set statuses, Set archiveStatuses, Instant threshold ->
+                assert statuses == Sets.newHashSet(JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.KILLED, JobStatus.INVALID)
+                assert archiveStatuses == Sets.newHashSet(ArchiveStatus.PENDING)
+                assert threshold < Instant.now() - props.gracePeriod
+                return Sets.newHashSet()
+        }
+        0 * agentRoutingService._
+        0 * persistenceServiceMock.updateJobArchiveStatus(_, _)
+
+        when:
+        task.run()
+
+        then:
+        1 * persistenceServiceMock.getJobsWithStatusAndArchiveStatusUpdatedBefore(_, _, _) >> Sets.newHashSet("j1", "j2", "j3")
+
+        then:
+        1 * agentRoutingService.isAgentConnected("j1") >> true
+        0 * persistenceServiceMock.updateJobArchiveStatus("j1", _)
+        1 * agentRoutingService.isAgentConnected("j2") >> false
+        1 * persistenceServiceMock.updateJobArchiveStatus("j2", ArchiveStatus.UNKNOWN) >> {throw new NotFoundException("...")}
+        1 * agentRoutingService.isAgentConnected("j3") >> false
+        1 * persistenceServiceMock.updateJobArchiveStatus("j3", ArchiveStatus.UNKNOWN)
+
+        when:
+        task.run()
+
+        then:
+        1 * persistenceServiceMock.getJobsWithStatusAndArchiveStatusUpdatedBefore(_, _, _) >> Sets.newHashSet("j4")
+
+        then:
+        1 * agentRoutingService.isAgentConnected("j4") >> { throw new RuntimeException("...")}
+        0 * persistenceServiceMock.updateJobArchiveStatus("j4", ArchiveStatus.UNKNOWN)
+        noExceptionThrown()
+    }
+
+    def "GetScheduleType and getFixedRate"() {
+        expect:
+        task.getScheduleType() == GenieTaskScheduleType.FIXED_RATE
+        task.getFixedRate() == props.getCheckInterval().toMillis()
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsTest.java
@@ -31,6 +31,7 @@ import com.netflix.genie.common.exceptions.GenieException;
 import com.netflix.genie.common.exceptions.GenieNotFoundException;
 import com.netflix.genie.common.exceptions.GeniePreconditionException;
 import com.netflix.genie.common.external.dtos.v4.AgentClientMetadata;
+import com.netflix.genie.common.external.dtos.v4.ArchiveStatus;
 import com.netflix.genie.common.external.dtos.v4.JobSpecification;
 import com.netflix.genie.common.external.dtos.v4.JobStatus;
 import com.netflix.genie.common.internal.exceptions.checked.GenieCheckedException;
@@ -1185,5 +1186,22 @@ class JpaPersistenceServiceImplJobsTest {
 
         Assertions.assertThat(jobEntity.getStatus()).isEqualTo(JobStatus.RUNNING.name());
         Assertions.assertThat(jobEntity.getStatusMsg()).isPresent().contains(StringUtils.truncate(tooLong, 255));
+    }
+
+    @Test
+    void testGetJobsWithStatusAndArchiveStatusUpdatedBefore() {
+        Mockito
+            .when(
+                this.jobRepository.getJobsWithStatusAndArchiveStatusUpdatedBefore(
+                    Mockito.anySet(),
+                    Mockito.anySet(),
+                    Mockito.any(Instant.class)
+                ))
+            .thenReturn(Sets.newHashSet());
+        this.persistenceService.getJobsWithStatusAndArchiveStatusUpdatedBefore(
+            Sets.newHashSet(JobStatus.FAILED, JobStatus.KILLED),
+            Sets.newHashSet(ArchiveStatus.FAILED),
+            Instant.now()
+        );
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/tasks/leader/LeaderAutoConfigurationTest.java
@@ -23,6 +23,7 @@ import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.PersistenceService;
 import com.netflix.genie.web.events.GenieEventBus;
 import com.netflix.genie.web.properties.AgentCleanupProperties;
+import com.netflix.genie.web.properties.ArchiveStatusCleanupProperties;
 import com.netflix.genie.web.properties.ClusterCheckerProperties;
 import com.netflix.genie.web.properties.DatabaseCleanupProperties;
 import com.netflix.genie.web.properties.JobsProperties;
@@ -32,6 +33,7 @@ import com.netflix.genie.web.services.ClusterLeaderService;
 import com.netflix.genie.web.spring.actuators.LeaderElectionActuator;
 import com.netflix.genie.web.spring.autoconfigure.tasks.TasksAutoConfiguration;
 import com.netflix.genie.web.tasks.leader.AgentJobCleanupTask;
+import com.netflix.genie.web.tasks.leader.ArchiveStatusCleanupTask;
 import com.netflix.genie.web.tasks.leader.ClusterCheckerTask;
 import com.netflix.genie.web.tasks.leader.DatabaseCleanupTask;
 import com.netflix.genie.web.tasks.leader.LeaderTasksCoordinator;
@@ -75,6 +77,7 @@ class LeaderAutoConfigurationTest {
         this.contextRunner.run(
             context -> {
                 Assertions.assertThat(context).hasSingleBean(AgentCleanupProperties.class);
+                Assertions.assertThat(context).hasSingleBean(ArchiveStatusCleanupProperties.class);
                 Assertions.assertThat(context).hasSingleBean(ClusterCheckerProperties.class);
                 Assertions.assertThat(context).hasSingleBean(DatabaseCleanupProperties.class);
                 Assertions.assertThat(context).hasSingleBean(LeadershipProperties.class);
@@ -90,6 +93,7 @@ class LeaderAutoConfigurationTest {
                 Assertions.assertThat(context).doesNotHaveBean(DatabaseCleanupTask.class);
                 Assertions.assertThat(context).doesNotHaveBean(UserMetricsTask.class);
                 Assertions.assertThat(context).doesNotHaveBean(AgentJobCleanupTask.class);
+                Assertions.assertThat(context).doesNotHaveBean(ArchiveStatusCleanupTask.class);
             }
         );
     }
@@ -103,11 +107,13 @@ class LeaderAutoConfigurationTest {
             .withPropertyValues(
                 "genie.tasks.database-cleanup.enabled=true",
                 "genie.tasks.user-metrics.enabled=true",
-                "genie.tasks.agent-cleanup.enabled=true"
+                "genie.tasks.agent-cleanup.enabled=true",
+                "genie.tasks.archive-status-cleanup.enabled=true"
             )
             .run(
                 context -> {
                     Assertions.assertThat(context).hasSingleBean(AgentCleanupProperties.class);
+                    Assertions.assertThat(context).hasSingleBean(ArchiveStatusCleanupProperties.class);
                     Assertions.assertThat(context).hasSingleBean(ClusterCheckerProperties.class);
                     Assertions.assertThat(context).hasSingleBean(DatabaseCleanupProperties.class);
                     Assertions.assertThat(context).hasSingleBean(LeadershipProperties.class);
@@ -124,6 +130,7 @@ class LeaderAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(DatabaseCleanupTask.class);
                     Assertions.assertThat(context).hasSingleBean(UserMetricsTask.class);
                     Assertions.assertThat(context).hasSingleBean(AgentJobCleanupTask.class);
+                    Assertions.assertThat(context).hasSingleBean(ArchiveStatusCleanupTask.class);
                 }
             );
     }


### PR DESCRIPTION
Mutate archive status from PENDING to UNKNOWN if the job has completed more than N minutes ago and the agent disappeared.

This covers primarily 2 cases:
 - Agent crashing or partitioned from server after updating the final job status
 - Old agents that do not include the new logic to update archive status after archiving