### PR TITLE
Make the eagerly loaded job dependencies and env variables to use the default fetch types

### DIFF
--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsIntegrationTest.java
@@ -59,11 +59,13 @@ import com.netflix.genie.common.internal.exceptions.unchecked.GenieInvalidStatus
 import com.netflix.genie.test.suppliers.RandomSuppliers;
 import com.netflix.genie.web.data.services.impl.jpa.entities.JobEntity;
 import com.netflix.genie.web.data.services.impl.jpa.queries.aggregates.JobInfoAggregate;
+import com.netflix.genie.web.data.services.impl.jpa.queries.projections.v4.JobSpecificationProjection;
 import com.netflix.genie.web.dtos.JobSubmission;
 import com.netflix.genie.web.dtos.ResolvedJob;
 import com.netflix.genie.web.exceptions.checked.IdAlreadyExistsException;
 import com.netflix.genie.web.exceptions.checked.NotFoundException;
 import org.assertj.core.api.Assertions;
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.core.io.FileSystemResource;
@@ -271,6 +273,35 @@ class JpaPersistenceServiceImplJobsIntegrationTest extends JpaPersistenceService
             .collect(Collectors.toSet());
 
         Assertions.assertThat(savedAttachmentURIs).isEqualTo(attachmentURIs);
+    }
+
+    @Test
+    @DatabaseSetup("persistence/jobs/jobSpecification.xml")
+    void verifyLazyLoadJobDependencyAndEnvironmentVariables() {
+
+        final String jobId = "job3";
+
+        // load the projection.
+        final Optional<JobSpecificationProjection> jobSpecificationProjectionOption =
+            this.jobRepository.getJobSpecification(jobId);
+        Assertions.assertThat(jobSpecificationProjectionOption).isPresent();
+
+        // None of the lazy-loading attributes is initialized.
+        final JobSpecificationProjection jobSpecificationProjection = jobSpecificationProjectionOption.get();
+        Assertions.assertThat(Hibernate.isInitialized(jobSpecificationProjection.getDependencies())).isFalse();
+        Assertions.assertThat(Hibernate.isInitialized(jobSpecificationProjection.getEnvironmentVariables())).isFalse();
+
+        // Initialize job dependencies and check the correctness.
+        Hibernate.initialize(jobSpecificationProjection.getDependencies());
+        Assertions.assertThat(Hibernate.isInitialized(jobSpecificationProjection.getDependencies())).isTrue();
+        Assertions.assertThat(jobSpecificationProjection.getDependencies()).hasSize(3);
+        // Ensure job environment variables are still not initialized.
+        Assertions.assertThat(Hibernate.isInitialized(jobSpecificationProjection.getEnvironmentVariables())).isFalse();
+
+        // Initialize job environment variables and check the correctness.
+        Hibernate.initialize(jobSpecificationProjection.getEnvironmentVariables());
+        Assertions.assertThat(Hibernate.isInitialized(jobSpecificationProjection.getEnvironmentVariables())).isTrue();
+        Assertions.assertThat(jobSpecificationProjection.getEnvironmentVariables()).hasSize(2);
     }
 
     @Test

