### PR TITLE
Remove codecov integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,0 @@
-codecov:
-  branch: master
-  # strict_yaml_branch: master # Enable this if we want to use the yml file in master to dictate the reports for all branches

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ before_script:
 - mysql -u root -e 'create database genie;'
 - psql  -U postgres -c 'create database genie;'
 script: "./travis/buildViaTravis.sh"
-after_success:
-- bash <(curl -s https://codecov.io/bash)
 before_cache:
 - rm -f  "${HOME}/.gradle/caches/modules-2/modules-2.lock"
 - rm -fr "${HOME}/.gradle/caches/*/plugin-resolution/"

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ For more details visit the [official documentation](https://netflix.github.io/ge
 
 Genie builds are run on Travis CI [here](https://travis-ci.com/Netflix/genie).
 
-| Branch |                                                     Build                                                     |                                                                 Coverage (coveralls.io)                                                                |                                                        Coverage (codecov.io)                                                       |
-|:------:|:-------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------:|
-| master (4.0.x) | [![Build Status](https://travis-ci.com/Netflix/genie.svg?branch=master)](https://travis-ci.com/Netflix/genie) | [![Coverage Status](https://coveralls.io/repos/github/Netflix/genie/badge.svg?branch=master)](https://coveralls.io/github/Netflix/genie?branch=master) | [![codecov](https://codecov.io/gh/Netflix/genie/branch/master/graph/badge.svg)](https://codecov.io/gh/Netflix/genie/branch/master) |
-|  3.3.x |  [![Build Status](https://travis-ci.com/Netflix/genie.svg?branch=3.3.x)](https://travis-ci.com/Netflix/genie) |  [![Coverage Status](https://coveralls.io/repos/github/Netflix/genie/badge.svg?branch=3.3.x)](https://coveralls.io/github/Netflix/genie?branch=3.3.x)  |  [![codecov](https://codecov.io/gh/Netflix/genie/branch/3.3.x/graph/badge.svg)](https://codecov.io/gh/Netflix/genie/branch/3.3.x)  |
+| Branch |                                                     Build                                                     |                                                                 Coverage (coveralls.io)                                                                |
+|:------:|:-------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| master (4.0.x) | [![Build Status](https://travis-ci.com/Netflix/genie.svg?branch=master)](https://travis-ci.com/Netflix/genie) | [![Coverage Status](https://coveralls.io/repos/github/Netflix/genie/badge.svg?branch=master)](https://coveralls.io/github/Netflix/genie?branch=master) |
+|  3.3.x |  [![Build Status](https://travis-ci.com/Netflix/genie.svg?branch=3.3.x)](https://travis-ci.com/Netflix/genie) |  [![Coverage Status](https://coveralls.io/repos/github/Netflix/genie/badge.svg?branch=3.3.x)](https://coveralls.io/github/Netflix/genie?branch=3.3.x) |
 
 ## Project structure
 


### PR DESCRIPTION
Hi @tgianos 

While we were not affected by the https://about.codecov.io/security-update/ 

We suggest to move away from this pattern of curling codecov.io to get the bash script

This is to prevent potential problems in the future