### PR TITLE
Make Agent routing more responsive

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/stages/ArchiveJobOutputsStage.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/statemachine/stages/ArchiveJobOutputsStage.java
@@ -17,6 +17,7 @@
  */
 package com.netflix.genie.agent.execution.statemachine.stages;
 
+import com.netflix.genie.agent.cli.logging.ConsoleLog;
 import com.netflix.genie.agent.execution.exceptions.ChangeJobArchiveStatusException;
 import com.netflix.genie.agent.execution.services.AgentJobService;
 import com.netflix.genie.agent.execution.statemachine.ExecutionContext;
@@ -81,6 +82,10 @@ public class ArchiveJobOutputsStage extends ExecutionStage {
                 } catch (JobArchiveException | URISyntaxException e) {
                     // Swallow the error and move on.
                     log.error("Error archiving job folder", e);
+                    ConsoleLog.getLogger().error(
+                        "Job file archive error: {}",
+                        e.getCause() != null ? e.getCause().getMessage() : e.getMessage()
+                    );
                 }
 
                 final String jobId = executionContext.getClaimedJobId();

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImpl.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/services/impl/JobArchiveServiceImpl.java
@@ -108,7 +108,7 @@ public class JobArchiveServiceImpl implements JobArchiveService {
         for (final JobArchiver archiver : this.jobArchivers) {
             // TODO: Perhaps we should pass the manifest down to the archive implementations if they want to use it?
             if (archiver.archiveDirectory(directory, filesList, target)) {
-                log.info(
+                log.debug(
                     "Successfully archived job directory {} to {} using {} ({} files)",
                     directory.toString(),
                     uriString,

--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -132,6 +132,11 @@ https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-featu
 |false
 |no
 
+|genie.agent.routing.refresh-interval
+|Interval at which individual connections are refreshed
+|3s
+|no
+
 |genie.agent.runtime.*
 |Properties with this prefix are forwarded to each agent during startup
 |

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
@@ -163,7 +163,7 @@ class JobRestControllerIntegrationTest extends RestControllerIntegrationTestBase
     // related to charset headers
     private static final String GB18030_TXT = "GB18030.txt";
     private static final List<String> SLEEP_AND_ECHO_COMMAND_ARGS =
-        Lists.newArrayList("-c", "'sleep 1 && echo hello world'");
+        Lists.newArrayList("-c", "'sleep 5 && echo hello world'");
     private static final ArrayList<String> SLEEP_60_COMMAND_ARGS = Lists.newArrayList("-c", "'sleep 60'");
     private static final String EXPECTED_STDOUT_CONTENT = "hello world\n";
     private static final int EXPECTED_STDOUT_LENGTH = EXPECTED_STDOUT_CONTENT.length();
@@ -1491,60 +1491,7 @@ class JobRestControllerIntegrationTest extends RestControllerIntegrationTestBase
                 .header(HttpHeaders.LOCATION)
         );
 
-        this.waitForDone(jobId);
-
-        RestAssured
-            .given(this.getRequestSpecification())
-            .when()
-            .port(this.port)
-            .get(JOBS_API + "/" + jobId + "/output/genie/logs/env.log")
-            .then()
-            .statusCode(Matchers.is(HttpStatus.OK.value()))
-            .contentType(Matchers.containsString(MediaType.TEXT_PLAIN_VALUE))
-            .contentType(Matchers.containsString(utf8));
-
-        if (this.agentExecution) {
-            RestAssured
-                .given(this.getRequestSpecification())
-                .when()
-                .port(this.port)
-                .get(JOBS_API + "/" + jobId + "/output/genie/logs/agent.log")
-                .then()
-                .statusCode(Matchers.is(HttpStatus.OK.value()))
-                .contentType(Matchers.containsString(MediaType.TEXT_PLAIN_VALUE))
-                .contentType(Matchers.containsString(utf8));
-
-            RestAssured
-                .given(this.getRequestSpecification())
-                .when()
-                .port(this.port)
-                .get(JOBS_API + "/" + jobId + "/output/genie/logs/setup.log")
-                .then()
-                .statusCode(Matchers.is(HttpStatus.OK.value()))
-                .contentType(Matchers.containsString(MediaType.TEXT_PLAIN_VALUE))
-                .contentType(Matchers.containsString(utf8));
-
-        } else {
-            RestAssured
-                .given(this.getRequestSpecification())
-                .when()
-                .port(this.port)
-                .get(JOBS_API + "/" + jobId + "/output/genie/logs/genie.log")
-                .then()
-                .statusCode(Matchers.is(HttpStatus.OK.value()))
-                .contentType(Matchers.containsString(MediaType.TEXT_PLAIN_VALUE))
-                .contentType(Matchers.containsString(utf8));
-
-            RestAssured
-                .given(this.getRequestSpecification())
-                .when()
-                .port(this.port)
-                .get(JOBS_API + "/" + jobId + "/output/genie/genie.done")
-                .then()
-                .statusCode(Matchers.is(HttpStatus.OK.value()))
-                .contentType(Matchers.containsString(MediaType.TEXT_PLAIN_VALUE))
-                .contentType(Matchers.containsString(utf8));
-        }
+        this.waitForRunning(jobId);
 
         RestAssured
             .given(this.getRequestSpecification())
@@ -1652,7 +1599,7 @@ class JobRestControllerIntegrationTest extends RestControllerIntegrationTestBase
                 .header(HttpHeaders.LOCATION)
         );
 
-        this.waitForDone(jobId);
+        this.waitForRunning(jobId);
 
         RestAssured
             .given(this.getRequestSpecification())

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/runsh-agent.txt
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/runsh-agent.txt
@@ -135,7 +135,7 @@ exec 2>&7 7>&-
 env | sort > ${__GENIE_ENVIRONMENT_DUMP_FILE}
 
 # Launch the command
-/bin/bash -c 'sleep 1 && echo hello world' <&0 &
+/bin/bash -c 'sleep 5 && echo hello world' <&0 &
 wait %1
 exit $?
 

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/runsh-embedded.txt
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTests/runsh-embedded.txt
@@ -124,7 +124,7 @@ source ${GENIE_JOB_DIR}/jobsetupfile
 env | sort > ${GENIE_JOB_DIR}/genie/logs/env.log
 
 # Kick off the command in background mode and wait for it using its pid
-/bin/bash -c 'sleep 1 && echo hello world' > ${GENIE_JOB_DIR}/stdout 2> ${GENIE_JOB_DIR}/stderr &
+/bin/bash -c 'sleep 5 && echo hello world' > ${GENIE_JOB_DIR}/stdout 2> ${GENIE_JOB_DIR}/stderr &
 export CHILDREN_PID=$!
 wait ${CHILDREN_PID}
 

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcAgentFileStreamServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcAgentFileStreamServiceImpl.java
@@ -258,7 +258,7 @@ public class GRpcAgentFileStreamServiceImpl
         private StreamObserver<AgentManifestMessage> handleNewControlStream(
             final StreamObserver<ServerControlMessage> responseObserver
         ) {
-            log.info("New agent control stream established");
+            log.debug("New agent control stream established");
             return new ControlStreamObserver(this, responseObserver);
         }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcAgentFileStreamServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcAgentFileStreamServiceImpl.java
@@ -344,7 +344,6 @@ public class GRpcAgentFileStreamServiceImpl
         public void onError(final Throwable t) {
             // Drop the stream, no other actions necessary
             this.controlStreamManager.removeControlStream(this, t);
-            this.responseObserver.onCompleted();
         }
 
         /**
@@ -735,7 +734,6 @@ public class GRpcAgentFileStreamServiceImpl
         @Override
         public void onError(final Throwable t) {
             this.transferManager.removeTransferStream(this, t);
-            this.responseObserver.onCompleted();
         }
 
         /**

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcHeartBeatServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcHeartBeatServiceImpl.java
@@ -150,10 +150,10 @@ public class GRpcHeartBeatServiceImpl extends HeartBeatServiceGrpc.HeartBeatServ
         } else if (StringUtils.isBlank(claimedJobId)) {
             log.warn("Ignoring heartbeat lacking job id");
         } else {
-            log.debug("Received heartbeat for job: {} (stream id: {})", claimedJobId, streamId);
+            log.debug("Received heartbeat from job: {} (stream id: {})", claimedJobId, streamId);
             final boolean isFirstHeartBeat = agentStreamRecord.updateRecord(claimedJobId);
             if (isFirstHeartBeat) {
-                log.info("Received first heartbeat for job: {} (stream id: {})", claimedJobId, streamId);
+                log.info("Received first heartbeat from job: {}", claimedJobId);
             }
             this.agentConnectionTrackingService.notifyHeartbeat(streamId, claimedJobId);
         }

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcHeartBeatServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcHeartBeatServiceImpl.java
@@ -215,7 +215,6 @@ public class GRpcHeartBeatServiceImpl extends HeartBeatServiceGrpc.HeartBeatServ
             if (agentStreamRecord.hasJobId()) {
                 this.agentConnectionTrackingService.notifyDisconnected(streamId, agentStreamRecord.getJobId());
             }
-            agentStreamRecord.responseObserver.onCompleted();
         }
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/data/observers/PersistedJobStatusObserverImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/observers/PersistedJobStatusObserverImpl.java
@@ -50,8 +50,9 @@ public class PersistedJobStatusObserverImpl implements PersistedJobStatusObserve
     @Override
     public void notify(final String jobId, @Nullable final JobStatus previousStatus, final JobStatus currentStatus) {
         final JobStateChangeEvent event = new JobStateChangeEvent(jobId, previousStatus, currentStatus, this);
-        log.warn("Publishing event: {}", event);
+        log.debug("Publishing event: {}", event);
         this.genieEventBus.publishAsynchronousEvent(event);
+        log.info("Job {} status changed from: {} to: {}", jobId, previousStatus, currentStatus);
     }
 
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/events/JobFinishedSNSPublisher.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/events/JobFinishedSNSPublisher.java
@@ -144,7 +144,7 @@ public class JobFinishedSNSPublisher
             return;
         }
 
-        log.info("Publishing SNS notification for completed job {}", jobId);
+        log.debug("Publishing SNS notification for completed job {}", jobId);
 
         final HashMap<String, Object> eventDetailsMap = Maps.newHashMap();
 

--- a/genie-web/src/main/java/com/netflix/genie/web/events/JobNotificationMetricPublisher.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/events/JobNotificationMetricPublisher.java
@@ -55,7 +55,7 @@ public class JobNotificationMetricPublisher implements ApplicationListener<JobSt
         final String toStateString = event.getNewStatus().name();
         final boolean isFinalState = event.getNewStatus().isFinished();
 
-        log.info(
+        log.debug(
             "Job '{}' changed state from {} to {} {}",
             event.getJobId(),
             fromStateString,

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/AgentRoutingServiceProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/AgentRoutingServiceProperties.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Properties for {@link com.netflix.genie.web.agent.services.AgentRoutingService}.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+@ConfigurationProperties(prefix = AgentRoutingServiceProperties.PREFIX)
+@Getter
+@Setter
+public class AgentRoutingServiceProperties {
+    /**
+     * Properties prefix.
+     */
+    static final String PREFIX = "genie.agent.routing";
+
+    private Duration refreshInterval = Duration.ofSeconds(3);
+}

--- a/genie-web/src/main/java/com/netflix/genie/web/scripts/ScriptManager.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/scripts/ScriptManager.java
@@ -328,7 +328,7 @@ public class ScriptManager {
                 throw new ScriptLoadingException("Failed to compile script: " + scriptUriString, e);
             }
 
-            log.info("Successfully compiled: " + scriptUriString);
+            log.debug("Successfully compiled: " + scriptUriString);
             return compiledScript;
         }
     }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobCoordinatorServiceImpl.java
