### PR TITLE
Configurable memory overhead for Titus launcher

### DIFF
--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -237,6 +237,11 @@ https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-featu
 |default
 |no
 
+|genie.agent.launcher.titus.additional-memory
+|Amount of memory requested for the container in addition to the amount requested by the job
+|2GB
+|no
+
 |genie.agent.routing.refresh-interval
 |Interval at which individual connections are refreshed
 |3s

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
@@ -187,6 +187,9 @@ public class TitusAgentLauncherImpl implements AgentLauncher {
                 .map(s -> placeholdersMap.getOrDefault(s, s))
                 .collect(Collectors.toList());
 
+        final long memory = resolvedJob.getJobEnvironment().getMemory()
+            + this.titusAgentLauncherProperties.getAdditionalMemory().toMegabytes();
+
         return new TitusBatchJobRequest(
             new TitusBatchJobRequest.Owner(this.titusAgentLauncherProperties.getOwnerEmail()),
             this.titusAgentLauncherProperties.getApplicationName(),
@@ -201,7 +204,7 @@ public class TitusAgentLauncherImpl implements AgentLauncher {
                 new TitusBatchJobRequest.Resources(
                     resolvedJob.getJobEnvironment().getCpu(),
                     0,
-                    resolvedJob.getJobEnvironment().getMemory(),
+                    memory,
                     this.titusAgentLauncherProperties.getDiskSize().toMegabytes(),
                     this.titusAgentLauncherProperties.getNetworkBandwidth().toMegabytes() * 8 //MB to Mb
                 ),

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/TitusAgentLauncherProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/TitusAgentLauncherProperties.java
@@ -199,4 +199,9 @@ public class TitusAgentLauncherProperties {
      */
     @NotNull
     private Map<String, String> additionalEnvironment = Maps.newHashMap();
+
+    /**
+     * The amount of memory to request in addition to the amount requested by the job.
+     */
+    private DataSize additionalMemory = DataSize.ofGigabytes(2);
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImplSpec.groovy
@@ -122,7 +122,7 @@ class TitusAgentLauncherImplSpec extends Specification {
         requestCapture.getAttributes().get("genie_job_id") == JOB_ID
         requestCapture.getContainer().getResources().getCpu() == 3
         requestCapture.getContainer().getResources().getGpu() == 0
-        requestCapture.getContainer().getResources().getMemoryMB() == 1024
+        requestCapture.getContainer().getResources().getMemoryMB() == 1024 + 2048
         requestCapture.getContainer().getResources().getDiskMB() == launcherProperties.getDiskSize().toMegabytes()
         requestCapture.getContainer().getResources().getNetworkMbps() == launcherProperties.getNetworkBandwidth().toMegabytes() * 8
         requestCapture.getContainer().getSecurityProfile().getAttributes() == launcherProperties.getSecurityAttributes()

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/TitusAgentLauncherPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/TitusAgentLauncherPropertiesSpec.groovy
@@ -57,6 +57,7 @@ class TitusAgentLauncherPropertiesSpec extends Specification {
         p.getHealthIndicatorMaxSize() == 100
         p.getHealthIndicatorExpiration() == Duration.ofMinutes(30)
         p.getAdditionalEnvironment() == [:]
+        p.getAdditionalMemory() == DataSize.ofGigabytes(2)
 
         when:
         p.setEnabled(true)
@@ -87,6 +88,7 @@ class TitusAgentLauncherPropertiesSpec extends Specification {
         p.setHealthIndicatorMaxSize(200)
         p.setHealthIndicatorExpiration(Duration.ofMinutes(15))
         p.setAdditionalEnvironment([FOO: "BAR"])
+        p.setAdditionalMemory(DataSize.ofGigabytes(4))
 
         then:
         p.isEnabled()
@@ -117,5 +119,6 @@ class TitusAgentLauncherPropertiesSpec extends Specification {
         p.getHealthIndicatorMaxSize() == 200
         p.getHealthIndicatorExpiration() == Duration.ofMinutes(15)
         p.getAdditionalEnvironment() == [FOO: "BAR"]
+        p.getAdditionalMemory() == DataSize.ofGigabytes(4)
     }
 }


### PR DESCRIPTION
Allow setting an additional amount of memory allocated when launching a job in a Titus container. For example, memory used by the Genie agent itself, or other system processes.