### PR TITLE
Intercept 429 http error code and raise an explicit GenieClientTooManyRequestException exception

### DIFF
--- a/genie-client/src/main/java/com/netflix/genie/client/exceptions/GenieClientTooManyRequestsException.java
+++ b/genie-client/src/main/java/com/netflix/genie/client/exceptions/GenieClientTooManyRequestsException.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  Copyright 2022 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.genie.client.exceptions;
+
+/**
+ * An exception class that represents 429 - Too Many Requests received from the server.
+ *
+ * @author andrew
+ * @since 4.0.0
+ */
+public class GenieClientTooManyRequestsException extends GenieClientException {
+
+    /**
+     * Constructor.
+     *
+     */
+    public GenieClientTooManyRequestsException() {
+        super(429, "");
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param msg       human readable message
+     */
+    public GenieClientTooManyRequestsException(final String msg) {
+        super(429, msg);
+    }
+}

--- a/genie-client/src/test/java/com/netflix/genie/client/interceptors/ResponseMappingInterceptorTest.java
+++ b/genie-client/src/test/java/com/netflix/genie/client/interceptors/ResponseMappingInterceptorTest.java
@@ -18,6 +18,7 @@
 package com.netflix.genie.client.interceptors;
 
 import com.netflix.genie.client.exceptions.GenieClientException;
+import com.netflix.genie.client.exceptions.GenieClientTooManyRequestsException;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -102,5 +103,14 @@ class ResponseMappingInterceptorTest {
             .satisfies(e -> Assertions.assertThat(e.getErrorCode()).isEqualTo(-1))
             .withMessage("Failed to parse server response as JSON");
 
+    }
+
+    @Test
+    void canIntercept429() {
+        this.server.enqueue(new MockResponse().setResponseCode(429));
+        final Request request = new Request.Builder().url(this.baseUrl).get().build();
+        Assertions
+            .assertThatExceptionOfType(GenieClientTooManyRequestsException.class)
+            .isThrownBy(() -> this.client.newCall(request).execute());
     }
 }


### PR DESCRIPTION
It is up to the client how to handle 429 error code by catching `GenieClientTooManyRequestException`.