### PR TITLE
Make Genie agent container's entry point and command dynamic

### DIFF
--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -190,7 +190,7 @@ https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-featu
 |genie.agent.launcher.titus.command-template
 |The container command array, placeholder values are substituted at runtime
 |[exec, --api-job, --launchInJobDirectory, --job-id, <JOB_ID>, --server-host, <SERVER_HOST>, --server-port, <SERVER_PORT>]
-|no
+|yes
 
 |genie.agent.launcher.titus.container-attributes
 |Map attributes to send to Titus specific to the container
@@ -215,7 +215,7 @@ https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-featu
 |genie.agent.launcher.titus.entry-point-template
 |The container entry point array, placeholder values are substituted at runtime
 |[/bin/genie-agent]
-|no
+|yes
 
 |genie.agent.launcher.titus.genie-server-host
 |The hostname of the Genie server or cluster for the agent to connect to

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
@@ -261,11 +261,17 @@ public class TitusAgentLauncherImpl implements AgentLauncher {
 
         // Substitute all placeholders with their values for the container entry point and command
         final List<String> entryPoint = REPLACE_PLACEHOLDERS.apply(
-            this.titusAgentLauncherProperties.getEntryPointTemplate(),
+            this.binder
+                .bind(
+                    TitusAgentLauncherProperties.ENTRY_POINT_TEMPLATE,
+                    Bindable.listOf(String.class))
+                .orElse(this.titusAgentLauncherProperties.getEntryPointTemplate()),
             placeholdersMap
         );
         final List<String> command = REPLACE_PLACEHOLDERS.apply(
-            this.titusAgentLauncherProperties.getCommandTemplate(),
+            this.binder
+                .bind(TitusAgentLauncherProperties.COMMAND_TEMPLATE, Bindable.listOf(String.class))
+                .orElse(this.titusAgentLauncherProperties.getCommandTemplate()),
             placeholdersMap
         );
         final Duration runtimeLimit = this.titusAgentLauncherProperties.getRuntimeLimit();

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/TitusAgentLauncherProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/TitusAgentLauncherProperties.java
@@ -95,6 +95,11 @@ public class TitusAgentLauncherProperties {
     public static final String CAPACITY_GROUP_PROPERTY = PREFIX + ".capacityGroup";
 
     /**
+     * The container command template array, placeholder values are substituted at runtime.
+     */
+    public static final String COMMAND_TEMPLATE = PREFIX + ".command-template";
+
+    /**
      * Any attributes that should be added to the request specifically for the container.
      */
     public static final String CONTAINER_ATTRIBUTES_PROPERTY = PREFIX + ".container-attributes";
@@ -103,6 +108,11 @@ public class TitusAgentLauncherProperties {
      * Name of the property that enables {@link TitusAgentLauncherImpl}.
      */
     public static final String ENABLE_PROPERTY = PREFIX + ".enabled";
+
+    /**
+     * The container entry point template array, placeholder values are substituted at runtime.
+     */
+    public static final String ENTRY_POINT_TEMPLATE = PREFIX + ".entry-point-template";
 
     /**
      * The name of the property that dictates which image to launch on Titus with.


### PR DESCRIPTION
### Summary

Make the entry point and command properties dynamic for Titus Launcher

### What changed?

- Added support for resolving container entry points and commands dynamically and falling back to default values if the properties are not set, specifically:
  - `genie.agent.launcher.titus.entry-point-template`
  - `genie.agent.launcher.titus.command-template`
- Added tests for container entry point and command resolution.
