### PR TITLE
log out fail-to-download dependency uri for debug and analysis purpose

### DIFF
--- a/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/FetchingCacheServiceImpl.java
+++ b/genie-agent/src/main/java/com/netflix/genie/agent/execution/services/impl/FetchingCacheServiceImpl.java
@@ -103,7 +103,11 @@ class FetchingCacheServiceImpl implements FetchingCacheService {
      */
     @Override
     public void get(final URI sourceFileUri, final File destinationFile) throws DownloadException, IOException {
-        lookupOrDownload(sourceFileUri, destinationFile);
+        try {
+            lookupOrDownload(sourceFileUri, destinationFile);
+        } catch (IOException e) {
+            throw  new IOException("failed to download: " + sourceFileUri.toASCIIString(), e);
+        }
     }
 
     /**
@@ -217,7 +221,7 @@ class FetchingCacheServiceImpl implements FetchingCacheService {
             Files.copy(cachedResourceVersionDataFile, destinationFile);
             //Critical section end
         } catch (LockException e) {
-            throw new DownloadException("Error downloading dependency", e);
+            throw new DownloadException("Error downloading dependency: " + uriString, e);
         }
 
         //Clean up any older versions


### PR DESCRIPTION
Genie agents download requested job dependencies before starting the job execution. When certain dependency download fails, we can log out the dependency uri for either debug or system analysis purposes. 