### PR TITLE
Upgrade Gradle Git Publish plugin to 3.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id "com.github.kt3k.coveralls" version "2.12.0"
     id "nebula.netflixoss" version "10.5.1"
     id "org.ajoberstar.grgit" version "4.1.1"
-    id "org.ajoberstar.git-publish" version "3.0.0"
+    id "org.ajoberstar.git-publish" version "3.0.1"
     id "org.springframework.boot" version "${spring_boot_version}" apply false
     id "org.asciidoctor.jvm.convert" version "3.3.2" apply false
     id "com.gorylenko.gradle-git-properties" version "2.3.2" apply false


### PR DESCRIPTION
Fixes floading dependency version. See: https://github.com/ajoberstar/gradle-git-publish/releases/tag/3.0.1