### PR TITLE
Fixing memory leak issue causes by parked jobs

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImpl.java
@@ -210,14 +210,7 @@ public class GRpcJobKillServiceImpl extends JobKillServiceGrpc.JobKillServiceImp
                     final StreamObserver<JobKillRegistrationResponse> observer = this.parkedJobKillResponseObservers
                         .remove(jobId);
 
-                    if (observer != null && !isStreamObserverCancelled(observer)) {
-                        try {
-                            observer.onCompleted();
-                        } catch (final Exception observerException) {
-                            log.error("Got exception while trying to complete streamObserver during cleanup"
-                                + "for jobID {}. Exception: {}", jobId, observerException);
-                        }
-                    }
+                    cancelObserverIfNecessary(observer);
                 }
             } catch (final Exception unexpectedException) {
                 log.error("Got unexpected exception while trying to cleanup jobID {}. Moving on. "
@@ -236,5 +229,21 @@ public class GRpcJobKillServiceImpl extends JobKillServiceGrpc.JobKillServiceImp
     @VisibleForTesting
     protected boolean isStreamObserverCancelled(final StreamObserver<JobKillRegistrationResponse> observer) {
         return ((ServerCallStreamObserver<JobKillRegistrationResponse>) observer).isCancelled();
+    }
+
+    /**
+     * If observer is null or already cancelled - do nothing.
+     * Otherwise call onCompleted.
+     * @param observer
+     */
+    private void cancelObserverIfNecessary(final StreamObserver<JobKillRegistrationResponse> observer) {
+        if (observer != null && !isStreamObserverCancelled(observer)) {
+            try {
+                observer.onCompleted();
+            } catch (final Exception observerException) {
+                log.error("Got exception while trying to complete streamObserver during cleanup"
+                    + "for jobID {}. Exception: {}", "jobId", observerException);
+            }
+        }
     }
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImpl.java
@@ -214,20 +214,27 @@ public class GRpcJobKillServiceImpl extends JobKillServiceGrpc.JobKillServiceImp
                         try {
                             observer.onCompleted();
                         } catch (final Exception observerException) {
-                            log.error("Got exception while trying to complete streamObserver during cleanup" +
-                                "for jobID {}. Exception: {}", jobId, observerException);
+                            log.error("Got exception while trying to complete streamObserver during cleanup"
+                                + "for jobID {}. Exception: {}", jobId, observerException);
                         }
                     }
                 }
-            } catch (Exception unexpectedException) {
-                log.error("Got unexpected exception while trying to cleanup jobID {}. Moving on. " +
-                    "Exception: {}", jobId, unexpectedException);
+            } catch (final Exception unexpectedException) {
+                log.error("Got unexpected exception while trying to cleanup jobID {}. Moving on. "
+                    + "Exception: {}", jobId, unexpectedException);
             }
         }
     }
 
+    /**
+     * Converts StreamObserver into ServerCallStreamObserver in order to tell
+     * whether the observer is cancelled or not.
+     *
+     * @param observer Observer for which we would check the status
+     * @return         Boolean value: true if observer has status CANCELLED
+     */
     @VisibleForTesting
