### PR TITLE
Amend the check on IllegalAttachmentFileNameException

### DIFF
--- a/genie-web/src/main/java/com/netflix/genie/web/services/impl/LocalFileSystemAttachmentServiceImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/services/impl/LocalFileSystemAttachmentServiceImpl.java
@@ -97,9 +97,9 @@ public class LocalFileSystemAttachmentServiceImpl implements AttachmentService {
 
                 if (filename != null) {
                     if ((filename.contains("/") || filename.contains("\\")
-                        || filename.equals(".") || filename.equals(".."))) {
+                        || filename.equals(".") || filename.contains(".."))) {
                         throw new IllegalAttachmentFileNameException("Attachment filename " + filename + " is illegal. "
-                            + "Filenames should not be . or .., or contain /, \\.");
+                            + "Filenames should not be ., or contain .., /, \\.");
                     }
 
                     final String attachmentCanonicalPath =

--- a/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/LocalFileSystemAttachmentServiceImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/services/impl/LocalFileSystemAttachmentServiceImplSpec.groovy
@@ -193,7 +193,7 @@ class LocalFileSystemAttachmentServiceImplSpec extends Specification {
         thrown(IllegalAttachmentFileNameException)
     }
 
-    def "reject attachments with illegal filename is .."() {
+    def "reject attachments with illegal filename containing .."() {
         Set<Resource> attachments = new HashSet<Resource>()
         Resource attachment = Mockito.mock(Resource.class)
         Mockito.doReturn("..").when(attachment).getFilename()


### PR DESCRIPTION
Revise the check on attachment filename from denying `filename.equals("..")` to `filename.contains("..")`