### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 - postgresql
 - docker
 git:
-  depth: false
+  depth: 3
 install: "./travis/installViaTravis.sh"
 before_script:
 - cat "$TRAVIS_BUILD_DIR/travis/config/mysql/my.cnf" | sudo tee -a /etc/mysql/my.cnf


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.