### PR TITLE
add soft and hard container constraints data model to titus batch job request

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/dtos/TitusBatchJobRequest.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/dtos/TitusBatchJobRequest.java
@@ -20,7 +20,9 @@ package com.netflix.genie.web.agent.launchers.dtos;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
+import org.apache.logging.log4j.util.Strings;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -108,6 +110,10 @@ public class TitusBatchJobRequest {
         @NotNull
         @NonNull
         private Map<String, String> attributes;
+        @Nullable
+        private ContainerConstraints softConstraints;
+        @Nullable
+        private ContainerConstraints hardConstraints;
     }
 
     /**
@@ -138,6 +144,22 @@ public class TitusBatchJobRequest {
         @NotNull
         @NonNull
         private String iamRole;
+    }
+
+    /**
+     * Titus job container constraints.
+     */
+    @Data
+    @Builder
+    public static class ContainerConstraints {
+        @NotNull
+        @NonNull
+        private Map<String, String> constraints;
+
+        @NotNull
+        @NonNull
+        @Builder.Default()
+        private String expression = Strings.EMPTY;
     }
 
     /**


### PR DESCRIPTION
Additional fields added to Titus Batch Job Request object. Currently there is no generic use cases so these fields only exist in the titus request object instead of living across all layers. If, in the future, additional use cases emerges, these constraints can be extended to be attributes on the persistent layer as well.