--- a/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/impl/jpa/persistence/jobs/jobSpecification.xml
+++ b/genie-web/src/integTest/resources/com/netflix/genie/web/data/services/impl/jpa/persistence/jobs/jobSpecification.xml
@@ -1,0 +1,642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2016 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<dataset>
+    <files
+        id="1"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/hadoop/config/file"
+    />
+    <files
+        id="2"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/other/hadoop/config/file"
+    />
+    <files
+        id="3"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="hadoop.jar"
+    />
+    <files
+        id="4"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/spark/config/file"
+    />
+    <files
+        id="5"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/other/spark/config/file"
+    />
+    <files
+        id="6"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="spark.jar"
+    />
+    <files
+        id="7"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/spark2/config/file"
+    />
+    <files
+        id="8"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/other/spark2/config/file"
+    />
+    <files
+        id="9"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="spark2.jar"
+    />
+    <files
+        id="10"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/config/file"
+    />
+    <files
+        id="11"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        file="s3://some/other/config/file"
+    />
+
+    <tags
+        id="1"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:app1"
+    />
+    <tags
+        id="2"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.name:hadoop"
+    />
+    <tags
+        id="3"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="type:hadoop"
+    />
+    <tags
+        id="4"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:app2"
+    />
+    <tags
+        id="5"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.name:spark"
+    />
+    <tags
+        id="6"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="type:spark"
+    />
+    <tags
+        id="7"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:app3"
+    />
+    <tags
+        id="8"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:command1"
+    />
+    <tags
+        id="9"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.id:cluster1"
+    />
+    <tags
+        id="10"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="genie.name:h2query"
+    />
+    <tags
+        id="11"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="sched:adhoc"
+    />
+    <tags
+        id="12"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="type:yarn"
+    />
+    <tags
+        id="13"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="sla"
+    />
+    <tags
+        id="14"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="yarn"
+    />
+    <tags
+        id="15"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="adhoc"
+    />
+    <tags
+        id="16"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="ver:1.6.0"
+    />
+    <tags
+        id="17"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:35:00"
+        entity_version="0"
+        tag="sched:sla"
+    />
+
+    <applications
+        id="1"
+        created="2016-03-21 01:35:00"
+        updated="2016-03-21 01:40:00"
+        entity_version="0"
+        unique_id="app1"
+        genie_user="tgianos"
+        name="hadoop"
+        version="4.5.6"
+        status="ACTIVE"
+        type="hadoop"
+    />
+    <applications_configs
+        application_id="1"
+        file_id="1"
+    />
+    <applications_configs
+        application_id="1"
+        file_id="2"
+    />
+    <applications_dependencies
+        application_id="1"
+        file_id="2"
+    />
+    <applications_tags
+        application_id="1"
+        tag_id="1"
+    />
+    <applications_tags
+        application_id="1"
+        tag_id="2"
+    />
+    <applications_tags
+        application_id="1"
+        tag_id="3"
+    />
+
+    <applications
+        id="2"
+        created="2016-03-21 01:45:00"
+        updated="2016-03-21 01:50:00"
+        entity_version="0"
+        unique_id="app2"
+        genie_user="tgianos"
+        name="spark"
+        version="1.6.0"
+        status="ACTIVE"
+        type="spark"
+    />
+    <applications_configs
+        application_id="2"
+        file_id="4"
+    />
+    <applications_configs
+        application_id="2"
+        file_id="5"
+    />
+    <applications_dependencies
+        application_id="2"
+        file_id="6"
+    />
+    <applications_tags
+        application_id="2"
+        tag_id="4"
+    />
+    <applications_tags
+        application_id="2"
+        tag_id="5"
+    />
+    <applications_tags
+        application_id="2"
+        tag_id="6"
+    />
+
+    <applications
+        id="3"
+        created="2016-03-21 01:55:00"
+        updated="2016-03-21 02:00:00"
+        entity_version="0"
+        unique_id="app3"
+        genie_user="tgianos"
+        name="spark"
+        version="2.0.0"
+        status="ACTIVE"
+        type="spark"
+    />
+    <applications_configs
+        application_id="3"
+        file_id="7"
+    />
+    <applications_configs
+        application_id="3"
+        file_id="8"
+    />
+    <applications_dependencies
+        application_id="3"
+        file_id="9"
+    />
+    <applications_tags
+        application_id="3"
+        tag_id="7"
+    />
+    <applications_tags
+        application_id="3"
+        tag_id="5"
+    />
+    <applications_tags
+        application_id="3"
+        tag_id="6"
+    />
+
+    <commands
+        id="1"
+        created="2016-03-21 01:47:00"
+        updated="2016-03-21 01:59:00"
+        entity_version="0"
+        unique_id="command1"
+        genie_user="tgianos"
+        name="spark"
+        version="1.6.0"
+        status="ACTIVE"
+    />
+
+    <commands_tags
+        command_id="1"
+        tag_id="8"
+    />
+    <commands_tags
+        command_id="1"
+        tag_id="5"
+    />
+    <command_executable_arguments
+        command_id="1"
+        argument="spark"
+        argument_order="0"
+    />
+
+    <commands_applications command_id="1" application_id="1" application_order="0"/>
+    <commands_applications command_id="1" application_id="2" application_order="1"/>
+
+    <clusters
+        id="1"
+        created="2016-03-21 01:49:00"
+        updated="2016-03-21 02:59:00"
+        entity_version="0"
+        unique_id="cluster1"
+        genie_user="tgianos"
+        name="h2query"
+        version="2.4.0"
+        status="UP"
+    />
+    <clusters_configs
+        cluster_id="1"
+        file_id="10"
+    />
+    <clusters_configs
+        cluster_id="1"
+        file_id="11"
+    />
+
+    <criteria
+        id="0"
+    />
+    <criteria_tags
+        criterion_id="0"
+        tag_id="6"
+    />
+    <criteria_tags
+        criterion_id="0"
+        tag_id="16"
+    />
+    <jobs
+        id="1"
+        created="2015-08-11 01:48:00"
+        updated="2015-08-11 02:59:00"
+        entity_version="1"
+        unique_id="job1"
+        genie_user="tgianos"
+        name="testSparkJob"
+        version="2.4"
+        command_criterion="0"
+        requested_cpu="1"
+        requested_memory="1560"
+        archiving_disabled="false"
+        archive_location="s3://somebucket/genie/logs/1/"
+        requested_timeout="608400"
+        num_attachments="2"
+        total_size_of_attachments="38083"
+        status="SUCCEEDED"
+        cluster_id="1"
+        command_id="1"
+        agent_hostname="a.netflix.com"
+        exit_code="0"
+        process_id="317"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/1"
+        resolved="true"
+        api="false"
+        archive_status="ARCHIVED"
+    />
+    <job_requested_applications
+        job_id="1"
+        application_id="app1"
+        application_order="0"
+    />
+    <job_requested_applications
+        job_id="1"
+        application_id="app3"
+        application_order="1"
+    />
+    <job_command_arguments
+        job_id="1"
+        argument="-f"
+        argument_order="0"
+    />
+    <job_command_arguments
+        job_id="1"
+        argument="query.q"
+        argument_order="1"
+    />
+    <criteria
+        id="1"
+    />
+    <criteria_tags
+        criterion_id="1"
+        tag_id="13"
+    />
+    <criteria_tags
+        criterion_id="1"
+        tag_id="14"
+    />
+    <jobs_cluster_criteria
+        job_id="1"
+        criterion_id="1"
+        priority_order="0"
+    />
+    <criteria
+        id="2"
+    />
+    <criteria_tags
+        criterion_id="2"
+        tag_id="13"
+    />
+    <criteria_tags
+        criterion_id="2"
+        tag_id="15"
+    />
+    <jobs_cluster_criteria
+        job_id="1"
+        criterion_id="2"
+        priority_order="1"
+    />
+
+    <jobs_applications job_id="1" application_id="1" application_order="0"/>
+    <jobs_applications job_id="1" application_id="3" application_order="1"/>
+
+    <criteria
+        id="3"
+    />
+    <criteria_tags
+        criterion_id="3"
+        tag_id="6"
+    />
+    <jobs
+        id="2"
+        created="2015-08-12 01:48:00"
+        updated="2015-08-12 02:59:00"
+        entity_version="1"
+        unique_id="job2"
+        genie_user="tgianos"
+        name="testSparkJob1"
+        version="2.4"
+        command_criterion="3"
+        requested_cpu="2"
+        requested_memory="2048"
+        archiving_disabled="false"
+        requested_timeout="608400"
+        num_attachments="3"
+        total_size_of_attachments="38082233"
+        status="RUNNING"
+        cluster_id="1"
+        command_id="1"
+        agent_hostname="a.netflix.com"
+        exit_code="-1"
+        process_id="318"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/2"
+        resolved="true"
+        api="true"
+        archive_status="PENDING"
+    />
+    <job_command_arguments
+        job_id="2"
+        argument="-f"
+        argument_order="0"
+    />
+    <job_command_arguments
+        job_id="2"
+        argument="spark.jar"
+        argument_order="1"
+    />
+    <criteria
+        id="4"
+    />
+    <criteria_tags
+        criterion_id="4"
+        tag_id="17"
+    />
+    <criteria_tags
+        criterion_id="4"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="2"
+        criterion_id="4"
+        priority_order="0"
+    />
+    <criteria
+        id="5"
+    />
+    <criteria_tags
+        criterion_id="5"
+        tag_id="11"
+    />
+    <criteria_tags
+        criterion_id="5"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="2"
+        criterion_id="5"
+        priority_order="1"
+    />
+
+    <jobs_applications job_id="2" application_id="1" application_order="0"/>
+    <jobs_applications job_id="2" application_id="2" application_order="1"/>
+
+    <criteria
+        id="6"
+    />
+    <criteria_tags
+        criterion_id="6"
+        tag_id="6"
+    />
+    <jobs
+        id="3"
+        created="2016-02-24 01:48:00"
+        updated="2016-02-24 02:59:00"
+        entity_version="1"
+        unique_id="job3"
+        genie_user="tgianos"
+        name="testSparkJob2"
+        version="2.4"
+        command_criterion="6"
+        requested_cpu="2"
+        requested_memory="2048"
+        archiving_disabled="true"
+        requested_timeout="608400"
+        num_attachments="1"
+        total_size_of_attachments="382"
+        status="RUNNING"
+        cluster_id="1"
+        command_id="1"
+        agent_hostname="b.netflix.com"
+        exit_code="-1"
+        process_id="319"
+        timeout_used="608400"
+        requested_id="true"
+        job_directory_location="/tmp/genie/jobs/3"
+        resolved="true"
+        api="true"
+    />
+    <job_command_arguments
+        job_id="3"
+        argument="-f"
+        argument_order="0"
+    />
+    <job_command_arguments
+        job_id="3"
+        argument="spark.jar"
+        argument_order="1"
+    />
+    <criteria
+        id="7"
+    />
+    <criteria_tags
+        criterion_id="7"
+        tag_id="17"
+    />
+    <criteria_tags
+        criterion_id="7"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="3"
+        criterion_id="7"
+        priority_order="0"
+    />
+    <criteria
+        id="8"
+    />
+    <criteria_tags
+        criterion_id="8"
+        tag_id="11"
+    />
+    <criteria_tags
+        criterion_id="8"
+        tag_id="12"
+    />
+    <jobs_cluster_criteria
+        job_id="3"
+        criterion_id="8"
+        priority_order="1"
+    />
+
+    <jobs_applications job_id="3" application_id="1" application_order="0"/>
+    <jobs_applications job_id="3" application_id="2" application_order="1"/>
+
+    <jobs_dependencies job_id="3" file_id="2"/>
+    <jobs_dependencies job_id="3" file_id="3"/>
+    <jobs_dependencies job_id="3" file_id="4"/>
+
+    <job_environment_variables job_id="3" name="GENIE_APP_MEMORY" value="10G"/>
+    <job_environment_variables job_id="3" name="GENIE_HOST_NAME" value="some_host_name"/>
+</dataset>