@@ -237,7 +237,7 @@ public class JobCoordinatorServiceImpl implements JobCoordinatorService {
                 final int maxSystemMemory = this.jobsProperties.getMemory().getMaxSystemMemory();
                 final int usedMemory = this.jobStateService.getUsedMemory();
                 if (usedMemory + memory <= maxSystemMemory) {
-                    log.info(
+                    log.debug(
                         "Job {} can run on this node as only {}/{} MB are used and requested {} MB",
                         jobId,
                         usedMemory,

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobResolverServiceImpl.java
@@ -517,7 +517,7 @@ public class JobResolverServiceImpl implements JobResolverService {
                 .getCommand()
                 .orElseThrow(() -> new IllegalStateException("Command hasn't been resolved before applications"))
                 .getId();
-            log.info("Selecting applications for job {} and command {}", id, commandId);
+            log.debug("Selecting applications for job {} and command {}", id, commandId);
             // TODO: What do we do about application status? Should probably check here
             final List<Application> applications = Lists.newArrayList();
             if (jobRequest.getCriteria().getApplicationIds().isEmpty()) {
@@ -527,7 +527,7 @@ public class JobResolverServiceImpl implements JobResolverService {
                     applications.add(this.persistenceService.getApplication(applicationId));
                 }
             }
-            log.info(
+            log.debug(
                 "Resolved applications {} for job {}",
                 applications
                     .stream()

--- a/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfiguration.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfiguration.java
@@ -33,6 +33,7 @@ import com.netflix.genie.web.agent.services.impl.AgentRoutingServiceImpl;
 import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.PersistenceService;
 import com.netflix.genie.web.properties.AgentConfigurationProperties;
+import com.netflix.genie.web.properties.AgentRoutingServiceProperties;
 import com.netflix.genie.web.services.JobResolverService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.framework.listen.Listenable;
@@ -58,7 +59,8 @@ import java.util.List;
 @Configuration
 @EnableConfigurationProperties(
     {
-        AgentConfigurationProperties.class
+        AgentConfigurationProperties.class,
+        AgentRoutingServiceProperties.class
     }
 )
 public class AgentServicesAutoConfiguration {
@@ -140,6 +142,7 @@ public class AgentServicesAutoConfiguration {
      * @param taskScheduler                    The task scheduler
      * @param listenableCuratorConnectionState the connection state listenable
      * @param registry                         The metrics registry
+     * @param properties                       The service properties
      * @return A {@link AgentRoutingServiceImpl} instance
      */
     @Bean
@@ -150,14 +153,16 @@ public class AgentServicesAutoConfiguration {
         final ServiceDiscovery<AgentRoutingServiceCuratorDiscoveryImpl.Agent> serviceDiscovery,
         @Qualifier("genieTaskScheduler") final TaskScheduler taskScheduler,
         final Listenable<ConnectionStateListener> listenableCuratorConnectionState,
-        final MeterRegistry registry
+        final MeterRegistry registry,
+        final AgentRoutingServiceProperties properties
     ) {
         return new AgentRoutingServiceCuratorDiscoveryImpl(
             genieHostInfo,
             serviceDiscovery,
             taskScheduler,
             listenableCuratorConnectionState,
-            registry
+            registry,
+            properties
         );
     }
 

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/ClusterCheckerTask.java
@@ -148,7 +148,7 @@ public class ClusterCheckerTask extends LeaderTask {
                 return result;
             }
         );
-        log.info("Finished checking for cluster node health.");
+        log.debug("Finished checking for cluster node health.");
     }
 
     private void updateJobsToFailedOnHost(final String host) {

--- a/genie-web/src/main/resources/genie-web-defaults.yml
+++ b/genie-web/src/main/resources/genie-web-defaults.yml
@@ -40,6 +40,8 @@ genie:
       write-retry-delay: 300ms
     heart-beat:
       send-interval: 5s
+    routing:
+      refresh-interval: 3s
   file:
     cache:
       location: file://${java.io.tmpdir:/tmp}/genie/cache

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcHeartBeatServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcHeartBeatServiceImplSpec.groovy
@@ -160,7 +160,7 @@ class GRpcHeartBeatServiceImplSpec extends Specification {
 
         then:
         1 * agentConnectionTrackingService.notifyDisconnected(streamId, jobId)
-        1 * responseObserver.onCompleted()
+        0 * responseObserver.onCompleted()
     }
 
 
@@ -237,7 +237,7 @@ class GRpcHeartBeatServiceImplSpec extends Specification {
 
         then:
         0 * agentConnectionTrackingService._
-        1 * responseObserver.onCompleted()
+        0 * responseObserver.onCompleted()
     }
 
     def "Send server heartbeats and close streams on shutdown"() {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentRoutingServicePropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/AgentRoutingServicePropertiesSpec.groovy
@@ -1,0 +1,39 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.web.properties
+
+import spock.lang.Specification
+
+import java.time.Duration
+
+class AgentRoutingServicePropertiesSpec extends Specification {
+
+    def "Default, setters, getters"() {
+        when:
+        AgentRoutingServiceProperties props = new AgentRoutingServiceProperties()
+
+        then:
+        props.getRefreshInterval() == Duration.ofSeconds(3)
+
+        when:
+        props.setRefreshInterval(Duration.ofMinutes(1))
+
+        then:
+        props.getRefreshInterval() == Duration.ofMinutes(1)
+    }
+}

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/services/AgentServicesAutoConfigurationTest.java
@@ -28,6 +28,7 @@ import com.netflix.genie.web.agent.services.impl.AgentRoutingServiceCuratorDisco
 import com.netflix.genie.web.data.services.DataServices;
 import com.netflix.genie.web.data.services.PersistenceService;
 import com.netflix.genie.web.properties.AgentConfigurationProperties;
+import com.netflix.genie.web.properties.AgentRoutingServiceProperties;
 import com.netflix.genie.web.services.JobResolverService;
 import com.netflix.genie.web.spring.autoconfigure.agent.apis.rpc.v4.endpoints.AgentRpcEndpointsAutoConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -75,6 +76,7 @@ class AgentServicesAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(AgentFilterService.class);
                     Assertions.assertThat(context).hasSingleBean(AgentConfigurationProperties.class);
                     Assertions.assertThat(context).hasSingleBean(AgentConfigurationService.class);
+                    Assertions.assertThat(context).hasSingleBean(AgentRoutingServiceProperties.class);
                 }
             );
     }
@@ -95,6 +97,7 @@ class AgentServicesAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(AgentFilterService.class);
                     Assertions.assertThat(context).hasSingleBean(AgentConfigurationProperties.class);
                     Assertions.assertThat(context).hasSingleBean(AgentConfigurationService.class);
+                    Assertions.assertThat(context).hasSingleBean(AgentRoutingServiceProperties.class);
                 }
             );
     }


### PR DESCRIPTION
With the previous curator-based implementation, the right timing of events was resulting in the routing table lagging seconds behind reality.
With enough jobs, these unlikely circumstances manifest multiple times a day, resulting in requests failing to route.

Re-implement AgentRoutingService to respond faster to change.