### PR TITLE
Surface error message when failing to launch Titus agent

### DIFF
--- a/genie-app/src/main/docker/Dockerfile
+++ b/genie-app/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:17-jdk-jammy
-MAINTAINER NetflixOSS <netflixoss@netflix.com>
+LABEL maintainer="NetflixOSS <netflixoss@netflix.com>"
 EXPOSE 8080
 VOLUME /tmp
 ARG SERVER_JAR

--- a/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImpl.java
@@ -227,7 +227,9 @@ public class TitusAgentLauncherImpl implements AgentLauncher {
         } catch (Throwable t) {
             LOG.error("Failed to launch job on Titus", t);
             MetricsUtils.addFailureTagsWithException(tags, t);
-            throw new AgentLaunchException("Failed to create titus job for job " + jobId, t);
+            throw new AgentLaunchException(
+                "Failed to create titus job for job " + jobId + ": " + t.getMessage(), t
+            );
         } finally {
             this.registry.timer(LAUNCH_TIMER, tags).record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
             this.healthIndicatorCache.put(jobId, StringUtils.isBlank(titusJobId) ? "-" : titusJobId);

--- a/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImplSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/agent/launchers/impl/TitusAgentLauncherImplSpec.groovy
@@ -260,13 +260,29 @@ class TitusAgentLauncherImplSpec extends Specification {
         }
         1 * cache.put(JOB_ID, "-")
         1 * this.adapter.modifyJobRequest(_ as TitusBatchJobRequest, this.resolvedJob)
-        thrown(AgentLaunchException)
+        def e = thrown(AgentLaunchException)
+        e.message.contains(exception.message)
 
         where:
         _ | exception
-        _ | new RestClientException("...")
-        _ | new IOException("...")
-        _ | new RuntimeException("...")
+        _ | new RestClientException("rest client error")
+        _ | new IOException("io error")
+        _ | new RuntimeException("unexpected error")
+    }
+
+    def "Adapter AgentLaunchException message is preserved in thrown exception"() {
+        given:
+        def cause = new AgentLaunchException("Not authorized for scope [ads-warehouse]")
+
+        when:
+        launcher.launchAgent(resolvedJob, null)
+
+        then:
+        1 * this.adapter.modifyJobRequest(_ as TitusBatchJobRequest, this.resolvedJob) >> { throw cause }
+        0 * restTemplate.postForObject(_, _, _)
+        1 * cache.put(JOB_ID, "-")
+        def e = thrown(AgentLaunchException)
+        e.message.contains("Not authorized for scope [ads-warehouse]")
     }
 
     private static TitusBatchJobResponse toTitusResponse(String s) {


### PR DESCRIPTION
### Summary

Currently, when Genie fails to launch the Titus agent, users only see a generic error message such as `Failed to create titus job for job {jobId}`. This message is not user-friendly and makes debugging difficult.

This change surfaces the original exception's message in the `AgentLaunchException` thrown to the caller, making it easier to diagnose launch failures (e.g., authorization errors, network issues) without having to look up logs.

### Test plan

- [x] Updated existing `TitusAgentLauncherImplSpec` to assert the thrown `AgentLaunchException`message contains the cause's message. 
- [x] Added a new test case to verify that descriptive errors propagate correctly.
- [x] Run ./gradlew :genie-web:test --tests "com.netflix.genie.web.agent.launchers.impl.TitusAgentLauncherImplSpec" to validate.