### PR TITLE
Improve agent kill logic

### DIFF
--- a/genie-agent/src/test/resources/slowlyDie.test.sh
+++ b/genie-agent/src/test/resources/slowlyDie.test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Start a process that can only be killed by 3 consecutive Ctrl-C
+# or wait for 45s to finish
+#
+
+runfile=$RUNFILE
+if [ -z "$runfile" ]; then
+  runfile=$1
+fi
+bail() {
+    echo hey...
+    sleep 15
+    echo ok...
+    sleep 15
+    echo exiting...
+    sleep 15
+    echo ...exited
+    rm $runfile
+
+    trap - SIGINT SIGTERM SIGKILL
+    kill -- -$$
+}
+
+if [ ! -z "$runfile" ]; then
+    touch $runfile || exit 1
+fi
+
+trap bail SIGTERM SIGINT SIGKILL
+
+echo "running..."
+sleep 50

--- a/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessages.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/dto/JobStatusMessages.java
@@ -52,6 +52,11 @@ public final class JobStatusMessages {
     public static final String JOB_KILLED_BY_USER = "Job was killed by user.";
 
     /**
+     * Job killed by system.
+     */
+    public static final String JOB_KILLED_BY_SYSTEM = "Job was killed by system.";
+
+    /**
      * Job completed successfully.
      */
     public static final String JOB_FINISHED_SUCCESSFULLY = "Job finished successfully.";


### PR DESCRIPTION
* Process gets killed after completion should return `SUCCEEDED` result
* Add `destroyForcibly()` after failing to graceful `destroy()` job process