--- a/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/entities/JobEntity.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/data/services/impl/jpa/entities/JobEntity.java
@@ -156,7 +156,6 @@ import java.util.Set;
             name = JobEntity.V4_JOB_SPECIFICATION_DTO_ENTITY_GRAPH,
             attributeNodes = {
                 @NamedAttributeNode("configs"),
-                @NamedAttributeNode("dependencies"),
                 @NamedAttributeNode("setupFile"),
                 @NamedAttributeNode("commandArgs"),
                 @NamedAttributeNode(
@@ -171,7 +170,6 @@ import java.util.Set;
                     value = "applications",
                     subgraph = "resource-sub-graph"
                 ),
-                @NamedAttributeNode("environmentVariables"),
             },
             subgraphs = {
                 @NamedSubgraph(


### PR DESCRIPTION
Entity graph loads the named attributes eagerly. This creates a very big list of returned rows when there are multiple layers of OneToMany relationships exist in a single query. 

For example, if a single job has 5 job dependencies and 5 job environment variables. The number of returned rows of this entity graph is 1*5*5 = 25. This number grows very fast.

This change makes the job_dependencies and job_env_variables to use the default FetchType, which is LAZY. Then in the above example, at most, the number of returned rows is 1 + 5 + 5 if both getJobDependencies() and getJobEnvironmentVariables() are called.

This diff does not make any changes to the cluster, command and application resources since those are mostly safe.

There is a cost of this. By adopting this change, the number of query/db connection needed for getJobSpecification() will be increased to 3 instead of 1. Since this call is associated with every single job launch, it worth to acknowledge the cost.