### PR TITLE
Upgrade dependencies to align with internal versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ configure((Set<Project>) ext.javaProjects) {
         imports {
             mavenBom SpringBootPlugin.BOM_COORDINATES
             mavenBom "org.springframework.cloud:spring-cloud-dependencies:${spring_cloud_version}"
-            mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:2.4.0"
+            mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:2.4.1"
             mavenBom "com.google.protobuf:protobuf-bom:${protobuf_version}"
             mavenBom "com.squareup.okhttp3:okhttp-bom:4.9.2"
             mavenBom "io.grpc:grpc-bom:${grpc_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,8 @@
 
 protobuf_version=3.16.1
 grpc_version=1.38.1
-spring_boot_version=2.6.4
-spring_cloud_version=2021.0.1
+spring_boot_version=2.6.7
+spring_cloud_version=2021.0.2
 
 ## Override Spring Dependency Managed Versions
 


### PR DESCRIPTION
- Spring boot -> 2.6.7
- Spring cloud -> 2021.0.2
- Sping cloud aws -> 2.4.1