### PR TITLE
Make attachments for job requests optional

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestController.java
@@ -263,7 +263,7 @@ public class JobRestController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ResponseEntity<Void> submitJob(
         @Valid @RequestPart("request") final JobRequest jobRequest,
-        @RequestPart("attachment") final MultipartFile[] attachments,
+        @RequestPart(value = "attachment", required = false) @Nullable final MultipartFile[] attachments,
         @RequestHeader(value = FORWARDED_FOR_HEADER, required = false) @Nullable final String clientHost,
         @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) @Nullable final String userAgent,
         final HttpServletRequest httpServletRequest
@@ -271,7 +271,7 @@ public class JobRestController {
         log.info(
             "[submitJob] Called multipart method to submit job: {}, with {} attachments",
             jobRequest,
-            attachments.length
+            attachments == null ? 0 : attachments.length
         );
         this.submitJobWithAttachmentsRate.increment();
         return this.handleSubmitJob(jobRequest, attachments, clientHost, userAgent, httpServletRequest);


### PR DESCRIPTION
For backwards compatibility some internal clients were sending requests to the multipart endpoint but not sending an attachment field. This worked on the 2.3.x line but on 2.5.x it is enforced more strictly and is throwing 400. The proper thing to do would be to make the clients do the right thing but it would be such a long tail that releasing this fix is more effective short term while that logic is slowly phased out.