### PR TITLE
Add retry logic to Titus API calls

### DIFF
--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImplSpec.groovy
@@ -30,8 +30,14 @@ import com.netflix.genie.web.dtos.ResolvedJob
 import com.netflix.genie.web.exceptions.checked.AgentLaunchException
 import com.netflix.genie.web.properties.TitusAgentLauncherProperties
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.springframework.http.HttpStatus
 import org.springframework.mock.env.MockEnvironment
+import org.springframework.retry.backoff.FixedBackOffPolicy
+import org.springframework.retry.policy.NeverRetryPolicy
+import org.springframework.retry.support.RetryTemplate
 import org.springframework.util.unit.DataSize
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpServerErrorException
 import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
@@ -96,8 +102,18 @@ class TitusAgentLauncherImplSpec extends Specification {
         this.registry = new SimpleMeterRegistry()
         this.environment = new MockEnvironment()
 
+        /*
+         *  Note: The retry template used here is "transparent" in the sense it doesn't do
+         *        Anything. We don't really want to test how retries work as that is up to
+         *        the configured retry policy and backoff not so much the business logic
+         *        of this class. For now this is fine
+         */
+        def retryTemplate = new RetryTemplate()
+        retryTemplate.setRetryPolicy(new NeverRetryPolicy())
+
         this.launcher = new TitusAgentLauncherImpl(
             this.restTemplate,
+            retryTemplate,
             this.adapter,
             this.cache,
             this.genieHostInfo,
@@ -606,5 +622,80 @@ class TitusAgentLauncherImplSpec extends Specification {
         requestCapture.getContainer().getAttributes().size() == 2
         requestCapture.getContainer().getAttributes().get(prop1Key) == prop1Value
         requestCapture.getContainer().getAttributes().get(prop2Key) == prop2Value
+    }
+
+    def "Retry policy works as expected"() {
+        def retryCodes = EnumSet.of(HttpStatus.REQUEST_TIMEOUT, HttpStatus.SERVICE_UNAVAILABLE)
+        def maxRetries = 2
+        def policy = new TitusAgentLauncherImpl.TitusAPIRetryPolicy(retryCodes, maxRetries)
+        def retryTemplate = new RetryTemplate()
+        def backoffPolicy = new FixedBackOffPolicy()
+        backoffPolicy.setBackOffPeriod(1L)
+        retryTemplate.setRetryPolicy(policy)
+        retryTemplate.setBackOffPolicy(backoffPolicy)
+        def mockResponse = Mock(TitusBatchJobResponse)
+
+        when:
+        retryTemplate.execute(
+            { arg ->
+                this.restTemplate.postForObject(TITUS_ENDPOINT, Mock(TitusBatchJobRequest), TitusBatchJobResponse.class)
+            }
+        )
+
+        then:
+        1 * this.restTemplate.postForObject(TITUS_ENDPOINT, _ as TitusBatchJobRequest, TitusBatchJobResponse.class) >> {
+            throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+        thrown(HttpServerErrorException)
+
+        when:
+        retryTemplate.execute(
+            { arg ->
+                this.restTemplate.postForObject(TITUS_ENDPOINT, Mock(TitusBatchJobRequest), TitusBatchJobResponse.class)
+            }
+        )
+
+        then:
+        2 * this.restTemplate.postForObject(TITUS_ENDPOINT, _ as TitusBatchJobRequest, TitusBatchJobResponse.class) >> {
+            throw new HttpClientErrorException(HttpStatus.REQUEST_TIMEOUT)
+        }
+        thrown(HttpClientErrorException)
+
+        when:
+        def response = retryTemplate.execute(
+            { arg ->
+                this.restTemplate.postForObject(TITUS_ENDPOINT, Mock(TitusBatchJobRequest), TitusBatchJobResponse.class)
+            }
+        )
+
+        then:
+        2 * this.restTemplate.postForObject(
+            TITUS_ENDPOINT,
+            _ as TitusBatchJobRequest,
+            TitusBatchJobResponse.class
+        ) >>> [] >> { throw new HttpClientErrorException(HttpStatus.REQUEST_TIMEOUT) } >> mockResponse
+        response == mockResponse
+        noExceptionThrown()
+
+        when:
+        retryTemplate.execute(
+            { arg ->
+                this.restTemplate.postForObject(TITUS_ENDPOINT, Mock(TitusBatchJobRequest), TitusBatchJobResponse.class)
+            }
+        )
+
+        then:
+        2 * this.restTemplate.postForObject(
+            TITUS_ENDPOINT,
+            _ as TitusBatchJobRequest,
+            TitusBatchJobResponse.class
+        ) >>> [
+
+        ] >> {
+            throw new HttpServerErrorException(HttpStatus.SERVICE_UNAVAILABLE)
+        } >> {
+            throw new HttpClientErrorException(HttpStatus.REQUEST_TIMEOUT)
+        }
+        thrown(HttpClientErrorException)
     }
 }

--- a/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/launchers/AgentLaunchersAutoConfigurationTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/spring/autoconfigure/agent/launchers/AgentLaunchersAutoConfigurationTest.java
@@ -33,8 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.UUID;
 
@@ -72,6 +72,11 @@ class AgentLaunchersAutoConfigurationTest {
                     Assertions.assertThat(context).hasSingleBean(LocalAgentLauncherImpl.class);
                     Assertions.assertThat(context).doesNotHaveBean(TitusAgentLauncherImpl.TitusJobRequestAdapter.class);
                     Assertions.assertThat(context).doesNotHaveBean(TitusAgentLauncherImpl.class);
+                    Assertions.assertThat(context).doesNotHaveBean("titusAPIRetryPolicy");
+                    Assertions.assertThat(context).doesNotHaveBean(TitusAgentLauncherImpl.TitusAPIRetryPolicy.class);
+                    Assertions.assertThat(context).doesNotHaveBean("titusAPIBackoffPolicy");
+                    Assertions.assertThat(context).doesNotHaveBean("titusAPIRetryTemplate");
+                    Assertions.assertThat(context).doesNotHaveBean("titusRestTemplate");
                 }
             );
     }
