### PR TITLE
Upgrade dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,10 +19,12 @@
 ## Dependency Versions
 
 protobuf_version=3.12.0
-spring_boot_version=2.3.9.RELEASE
-spring_cloud_version=Hoxton.SR10
+spring_boot_version=2.3.11.RELEASE
+spring_cloud_version=Hoxton.SR11
 
 ## Override Spring Dependency Managed Versions
+
+log4j2.version=2.16.0
 
 ## Gradle Property Overrides
 


### PR DESCRIPTION
Primarily push log4j to 2.16.0 for log4shell vulnerabilities