### PR TITLE
Fix state bug for job group info object

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
@@ -88,7 +88,6 @@ public class TitusAgentLauncherImpl implements AgentLauncher {
     private final TitusAgentLauncherProperties titusAgentLauncherProperties;
     private final Environment environment;
     private final TitusJobRequestAdapter jobRequestAdapter;
-    private final TitusBatchJobRequest.JobGroupInfo jobGroupInfo;
     private final boolean hasDataSizeConverters;
     private final Binder binder;
     private final MeterRegistry registry;
@@ -130,12 +129,6 @@ public class TitusAgentLauncherImpl implements AgentLauncher {
         }
         this.binder = Binder.get(this.environment);
         this.registry = registry;
-
-        this.jobGroupInfo = TitusBatchJobRequest.JobGroupInfo.builder()
-            .stack(this.titusAgentLauncherProperties.getStack())
-            .detail(this.titusAgentLauncherProperties.getDetail())
-            .sequence(this.titusAgentLauncherProperties.getSequence())
-            .build();
     }
 
     /**
@@ -394,7 +387,13 @@ public class TitusAgentLauncherImpl implements AgentLauncher {
                     )
                     .build()
             )
-            .jobGroupInfo(this.jobGroupInfo)
+            .jobGroupInfo(
+                TitusBatchJobRequest.JobGroupInfo.builder()
+                    .stack(this.titusAgentLauncherProperties.getStack())
+                    .detail(this.titusAgentLauncherProperties.getDetail())
+                    .sequence(this.titusAgentLauncherProperties.getSequence())
+                    .build()
+            )
             .build();
 
         // Run the request through the security adapter to add any necessary context


### PR DESCRIPTION
Previously the Titus request was immutable so sharing a static job info object wasn't a problem. Now that we allow the request to be mutated, particularly by the adapter implementation, this shared object represents a problem. This commit simply switches to creating a new JobGroupInfo object for every request so that state is isolated and not reused and subject to race conditions between request threads.