### PR TITLE
Delete unused entities in batches

### DIFF
--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -574,6 +574,11 @@ of 2.0
 |2m
 |no
 
+|genie.tasks.database-cleanup.batch-size
+|The max number of entities to delete per transaction (applies to files, clusters, commands, tags, applications)
+|1000
+|yes
+
 |genie.tasks.database-cleanup.application-cleanup.skip
 |Skip the Applications table when performing database cleanup
 |false

--- a/genie-test-web/src/main/resources/application.yml
+++ b/genie-test-web/src/main/resources/application.yml
@@ -72,6 +72,7 @@ genie:
   tasks:
     database-cleanup:
       enabled: true
+      batch-size: 10000
       expression: 0 0 0 * * *
       retention: 90
     disk-cleanup:

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplApplicationsIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplApplicationsIntegrationTest.java
@@ -572,7 +572,7 @@ class JpaPersistenceServiceImplApplicationsIntegrationTest extends JpaPersistenc
         Assertions.assertThat(this.applicationRepository.existsByUniqueId("app2")).isTrue();
         Assertions.assertThat(this.applicationRepository.count()).isEqualTo(6);
         final Instant createdThreshold = Instant.parse("2020-03-10T02:44:00.000Z");
-        Assertions.assertThat(this.service.deleteUnusedApplications(createdThreshold)).isEqualTo(1L);
+        Assertions.assertThat(this.service.deleteUnusedApplications(createdThreshold, 10)).isEqualTo(1L);
         Assertions.assertThat(this.applicationRepository.count()).isEqualTo(5);
         Assertions.assertThat(this.applicationRepository.existsByUniqueId("app2")).isFalse();
     }

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplClustersIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplClustersIntegrationTest.java
@@ -538,6 +538,7 @@ class JpaPersistenceServiceImplClustersIntegrationTest extends JpaPersistenceSer
     @Test
     @DatabaseSetup("persistence/clusters/init.xml")
     void testDeleteUnusedClusters() throws GenieCheckedException {
+        final int batchSize = 10;
         Assertions.assertThat(this.clusterRepository.count()).isEqualTo(2L);
         final String testCluster0Id = this.createTestCluster(null, null, ClusterStatus.OUT_OF_SERVICE).getId();
 
@@ -545,19 +546,25 @@ class JpaPersistenceServiceImplClustersIntegrationTest extends JpaPersistenceSer
         final Set<ClusterStatus> deleteStatuses = EnumSet.of(ClusterStatus.TERMINATED);
 
         // Shouldn't delete any clusters as all are UP or OOS
-        Assertions.assertThat(this.service.deleteUnusedClusters(deleteStatuses, creationThreshold)).isEqualTo(0);
+        Assertions
+            .assertThat(this.service.deleteUnusedClusters(deleteStatuses, creationThreshold, batchSize))
+            .isEqualTo(0);
 
         // Add new up cluster
         final String testCluster1Id = this.createTestCluster(null, null, ClusterStatus.UP).getId();
 
         // All clusters are UP/OOS or attached to jobs
-        Assertions.assertThat(this.service.deleteUnusedClusters(deleteStatuses, creationThreshold)).isEqualTo(0);
+        Assertions
+            .assertThat(this.service.deleteUnusedClusters(deleteStatuses, creationThreshold, batchSize))
+            .isEqualTo(0);
 
         // Create Terminated Cluster
         final String testCluster2Id = this.createTestCluster(null, null, ClusterStatus.TERMINATED).getId();
 
         // All clusters are UP/OOS or attached to jobs
-        Assertions.assertThat(this.service.deleteUnusedClusters(deleteStatuses, creationThreshold)).isEqualTo(1);
+        Assertions
+            .assertThat(this.service.deleteUnusedClusters(deleteStatuses, creationThreshold, batchSize))
+            .isEqualTo(1);
 
         // Make sure it didn't delete any of the clusters we wanted
         Assertions.assertThat(this.clusterRepository.existsByUniqueId(CLUSTER_1_ID)).isTrue();

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplCommandsIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplCommandsIntegrationTest.java
@@ -975,7 +975,8 @@ class JpaPersistenceServiceImplCommandsIntegrationTest extends JpaPersistenceSer
             .assertThat(
                 this.service.deleteUnusedCommands(
                     EnumSet.of(CommandStatus.INACTIVE, CommandStatus.DEPRECATED),
-                    createdThreshold
+                    createdThreshold,
+                    10
                 )
             )
             .isEqualTo(3);

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplFilesIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplFilesIntegrationTest.java
@@ -75,7 +75,7 @@ class JpaPersistenceServiceImplFilesIntegrationTest extends JpaPersistenceServic
         Assertions.assertThat(this.fileRepository.existsByFile(file4)).isTrue();
         Assertions.assertThat(this.fileRepository.existsByFile(file5)).isTrue();
 
-        Assertions.assertThat(this.service.deleteUnusedFiles(Instant.now())).isEqualTo(2L);
+        Assertions.assertThat(this.service.deleteUnusedFiles(Instant.now(), 10)).isEqualTo(2L);
 
         Assertions.assertThat(this.fileRepository.existsByFile(file1)).isFalse();
         Assertions.assertThat(this.fileRepository.existsByFile(file2)).isTrue();

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplTagsIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplTagsIntegrationTest.java
@@ -61,7 +61,7 @@ class JpaPersistenceServiceImplTagsIntegrationTest extends JpaPersistenceService
         Assertions.assertThat(this.tagRepository.existsByTag(tag1)).isTrue();
         Assertions.assertThat(this.tagRepository.existsByTag(tag2)).isTrue();
 
-        Assertions.assertThat(this.service.deleteUnusedTags(Instant.now())).isEqualTo(1L);
+        Assertions.assertThat(this.service.deleteUnusedTags(Instant.now(), 10)).isEqualTo(1L);
 
         Assertions.assertThat(this.tagRepository.existsByTag(tag1)).isFalse();
         Assertions.assertThat(this.tagRepository.existsByTag(tag2)).isTrue();

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
@@ -166,9 +166,10 @@ public interface PersistenceService {
      * @param createdThreshold The instant in time that any application had to be created before (exclusive) to be
      *                         considered for deletion. Presents ability to filter out newly created applications if
      *                         desired.
+     * @param batchSize        The maximum number of applications to delete in a single transaction
      * @return The number of successfully deleted applications
      */
-    long deleteUnusedApplications(Instant createdThreshold);
+    long deleteUnusedApplications(@NotNull Instant createdThreshold, @Min(1) int batchSize);
     //endregion
 
     //region Cluster APIs
@@ -247,9 +248,14 @@ public interface PersistenceService {
      *                                deletion.
      * @param clusterCreatedThreshold The instant in time before which a cluster must have been created to be
      *                                considered for deletion. Exclusive.
+     * @param batchSize               The maximum number of clusters to delete in a single transaction
      * @return The number of clusters deleted
      */
-    long deleteUnusedClusters(Set<ClusterStatus> deleteStatuses, Instant clusterCreatedThreshold);
+    long deleteUnusedClusters(
+        Set<ClusterStatus> deleteStatuses,
+        @NotNull Instant clusterCreatedThreshold,
+        @Min(1) int batchSize
+    );
 
     /**
      * Find all the {@link Cluster}'s that match the given {@link Criterion}.
@@ -511,9 +517,14 @@ public interface PersistenceService {
      * @param deleteStatuses          The set of statuses a command must be in in order to be considered for deletion
      * @param commandCreatedThreshold The instant in time a command must have been created before to be considered for
      *                                deletion. Exclusive.
+     * @param batchSize               The maximum number of commands to delete in a single transaction
      * @return The number of commands that were deleted
      */
-    long deleteUnusedCommands(Set<CommandStatus> deleteStatuses, Instant commandCreatedThreshold);
+    long deleteUnusedCommands(
+        Set<CommandStatus> deleteStatuses,
+        @NotNull Instant commandCreatedThreshold,
+        @Min(1) int batchSize
+    );
     //endregion
 
     //region Job APIs
@@ -1128,9 +1139,10 @@ public interface PersistenceService {
      *
      * @param createdThreshold The instant in time where tags created before this time that aren't referenced
      *                         will be deleted. Inclusive
+     * @param batchSize        The maximum number of tags to delete in a single transaction
      * @return The number of tags deleted
      */
-    long deleteUnusedTags(@NotNull Instant createdThreshold);
+    long deleteUnusedTags(@NotNull Instant createdThreshold, @Min(1) int batchSize);
     //endregion
 
     //region File APIs
@@ -1141,8 +1153,9 @@ public interface PersistenceService {
      *
      * @param createdThreshold The instant in time where files created before this time that aren't referenced
      *                         will be deleted. Inclusive
+     * @param batchSize        The maximum number of files to delete in a single transaction
      * @return The number of files deleted
      */
-    long deleteUnusedFiles(@NotNull Instant createdThreshold);
+    long deleteUnusedFiles(@NotNull Instant createdThreshold, @Min(1) int batchSize);
     //endregion
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
@@ -203,8 +203,9 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
 
     /**
      * Constructor.
-     *  @param entityManager           The {@link EntityManager} to use
-     * @param jpaRepositories         All the repositories in the Genie application
+     *
+     * @param entityManager   The {@link EntityManager} to use
+     * @param jpaRepositories All the repositories in the Genie application
      */
     public JpaPersistenceServiceImpl(
         final EntityManager entityManager,
@@ -457,10 +458,10 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
      */
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public long deleteUnusedApplications(final Instant createdThreshold) {
+    public long deleteUnusedApplications(final Instant createdThreshold, final int batchSize) {
         log.info("Attempting to delete unused applications created before {}", createdThreshold);
         return this.applicationRepository.deleteByIdIn(
-            this.applicationRepository.findUnusedApplications(createdThreshold)
+            this.applicationRepository.findUnusedApplications(createdThreshold, batchSize)
         );
     }
     //endregion
@@ -675,7 +676,11 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
      */
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public long deleteUnusedClusters(final Set<ClusterStatus> deleteStatuses, final Instant clusterCreatedThreshold) {
+    public long deleteUnusedClusters(
+        final Set<ClusterStatus> deleteStatuses,
+        final Instant clusterCreatedThreshold,
+        final int batchSize
+    ) {
         log.info(
             "[deleteUnusedClusters] Deleting with statuses {} that were created before {}",
             deleteStatuses,
@@ -684,7 +689,8 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
         return this.clusterRepository.deleteByIdIn(
             this.clusterRepository.findUnusedClusters(
                 deleteStatuses.stream().map(Enum::name).collect(Collectors.toSet()),
-                clusterCreatedThreshold
+                clusterCreatedThreshold,
+                batchSize
             )
         );
     }
@@ -1262,7 +1268,11 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
      */
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public long deleteUnusedCommands(final Set<CommandStatus> deleteStatuses, final Instant commandCreatedThreshold) {
+    public long deleteUnusedCommands(
+        final Set<CommandStatus> deleteStatuses,
+        final Instant commandCreatedThreshold,
+        final int batchSize
+    ) {
         log.info(
             "Deleting commands with statuses {} that were created before {}",
             deleteStatuses,
@@ -1271,7 +1281,8 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
         return this.commandRepository.deleteByIdIn(
             this.commandRepository.findUnusedCommands(
                 deleteStatuses.stream().map(Enum::name).collect(Collectors.toSet()),
-                commandCreatedThreshold
+                commandCreatedThreshold,
+                batchSize
             )
         );
     }
@@ -2289,11 +2300,11 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
      */
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public long deleteUnusedTags(@NotNull final Instant createdThreshold) {
+    public long deleteUnusedTags(@NotNull final Instant createdThreshold, @Min(1) final int batchSize) {
         log.info("[deleteUnusedTags] Called to delete unused tags created before {}", createdThreshold);
         return this.tagRepository.deleteByIdIn(
             this.tagRepository
-                .findUnusedTags(createdThreshold)
+                .findUnusedTags(createdThreshold, batchSize)
                 .stream()
                 .map(Number::longValue)
                 .collect(Collectors.toSet())
@@ -2308,11 +2319,11 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
      */
     @Override
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public long deleteUnusedFiles(@NotNull final Instant createdThreshold) {
+    public long deleteUnusedFiles(@NotNull final Instant createdThreshold, @Min(1) final int batchSize) {
         log.debug("[deleteUnusedFiles] Called to delete unused files created before {}", createdThreshold);
         return this.fileRepository.deleteByIdIn(
             this.fileRepository
-                .findUnusedFiles(createdThreshold)
+                .findUnusedFiles(createdThreshold, batchSize)
                 .stream()
                 .map(Number::longValue)
                 .collect(Collectors.toSet())

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaApplicationRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaApplicationRepository.java
@@ -40,17 +40,22 @@ public interface JpaApplicationRepository extends JpaBaseRepository<ApplicationE
             + " FROM applications"
             + " WHERE created < :createdThreshold"
             + " AND id NOT IN (SELECT DISTINCT(application_id) FROM commands_applications)"
-            + " AND id NOT IN (SELECT DISTINCT(application_id) FROM jobs_applications)";
+            + " AND id NOT IN (SELECT DISTINCT(application_id) FROM jobs_applications)"
+            + " LIMIT :limit";
 
     /**
      * Delete any application records where it's not linked to any jobs and it's not linked to any commands and was
      * created before the given time.
      *
-     * @param createdThreshold The instant in time before which records should be considered for deletion. Exclusive.O
+     * @param createdThreshold The instant in time before which records should be considered for deletion. Exclusive.
+     * @param limit            Maximum number of IDs to return
      * @return The ids of the applications that are unused
      */
     @Query(value = FIND_UNUSED_APPLICATIONS_QUERY, nativeQuery = true)
-    Set<Long> findUnusedApplications(@Param("createdThreshold") Instant createdThreshold);
+    Set<Long> findUnusedApplications(
+        @Param("createdThreshold") Instant createdThreshold,
+        @Param("limit") int limit
+    );
 
     /**
      * Get the {@link ApplicationEntity} but eagerly fetch all relational information needed to construct a DTO.

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaClusterRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaClusterRepository.java
@@ -40,7 +40,8 @@ public interface JpaClusterRepository extends JpaBaseRepository<ClusterEntity> {
             + " FROM clusters"
             + " WHERE status IN (:unusedStatuses)"
             + " AND created < :clusterCreatedThreshold"
-            + " AND id NOT IN (SELECT DISTINCT(cluster_id) FROM jobs WHERE cluster_id IS NOT NULL)";
+            + " AND id NOT IN (SELECT DISTINCT(cluster_id) FROM jobs WHERE cluster_id IS NOT NULL)"
+            + " LIMIT :limit";
 
     /**
      * Find all the clusters that aren't attached to any jobs in the database, were created before the given time
@@ -49,13 +50,15 @@ public interface JpaClusterRepository extends JpaBaseRepository<ClusterEntity> {
      * @param unusedStatuses          The set of statuses a cluster must have to be considered unused
      * @param clusterCreatedThreshold The instant in time which a cluster must have been created before to be considered
      *                                unused. Exclusive.
+     * @param limit                   Maximum number of IDs to return
      * @return The ids of the clusters that are considered unused
      */
     @Query(value = FIND_UNUSED_CLUSTERS_SQL, nativeQuery = true)
     // TODO: Could use different lock mode
     Set<Long> findUnusedClusters(
         @Param("unusedStatuses") Set<String> unusedStatuses,
-        @Param("clusterCreatedThreshold") Instant clusterCreatedThreshold
+        @Param("clusterCreatedThreshold") Instant clusterCreatedThreshold,
+        @Param("limit") int limit
     );
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaCommandRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaCommandRepository.java
@@ -59,7 +59,8 @@ public interface JpaCommandRepository extends JpaBaseRepository<CommandEntity> {
             + "SELECT DISTINCT(command_id)"
             + " FROM jobs"
             + " WHERE command_id IS NOT NULL"
-            + ")";
+            + ")"
+            + " LIMIT :limit";
 
     /**
      * Bulk set the status of commands which match the given inputs. Considers whether a command was used in some
@@ -89,12 +90,14 @@ public interface JpaCommandRepository extends JpaBaseRepository<CommandEntity> {
      * @param unusedStatuses          The set of statuses a command must be in in order to be considered unused
      * @param commandCreatedThreshold The instant in time a command must have been created before to be considered
      *                                unused. Exclusive.
+     * @param limit                   Maximum number of IDs to return
      * @return The ids of the commands that are considered unused
      */
     @Query(value = FIND_UNUSED_COMMANDS_QUERY, nativeQuery = true)
     Set<Long> findUnusedCommands(
         @Param("unusedStatuses") Set<String> unusedStatuses,
-        @Param("commandCreatedThreshold") Instant commandCreatedThreshold
+        @Param("commandCreatedThreshold") Instant commandCreatedThreshold,
+        @Param("limit") int limit
     );
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaFileRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaFileRepository.java
@@ -53,6 +53,7 @@ public interface JpaFileRepository extends JpaIdRepository<FileEntity> {
             + "AND id NOT IN (SELECT DISTINCT(file_id) FROM jobs_configs) "
             + "AND id NOT IN (SELECT DISTINCT(file_id) FROM jobs_dependencies) "
             + "AND created <= :createdThreshold "
+            + "LIMIT :limit "
             + "FOR UPDATE;";
 
     /**
@@ -85,10 +86,14 @@ public interface JpaFileRepository extends JpaIdRepository<FileEntity> {
      *
      * @param createdThreshold The instant in time where files created before this time that aren't referenced
      *                         will be selected. Inclusive.
+     * @param limit            The maximum number of file ids to retrieve
      * @return The ids of the files which should be deleted
      */
     @Query(value = SELECT_FOR_UPDATE_UNUSED_FILES_SQL, nativeQuery = true)
-    Set<Number> findUnusedFiles(@Param("createdThreshold") Instant createdThreshold);
+    Set<Number> findUnusedFiles(
+        @Param("createdThreshold") Instant createdThreshold,
+        @Param("limit") int limit
+    );
 
     /**
      * Delete all files from the database that are in the current set of ids.

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaTagRepository.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/repositories/JpaTagRepository.java
@@ -46,6 +46,7 @@ public interface JpaTagRepository extends JpaIdRepository<TagEntity> {
             + "AND id NOT IN (SELECT DISTINCT(tag_id) FROM criteria_tags) "
             + "AND id NOT IN (SELECT DISTINCT(tag_id) FROM jobs_tags) "
             + "AND created <= :createdThreshold "
+            + "LIMIT :limit "
             + "FOR UPDATE;";
 
     /**
@@ -78,10 +79,14 @@ public interface JpaTagRepository extends JpaIdRepository<TagEntity> {
      *
      * @param createdThreshold The instant in time where tags created before this time that aren't referenced
      *                         will be returned. Inclusive
+     * @param limit            Maximum number of IDs to return
      * @return The number of tags deleted
      */
     @Query(value = SELECT_FOR_UPDATE_UNUSED_TAGS_SQL, nativeQuery = true)
-    Set<Number> findUnusedTags(@Param("createdThreshold") Instant createdThreshold);
+    Set<Number> findUnusedTags(
+        @Param("createdThreshold") Instant createdThreshold,
+        @Param("limit") int limit
+    );
 
     /**
      * Delete all tags from the database whose ids are in the supplied set.

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/DatabaseCleanupProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/DatabaseCleanupProperties.java
@@ -54,6 +54,11 @@ public class DatabaseCleanupProperties {
     public static final String EXPRESSION_PROPERTY = PROPERTY_PREFIX + ".expression";
 
     /**
+     * The batch size used to iteratively delete unused entities.
+     */
+    public static final String BATCH_SIZE_PROPERTY = PROPERTY_PREFIX + ".batchSize";
+
+    /**
      * The property key for whether this feature is enabled or not.
      */
     private boolean enabled;
@@ -63,6 +68,12 @@ public class DatabaseCleanupProperties {
      */
     @NotBlank
     private String expression = "0 0 0 * * *";
+
+    /**
+     * The batch size used to iteratively delete unused entities.
+     */
+    @Min(1)
+    private int batchSize = 10_000;
 
     /**
      * Properties related to cleaning up application records from the database.

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/DatabaseCleanupTask.java
@@ -279,18 +279,37 @@ public class DatabaseCleanupTask extends LeaderTask {
                 log.info("Skipping clusters cleanup");
                 this.numDeletedClusters.set(0);
             } else {
-                final long countDeletedClusters = this.persistenceService.deleteUnusedClusters(
-                    TO_DELETE_CLUSTER_STATUSES,
-                    creationThreshold
+                final int batchSize = this.environment.getProperty(
+                    DatabaseCleanupProperties.BATCH_SIZE_PROPERTY,
+                    Integer.class,
+                    this.cleanupProperties.getBatchSize()
                 );
+
+                log.info(
+                    "Attempting to delete unused clusters from before {} in batches of {}",
+                    creationThreshold,
+                    batchSize
+                );
+
+                long deleted;
+                long totalDeleted = 0L;
+                do {
+                    deleted = this.persistenceService.deleteUnusedClusters(
+                        TO_DELETE_CLUSTER_STATUSES,
+                        creationThreshold,
+                        batchSize
+                    );
+                    totalDeleted += deleted;
+                } while (deleted > 0);
+
                 log.info(
                     "Deleted {} clusters that were in one of {} states, were created before {} and weren't "
                         + " attached to any jobs",
-                    countDeletedClusters,
+                    totalDeleted,
                     TO_DELETE_CLUSTER_STATUSES,
                     creationThreshold
                 );
-                this.numDeletedClusters.set(countDeletedClusters);
+                this.numDeletedClusters.set(totalDeleted);
             }
         } catch (final Exception e) {
             log.error("Unable to delete clusters from database", e);
@@ -315,12 +334,29 @@ public class DatabaseCleanupTask extends LeaderTask {
                 log.info("Skipping files cleanup");
                 this.numDeletedFiles.set(0);
             } else {
-                final long countDeletedFiles = this.persistenceService.deleteUnusedFiles(creationThreshold);
-                log.info(
-                    "Deleted {} files that were unused by any resource and created over an hour ago",
-                    countDeletedFiles
+                final int batchSize = this.environment.getProperty(
+                    DatabaseCleanupProperties.BATCH_SIZE_PROPERTY,
+                    Integer.class,
+                    this.cleanupProperties.getBatchSize()
                 );
-                this.numDeletedFiles.set(countDeletedFiles);
+                log.info(
+                    "Attempting to delete unused files from before {} in batches of {}",
+                    creationThreshold,
+                    batchSize
+                );
+
+                long deleted;
+                long totalDeleted = 0L;
+                do {
+                    deleted = this.persistenceService.deleteUnusedFiles(creationThreshold, batchSize);
+                    totalDeleted += deleted;
+                } while (deleted > 0);
+                log.info(
+                    "Deleted {} files that were unused by any resource and created before {}",
+                    totalDeleted,
+                    creationThreshold
+                );
+                this.numDeletedFiles.set(totalDeleted);
             }
         } catch (final Exception e) {
             log.error("Unable to delete files from database", e);
@@ -345,12 +381,30 @@ public class DatabaseCleanupTask extends LeaderTask {
                 log.info("Skipping tags cleanup");
                 this.numDeletedTags.set(0);
             } else {
-                final long countDeletedTags = this.persistenceService.deleteUnusedTags(creationThreshold);
-                log.info(
-                    "Deleted {} tags that were unused by any resource and created over an hour ago",
-                    countDeletedTags
+                final int batchSize = this.environment.getProperty(
+                    DatabaseCleanupProperties.BATCH_SIZE_PROPERTY,
+                    Integer.class,
+                    this.cleanupProperties.getBatchSize()
                 );
-                this.numDeletedTags.set(countDeletedTags);
+
+                log.info(
+                    "Attempting to delete unused tags from before {} in batches of {}",
+                    creationThreshold,
+                    batchSize
+                );
+
+                long deleted;
+                long totalDeleted = 0L;
+                do {
+                    deleted = this.persistenceService.deleteUnusedTags(creationThreshold, batchSize);
+                    totalDeleted += deleted;
+                } while (deleted > 0);
+                log.info(
+                    "Deleted {} tags that were unused by any resource and created before {}",
+                    totalDeleted,
+                    creationThreshold
+                );
+                this.numDeletedTags.set(totalDeleted);
             }
         } catch (final Exception e) {
             log.error("Unable to delete tags from database", e);
@@ -432,15 +486,33 @@ public class DatabaseCleanupTask extends LeaderTask {
                 log.info("Skipping command cleanup");
                 this.numDeletedCommands.set(0);
             } else {
-                final long deletedCommandCount = this.persistenceService.deleteUnusedCommands(
-                    TO_DELETE_COMMAND_STATUSES,
-                    creationThreshold
+                final int batchSize = this.environment.getProperty(
+                    DatabaseCleanupProperties.BATCH_SIZE_PROPERTY,
+                    Integer.class,
+                    this.cleanupProperties.getBatchSize()
                 );
                 log.info(
-                    "Deleted {} commands that were unused by any resource and created over an hour ago",
-                    deletedCommandCount
+                    "Attempting to delete unused commands from before {} in batches of {}",
+                    creationThreshold,
+                    batchSize
                 );
-                this.numDeletedCommands.set(deletedCommandCount);
+
+                long deleted;
+                long totalDeleted = 0L;
+                do {
+                    deleted = this.persistenceService.deleteUnusedCommands(
+                        TO_DELETE_COMMAND_STATUSES,
+                        creationThreshold,
+                        batchSize
+                    );
+                    totalDeleted += deleted;
+                } while (deleted > 0);
+                log.info(
+                    "Deleted {} commands that were unused by any resource and created before {}",
+                    totalDeleted,
+                    creationThreshold
+                );
+                this.numDeletedCommands.set(totalDeleted);
             }
         } catch (final Exception e) {
             log.error("Unable to delete commands in database", e);
@@ -465,13 +537,32 @@ public class DatabaseCleanupTask extends LeaderTask {
                 log.info("Skipping application cleanup");
                 this.numDeletedCommands.set(0);
             } else {
-                final long deletedApplicationCount = this.persistenceService
-                    .deleteUnusedApplications(creationThreshold);
-                log.info(
-                    "Deleted {} applications that were unused by any resource and created over an hour ago",
-                    deletedApplicationCount
+                final int batchSize = this.environment.getProperty(
+                    DatabaseCleanupProperties.BATCH_SIZE_PROPERTY,
+                    Integer.class,
+                    this.cleanupProperties.getBatchSize()
                 );
-                this.numDeletedApplications.set(deletedApplicationCount);
+                log.info(
+                    "Attempting to delete unused applications from before {} in batches of {}",
+                    creationThreshold,
+                    batchSize
+                );
+
+                long deleted;
+                long totalDeleted = 0L;
+                do {
+                    deleted = this.persistenceService.deleteUnusedApplications(
+                        creationThreshold,
+                        batchSize
+                    );
+                    totalDeleted += deleted;
+                } while (deleted > 0);
+                log.info(
+                    "Deleted {} applications that were unused by any resource and created before {}",
+                    totalDeleted,
+                    creationThreshold
+                );
+                this.numDeletedApplications.set(totalDeleted);
             }
         } catch (final Exception e) {
             log.error("Unable to delete applications in database", e);

--- a/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/properties/DatabaseCleanupPropertiesTest.java
@@ -42,6 +42,7 @@ class DatabaseCleanupPropertiesTest {
     void canGetDefaultValues() {
         Assertions.assertThat(this.properties.isEnabled()).isFalse();
         Assertions.assertThat(this.properties.getExpression()).isEqualTo("0 0 0 * * *");
+        Assertions.assertThat(this.properties.getBatchSize()).isEqualTo(10_000);
         Assertions.assertThat(this.properties.getApplicationCleanup().isSkip()).isFalse();
         Assertions.assertThat(this.properties.getCommandCleanup().isSkip()).isFalse();
         Assertions.assertThat(this.properties.getCommandDeactivation().isSkip()).isFalse();
@@ -67,6 +68,14 @@ class DatabaseCleanupPropertiesTest {
         final String expression = UUID.randomUUID().toString();
         this.properties.setExpression(expression);
         Assertions.assertThat(this.properties.getExpression()).isEqualTo(expression);
+    }
+
+
+    @Test
+    void canSetBatchSize() {
+        final int batchSize = 123;
+        this.properties.setBatchSize(batchSize);
+        Assertions.assertThat(this.properties.getBatchSize()).isEqualTo(batchSize);
     }
 
     @Test


### PR DESCRIPTION
Update the cleanup strategy to delete unused entities in batches rather than attempting a single-shot deletion.

Motivation: if the number of entities to delete is high, attempting to delete all unused entities in a single shot could fail.
This is due to the size of the transaction data exceeding limits.

Change overview:
 * Update persistence APIs to include a LIMIT clause in the queries that retrieve unused entities
 * Update the cleanup strategy to delete in batches until there's nothing left to delete
 * Introduce new property that control the batch size

This applies to files, tags, commands, clusters, applications. Jobs are already deleted in batches.