### PR TITLE
Bug: integer overflow for large files

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentFileStreamServiceImpl.java
@@ -255,8 +255,8 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
     private synchronized void handleFileRequest(
         final String streamId,
         final String relativePath,
-        final int startOffset,
-        final int endOffset
+        final long startOffset,
+        final long endOffset
     ) {
         log.info(
             "Server is requesting file {} (range: [{}, {}), streamId: {})",
@@ -350,19 +350,19 @@ public class GRpcAgentFileStreamServiceImpl implements AgentFileStreamService {
         private final GRpcAgentFileStreamServiceImpl gRpcAgentFileStreamService;
         private final String streamId;
         private final Path absolutePath;
-        private final int startOffset;
-        private final int endOffset;
+        private final long startOffset;
+        private final long endOffset;
         private final StreamObserver<AgentFileMessage> outboundStreamObserver;
         private final ByteBuffer readBuffer;
         private final AtomicBoolean completed = new AtomicBoolean();
-        private int watermark;
+        private long watermark;
 
         FileTransfer(
             final GRpcAgentFileStreamServiceImpl gRpcAgentFileStreamService,
             final String streamId,
             final Path absolutePath,
-            final int startOffset,
-            final int endOffset,
+            final long startOffset,
+            final long endOffset,
             final long maxChunkSize
         ) {
             this.gRpcAgentFileStreamService = gRpcAgentFileStreamService;

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dtos/v4/converters/JobDirectoryManifestProtoConverter.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/dtos/v4/converters/JobDirectoryManifestProtoConverter.java
@@ -71,6 +71,7 @@ public class JobDirectoryManifestProtoConverter {
         return AgentManifestMessage.newBuilder()
             .setJobId(claimedJobId)
             .setManifestJson(manifestJsonString)
+            .setLargeFilesSupported(true)
             .build();
     }
 

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dtos/v4/converters/DirectoryManifestProtoConverterSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/dtos/v4/converters/DirectoryManifestProtoConverterSpec.groovy
@@ -46,6 +46,7 @@ class DirectoryManifestProtoConverterSpec extends Specification {
         1 * objectMapper.writeValueAsString(manifest) >> JSON_MANIFEST
         message.getJobId() == jobId
         message.getManifestJson() == JSON_MANIFEST
+        message.getLargeFilesSupported()
 
         when:
         DirectoryManifest loadedManifest = converter.toManifest(message)

--- a/genie-proto/src/main/proto/genie.proto
+++ b/genie-proto/src/main/proto/genie.proto
@@ -324,6 +324,7 @@ service FileStreamService {
 message AgentManifestMessage {
     string job_id = 1;
     string manifest_json = 2;
+    bool large_files_supported = 3; // To be removed once all agents are running a recent version
 }
 
 message ServerControlMessage {
@@ -335,8 +336,10 @@ message ServerControlMessage {
 message ServerFileRequestMessage {
     string stream_id = 1;
     string relative_path = 2;
-    int32 start_offset = 3;
-    int32 end_offset = 4;
+    int32 deprecated_start_offset = 3 [deprecated = true];
+    int32 deprecated_end_offset = 4   [deprecated = true];
+    int64 start_offset = 5;
+    int64 end_offset = 6;
 }
 
 message AgentFileMessage {

--- a/genie-web/src/main/java/com/netflix/genie/web/util/StreamBuffer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/StreamBuffer.java
@@ -56,7 +56,7 @@ public class StreamBuffer {
      * Constructor.
      * @param skipOffset index of the first actual byte to return (
      */
-    public StreamBuffer(final int skipOffset) {
+    public StreamBuffer(final long skipOffset) {
         this.inputStreamRef.set(new StreamBufferInputStream(this, skipOffset));
     }
 
@@ -190,9 +190,9 @@ public class StreamBuffer {
 
     private static class StreamBufferInputStream extends InputStream {
         private final StreamBuffer streamBuffer;
-        private int skipBytesLeft;
+        private long skipBytesLeft;
 
-        StreamBufferInputStream(final StreamBuffer streamBuffer, final int skipOffset) {
+        StreamBufferInputStream(final StreamBuffer streamBuffer, final long skipOffset) {
             this.streamBuffer = streamBuffer;
             this.skipBytesLeft = skipOffset;
         }
@@ -218,7 +218,9 @@ public class StreamBuffer {
 
             // Efficiently skip over range of bytes that should be ignored
             if (this.skipBytesLeft > 0) {
-                final int skippedBytesRead = Math.min(this.skipBytesLeft, len);
+                final int maxSkipBytes =
+                    this.skipBytesLeft <= Integer.MAX_VALUE ? (int) this.skipBytesLeft : Integer.MAX_VALUE;
+                final int skippedBytesRead = Math.min(len, maxSkipBytes);
                 System.arraycopy(new byte[skippedBytesRead], 0, b, off, skippedBytesRead);
                 this.skipBytesLeft -= skippedBytesRead;
                 return skippedBytesRead;


### PR DESCRIPTION
Updates the gRPC protocol to allow downloading files that are over 2GB in size.
The previous version of the protocol was (naively) using int32 for offsets. So anything beyond the 2GB mark would produce an integer overflow server-side.

 - Rename deprecated unit32 fields, they will be ignored by current and future agent in favor of new int64
 - Add a field so that an agent can inform the server it is recent and supports files/ranges over 2GB
 - Block request whose range is over the 2GB mark IFF the target agent is old and does not support it
 - Migrate from int to long where appropriate

Old behavior:
 1) Files smaller than 2GB: no problem
 2) Range below 2GB for larger than 2GB file: no problem
 3) Range above 2GB for larger than 2GB files: error 500, integer overflow

New behavior
 1) Unchanged
 2) Unchanged
 3) (against old agent) Unchanged (but better error message)
 3) (against new agent) successful