### PR TITLE
Upgrade to Spock 2.0-M4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ configure(javaProjects) {
             mavenBom "com.google.protobuf:protobuf-bom:${protobuf_version}"
             mavenBom "com.squareup.okhttp3:okhttp-bom:4.6.0"
             mavenBom "io.grpc:grpc-bom:1.21.1"
-            mavenBom "org.spockframework:spock-bom:1.3-groovy-2.5"
+            mavenBom "org.spockframework:spock-bom:2.0-M4-groovy-2.5"
             mavenBom "org.testcontainers:testcontainers-bom:1.15.0"
         }
         dependencies {
@@ -178,6 +178,8 @@ configure(javaProjects) {
 
         testImplementation("cglib:cglib-nodep")
         testImplementation("org.spockframework:spock-core")
+        // Needed to support JUnit 4 Rules that we still can't get away from (e.g. GRpcServerRule) in test files
+        testImplementation("org.spockframework:spock-junit4")
         testImplementation("org.spockframework:spock-spring")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
@@ -189,9 +191,6 @@ configure(javaProjects) {
         testRuntimeOnly("jakarta.el:jakarta.el-api")
         testRuntimeOnly("org.glassfish:jakarta.el")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-        testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
-            exclude group: "org.hamcrest", module: "hamcrest-core"
-        }
     }
 
     task removeGeneratedSources(type: Delete) {

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/AgentLogManagerSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/AgentLogManagerSpec.groovy
@@ -21,10 +21,9 @@ import com.netflix.genie.agent.cli.logging.AgentLogManagerLog4j2Impl
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.appender.FileAppender
 import org.apache.logging.log4j.core.config.Configuration
-import org.junit.Ignore
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
+import spock.lang.Ignore
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -38,16 +37,16 @@ class AgentLogManagerSpec extends Specification {
     Path temporaryLogFilePath
     Path newLogFilePath
 
-    @Rule
-    TemporaryFolder temporaryFolder = new TemporaryFolder()
+    @TempDir
+    Path temporaryFolder
 
     void setup() {
         this.loggerContext = Mock(LoggerContext)
         this.configuration = Mock(Configuration)
-        this.temporaryLogFilePath = Paths.get(temporaryFolder.getRoot().toString(), "agent.log")
+        this.temporaryLogFilePath = this.temporaryFolder.resolve("agent.log")
         this.newLogFilePath = Paths.get(temporaryFolder.getRoot().toString(), "agent-relocated.log")
         this.appender = GroovyMock(FileAppender)
-        Files.createFile(temporaryLogFilePath)
+        Files.createFile(this.temporaryLogFilePath)
     }
 
     def "Relocate successfully"() {

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/JobRequestArgumentsImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/JobRequestArgumentsImplSpec.groovy
@@ -22,14 +22,16 @@ import com.beust.jcommander.ParameterException
 import com.beust.jcommander.ParametersDelegate
 import com.netflix.genie.common.external.dtos.v4.Criterion
 import com.netflix.genie.common.external.util.GenieObjectMapper
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 class JobRequestArgumentsImplSpec extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder
+    @TempDir
+    Path temporaryFolder
     MainCommandArguments commandArguments
     TestOptions options
     JCommander jCommander
@@ -81,11 +83,11 @@ class JobRequestArgumentsImplSpec extends Specification {
     def "Parse"() {
         setup:
         def archiveLocationPrefix = "s3://bucket/" + UUID.randomUUID().toString()
-        File cfg1 = temporaryFolder.newFile("cfg1.cfg")
-        File cfg2 = temporaryFolder.newFile("cfg2.cfg")
-        File dep1 = temporaryFolder.newFile("dep1.bin")
-        File dep2 = temporaryFolder.newFile("dep2.jar")
-        File setup = temporaryFolder.newFile("setup.sh")
+        Path cfg1 = Files.createFile(temporaryFolder.resolve("cfg1.cfg"))
+        Path cfg2 = Files.createFile(temporaryFolder.resolve("cfg2.cfg"))
+        Path dep1 = Files.createFile(temporaryFolder.resolve("dep1.bin"))
+        Path dep2 = Files.createFile(temporaryFolder.resolve("dep2.jar"))
+        Path setup = Files.createFile(temporaryFolder.resolve("setup.sh"))
 
         when:
         jCommander.parse(
@@ -109,11 +111,11 @@ class JobRequestArgumentsImplSpec extends Specification {
             "--job-version", "1.0",
             "--job-metadata", "{\"foo\": false}",
             "--api-job",
-            "--job-configuration", cfg1.getPath().toString(),
-            "--job-configuration", cfg2.getPath().toString(),
-            "--job-dependency", dep1.getPath().toString(),
-            "--job-dependency", dep2.getPath().toString(),
-            "--job-setup", setup.getPath().toString(),
+            "--job-configuration", cfg1.toString(),
+            "--job-configuration", cfg2.toString(),
+            "--job-dependency", dep1.toString(),
+            "--job-dependency", dep2.toString(),
+            "--job-setup", setup.toString(),
             "--disable-archiving"
         )
 
@@ -148,8 +150,8 @@ class JobRequestArgumentsImplSpec extends Specification {
         options.jobRequestArguments.isArchivingDisabled()
     }
 
-    String fileResource(final File file) {
-        return "file:" + file.toPath().toAbsolutePath().toString()
+    static String fileResource(final Path file) {
+        return "file:" + file.toAbsolutePath().toString()
     }
 
     def "Unknown parameters throw"() {
@@ -194,10 +196,10 @@ class JobRequestArgumentsImplSpec extends Specification {
     def "Invalid file references throw ParameterException"() {
 
         setup:
-        File folder = temporaryFolder.newFolder()
+        Path folder = Files.createDirectory(temporaryFolder.resolve(UUID.randomUUID().toString()))
 
         when:
-        jCommander.parse("--job-dependency", folder.toPath().toString())
+        jCommander.parse("--job-dependency", folder.toString())
 
         then:
         thrown(ParameterException)

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/ResolveJobSpecCommandSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/ResolveJobSpecCommandSpec.groovy
@@ -23,14 +23,16 @@ import com.netflix.genie.agent.execution.services.AgentJobService
 import com.netflix.genie.common.external.dtos.v4.AgentJobRequest
 import com.netflix.genie.common.external.dtos.v4.JobSpecification
 import com.netflix.genie.common.external.util.GenieObjectMapper
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 class ResolveJobSpecCommandSpec extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder
+    @TempDir
+    Path temporaryFolder
 
     ResolveJobSpecCommand.ResolveJobSpecCommandArguments commandArgs
     AgentJobService service
@@ -102,7 +104,7 @@ class ResolveJobSpecCommandSpec extends Specification {
         String specId = "12345"
 
         when:
-        ExitCode exitCode = command.run()
+        command.run()
 
         then:
         1 * commandArgs.getSpecificationId() >> specId
@@ -114,7 +116,7 @@ class ResolveJobSpecCommandSpec extends Specification {
     def "Write spec to file"() {
         setup:
         String specId = "12345"
-        File outputFile = new File(temporaryFolder.getRoot(), "spec.json")
+        File outputFile = this.temporaryFolder.resolve( "spec.json").toFile()
 
         when:
         ExitCode exitCode = command.run()
@@ -131,10 +133,10 @@ class ResolveJobSpecCommandSpec extends Specification {
     def "Write spec to file that exists"() {
         setup:
         String specId = "12345"
-        File outputFile = temporaryFolder.newFile()
+        File outputFile = Files.createFile(this.temporaryFolder.resolve(UUID.randomUUID().toString())).toFile()
 
         when:
-        ExitCode exitCode = command.run()
+        command.run()
 
         then:
         1 * commandArgs.getSpecificationId() >> specId
@@ -148,7 +150,7 @@ class ResolveJobSpecCommandSpec extends Specification {
         setup:
 
         when:
-        ExitCode exitCode = command.run()
+        command.run()
 
         then:
         1 * commandArgs.getSpecificationId() >> " "
@@ -164,7 +166,7 @@ class ResolveJobSpecCommandSpec extends Specification {
         setup:
 
         when:
-        ExitCode exitCode = command.run()
+        command.run()
 
         then:
         1 * commandArgs.getSpecificationId() >> " "

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/logging/ConsoleLogSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/cli/logging/ConsoleLogSpec.groovy
@@ -17,9 +17,6 @@
  */
 package com.netflix.genie.agent.cli.logging
 
-
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import org.slf4j.Logger
 import org.springframework.core.env.Environment
 import spock.lang.Specification
@@ -28,9 +25,6 @@ import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 
 class ConsoleLogSpec extends Specification {
-
-    @Rule
-    TemporaryFolder temporaryFolder = new TemporaryFolder()
 
     def "GetLogger"() {
         when:

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/DownloadServiceImplSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/execution/services/impl/DownloadServiceImplSpec.groovy
@@ -21,16 +21,17 @@ import com.netflix.genie.agent.execution.exceptions.DownloadException
 import com.netflix.genie.agent.execution.services.DownloadService
 import com.netflix.genie.agent.execution.services.FetchingCacheService
 import org.apache.commons.lang3.tuple.Pair
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import org.mockito.internal.util.collections.Sets
 import spock.lang.Specification
+import spock.lang.TempDir
 
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.stream.Collectors
 
 class DownloadServiceImplSpec extends Specification {
-    @Rule
-    TemporaryFolder temporaryFolder
+    @TempDir
+    Path temporaryFolder
 
     FetchingCacheService cacheService
     DownloadServiceImpl downloadService
@@ -40,18 +41,18 @@ class DownloadServiceImplSpec extends Specification {
     File fileInCache
     String fileContents = "Example content of a file in cache\n"
 
-    void setup() {
+    def setup() {
         cacheService = Mock()
         downloadService = new DownloadServiceImpl(cacheService)
         manifest = Mock()
-        cacheDir = temporaryFolder.newFolder("cache")
-        jobDir = temporaryFolder.newFolder("job")
+        cacheDir = Files.createDirectory(this.temporaryFolder.resolve("cache")).toFile()
+        jobDir = Files.createDirectory(this.temporaryFolder.resolve("job")).toFile()
         fileInCache = new File(cacheDir, "cached-file")
         fileInCache.createNewFile()
         fileInCache.write(fileContents)
     }
 
-    void cleanup() {
+    def cleanup() {
     }
 
     def "Download empty manifest"() {

--- a/genie-agent/src/test/groovy/com/netflix/genie/agent/utils/locks/impl/FileLockSpec.groovy
+++ b/genie-agent/src/test/groovy/com/netflix/genie/agent/utils/locks/impl/FileLockSpec.groovy
@@ -18,24 +18,26 @@
 package com.netflix.genie.agent.utils.locks.impl
 
 import com.netflix.genie.agent.execution.exceptions.LockException
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * Specifications for the {@link FileLock} class.
  *
- * @author standon* @since 4.0.0
+ * @author standon
  */
 class FileLockSpec extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder
+    @TempDir
+    Path tmpDir
 
     def "Valid file returns a lock"() {
         FileLock lock
         when:
-        lock = new FileLock(temporaryFolder.newFile())
+        lock = new FileLock(Files.createFile(this.tmpDir.resolve(UUID.randomUUID().toString())).toFile())
 
         then:
         lock != null
@@ -43,7 +45,7 @@ class FileLockSpec extends Specification {
 
     def "Throws exception for bad file"() {
         when:
-        new FileLock(new File(temporaryFolder.getRoot(), UUID.randomUUID().toString()))
+        new FileLock(this.tmpDir.resolve(UUID.randomUUID().toString()).toFile())
 
         then:
         thrown(LockException)

--- a/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/S3JobArchiverImplSpec.groovy
+++ b/genie-common-internal/src/test/groovy/com/netflix/genie/common/internal/services/impl/S3JobArchiverImplSpec.groovy
@@ -23,9 +23,11 @@ import com.amazonaws.services.s3.transfer.MultipleFileUpload
 import com.amazonaws.services.s3.transfer.TransferManager
 import com.netflix.genie.common.internal.aws.s3.S3ClientFactory
 import com.netflix.genie.common.internal.exceptions.checked.JobArchiveException
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * Specifications for {@link S3JobArchiverImpl}.
@@ -33,8 +35,8 @@ import spock.lang.Specification
  * @author standon
  */
 class S3JobArchiverImplSpec extends Specification {
-    @Rule
-    TemporaryFolder temporaryFolder
+    @TempDir
+    Path temporaryFolder
     S3ClientFactory s3ClientFactory
     TransferManager transferManager
     S3JobArchiverImpl s3ArchivalService
@@ -65,7 +67,7 @@ class S3JobArchiverImplSpec extends Specification {
         this.s3ClientFactory = Mock(S3ClientFactory)
         this.transferManager = Mock(TransferManager)
         this.s3ArchivalService = new S3JobArchiverImpl(this.s3ClientFactory)
-        this.jobDir = this.temporaryFolder.newFolder()
+        this.jobDir = Files.createDirectory(this.temporaryFolder.resolve(UUID.randomUUID().toString())).toFile()
         this.stdout = new File(jobDir, "stdout")
         this.stdout.createNewFile()
         this.stdout.write("Stdout content")

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/inspectors/impl/WhitelistedVersionAgentMetadataInspectorSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/inspectors/impl/WhitelistedVersionAgentMetadataInspectorSpec.groovy
@@ -36,7 +36,7 @@ class WhitelistedVersionAgentMetadataInspectorSpec extends Specification {
     }
 
     @Unroll
-    def "Match #agentVersion against #blacklistExpression and expect #expectedDecision"() {
+    def "Match #agentVersion against #whitelistExpression and expect #expectedDecision"() {
 
         InspectionReport decision
 


### PR DESCRIPTION
Upgrading to Spock 2 while bringing new features also paves the path to upgrading to Groovy 3 which will allow using Java > 11 where Groovy 2 breaks on illegal access for reflection

- Remove all usages of Junit 4 TemporaryFolder from spock tests and use spock "native" @TempDir instead to make it execution independent
- Clean up warnings found in files that were being editted