-    protected boolean isStreamObserverCancelled(StreamObserver<JobKillRegistrationResponse> observer) {
-        return ((ServerCallStreamObserver<JobKillRegistrationResponse>)observer).isCancelled();
+    protected boolean isStreamObserverCancelled(final StreamObserver<JobKillRegistrationResponse> observer) {
+        return ((ServerCallStreamObserver<JobKillRegistrationResponse>) observer).isCancelled();
     }
 }

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImplSpec.groovy
@@ -40,7 +40,6 @@ import javax.servlet.http.HttpServletRequest
  */
 class GRpcJobKillServiceImplSpec extends Specification {
 
-    GRpcJobKillServiceImpl service
     GRpcJobKillServiceImpl serviceSpy
     String jobId
     String reason
@@ -65,7 +64,7 @@ class GRpcJobKillServiceImplSpec extends Specification {
         def dataServices = Mock(DataServices) {
             getPersistenceService() >> this.persistenceService
         }
-        this.service = new GRpcJobKillServiceImpl(dataServices, this.agentRoutingService, this.requestForwardingService)
+        def service = new GRpcJobKillServiceImpl(dataServices, this.agentRoutingService, this.requestForwardingService)
 
         this.serviceSpy = Spy(service);
         this.servletRequest = Mock(HttpServletRequest)

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/apis/rpc/v4/endpoints/GRpcJobKillServiceImplSpec.groovy
@@ -41,6 +41,7 @@ import javax.servlet.http.HttpServletRequest
 class GRpcJobKillServiceImplSpec extends Specification {
 
     GRpcJobKillServiceImpl service
+    GRpcJobKillServiceImpl serviceSpy
     String jobId
     String reason
     String remoteHost
@@ -65,31 +66,39 @@ class GRpcJobKillServiceImplSpec extends Specification {
             getPersistenceService() >> this.persistenceService
         }
         this.service = new GRpcJobKillServiceImpl(dataServices, this.agentRoutingService, this.requestForwardingService)
+
+        this.serviceSpy = Spy(service);
         this.servletRequest = Mock(HttpServletRequest)
     }
 
     def "Can register for kill notification"() {
+        setup:
+        serviceSpy.isStreamObserverCancelled(_) >> false
+
         when:
-        this.service.registerForKillNotification(this.request, this.responseObserver)
+        this.serviceSpy.registerForKillNotification(this.request, this.responseObserver)
 
         then:
         noExceptionThrown()
-        this.service.getParkedJobKillResponseObservers().size() == 1
-        this.service.getParkedJobKillResponseObservers().get(this.jobId) == this.responseObserver
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(this.jobId) == this.responseObserver
 
         when: "A new registration occurs for the same job id"
-        this.service.registerForKillNotification(this.request, Mock(StreamObserver))
+        this.serviceSpy.registerForKillNotification(this.request, Mock(StreamObserver))
 
         then: "The old one is removed and closed"
         noExceptionThrown()
-        this.service.getParkedJobKillResponseObservers().size() == 1
-        this.service.getParkedJobKillResponseObservers().get(this.jobId) != this.responseObserver
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(this.jobId) != this.responseObserver
         1 * this.responseObserver.onCompleted()
     }
 
     def "Kill logic works as expected"() {
+        setup:
+        serviceSpy.isStreamObserverCancelled(_) >> false
+
         when: "Job doesn't exist"
-        this.service.killJob(this.jobId, this.reason, null)
+        this.serviceSpy.killJob(this.jobId, this.reason, null)
 
         then: "Expected exception is thrown"
         1 * this.persistenceService.getJobStatus(this.jobId) >> {
@@ -98,7 +107,7 @@ class GRpcJobKillServiceImplSpec extends Specification {
         thrown(GenieJobNotFoundException)
 
         when: "The job is already finished"
-        this.service.killJob(this.jobId, this.reason, this.servletRequest)
+        this.serviceSpy.killJob(this.jobId, this.reason, this.servletRequest)
 
         then: "Nothing needs to be done"
         1 * this.persistenceService.getJobStatus(this.jobId) >> JobStatus.SUCCEEDED
@@ -107,7 +116,7 @@ class GRpcJobKillServiceImplSpec extends Specification {
         0 * this.agentRoutingService.isAgentConnectionLocal(this.jobId)
 
         when: "The job is active, the agent isn't yet started but status has changed since initial call"
-        this.service.killJob(this.jobId, this.reason, null)
+        this.serviceSpy.killJob(this.jobId, this.reason, null)
 
         then: "Only try to set killed in database but is rejected and exception is thrown"
         1 * this.persistenceService.getJobStatus(this.jobId) >> JobStatus.RESERVED
@@ -118,7 +127,7 @@ class GRpcJobKillServiceImplSpec extends Specification {
         thrown(GenieInvalidStatusException)
 
         when: "The job is active, the agent isn't yet started but for some reason db can't find job"
-        this.service.killJob(this.jobId, this.reason, null)
+        this.serviceSpy.killJob(this.jobId, this.reason, null)
 
         then: "Correct exception is thrown"
         1 * this.persistenceService.getJobStatus(this.jobId) >> JobStatus.ACCEPTED
@@ -129,7 +138,7 @@ class GRpcJobKillServiceImplSpec extends Specification {
         thrown(GenieJobNotFoundException)
 
         when: "The job is active, the agent isn't yet started and the db can find the job"
-        this.service.killJob(this.jobId, this.reason, this.servletRequest)
+        this.serviceSpy.killJob(this.jobId, this.reason, this.servletRequest)
 
         then: "The database is updated and no exception is thrown"
         1 * this.persistenceService.getJobStatus(this.jobId) >> JobStatus.RESOLVED
@@ -138,7 +147,7 @@ class GRpcJobKillServiceImplSpec extends Specification {
         noExceptionThrown()
 
         when: "The job is active, the agent is connected, the job is local but no observer"
-        this.service.killJob(this.jobId, this.reason, this.servletRequest)
+        this.serviceSpy.killJob(this.jobId, this.reason, this.servletRequest)
 
         then: "Correct exception is thrown"
         1 * this.persistenceService.getJobStatus(this.jobId) >> JobStatus.CLAIMED
@@ -149,8 +158,8 @@ class GRpcJobKillServiceImplSpec extends Specification {
         thrown(GenieServerException)
 
         when: "The job is active, the agent is connected, and there is an observer"
-        this.service.registerForKillNotification(this.request, this.responseObserver)
-        this.service.killJob(this.jobId, this.reason, null)
+        this.serviceSpy.registerForKillNotification(this.request, this.responseObserver)
+        this.serviceSpy.killJob(this.jobId, this.reason, null)
 
         then: "Kill message is sent and the observer is removed"
         1 * this.persistenceService.getJobStatus(this.jobId) >> JobStatus.INIT
@@ -158,10 +167,10 @@ class GRpcJobKillServiceImplSpec extends Specification {
         1 * this.agentRoutingService.isAgentConnectionLocal(this.jobId) >> true
         1 * this.responseObserver.onNext(_ as JobKillRegistrationResponse)
         1 * this.responseObserver.onCompleted()
-        this.service.getParkedJobKillResponseObservers().isEmpty()
+        this.serviceSpy.getParkedJobKillResponseObservers().isEmpty()
 
         when: "The job is active, the agent is connected to another server but we can't determine where"
-        this.service.killJob(this.jobId, this.reason, this.servletRequest)
+        this.serviceSpy.killJob(this.jobId, this.reason, this.servletRequest)
 
         then: "An exception is thrown"
         1 * this.persistenceService.getJobStatus(this.jobId) >> JobStatus.RUNNING
@@ -173,7 +182,7 @@ class GRpcJobKillServiceImplSpec extends Specification {
         thrown(GenieServerException)
 
         when: "The job is active and we try to forward request"
-        this.service.killJob(this.jobId, this.reason, this.servletRequest)
+        this.serviceSpy.killJob(this.jobId, this.reason, this.servletRequest)
 
         then: "No exception is thrown"
         1 * this.persistenceService.getJobStatus(this.jobId) >> JobStatus.RUNNING
@@ -187,6 +196,9 @@ class GRpcJobKillServiceImplSpec extends Specification {
     }
 
     def "can clean up orphans"() {
+        setup:
+        serviceSpy.isStreamObserverCancelled(_) >> false
+
         def jobId0 = UUID.randomUUID().toString()
         def jobId1 = UUID.randomUUID().toString()
         def jobId2 = UUID.randomUUID().toString()
@@ -200,50 +212,183 @@ class GRpcJobKillServiceImplSpec extends Specification {
         def jobObserver2 = Mock(StreamObserver)
 
         when: "Nothing is registered"
-        this.service.cleanupOrphanedObservers()
+        this.serviceSpy.cleanupOrphanedObservers()
 
         then: "Nothing happens"
-        this.service.getParkedJobKillResponseObservers().isEmpty()
+        this.serviceSpy.getParkedJobKillResponseObservers().isEmpty()
 
         when: "Jobs are registered"
-        this.service.registerForKillNotification(request0, jobObserver0)
-        this.service.registerForKillNotification(request1, jobObserver1)
-        this.service.registerForKillNotification(request2, jobObserver2)
+        this.serviceSpy.registerForKillNotification(request0, jobObserver0)
+        this.serviceSpy.registerForKillNotification(request1, jobObserver1)
+        this.serviceSpy.registerForKillNotification(request2, jobObserver2)
 
         then: "They're saved in map"
-        this.service.getParkedJobKillResponseObservers().size() == 3
-        this.service.getParkedJobKillResponseObservers().get(jobId0) == jobObserver0
-        this.service.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
-        this.service.getParkedJobKillResponseObservers().get(jobId2) == jobObserver2
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 3
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId0) == jobObserver0
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId2) == jobObserver2
 
         when: "All jobs still attached locally"
-        this.service.cleanupOrphanedObservers()
+        this.serviceSpy.cleanupOrphanedObservers()
 
         then: "Nothing happens"
         1 * this.agentRoutingService.isAgentConnectionLocal(jobId0) >> true
         1 * this.agentRoutingService.isAgentConnectionLocal(jobId1) >> true
         1 * this.agentRoutingService.isAgentConnectionLocal(jobId2) >> true
-        this.service.getParkedJobKillResponseObservers().size() == 3
-        this.service.getParkedJobKillResponseObservers().get(jobId0) == jobObserver0
-        this.service.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
-        this.service.getParkedJobKillResponseObservers().get(jobId2) == jobObserver2
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 3
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId0) == jobObserver0
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId2) == jobObserver2
         0 * jobObserver0.onCompleted()
         0 * jobObserver1.onCompleted()
         0 * jobObserver2.onCompleted()
 
         when: "The jobs switch servers or complete"
-        this.service.cleanupOrphanedObservers()
+        this.serviceSpy.cleanupOrphanedObservers()
 
         then: "It is removed from the map and the observer is completed"
         1 * this.agentRoutingService.isAgentConnectionLocal(jobId0) >> false
         1 * this.agentRoutingService.isAgentConnectionLocal(jobId1) >> true
         1 * this.agentRoutingService.isAgentConnectionLocal(jobId2) >> false
-        this.service.getParkedJobKillResponseObservers().size() == 1
-        this.service.getParkedJobKillResponseObservers().get(jobId0) == null
-        this.service.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
-        this.service.getParkedJobKillResponseObservers().get(jobId2) == null
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId0) == null
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId2) == null
         1 * jobObserver0.onCompleted()
         0 * jobObserver1.onCompleted()
         1 * jobObserver2.onCompleted()
+        noExceptionThrown()
+    }
+
+    def "cleans up orphans but does not complete cancelled"() {
+        setup:
+        serviceSpy.isStreamObserverCancelled(_) >> true
+
+        def jobId0 = UUID.randomUUID().toString()
+        def jobId1 = UUID.randomUUID().toString()
+        def jobId2 = UUID.randomUUID().toString()
+
+        def request0 = JobKillRegistrationRequest.newBuilder().setJobId(jobId0).build()
+        def request1 = JobKillRegistrationRequest.newBuilder().setJobId(jobId1).build()
+        def request2 = JobKillRegistrationRequest.newBuilder().setJobId(jobId2).build()
+
+        def jobObserver0 = Mock(StreamObserver)
+        def jobObserver1 = Mock(StreamObserver)
+        def jobObserver2 = Mock(StreamObserver)
+
+        when: "Jobs are registered"
+        this.serviceSpy.registerForKillNotification(request0, jobObserver0)
+        this.serviceSpy.registerForKillNotification(request1, jobObserver1)
+        this.serviceSpy.registerForKillNotification(request2, jobObserver2)
+
+        then: "They're saved in map"
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 3
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId0) == jobObserver0
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId2) == jobObserver2
+
+        when: "The jobs switch servers or complete"
+        this.serviceSpy.cleanupOrphanedObservers()
+
+        then: "It is removed from the map but the observers are cancelled so no onCompleted"
+        1 * this.agentRoutingService.isAgentConnectionLocal(jobId0) >> false
+        1 * this.agentRoutingService.isAgentConnectionLocal(jobId1) >> true
+        1 * this.agentRoutingService.isAgentConnectionLocal(jobId2) >> false
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId0) == null
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId2) == null
+        0 * jobObserver0.onCompleted()
+        0 * jobObserver1.onCompleted()
+        0 * jobObserver2.onCompleted()
+        noExceptionThrown()
+    }
+
+    def "clean up orphans and no exceptions thrown when onComplete throws"() {
+        setup:
+        serviceSpy.isStreamObserverCancelled(_) >> false
+
+        def jobId0 = UUID.randomUUID().toString()
+        def jobId1 = UUID.randomUUID().toString()
+        def jobId2 = UUID.randomUUID().toString()
+
+        def request0 = JobKillRegistrationRequest.newBuilder().setJobId(jobId0).build()
+        def request1 = JobKillRegistrationRequest.newBuilder().setJobId(jobId1).build()
+        def request2 = JobKillRegistrationRequest.newBuilder().setJobId(jobId2).build()
+
+        def jobObserver0 = Mock(StreamObserver)
+        def jobObserver1 = Mock(StreamObserver)
+        def jobObserver2 = Mock(StreamObserver)
+
+        when: "Jobs are registered"
+        this.serviceSpy.registerForKillNotification(request0, jobObserver0)
+        this.serviceSpy.registerForKillNotification(request1, jobObserver1)
+        this.serviceSpy.registerForKillNotification(request2, jobObserver2)
+
+        then: "They're saved in map"
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 3
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId0) == jobObserver0
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId2) == jobObserver2
+
+        when: "The jobs switch servers or complete"
+        this.serviceSpy.cleanupOrphanedObservers()
+
+        then: "It is removed from the map and onComplete throws exception we catch"
+        1 * this.agentRoutingService.isAgentConnectionLocal(jobId0) >> false
+        1 * this.agentRoutingService.isAgentConnectionLocal(jobId1) >> true
+        1 * this.agentRoutingService.isAgentConnectionLocal(jobId2) >> false
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId0) == null
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId2) == null
+        1 * jobObserver0.onCompleted() >> { throw new RuntimeException("Mock exception") }
+        0 * jobObserver1.onCompleted()
+        1 * jobObserver2.onCompleted() >> { throw new RuntimeException("Mock exception") }
+        noExceptionThrown()
+    }
+
+    def "clean up orphans and no exceptions thrown when loop body throws"() {
+        setup:
+        serviceSpy.isStreamObserverCancelled(_) >> false
+
+        def jobId0 = UUID.randomUUID().toString()
+        def jobId1 = UUID.randomUUID().toString()
+        def jobId2 = UUID.randomUUID().toString()
+
+        def request0 = JobKillRegistrationRequest.newBuilder().setJobId(jobId0).build()
+        def request1 = JobKillRegistrationRequest.newBuilder().setJobId(jobId1).build()
+        def request2 = JobKillRegistrationRequest.newBuilder().setJobId(jobId2).build()
+
+        def jobObserver0 = Mock(StreamObserver)
+        def jobObserver1 = Mock(StreamObserver)
+        def jobObserver2 = Mock(StreamObserver)
+
+        when: "Jobs are registered"
+        this.serviceSpy.registerForKillNotification(request0, jobObserver0)
+        this.serviceSpy.registerForKillNotification(request1, jobObserver1)
+        this.serviceSpy.registerForKillNotification(request2, jobObserver2)
+
+        then: "They're saved in map"
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 3
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId0) == jobObserver0
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId1) == jobObserver1
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId2) == jobObserver2
+
+        when: "The jobs switch servers or complete"
+        this.serviceSpy.cleanupOrphanedObservers()
+
+        then: "It is removed from the map and onComplete throws exception we catch"
+        1 * this.agentRoutingService.isAgentConnectionLocal(jobId0) >> { throw new RuntimeException("Mock exception") }
+        1 * this.agentRoutingService.isAgentConnectionLocal(jobId1) >> false
+        1 * this.agentRoutingService.isAgentConnectionLocal(jobId2) >> { throw new RuntimeException("Mock exception") }
+        this.serviceSpy.getParkedJobKillResponseObservers().size() == 2
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId0) == jobObserver0
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId1) == null
+        this.serviceSpy.getParkedJobKillResponseObservers().get(jobId2) == jobObserver2
+        0 * jobObserver0.onCompleted()
+        1 * jobObserver1.onCompleted()
+        0 * jobObserver2.onCompleted()
+        noExceptionThrown()
     }
 }


### PR DESCRIPTION
Fixing the memory leak issue caused by parked jobs not getting cleaned up when exception happens during onComplete.
I've added 2 try-catch blocks: one wrapping around onComplete to specifically catch known exceptions that we saw cause this issue. And second try-catch block is wrapping the whole block of the for loop, in case there are other unknown exceptions we have during cleanup.