### PR TITLE
downgrade awssdk from 2.30.17 to 2.30.16

### DIFF
--- a/.github/workflows/genie-build.yml
+++ b/.github/workflows/genie-build.yml
@@ -9,6 +9,10 @@ on:
       - v*.*.*-rc.*
   pull_request:
 
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,8 @@ configure((Set<Project>) ext.javaProjects) {
         }
 
         imports {
-            mavenBom "software.amazon.awssdk:bom:2.30.17"
+            // pin to 2.30.16 for now to avoid a potential AWS SDK2 bug: https://github.com/aws/aws-sdk-java-v2/issues/6174
+            mavenBom "software.amazon.awssdk:bom:2.30.16"
             mavenBom "com.google.protobuf:protobuf-bom:${protobuf_version}"
             mavenBom "com.squareup.okhttp3:okhttp-bom:4.9.2"
             mavenBom "io.grpc:grpc-bom:${grpc_version}"

--- a/genie-agent-app/dependencies.lock
+++ b/genie-agent-app/dependencies.lock
@@ -185,25 +185,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestAnnotationProcessor": {
@@ -411,25 +411,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestRuntimeClasspath": {
@@ -748,25 +748,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "jacocoAgent": {
@@ -1067,25 +1067,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "runtimeClasspath": {
@@ -1376,25 +1376,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestAnnotationProcessor": {
@@ -1602,25 +1602,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestRuntimeClasspath": {
@@ -1939,25 +1939,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "spotbugs": {
@@ -2175,25 +2175,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "testRuntimeClasspath": {
@@ -2512,25 +2512,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     }
 }

--- a/genie-agent/dependencies.lock
+++ b/genie-agent/dependencies.lock
@@ -181,25 +181,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestAnnotationProcessor": {
@@ -400,25 +400,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestRuntimeClasspath": {
@@ -687,25 +687,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "jacocoAgent": {
@@ -953,25 +953,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestAnnotationProcessor": {
@@ -1172,25 +1172,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestRuntimeClasspath": {
@@ -1459,25 +1459,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "spotbugs": {
@@ -1688,25 +1688,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "testRuntimeClasspath": {
@@ -1975,25 +1975,25 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     }
 }

--- a/genie-app/dependencies.lock
+++ b/genie-app/dependencies.lock
@@ -300,31 +300,31 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "genieAgent": {
@@ -655,31 +655,31 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestRuntimeClasspath": {
@@ -1290,33 +1290,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "jacocoAgent": {
@@ -1896,33 +1896,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "runtimeClasspath": {
@@ -2492,33 +2492,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestAnnotationProcessor": {
@@ -2844,31 +2844,31 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestRuntimeClasspath": {
@@ -3482,33 +3482,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "spotbugs": {
@@ -3844,31 +3844,31 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "testRuntimeClasspath": {
@@ -4479,33 +4479,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     }
 }

--- a/genie-common-internal/dependencies.lock
+++ b/genie-common-internal/dependencies.lock
@@ -124,16 +124,16 @@
             "locked": "6.2.7"
         },
         "software.amazon.awssdk:aws-core": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestAnnotationProcessor": {
@@ -274,16 +274,16 @@
             "locked": "6.2.7"
         },
         "software.amazon.awssdk:aws-core": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestRuntimeClasspath": {
@@ -458,16 +458,16 @@
             "locked": "6.2.7"
         },
         "software.amazon.awssdk:aws-core": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "jacocoAgent": {
@@ -624,16 +624,16 @@
             "locked": "6.2.7"
         },
         "software.amazon.awssdk:aws-core": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestAnnotationProcessor": {
@@ -774,16 +774,16 @@
             "locked": "6.2.7"
         },
         "software.amazon.awssdk:aws-core": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestRuntimeClasspath": {
@@ -958,16 +958,16 @@
             "locked": "6.2.7"
         },
         "software.amazon.awssdk:aws-core": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "spotbugs": {
@@ -1118,16 +1118,16 @@
             "locked": "6.2.7"
         },
         "software.amazon.awssdk:aws-core": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "testRuntimeClasspath": {
@@ -1302,16 +1302,16 @@
             "locked": "6.2.7"
         },
         "software.amazon.awssdk:aws-core": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     }
 }

--- a/genie-swagger/dependencies.lock
+++ b/genie-swagger/dependencies.lock
@@ -706,33 +706,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "jacocoAgent": {
@@ -1269,33 +1269,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestAnnotationProcessor": {
@@ -1945,33 +1945,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "spotbugs": {
@@ -2631,33 +2631,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     }
 }

--- a/genie-ui/dependencies.lock
+++ b/genie-ui/dependencies.lock
@@ -282,31 +282,31 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestAnnotationProcessor": {
@@ -617,31 +617,31 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestRuntimeClasspath": {
@@ -1206,33 +1206,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "jacocoAgent": {
@@ -1766,33 +1766,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestAnnotationProcessor": {
@@ -2100,31 +2100,31 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestRuntimeClasspath": {
@@ -2689,33 +2689,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "spotbugs": {
@@ -3033,31 +3033,31 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "testRuntimeClasspath": {
@@ -3622,33 +3622,33 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     }
 }

--- a/genie-web/dependencies.lock
+++ b/genie-web/dependencies.lock
@@ -292,28 +292,28 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "genieAgent": {
@@ -648,28 +648,28 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "integTestRuntimeClasspath": {
@@ -1096,28 +1096,28 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "jacocoAgent": {
@@ -1479,28 +1479,28 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestAnnotationProcessor": {
@@ -1818,28 +1818,28 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "smokeTestRuntimeClasspath": {
@@ -2251,28 +2251,28 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "spotbugs": {
@@ -2600,28 +2600,28 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     },
     "testRuntimeClasspath": {
@@ -3033,28 +3033,28 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:s3-transfer-manager": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sns": {
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         },
         "software.amazon.awssdk:sts": {
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.30.17"
+            "locked": "2.30.16"
         }
     }
 }


### PR DESCRIPTION
downgrade awssdk from 2.30.17 to 2.30.16 to avoid a potential AWS SDK2 bug: https://github.com/aws/aws-sdk-java-v2/issues/6174