### PR TITLE
Use strict equality in code

### DIFF
--- a/genie-ui/src/main/web/scripts/utils.js
+++ b/genie-ui/src/main/web/scripts/utils.js
@@ -67,7 +67,7 @@ export const momentFormat = (
 ) => {
   // only UTC & PST are supported timezones
   // default is UTC
-  if (tz == "PST") {
+  if (tz === "PST") {
     return dateStr
       ? moment.tz(dateStr, "America/Los_Angeles").format(format)
       : "";


### PR DESCRIPTION
This might be minor, but it jumped out in genie-ui/src/main/web/scripts/utils.js: The loose equality here can coerce values in ways that are hard to spot later. this patch tightens it to strict equality.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.