### PR TITLE
Refactor Titus launcher properties related to resources

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/properties/TitusAgentLauncherProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/TitusAgentLauncherProperties.java
@@ -147,18 +147,6 @@ public class TitusAgentLauncherProperties {
     private String imageTag = "latest";
 
     /**
-     * The disk size to allocate.
-     */
-    @NotNull
-    private DataSize diskSize = DataSize.ofGigabytes(10);
-
-    /**
-     * The network bandwidth to allocate.
-     */
-    @NotNull
-    private DataSize networkBandwidth = DataSize.ofMegabytes(7);
-
-    /**
      * The number of retries if the job fails.
      */
     @Min(0)
@@ -201,7 +189,59 @@ public class TitusAgentLauncherProperties {
     private Map<String, String> additionalEnvironment = Maps.newHashMap();
 
     /**
+     * The amount of bandwidth to request in addition to the amount requested by the job.
+     */
+    private DataSize additionalBandwidth = DataSize.ofBytes(0);
+
+    /**
+     * The amount of CPUs to request in addition to the amount requested by the job.
+     */
+    @Min(0)
+    private int additionalCPU = 1;
+
+    /**
+     * The amount of disk space to request in addition to the amount requested by the job.
+     */
+    private DataSize additionalDiskSize = DataSize.ofGigabytes(1);
+
+    /**
+     * The amount of GPUs to request in addition to the amount requested by the job.
+     */
+    @Min(0)
+    private int additionalGPU;
+
+    /**
      * The amount of memory to request in addition to the amount requested by the job.
      */
     private DataSize additionalMemory = DataSize.ofGigabytes(2);
+
+    /**
+     * The minimum amount of bandwidth to request for the container.
+     */
+    @NotNull
+    private DataSize minimumBandwidth = DataSize.ofMegabytes(7);
+
+    /**
+     * The minimum amount of CPUs to request for the container.
+     */
+    @Min(1)
+    private int minimumCPU = 1;
+
+    /**
+     * The minimum amount of storage to request for the container.
+     */
+    @NotNull
+    private DataSize minimumDiskSize = DataSize.ofGigabytes(10);
+
+    /**
+     * The minimum amount of GPUs to request for the container.
+     */
+    @Min(0)
+    private int minimumGPU;
+
+    /**
+     * The minimum amount of memory to request for the container.
+     */
+    @NotNull
+    private DataSize minimumMemory = DataSize.ofGigabytes(4);
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/properties/TitusAgentLauncherPropertiesSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/properties/TitusAgentLauncherPropertiesSpec.groovy
@@ -48,8 +48,6 @@ class TitusAgentLauncherPropertiesSpec extends Specification {
         p.getIAmRole() == "arn:aws:iam::000000000:role/SomeProfile"
         p.getImageName() == "image-name"
         p.getImageTag() == "latest"
-        p.getDiskSize() == DataSize.ofGigabytes(10)
-        p.getNetworkBandwidth() == DataSize.ofMegabytes(7)
         p.getRetries() == 0
         p.getRuntimeLimit() == Duration.ofHours(12)
         p.getGenieServerHost() == "example.genie.tld"
@@ -57,7 +55,16 @@ class TitusAgentLauncherPropertiesSpec extends Specification {
         p.getHealthIndicatorMaxSize() == 100
         p.getHealthIndicatorExpiration() == Duration.ofMinutes(30)
         p.getAdditionalEnvironment() == [:]
-        p.getAdditionalMemory() == DataSize.ofGigabytes(2)
+        p.getAdditionalMemory().toGigabytes() == 2
+        p.getAdditionalBandwidth().toMegabytes() == 0
+        p.getAdditionalCPU() == 1
+        p.getAdditionalDiskSize().toGigabytes() == 1
+        p.getAdditionalGPU() == 0
+        p.getMinimumBandwidth().toMegabytes() == 7
+        p.getMinimumCPU() == 1
+        p.getMinimumDiskSize().toGigabytes() == 10
+        p.getMinimumMemory().toGigabytes() == 4
+        p.getMinimumGPU() == 0
 
         when:
         p.setEnabled(true)
@@ -79,8 +86,6 @@ class TitusAgentLauncherPropertiesSpec extends Specification {
         p.setIAmRole("arn:aws:iam::99999999:role/SomeOtherProfile")
         p.setImageName("another-image-name")
         p.setImageTag("latest.release")
-        p.setDiskSize(DataSize.ofGigabytes(20))
-        p.setNetworkBandwidth(DataSize.ofMegabytes(14))
         p.setRetries(1)
         p.setRuntimeLimit(Duration.ofHours(24))
         p.setGenieServerHost("genie.tld")
@@ -89,6 +94,15 @@ class TitusAgentLauncherPropertiesSpec extends Specification {
         p.setHealthIndicatorExpiration(Duration.ofMinutes(15))
         p.setAdditionalEnvironment([FOO: "BAR"])
         p.setAdditionalMemory(DataSize.ofGigabytes(4))
+        p.setAdditionalBandwidth(DataSize.ofMegabytes(2))
+        p.setAdditionalCPU(2)
+        p.setAdditionalDiskSize(DataSize.ofGigabytes(2))
+        p.setAdditionalGPU(1)
+        p.setMinimumBandwidth(DataSize.ofMegabytes(14))
+        p.setMinimumCPU(2)
+        p.setMinimumDiskSize(DataSize.ofGigabytes(20))
+        p.setMinimumMemory(DataSize.ofGigabytes(8))
+        p.setMinimumGPU(1)
 
         then:
         p.isEnabled()
@@ -110,8 +124,6 @@ class TitusAgentLauncherPropertiesSpec extends Specification {
         p.getIAmRole() == "arn:aws:iam::99999999:role/SomeOtherProfile"
         p.getImageName() == "another-image-name"
         p.getImageTag() == "latest.release"
-        p.getDiskSize() == DataSize.ofGigabytes(20)
-        p.getNetworkBandwidth() == DataSize.ofMegabytes(14)
         p.getRetries() == 1
         p.getRuntimeLimit() == Duration.ofHours(24)
         p.getGenieServerHost() == "genie.tld"
@@ -120,5 +132,15 @@ class TitusAgentLauncherPropertiesSpec extends Specification {
         p.getHealthIndicatorExpiration() == Duration.ofMinutes(15)
         p.getAdditionalEnvironment() == [FOO: "BAR"]
         p.getAdditionalMemory() == DataSize.ofGigabytes(4)
+        p.getAdditionalMemory().toGigabytes() == 4
+        p.getAdditionalBandwidth().toMegabytes() == 2
+        p.getAdditionalCPU() == 2
+        p.getAdditionalGPU() == 1
+        p.getAdditionalDiskSize().toGigabytes() == 2
+        p.getMinimumBandwidth().toMegabytes() == 14
+        p.getMinimumCPU() == 2
+        p.getMinimumDiskSize().toGigabytes() == 20
+        p.getMinimumMemory().toGigabytes() == 8
+        p.getMinimumGPU() == 1
     }
 }


### PR DESCRIPTION
Update launcher properties related to container resources: CPU, GPU, memory, disk, bandwidth.
For each resource type, allow specifying an additional amount to request (i.e. in addition to what the job is requesting).
For each resource type, also provide a minimum value.

Semantically, this allows controlling container resources, for example by expressing:
 - Request 2GB extra memory for the agent and OS
 - Never allocate fewer than than 10GB of storage
 - Etc.