### PR TITLE
Fix search by tag count queries for commands, clusters and applications

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImpl.java
@@ -125,6 +125,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Order;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -313,11 +314,13 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
         final CriteriaBuilder criteriaBuilder = this.entityManager.getCriteriaBuilder();
         final CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
         final Root<ApplicationEntity> countQueryRoot = countQuery.from(ApplicationEntity.class);
-        countQuery.select(criteriaBuilder.count(countQueryRoot));
-        countQuery.where(
+        final Subquery<Long> countIdSubQuery = countQuery.subquery(Long.class);
+        final Root<ApplicationEntity> countIdSubQueryRoot = countIdSubQuery.from(ApplicationEntity.class);
+        countIdSubQuery.select(countIdSubQueryRoot.get(ApplicationEntity_.id));
+        countIdSubQuery.where(
             ApplicationPredicates.find(
-                countQueryRoot,
-                countQuery,
+                countIdSubQueryRoot,
+                countIdSubQuery,
                 criteriaBuilder,
                 name,
                 user,
@@ -326,15 +329,11 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
                 type
             )
         );
+        countQuery.select(criteriaBuilder.count(countQueryRoot));
+        countQuery.where(countQueryRoot.get(ApplicationEntity_.id).in(countIdSubQuery));
 
-        final List<Long> applicationsCount = this.entityManager.createQuery(countQuery).getResultList();
-        if (applicationsCount.isEmpty()) {
-            // SELECT COUNT ... GROUP BY ... HAVING ... may return NULL
-            return new PageImpl<>(new ArrayList<>(0));
-        }
-
-        final Long totalCount = applicationsCount.get(0);
-        if (totalCount == 0) {
+        final Long totalCount = this.entityManager.createQuery(countQuery).getSingleResult();
+        if (totalCount == null || totalCount == 0) {
             // short circuit for no results
             return new PageImpl<>(new ArrayList<>(0));
         }
@@ -552,11 +551,13 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
         final CriteriaBuilder criteriaBuilder = this.entityManager.getCriteriaBuilder();
         final CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
         final Root<ClusterEntity> countQueryRoot = countQuery.from(ClusterEntity.class);
-        countQuery.select(criteriaBuilder.count(countQueryRoot));
-        countQuery.where(
+        final Subquery<Long> countIdSubQuery = countQuery.subquery(Long.class);
+        final Root<ClusterEntity> countIdSubQueryRoot = countIdSubQuery.from(ClusterEntity.class);
+        countIdSubQuery.select(countIdSubQueryRoot.get(ClusterEntity_.id));
+        countIdSubQuery.where(
             ClusterPredicates.find(
-                countQueryRoot,
-                countQuery,
+                countIdSubQueryRoot,
+                countIdSubQuery,
                 criteriaBuilder,
                 name,
                 statusStrings,
@@ -565,15 +566,11 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
                 maxUpdateTime
             )
         );
+        countQuery.select(criteriaBuilder.count(countQueryRoot));
+        countQuery.where(countQueryRoot.get(ClusterEntity_.id).in(countIdSubQuery));
 
-        final List<Long> clustersCount = this.entityManager.createQuery(countQuery).getResultList();
-        if (clustersCount.isEmpty()) {
-            // SELECT COUNT ... GROUP BY ... HAVING ... may return NULL
-            return new PageImpl<>(new ArrayList<>(0));
-        }
-
-        final Long totalCount = clustersCount.get(0);
-        if (totalCount == 0) {
+        final Long totalCount = this.entityManager.createQuery(countQuery).getSingleResult();
+        if (totalCount == null || totalCount == 0) {
             // short circuit for no results
             return new PageImpl<>(new ArrayList<>(0));
         }
@@ -860,11 +857,13 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
         final CriteriaBuilder criteriaBuilder = this.entityManager.getCriteriaBuilder();
         final CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
         final Root<CommandEntity> countQueryRoot = countQuery.from(CommandEntity.class);
-        countQuery.select(criteriaBuilder.count(countQueryRoot));
-        countQuery.where(
+        final Subquery<Long> countIdSubQuery = countQuery.subquery(Long.class);
+        final Root<CommandEntity> countIdSubQueryRoot = countIdSubQuery.from(CommandEntity.class);
+        countIdSubQuery.select(countIdSubQueryRoot.get(CommandEntity_.id));
+        countIdSubQuery.where(
             CommandPredicates.find(
-                countQueryRoot,
-                countQuery,
+                countIdSubQueryRoot,
+                countIdSubQuery,
                 criteriaBuilder,
                 name,
                 user,
@@ -872,16 +871,11 @@ public class JpaPersistenceServiceImpl implements PersistenceService {
                 tagEntities
             )
         );
+        countQuery.select(criteriaBuilder.count(countQueryRoot));
+        countQuery.where(countQueryRoot.get(CommandEntity_.id).in(countIdSubQuery));
 
-        final List<Long> commandsCount = this.entityManager.createQuery(countQuery).getResultList();
-
-        if (commandsCount.isEmpty()) {
-            // SELECT COUNT ... GROUP BY ... HAVING ... may return NULL
-            return new PageImpl<>(new ArrayList<>(0));
-        }
-
-        final Long totalCount = commandsCount.get(0);
-        if (totalCount == 0) {
+        final Long totalCount = this.entityManager.createQuery(countQuery).getSingleResult();
+        if (totalCount == null || totalCount == 0) {
             // short circuit for no results
             return new PageImpl<>(new ArrayList<>(0));
         }

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/queries/predicates/ApplicationPredicates.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/queries/predicates/ApplicationPredicates.java
@@ -21,6 +21,7 @@ import com.netflix.genie.web.data.services.impl.jpa.entities.TagEntity;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
+import javax.persistence.criteria.AbstractQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
@@ -58,7 +59,7 @@ public final class ApplicationPredicates {
      */
     public static Predicate find(
         final Root<ApplicationEntity> root,
-        final CriteriaQuery<?> cq,
+        final AbstractQuery<?> cq,
         final CriteriaBuilder cb,
         @Nullable final String name,
         @Nullable final String user,

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/queries/predicates/ClusterPredicates.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/queries/predicates/ClusterPredicates.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.jpa.domain.Specification;
 
 import javax.annotation.Nullable;
+import javax.persistence.criteria.AbstractQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
@@ -64,7 +65,7 @@ public final class ClusterPredicates {
      */
     public static Predicate find(
         final Root<ClusterEntity> root,
-        final CriteriaQuery<?> cq,
+        final AbstractQuery<?> cq,
         final CriteriaBuilder cb,
         @Nullable final String name,
         @Nullable final Set<String> statuses,

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/queries/predicates/CommandPredicates.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/queries/predicates/CommandPredicates.java
@@ -22,6 +22,7 @@ import com.netflix.genie.web.data.services.impl.jpa.entities.TagEntity;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
+import javax.persistence.criteria.AbstractQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
@@ -60,7 +61,7 @@ public final class CommandPredicates {
      */
     public static Predicate find(
         final Root<CommandEntity> root,
-        final CriteriaQuery<?> cq,
+        final AbstractQuery<?> cq,
         final CriteriaBuilder cb,
         @Nullable final String name,
         @Nullable final String user,


### PR DESCRIPTION
Searching by tags for these entites results in a query using `group by` and `having`. This was working fine for the actual
content queries but the count queries were getting messed up because it couldn't count the result properly as it was just
and array of 1's being return (counting the group size and all were one). It was actually the length of the result set we'd
have wanted for the total count. This wouldn't work though for the ones were tags weren't involved because that query doesn't
have a group by and a having.

This change modifies the count queries to instead of trying to count directly with the same where predicate it actually
counts the results of the real query as a subquery (all on database side so it doesn't return all the data). This way it
doesn't matter if there's a `group by` or not. Now the total results returned via the API in the `Page` object are correct and
pagination can continue properly.