### PR TITLE
refactor: Polish use of JUnit 5

### DIFF
--- a/genie-agent-app/src/smokeTest/java/com/netflix/genie/GenieAgentApplicationSmokeTest.java
+++ b/genie-agent-app/src/smokeTest/java/com/netflix/genie/GenieAgentApplicationSmokeTest.java
@@ -21,11 +21,9 @@ import com.netflix.genie.agent.cli.ExitCode;
 import com.netflix.genie.agent.cli.GenieAgentRunner;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Tests that ensure the app comes up correctly with default values.
@@ -33,7 +31,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * @author tgianos
  * @since 4.0.0
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
     classes = GenieAgentApplication.class,
     webEnvironment = SpringBootTest.WebEnvironment.NONE

--- a/genie-app/src/smokeTest/java/com/netflix/genie/GenieAppSmokeTest.java
+++ b/genie-app/src/smokeTest/java/com/netflix/genie/GenieAppSmokeTest.java
@@ -19,13 +19,11 @@ package com.netflix.genie;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Smoke test to make sure the app comes up successfully with all defaults.
@@ -33,7 +31,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * @author tgianos
  * @since 4.0.0
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(
     classes = {
         GenieApp.class

--- a/genie-common/src/test/java/com/netflix/genie/common/dto/ClusterCriteriaTest.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/dto/ClusterCriteriaTest.java
@@ -19,7 +19,7 @@ package com.netflix.genie.common.dto;
 
 import com.google.common.collect.Sets;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
@@ -67,8 +67,8 @@ class ClusterCriteriaTest {
         tags.add(UUID.randomUUID().toString());
         final ClusterCriteria clusterCriteria3 = new ClusterCriteria(tags);
 
-        Assert.assertEquals(clusterCriteria1, clusterCriteria2);
-        Assert.assertNotEquals(clusterCriteria1, clusterCriteria3);
+        Assertions.assertEquals(clusterCriteria1, clusterCriteria2);
+        Assertions.assertNotEquals(clusterCriteria1, clusterCriteria3);
     }
 
     /**
@@ -83,7 +83,7 @@ class ClusterCriteriaTest {
         tags.add(UUID.randomUUID().toString());
         final ClusterCriteria clusterCriteria3 = new ClusterCriteria(tags);
 
-        Assert.assertEquals(clusterCriteria1.hashCode(), clusterCriteria2.hashCode());
-        Assert.assertNotEquals(clusterCriteria1.hashCode(), clusterCriteria3.hashCode());
+        Assertions.assertEquals(clusterCriteria1.hashCode(), clusterCriteria2.hashCode());
+        Assertions.assertNotEquals(clusterCriteria1.hashCode(), clusterCriteria3.hashCode());
     }
 }

--- a/genie-ui/src/integTest/java/com/netflix/genie/ui/controllers/UIControllerIntegrationTest.java
+++ b/genie-ui/src/integTest/java/com/netflix/genie/ui/controllers/UIControllerIntegrationTest.java
@@ -21,13 +21,11 @@ import com.netflix.genie.web.apis.rest.v3.controllers.GenieExceptionMapper;
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -44,7 +42,6 @@ import java.util.UUID;
  * @author mprimi
  * @since 3.2.0
  */
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(UIController.class)
 @ActiveProfiles("integration")
 class UIControllerIntegrationTest {


### PR DESCRIPTION
👋 @tgianos hope all is well! `@ExtendWith` is no longer necessary for `@SpringBootTest`. Also moving a handful of asserts to JUnit 5. Let me know if you'd like to move to AssertJ and we can generate that change as well.

Co-authored-by: Moderne <team@moderne.io>