### PR TITLE
add prometheus metrics for Genie

### DIFF
--- a/genie-web/build.gradle
+++ b/genie-web/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     api("io.grpc:grpc-stub")
     api("io.grpc:grpc-core")
     api("io.micrometer:micrometer-core")
+    api("io.micrometer:micrometer-registry-prometheus")
     api("jakarta.persistence:jakarta.persistence-api")
     api("jakarta.validation:jakarta.validation-api")
     api("org.apache.commons:commons-exec")


### PR DESCRIPTION
- Add dependencies to Genie that are needed to support the `/admin/prometheus` endpoint.

- We've built our own JARs and are already using Prometheus to power our metrics around Genie's health. Hoping to remove the need for us to locally fork Genie by getting this into open source 👍 