@@ -82,9 +87,6 @@ class AgentLaunchersAutoConfigurationTest {
     @Test
     void testTitusAgentLauncherOnlyBean() {
         this.contextRunner
-            .withUserConfiguration(
-                TitusRestTemplateConfig.class
-            )
             .withPropertyValues(
                 "genie.agent.launcher.titus.enabled=true",
                 "genie.agent.launcher.local.enabled=false"
@@ -93,6 +95,11 @@ class AgentLaunchersAutoConfigurationTest {
                 context -> {
                     Assertions.assertThat(context).hasSingleBean(LocalAgentLauncherProperties.class);
                     Assertions.assertThat(context).hasSingleBean(TitusAgentLauncherProperties.class);
+                    Assertions.assertThat(context).hasBean("titusAPIRetryPolicy");
+                    Assertions.assertThat(context).hasSingleBean(TitusAgentLauncherImpl.TitusAPIRetryPolicy.class);
+                    Assertions.assertThat(context).hasBean("titusAPIBackoffPolicy");
+                    Assertions.assertThat(context).hasBean("titusAPIRetryTemplate");
+                    Assertions.assertThat(context).hasBean("titusRestTemplate");
                     Assertions.assertThat(context).hasSingleBean(TitusAgentLauncherImpl.TitusJobRequestAdapter.class);
                     Assertions.assertThat(context).hasSingleBean(TitusAgentLauncherImpl.class);
                     Assertions.assertThat(context).doesNotHaveBean(LocalAgentLauncherImpl.class);
@@ -127,12 +134,10 @@ class AgentLaunchersAutoConfigurationTest {
         MeterRegistry meterRegistry() {
             return new SimpleMeterRegistry();
         }
-    }
 
-    static class TitusRestTemplateConfig {
-        @Bean(name = "titusRestTemplate")
-        RestTemplate restTemplate() {
-            return Mockito.mock(RestTemplate.class);
+        @Bean
+        RestTemplateBuilder restTemplateBuilder() {
+            return new RestTemplateBuilder();
         }
     }
 }


### PR DESCRIPTION
Will retry on 408 and 503 by default 3 times with exponential backoff. All beans are configurable/overridable