### PR TITLE
Fix exposing inconsistency in job status outside of persistence API

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/PersistenceService.java
@@ -695,23 +695,22 @@ public interface PersistenceService {
      * of the job matches {@code newStatus}. Optionally a status message can be provided to provide more details to
      * users. If the {@code newStatus} is {@link JobStatus#RUNNING} the start time will be set. If the {@code newStatus}
      * is a member of {@link JobStatus#getFinishedStatuses()} and the job had a started time set the finished time of
-     * the job will be set.
+     * the job will be set. If the {@literal currentStatus} is different from what the source of truth thinks this
+     * function will skip the update and just return the current source of truth value.
      *
      * @param id               The id of the job to update status for. Must exist in the system.
      * @param currentStatus    The status the caller to this API thinks the job currently has
      * @param newStatus        The new status the caller would like to update the status to
      * @param newStatusMessage An optional status message to associate with this change
-     * @throws NotFoundException           if no job with the given {@code id} exists
-     * @throws GenieInvalidStatusException if the current status of the job identified by {@code id} in the system
-     *                                     doesn't match the supplied {@code currentStatus}.
-     *                                     Also if the {@code currentStatus} equals the {@code newStatus}.
+     * @return The job status in the source of truth
+     * @throws NotFoundException if no job with the given {@code id} exists
      */
-    void updateJobStatus(
+    JobStatus updateJobStatus(
         @NotBlank String id,
         @NotNull JobStatus currentStatus,
         @NotNull JobStatus newStatus,
         @Nullable String newStatusMessage
-    ) throws NotFoundException, GenieInvalidStatusException;
+    ) throws NotFoundException;
 
     /**
      * Update the status and status message of the job.

--- a/genie-web/src/test/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsTest.java
+++ b/genie-web/src/test/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsTest.java
@@ -307,16 +307,11 @@ class JpaPersistenceServiceImplJobsTest {
     }
 
     @Test
-    void testUpdateJobStatusErrorCases() {
+    void testUpdateJobStatusErrorCases() throws NotFoundException {
         final String id = UUID.randomUUID().toString();
         Assertions
-            .assertThatExceptionOfType(GenieInvalidStatusException.class)
-            .isThrownBy(() -> this.persistenceService.updateJobStatus(
-                id,
-                JobStatus.CLAIMED,
-                JobStatus.CLAIMED,
-                null)
-            );
+            .assertThat(this.persistenceService.updateJobStatus(id, JobStatus.CLAIMED, JobStatus.CLAIMED, null))
+            .isEqualTo(JobStatus.CLAIMED);
 
         Mockito
             .when(this.jobRepository.findByUniqueId(id))
@@ -325,10 +320,10 @@ class JpaPersistenceServiceImplJobsTest {
         Assertions
             .assertThatExceptionOfType(NotFoundException.class)
             .isThrownBy(() -> this.persistenceService.updateJobStatus(
-                id,
-                JobStatus.CLAIMED,
-                JobStatus.INIT,
-                null
+                    id,
+                    JobStatus.CLAIMED,
+                    JobStatus.INIT,
+                    null
                 )
             );
 
@@ -338,17 +333,9 @@ class JpaPersistenceServiceImplJobsTest {
             .thenReturn(Optional.of(jobEntity));
 
         Mockito.when(jobEntity.getStatus()).thenReturn(JobStatus.INIT.name());
-
         Assertions
-            .assertThatExceptionOfType(GenieInvalidStatusException.class)
-            .isThrownBy(
-                () -> this.persistenceService.updateJobStatus(
-                    id,
-                    JobStatus.CLAIMED,
-                    JobStatus.INIT,
-                    null
-                )
-            );
+            .assertThat(this.persistenceService.updateJobStatus(id, JobStatus.CLAIMED, JobStatus.INIT, null))
+            .isEqualTo(JobStatus.INIT);
     }
 
     @Test


### PR DESCRIPTION
Within job launch logic there was a helper method which would query the job status and based on the returned value proceed with some logic to either update it or fall back to other logic. This works ok if all requests to the persistence service implementation go to a single cosistent backend. If, however, read only queries go to a read replica which may have lag or some other implementation entirely this breaks down without the service actually knowing why or how.

Moving the logic for this behind the persistence API and letting the launch service only act the returned job status from the source of truth api should fix this problem.