### PR TITLE
Improve handling of command/cluster selector runtime errors

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobServiceImpl.java
@@ -384,6 +384,9 @@ class GRpcAgentJobServiceImpl implements AgentJobService {
                         + ": "
                         + error.getMessage()
                 );
+            case RUNTIME_ERROR:
+                throw new GenieRuntimeException(
+                    "Transient error resolving job specification: " + error.getMessage());
             case UNKNOWN:
             default:
                 throw new GenieRuntimeException(

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobServiceImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/grpc/GRpcAgentJobServiceImplSpec.groovy
@@ -288,6 +288,7 @@ class GRpcAgentJobServiceImplSpec extends Specification {
         JobSpecificationError.Type.NO_JOB_FOUND         | JobSpecificationResolutionException
         JobSpecificationError.Type.NO_COMMAND_FOUND     | JobSpecificationResolutionException
         JobSpecificationError.Type.RESOLUTION_FAILED    | JobSpecificationResolutionException
+        JobSpecificationError.Type.RUNTIME_ERROR        | GenieRuntimeException
         JobSpecificationError.Type.UNKNOWN              | GenieRuntimeException
     }
 

--- a/genie-common-internal/src/main/java/com/netflix/genie/common/internal/exceptions/unchecked/GenieJobResolutionRuntimeException.java
+++ b/genie-common-internal/src/main/java/com/netflix/genie/common/internal/exceptions/unchecked/GenieJobResolutionRuntimeException.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.common.internal.exceptions.unchecked;
+
+/**
+ * When resolution fails with a runtime error, such as the selector timing out.
+ *
+ * @author mprimi
+ * @since 4.0.0
+ */
+public class GenieJobResolutionRuntimeException extends GenieRuntimeException {
+    /**
+     * Constructor.
+     */
+    public GenieJobResolutionRuntimeException() {
+        super();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message The detail message
+     */
+    public GenieJobResolutionRuntimeException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message The detail message
+     * @param cause   The root cause of this exception
+     */
+    public GenieJobResolutionRuntimeException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cause The root cause of this exception
+     */
+    public GenieJobResolutionRuntimeException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/exceptions/unchecked/GenieUncheckedExceptionsSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/exceptions/unchecked/GenieUncheckedExceptionsSpec.groovy
@@ -70,6 +70,7 @@ class GenieUncheckedExceptionsSpec extends Specification {
         GenieIdAlreadyExistsException          | _
         GenieInvalidStatusException            | _
         GenieJobAlreadyClaimedException        | _
+        GenieJobResolutionRuntimeException     | _
         GenieJobSpecificationNotFoundException | _
         GenieRuntimeException                  | _
     }

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessages.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessages.java
@@ -152,6 +152,11 @@ public final class JobStatusMessages {
     public static final String JOB_MARKED_FAILED = "The job status changed server-side while the job was running";
 
     /**
+     * Job resolution fails due to runtime error (i.e. NOT due to unsatisfiable constraints).
+     */
+    public static final String RESOLUTION_RUNTIME_ERROR = "Runtime error during job resolution";
+
+    /**
      * Private constructor, this class is not meant to be instantiated.
      */
     private JobStatusMessages() {

--- a/genie-proto/src/main/proto/genie.proto
+++ b/genie-proto/src/main/proto/genie.proto
@@ -184,6 +184,7 @@ message JobSpecificationError {
         NO_SPECIFICATION_FOUND = 5;
         INVALID_REQUEST = 6;
         RESOLUTION_FAILED = 7;
+        RUNTIME_ERROR = 8;
     }
     Type type = 1;
     string message = 2;

--- a/genie-web/src/integTest/resources/application-integration.yml
+++ b/genie-web/src/integTest/resources/application-integration.yml
@@ -25,10 +25,6 @@ genie:
         maxInterval: 10
   health:
     maxCpuLoadPercent: 100
-  scripts:
-    cluster-selector:
-      source: file:///tmp/genie/scripts/selectCluster.js
-      auto-load-enabled: true
 
 # Start gRPC on a random available port to avoid port binding conflicts during
 # integration tests shutting down less than gracefully

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposer.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/JobServiceProtoErrorComposer.java
@@ -29,6 +29,7 @@ import com.netflix.genie.common.internal.exceptions.unchecked.GenieIdAlreadyExis
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieInvalidStatusException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobAlreadyClaimedException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
+import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobResolutionRuntimeException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobSpecificationNotFoundException;
 import com.netflix.genie.proto.ChangeJobStatusError;
 import com.netflix.genie.proto.ChangeJobStatusResponse;
@@ -70,6 +71,7 @@ public class JobServiceProtoErrorComposer {
             .put(ConstraintViolationException.class, JobSpecificationError.Type.INVALID_REQUEST)
             .put(GenieJobResolutionException.class, JobSpecificationError.Type.RESOLUTION_FAILED)
             .put(GeniePreconditionException.class, JobSpecificationError.Type.RESOLUTION_FAILED)
+            .put(GenieJobResolutionRuntimeException.class, JobSpecificationError.Type.RUNTIME_ERROR)
             .build();
 
     private static final Map<Class<? extends Exception>, ClaimJobError.Type> CLAIM_JOB_ERROR_MAP =

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentJobService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/AgentJobService.java
@@ -28,6 +28,7 @@ import com.netflix.genie.common.internal.exceptions.unchecked.GenieIdAlreadyExis
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieInvalidStatusException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobAlreadyClaimedException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
+import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobResolutionRuntimeException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobSpecificationNotFoundException;
 import org.springframework.validation.annotation.Validated;
 
@@ -81,10 +82,14 @@ public interface AgentJobService {
      *
      * @param id The id of the job to resolve the specification for. Must already have a reserved an id in the database
      * @return The job specification if one could be resolved
-     * @throws GenieJobResolutionException  On error resolving the job given the input parameters and system state
-     * @throws ConstraintViolationException If the arguments fail validation
+     * @throws GenieJobResolutionException        On error resolving the job given the input parameters and system state
+     * @throws ConstraintViolationException       If the arguments fail validation
+     * @throws GenieJobResolutionRuntimeException If job resolution fails due to a runtime error (as opposed to
+     *                                            unsatisfiable constraints)
      */
-    JobSpecification resolveJobSpecification(@NotBlank String id) throws GenieJobResolutionException;
+    JobSpecification resolveJobSpecification(
+        @NotBlank String id
+    ) throws GenieJobResolutionException, GenieJobResolutionRuntimeException;
 
     /**
      * Get a job specification if has been resolved.

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/services/impl/AgentJobServiceImpl.java
@@ -28,6 +28,7 @@ import com.netflix.genie.common.internal.exceptions.checked.GenieJobResolutionEx
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieAgentRejectedException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieIdAlreadyExistsException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobNotFoundException;
+import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobResolutionRuntimeException;
 import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobSpecificationNotFoundException;
 import com.netflix.genie.web.agent.inspectors.InspectionReport;
 import com.netflix.genie.web.agent.services.AgentConfigurationService;
@@ -174,7 +175,9 @@ public class AgentJobServiceImpl implements AgentJobService {
      * {@inheritDoc}
      */
     @Override
-    public JobSpecification resolveJobSpecification(@NotBlank final String id) throws GenieJobResolutionException {
+    public JobSpecification resolveJobSpecification(
+        @NotBlank final String id
+    ) throws GenieJobResolutionException, GenieJobResolutionRuntimeException {
         try {
             final JobRequest jobRequest = this.persistenceService.getJobRequest(id);
             final ResolvedJob resolvedJob = this.jobResolverService.resolveJob(id, jobRequest, false);

--- a/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/JobResolverService.java
@@ -20,6 +20,7 @@ package com.netflix.genie.web.services;
 import com.netflix.genie.common.external.dtos.v4.JobRequest;
 import com.netflix.genie.common.external.dtos.v4.JobStatus;
 import com.netflix.genie.common.internal.exceptions.checked.GenieJobResolutionException;
+import com.netflix.genie.common.internal.exceptions.unchecked.GenieJobResolutionRuntimeException;
 import com.netflix.genie.web.dtos.ResolvedJob;
 import org.springframework.validation.annotation.Validated;
 
@@ -44,11 +45,11 @@ public interface JobResolverService {
      * @param id The id of the job to resolve. The job must exist and its status must return {@literal true} from
      *           {@link JobStatus#isResolvable()}
      * @return A {@link ResolvedJob} instance containing all the concrete information needed to execute the job
-     * @throws GenieJobResolutionException When there is an issue resolving the job based on the information provided
-     *                                     by the user in conjunction with the configuration available in the system
+     * @throws GenieJobResolutionException        When the job cannot resolved due to unsatisfiable constraints
+     * @throws GenieJobResolutionRuntimeException When the job fails to resolve due to a runtime error.
      */
     @Nonnull
-    ResolvedJob resolveJob(String id) throws GenieJobResolutionException;
+    ResolvedJob resolveJob(String id) throws GenieJobResolutionException, GenieJobResolutionRuntimeException;
 
     /**
      * Given a job request resolve all the details needed to run a job. This API is stateless and saves nothing.
@@ -57,9 +58,13 @@ public interface JobResolverService {
      * @param jobRequest The job request containing all details a user wants to have for their job
      * @param apiJob     {@literal true} if this job was submitted via the REST API. {@literal false} otherwise.
      * @return The completely resolved job information within a {@link ResolvedJob} instance
-     * @throws GenieJobResolutionException When there is an issue resolving the job based on the information provided
-     *                                     by the user in conjunction with the configuration available in the system
+     * @throws GenieJobResolutionException        When the job cannot resolved due to unsatisfiable constraints
+     * @throws GenieJobResolutionRuntimeException When the job fails to resolve due to a runtime error.
      */
     @Nonnull
-    ResolvedJob resolveJob(String id, @Valid JobRequest jobRequest, boolean apiJob) throws GenieJobResolutionException;
+    ResolvedJob resolveJob(
+        String id,
+        @Valid JobRequest jobRequest,
+        boolean apiJob
+    ) throws GenieJobResolutionException, GenieJobResolutionRuntimeException;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
@@ -119,12 +119,19 @@ public class JobLaunchServiceImpl implements JobLaunchService {
             try {
                 resolvedJob = this.jobResolverService.resolveJob(jobId);
             } catch (final Throwable t) {
+                final String message;
+                if (t instanceof  GenieJobResolutionException) {
+                    message = JobStatusMessages.FAILED_TO_RESOLVE_JOB;
+                } else {
+                    message = JobStatusMessages.RESOLUTION_RUNTIME_ERROR;
+                }
+
                 MetricsUtils.addFailureTagsWithException(tags, t);
                 this.persistenceService.updateJobStatus(
                     jobId,
                     JobStatus.RESERVED,
                     JobStatus.FAILED,
-                    JobStatusMessages.FAILED_TO_RESOLVE_JOB // TODO: Move somewhere not in genie-common
+                    message // TODO: Move somewhere not in genie-common
                 );
                 this.persistenceService.updateJobArchiveStatus(jobId, ArchiveStatus.NO_FILES);
                 throw t; // Caught below for metrics gathering

--- a/genie-web/src/main/resources/genie-web-defaults.yml
+++ b/genie-web/src/main/resources/genie-web-defaults.yml
@@ -82,11 +82,6 @@ genie:
       noOfRetries: 5
   scripts-manager:
     refresh-interval: 300000
-  scripts:
-    cluster-selector:
-      source:
-      auto-load-enabled: false
-      timeout: 5000
   smoke: true
   swagger:
     enabled: false

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,8 @@
 ## Spring Dependency Versions
 
 # Used in documentation and for including the Gradle plugin
-spring_boot_version=2.3.2.RELEASE
-spring_cloud_version=Hoxton.SR7
+spring_boot_version=2.3.3.RELEASE
+spring_cloud_version=Hoxton.SR8
 
 ## Override Spring Dependency Managed Versions
 


### PR DESCRIPTION
Motivation: allow a client or user to distinguish between 2 failure cases:

 - The job is submitted with criteria that cannot be satisfied, criteria must be updated for this job to be accepted.
 - The selector encountered a runtime error, resubmitting the job with the same criteria may work

Until now, both cases would be handled the same leading to: 
 * Error `412: Precondition Failed' via API
 * Fatal error resolving job request via Agent
And the job would be marked FAILED with status message JobStatusMessages.FAILED_TO_RESOLVE_JOB

This change better distinguishes the 2 error conditions such that:
 - Selector runtime error returns a `500` via API
 - Selector runtime error produces a retryable error in the agent
 - Selector runtime error sets a different message with the final job status
 - Cluster selector runtime error does not proceed to the next selector (for better determinism)

This allows clients to retry, if appropriate.