### PR TITLE
Amend the check on IllegalAttachmentFileNameException

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/LocalFileSystemAttachmentServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/LocalFileSystemAttachmentServiceImpl.java
@@ -94,9 +94,9 @@ public class LocalFileSystemAttachmentServiceImpl implements AttachmentService {
                 final long attachmentSize = attachment.contentLength();
                 final String filename = attachment.getFilename();
 
-                if (filename != null && filename.contains("/")) {
+                if (filename != null && (filename.contains("/") || filename.contains("\\"))) {
                     throw new IllegalAttachmentFileNameException("Attachment filename " + filename + " is illegal. "
-                        + "It should not contain the char: /.");
+                        + "Filenames should not contain / or \\.");
                 }
 
                 if (attachmentSize > this.attachmentServiceProperties.getMaxSize().toBytes()) {

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/LocalFileSystemAttachmentServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/LocalFileSystemAttachmentServiceImplSpec.groovy
@@ -154,10 +154,23 @@ class LocalFileSystemAttachmentServiceImplSpec extends Specification {
         thrown(SaveAttachmentException)
     }
 
-    def "reject attachments with illegal filename"() {
+    def "reject attachments with illegal filename containing /"() {
         Set<Resource> attachments = new HashSet<Resource>()
         Resource attachment = Mockito.mock(Resource.class)
         Mockito.doReturn("../../../root/breakout.file").when(attachment).getFilename()
+        attachments.add(attachment)
+
+        when:
+        service.saveAttachments(null, attachments)
+
+        then:
+        thrown(IllegalAttachmentFileNameException)
+    }
+
+    def "reject attachments with illegal filename containing \\"() {
+        Set<Resource> attachments = new HashSet<Resource>()
+        Resource attachment = Mockito.mock(Resource.class)
+        Mockito.doReturn("c:\\root\\breakout.file").when(attachment).getFilename()
         attachments.add(attachment)
 
         when:


### PR DESCRIPTION
In addition to blocking the char / in the filename, we should also block the char \ as it can be used in the window environment as a part of file path.