### PR TITLE
Upgrade to netflixoss 9.2.2 to publish candidates to maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 
 plugins {
     id "com.github.kt3k.coveralls" version "2.10.2"
-    id "nebula.netflixoss" version "9.1.0"
+    id "nebula.netflixoss" version "9.2.2"
     id "org.ajoberstar.grgit" version "4.1.0"
     id "org.ajoberstar.git-publish" version "3.0.0"
     id "org.springframework.boot" version "${spring_boot_version}" apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ spring_cloud_version=Hoxton.SR9
 # org.gradle.parallel=true
 
 ## Ensure release candidates are published to JCenter/Maven Central
-netflixossAltCandidateRepo=false
+netflixossPublishCandidatesToMavenCentral=true
 
 # Force publishing snapshots with version 4.0.0
 # Remove once the first v4.x.x tag/branch is created.


### PR DESCRIPTION
Hi folks,

This upgrades our netflixoss plugin to allow publishing candidates to maven central via:

* `netflixossAltCandidateRepo=false` (to support the old flag)
* `netflixossPublishCandidatesToMavenCentral=true`

Here is a sample project using this change: https://github.com/Netflix/netflixoss-sample-project/runs/2059598228?check_suite_focus=true 