### PR TITLE
Fix gap in CPU resolution

### DIFF
--- a/genie-docs/src/docs/asciidoc/_metrics.adoc
+++ b/genie-docs/src/docs/asciidoc/_metrics.adoc
@@ -107,6 +107,12 @@ It will have to be added if one is desired otherwise metrics are just published 
 |GRpcAgentFileStreamServiceImpl
 |-
 
+|genie.agents.launchers.launch.timer
+|Timer recording how long it takes to execute the launch API for that specific implementation
+|nanoseconds
+|LocalAgentLauncherImpl, TitusAgentLauncherImpl
+|status, exceptionClass, launcherClass
+
 |genie.api.v3.jobs.submitJobWithoutAttachments.rate
 |Counts the number of jobs submitted without an attachment
 |count
@@ -316,7 +322,7 @@ It will have to be added if one is desired otherwise metrics are just published 
 |Time taken to launch a job (includes record creation and update, job resolution and agent launch)
 |nanoseconds
 |JobLaunchServiceImpl
-|
+|status, exceptionClass, agentLauncherSelectedClass
 
 |genie.services.jobLaunch.selectLauncher.timer
 |Time taken to invoke a selector to choose which agent launcher to use

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/Snippets.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/Snippets.java
@@ -72,14 +72,6 @@ final class Snippets {
     static final ResponseHeadersSnippet JSON_CONTENT_TYPE_HEADER = HeaderDocumentation.responseHeaders(
         HeaderDocumentation.headerWithName(HttpHeaders.CONTENT_TYPE).description(MediaType.APPLICATION_JSON_VALUE)
     );
-    //    static final ResponseFieldsSnippet ERROR_FIELDS = PayloadDocumentation.responseFields(
-//        PayloadDocumentation.fieldWithPath("error").description("The HTTP error that occurred, e.g. `Bad Request`"),
-//        PayloadDocumentation.fieldWithPath("message").description("A description of the cause of the error"),
-//        PayloadDocumentation.fieldWithPath("path").description("The path to which the request was made"),
-//        PayloadDocumentation.fieldWithPath("status").description("The HTTP status code, e.g. `400`"),
-//        PayloadDocumentation.fieldWithPath("timestamp")
-//            .description("The time, in milliseconds, at which the error occurred")
-//    );
     static final PathParametersSnippet ID_PATH_PARAM = RequestDocumentation.pathParameters(
         RequestDocumentation.parameterWithName("id").description("The resource id")
     );
@@ -1060,9 +1052,9 @@ final class Snippets {
                 .type(JsonFieldType.STRING)
                 .optional(),
             PayloadDocumentation
-                .fieldWithPath("launcherExt")
+                .subsectionWithPath("launcherExt")
                 .attributes(getConstraintsForField(JOB_EXECUTION_CONSTRAINTS, "launcherExt"))
-                .description("The launcher extension")
+                .description("JSON object that contains metadata specific to the launcher implementation for the job")
                 .type(JsonFieldType.OBJECT)
                 .optional()
         );

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/AgentLauncher.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/AgentLauncher.java
@@ -34,12 +34,36 @@ import java.util.Optional;
 public interface AgentLauncher extends HealthIndicator {
 
     /**
+     * Shared name of a timer that can be used by launchers to record how long it took them to perform their
+     * respective launch.
+     */
+    String LAUNCH_TIMER = "genie.agents.launchers.launch.timer";
+
+    /**
+     * Shared key for a tag that can be added to the timer metric to add the implementation class in order to aid in
+     * adding a convenient dimension.
+     *
+     * @see #LAUNCH_TIMER
+     */
+    String LAUNCHER_CLASS_KEY = "launcherClass";
+
+    /**
+     * Shared key representing the class that key for the Launcher Ext context the API can return.
+     */
+    String LAUNCHER_CLASS_EXT_FIELD = "launcherClass";
+
+    /**
+     * Shared key representing the hostname of the Genie server the Agent Launcher was executed on.
+     */
+    String SOURCE_HOST_EXT_FIELD = "sourceHostname";
+
+    /**
      * Launch an agent to execute the given {@link ResolvedJob} information.
      *
      * @param resolvedJob          The {@link ResolvedJob} information for the agent to act on
      * @param requestedLauncherExt The launcher requested extension, or null
-     * @throws AgentLaunchException For any error launching an Agent instance to run the job
      * @return an optional {@link JsonNode} with the launcher context about the launched job
+     * @throws AgentLaunchException For any error launching an Agent instance to run the job
      */
     Optional<JsonNode> launchAgent(
         ResolvedJob resolvedJob,

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImpl.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.web.agent.launchers.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
@@ -36,6 +37,7 @@ import com.netflix.genie.web.introspection.GenieWebHostInfo;
 import com.netflix.genie.web.introspection.GenieWebRpcInfo;
 import com.netflix.genie.web.properties.LocalAgentLauncherProperties;
 import com.netflix.genie.web.util.ExecutorFactory;
+import com.netflix.genie.web.util.MetricsUtils;
 import com.netflix.genie.web.util.UNIXUtils;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -53,10 +55,12 @@ import javax.validation.Valid;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -81,6 +85,8 @@ public class LocalAgentLauncherImpl implements AgentLauncher {
     private static final String RUN_USER_PLACEHOLDER = "<GENIE_USER>";
     private static final String SETS_ID = "setsid";
     private static final Object MEMORY_CHECK_LOCK = new Object();
+    private static final String THIS_CLASS = LocalAgentLauncherImpl.class.getCanonicalName();
+    private static final Tag CLASS_TAG = Tag.of(LAUNCHER_CLASS_KEY, THIS_CLASS);
 
     private final String hostname;
     private final PersistenceService persistenceService;
@@ -90,6 +96,7 @@ public class LocalAgentLauncherImpl implements AgentLauncher {
     private final Executor sharedExecutor;
     private final int rpcPort;
     private final LoadingCache<String, JobInfoAggregate> jobInfoCache;
+    private final JsonNode launcherExt;
 
     private final AtomicLong numActiveJobs;
     private final AtomicLong usedMemory;
@@ -163,6 +170,10 @@ public class LocalAgentLauncherImpl implements AgentLauncher {
                 }
             );
 
+        this.launcherExt = JsonNodeFactory.instance.objectNode()
+            .put(LAUNCHER_CLASS_EXT_FIELD, THIS_CLASS)
+            .put(SOURCE_HOST_EXT_FIELD, this.hostname);
+
         // Force the initial fetch so that all subsequent fetches will be non-blocking
         try {
             this.jobInfoCache.get(this.hostname);
@@ -179,99 +190,115 @@ public class LocalAgentLauncherImpl implements AgentLauncher {
         @Valid final ResolvedJob resolvedJob,
         @Nullable final JsonNode requestedLauncherExt
     ) throws AgentLaunchException {
-        log.debug("Received request to launch local agent to run job: {}", resolvedJob);
-
-        final JobMetadata jobMetadata = resolvedJob.getJobMetadata();
-        final String user = jobMetadata.getUser();
-
-        if (this.launcherProperties.isRunAsUserEnabled()) {
-            final String group = jobMetadata.getGroup().orElse(null);
-            try {
-                UNIXUtils.createUser(user, group, this.sharedExecutor);
-            } catch (IOException e) {
-                log.error("Failed to create user {}: {}", jobMetadata.getUser(), e.getMessage(), e);
-                throw new AgentLaunchException(e);
-            }
-        }
-
-        // Check error conditions
-        final int jobMemory = resolvedJob.getJobEnvironment().getMemory();
-        final String jobId = resolvedJob.getJobSpecification().getJob().getId();
-
-        // Job was resolved with more memory allocated than the system was configured to allow
-        if (jobMemory > this.launcherProperties.getMaxJobMemory()) {
-            throw new AgentLaunchException(
-                "Unable to launch job as the requested job memory ("
-                    + jobMemory
-                    + "MB) exceeds the maximum allowed by the configuration of the system ("
-                    + this.launcherProperties.getMaxJobMemory()
-                    + "MB)"
-            );
-        }
-
-        final CommandLine commandLine = this.createCommandLine(
-            ImmutableMap.of(
-                LocalAgentLauncherProperties.SERVER_HOST_PLACEHOLDER, this.launcherProperties.getServerHostname(),
-                LocalAgentLauncherProperties.SERVER_PORT_PLACEHOLDER, Integer.toString(this.rpcPort),
-                LocalAgentLauncherProperties.JOB_ID_PLACEHOLDER, jobId,
-                RUN_USER_PLACEHOLDER, user,
-                LocalAgentLauncherProperties.AGENT_JAR_PLACEHOLDER, this.launcherProperties.getAgentJarPath()
-            )
-        );
-
-        // One at a time to ensure we don't overflow configured max
-        synchronized (MEMORY_CHECK_LOCK) {
-            final long usedMemoryOnHost = this.persistenceService.getUsedMemoryOnHost(this.hostname);
-            final long expectedUsedMemoryOnHost = usedMemoryOnHost + jobMemory;
-            if (expectedUsedMemoryOnHost > this.launcherProperties.getMaxTotalJobMemory()) {
-                throw new AgentLaunchException(
-                    "Running job "
-                        + jobId
-                        + " with "
-                        + jobMemory
-                        + "MB of memory would cause there to be more memory used than the configured amount of "
-                        + this.launcherProperties.getMaxTotalJobMemory()
-                        + "MB. "
-                        + usedMemoryOnHost
-                        + "MB worth of jobs are currently running on this node."
-                );
-            }
-        }
-
-        // Inherit server environment
-        final Map<String, String> environment = Maps.newHashMap(System.getenv());
-        // Add extra environment from configuration, if any
-        environment.putAll(this.launcherProperties.getAdditionalEnvironment());
-        log.debug("Launching agent: {}, env: {}", commandLine, environment);
-
-        // TODO: What happens if the server crashes? Does the process live on? Make sure this is totally detached
-        final Executor executor = this.executorFactory.newInstance(true);
-
-        if (this.launcherProperties.isProcessOutputCaptureEnabled()) {
-            final String debugOutputPath =
-                System.getProperty(SystemUtils.JAVA_IO_TMPDIR, "/tmp") + "/agent-job-" + jobId + ".txt";
-            try {
-                final FileOutputStream fileOutput = new FileOutputStream(debugOutputPath, false);
-                executor.setStreamHandler(new PumpStreamHandler(fileOutput));
-            } catch (FileNotFoundException e) {
-                log.error("Failed to create agent process output file", e);
-            }
-        }
-
-        log.info("Launching agent for job {}", jobId);
-
-        final AgentResultHandler resultHandler = new AgentResultHandler(jobId);
+        final long start = System.nanoTime();
+        log.info("Received request to launch local agent to run job: {}", resolvedJob);
+        final Set<Tag> tags = new HashSet<>();
+        tags.add(CLASS_TAG);
 
         try {
-            executor.execute(commandLine, environment, resultHandler);
-        } catch (final IOException ioe) {
-            throw new AgentLaunchException(
-                "Unable to launch agent using command: " + commandLine.toString(),
-                ioe
-            );
-        }
+            final JobMetadata jobMetadata = resolvedJob.getJobMetadata();
+            final String user = jobMetadata.getUser();
 
-        return Optional.empty();
+            if (this.launcherProperties.isRunAsUserEnabled()) {
+                final String group = jobMetadata.getGroup().orElse(null);
+                try {
+                    UNIXUtils.createUser(user, group, this.sharedExecutor);
+                } catch (IOException e) {
+                    log.error("Failed to create user {}: {}", jobMetadata.getUser(), e.getMessage(), e);
+                    throw new AgentLaunchException(e);
+                }
+            }
+
+            // Check error conditions
+            final int jobMemory = resolvedJob.getJobEnvironment().getMemory();
+            final String jobId = resolvedJob.getJobSpecification().getJob().getId();
+
+            // Job was resolved with more memory allocated than the system was configured to allow
+            if (jobMemory > this.launcherProperties.getMaxJobMemory()) {
+                throw new AgentLaunchException(
+                    "Unable to launch job as the requested job memory ("
+                        + jobMemory
+                        + "MB) exceeds the maximum allowed by the configuration of the system ("
+                        + this.launcherProperties.getMaxJobMemory()
+                        + "MB)"
+                );
+            }
+
+            final CommandLine commandLine = this.createCommandLine(
+                ImmutableMap.of(
+                    LocalAgentLauncherProperties.SERVER_HOST_PLACEHOLDER, this.launcherProperties.getServerHostname(),
+                    LocalAgentLauncherProperties.SERVER_PORT_PLACEHOLDER, Integer.toString(this.rpcPort),
+                    LocalAgentLauncherProperties.JOB_ID_PLACEHOLDER, jobId,
+                    RUN_USER_PLACEHOLDER, user,
+                    LocalAgentLauncherProperties.AGENT_JAR_PLACEHOLDER, this.launcherProperties.getAgentJarPath()
+                )
+            );
+
+            // One at a time to ensure we don't overflow configured max
+            synchronized (MEMORY_CHECK_LOCK) {
+                final long usedMemoryOnHost = this.persistenceService.getUsedMemoryOnHost(this.hostname);
+                final long expectedUsedMemoryOnHost = usedMemoryOnHost + jobMemory;
+                if (expectedUsedMemoryOnHost > this.launcherProperties.getMaxTotalJobMemory()) {
+                    throw new AgentLaunchException(
+                        "Running job "
+                            + jobId
+                            + " with "
+                            + jobMemory
+                            + "MB of memory would cause there to be more memory used than the configured amount of "
+                            + this.launcherProperties.getMaxTotalJobMemory()
+                            + "MB. "
+                            + usedMemoryOnHost
+                            + "MB worth of jobs are currently running on this node."
+                    );
+                }
+            }
+
+            // Inherit server environment
+            final Map<String, String> environment = Maps.newHashMap(System.getenv());
+            // Add extra environment from configuration, if any
+            environment.putAll(this.launcherProperties.getAdditionalEnvironment());
+            log.debug("Launching agent: {}, env: {}", commandLine, environment);
+
+            // TODO: What happens if the server crashes? Does the process live on? Make sure this is totally detached
+            final Executor executor = this.executorFactory.newInstance(true);
+
+            if (this.launcherProperties.isProcessOutputCaptureEnabled()) {
+                final String debugOutputPath =
+                    System.getProperty(SystemUtils.JAVA_IO_TMPDIR, "/tmp") + "/agent-job-" + jobId + ".txt";
+                try {
+                    final FileOutputStream fileOutput = new FileOutputStream(debugOutputPath, false);
+                    executor.setStreamHandler(new PumpStreamHandler(fileOutput));
+                } catch (final FileNotFoundException e) {
+                    log.error("Failed to create agent process output file", e);
+                    throw new AgentLaunchException(e);
+                }
+            }
+
+            log.info("Launching agent for job {}", jobId);
+
+            final AgentResultHandler resultHandler = new AgentResultHandler(jobId);
+
+            try {
+                executor.execute(commandLine, environment, resultHandler);
+            } catch (final IOException ioe) {
+                throw new AgentLaunchException(
+                    "Unable to launch agent using command: " + commandLine.toString(),
+                    ioe
+                );
+            }
+
+            MetricsUtils.addSuccessTags(tags);
+            return Optional.of(this.launcherExt);
+        } catch (final AgentLaunchException e) {
+            MetricsUtils.addFailureTagsWithException(tags, e);
+            throw e;
+        } catch (final Exception e) {
+            log.error("Unable to launch local agent due to {}", e.getMessage(), e);
+            MetricsUtils.addFailureTagsWithException(tags, e);
+            throw new AgentLaunchException("Unable to launch local agent due to unhandled error", e);
+        } finally {
+            this.registry.timer(LAUNCH_TIMER, tags).record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        }
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
@@ -54,10 +54,10 @@ import java.util.stream.Collectors;
 @Slf4j
 public class TitusAgentLauncherImpl implements AgentLauncher {
 
-    private static final String GENIE_USER_ATTR = "genie_user";
-    private static final String GENIE_SOURCE_HOST_ATTR = "genie_source_host";
-    private static final String GENIE_ENDPOINT_ATTR = "genie_endpoint";
-    private static final String GENIE_JOB_ID_ATTR = "genie_job_id";
+    private static final String GENIE_USER_ATTR = "genie.user";
+    private static final String GENIE_SOURCE_HOST_ATTR = "genie.sourceHost";
+    private static final String GENIE_ENDPOINT_ATTR = "genie.endpoint";
+    private static final String GENIE_JOB_ID_ATTR = "genie.jobId";
     private static final String TITUS_API_JOB_PATH = "/api/v3/jobs";
     private static final String TITUS_JOB_ID_EXT_FIELD = "titusId";
     private static final String TITUS_JOB_REQUEST_EXT_FIELD = "titusRequest";

--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
@@ -311,7 +311,7 @@ public class JobRestController {
             null,
             numAttachments,
             totalSizeOfAttachments,
-            getGenieHeaders(httpServletRequest)
+            this.getGenieHeaders(httpServletRequest)
         );
 
         final JobSubmission.Builder jobSubmissionBuilder = new JobSubmission.Builder(

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
@@ -2072,14 +2072,14 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
         @NotBlank(message = "No job id entered. Unable to update.") final String id,
         @NotNull(message = "Status cannot be null.") final JsonNode launcherExtension
     ) throws NotFoundException {
-        log.debug("[updateRequestedLauncherExt] Requested to update launcher ext of job {}", id);
+        log.debug("[updateLauncherExt] Requested to update launcher ext of job {}", id);
 
         this.jobRepository
             .findByUniqueId(id)
             .orElseThrow(() -> new NotFoundException("No job exists for the id specified"))
             .setLauncherExt(launcherExtension);
 
-        log.debug("[updateRequestedLauncherExt] Updated launcher ext of job {}", id);
+        log.debug("[updateLauncherExt] Updated launcher ext of job {}", id);
     }
 
     /**

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
@@ -120,7 +120,7 @@ public class JobLaunchServiceImpl implements JobLaunchService {
                 resolvedJob = this.jobResolverService.resolveJob(jobId);
             } catch (final Throwable t) {
                 final String message;
-                if (t instanceof  GenieJobResolutionException) {
+                if (t instanceof GenieJobResolutionException) {
                     message = JobStatusMessages.FAILED_TO_RESOLVE_JOB;
                 } else {
                     message = JobStatusMessages.RESOLUTION_RUNTIME_ERROR;
@@ -153,12 +153,12 @@ public class JobLaunchServiceImpl implements JobLaunchService {
             }
 
             // TODO: at the moment this is not populated, it's going to be a null node (not null)
-            final JsonNode requestedLauncherExt =
-                this.persistenceService.getRequestedLauncherExt(jobId);
+            final JsonNode requestedLauncherExt = this.persistenceService.getRequestedLauncherExt(jobId);
 
             final Optional<JsonNode> launcherExt;
             try {
-                 launcherExt = this.selectLauncher(jobId, jobSubmission, resolvedJob)
+                launcherExt = this
+                    .selectLauncher(jobId, jobSubmission, resolvedJob)
                     .launchAgent(resolvedJob, requestedLauncherExt);
             } catch (final AgentLaunchException e) {
                 // TODO: this could fail as well

--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/JobLaunchServiceImpl.java
@@ -157,9 +157,9 @@ public class JobLaunchServiceImpl implements JobLaunchService {
 
             final Optional<JsonNode> launcherExt;
             try {
-                launcherExt = this
-                    .selectLauncher(jobId, jobSubmission, resolvedJob)
-                    .launchAgent(resolvedJob, requestedLauncherExt);
+                final AgentLauncher launcher = this.selectLauncher(jobId, jobSubmission, resolvedJob);
+                tags.add(Tag.of(LAUNCHER_CLASS_TAG, launcher.getClass().getCanonicalName()));
+                launcherExt = launcher.launchAgent(resolvedJob, requestedLauncherExt);
             } catch (final AgentLaunchException e) {
                 // TODO: this could fail as well
                 this.persistenceService.updateJobStatus(jobId, JobStatus.ACCEPTED, JobStatus.FAILED, e.getMessage());

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/LocalAgentLauncherImplSpec.groovy
@@ -162,7 +162,7 @@ class LocalAgentLauncherImplSpec extends Specification {
                 assert env.get("foo") == "bar"
                 assert env.size() > 1
         }
-        !launcherExt.isPresent()
+        launcherExt.isPresent()
 
         where:
         runAsUser | expectedCommandLine

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImplSpec.groovy
@@ -123,10 +123,10 @@ class TitusAgentLauncherImplSpec extends Specification {
         requestCapture.getOwner().getTeamEmail() == launcherProperties.getOwnerEmail()
         requestCapture.getApplicationName() == launcherProperties.getApplicationName()
         requestCapture.getCapacityGroup() == launcherProperties.getCapacityGroup()
-        requestCapture.getAttributes().get("genie_user") == USER
-        requestCapture.getAttributes().get("genie_source_host") == "hostname"
-        requestCapture.getAttributes().get("genie_endpoint") == launcherProperties.getGenieServerHost()
-        requestCapture.getAttributes().get("genie_job_id") == JOB_ID
+        requestCapture.getAttributes().get("genie.user") == USER
+        requestCapture.getAttributes().get("genie.sourceHost") == "hostname"
+        requestCapture.getAttributes().get("genie.endpoint") == launcherProperties.getGenieServerHost()
+        requestCapture.getAttributes().get("genie.jobId") == JOB_ID
         requestCapture.getContainer().getResources().getCpu() == 3 + 1
         requestCapture.getContainer().getResources().getGpu() == 0
         requestCapture.getContainer().getResources().getMemoryMB() == DataSize.ofGigabytes(4).toMegabytes()


### PR DESCRIPTION
The requested CPU was being dropped on the floor in favor of the default value (1) all the time. While this fix fixes that problem somewhat it doesn't address the fact that the resolved CPU value isn't persisted to the database as no field currently exists to save that. It would have to be done subsequently if we ever want to update the db schema.