### PR TITLE
Upgrade tika-core to address CVE-2025-66516

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ configure((Set<Project>) ext.javaProjects) {
                 entry "converter-jackson"
             }
             dependency("com.google.guava:guava:20.0")
-            dependency("commons-io:commons-io:2.11.0")
+            dependency("commons-io:commons-io:2.20.0")
             dependency("commons-validator:commons-validator:1.7")
             dependency("jakarta.el:jakarta.el-api:3.0.3")
             dependency("net.sf.jtidy:jtidy:r938")
@@ -145,7 +145,7 @@ configure((Set<Project>) ext.javaProjects) {
             dependency("org.apache.commons:commons-configuration2:2.7")
             dependency("org.apache.commons:commons-exec:1.3")
             dependency("org.apache.commons:commons-text:1.9")
-            dependency("org.apache.tika:tika-core:2.3.0")
+            dependency("org.apache.tika:tika-core:3.2.2")
             dependency("org.apache.maven:maven-artifact:3.6.3")
             dependency("org.apache.zookeeper:zookeeper:3.5.8")
             dependency("org.codehaus.groovy:groovy-all:3.0.25")

--- a/genie-agent-app/dependencies.lock
+++ b/genie-agent-app/dependencies.lock
@@ -658,7 +658,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -998,7 +998,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -1307,7 +1307,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -1849,7 +1849,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -2422,7 +2422,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [

--- a/genie-agent/dependencies.lock
+++ b/genie-agent/dependencies.lock
@@ -619,7 +619,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -906,7 +906,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -1391,7 +1391,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -1907,7 +1907,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [

--- a/genie-app/dependencies.lock
+++ b/genie-app/dependencies.lock
@@ -819,7 +819,7 @@
                 "com.netflix.genie:genie-test-web",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -1028,7 +1028,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -1452,7 +1452,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -1659,7 +1659,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -2048,7 +2048,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -2255,7 +2255,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -3008,7 +3008,7 @@
                 "com.netflix.genie:genie-test-web",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -3217,7 +3217,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -4008,7 +4008,7 @@
                 "com.netflix.genie:genie-test-web",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -4217,7 +4217,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [

--- a/genie-client/dependencies.lock
+++ b/genie-client/dependencies.lock
@@ -123,7 +123,7 @@
             "locked": "2.9.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "jakarta.validation:jakarta.validation-api": {
             "firstLevelTransitive": [
@@ -231,7 +231,7 @@
             "locked": "2.9.0"
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "jakarta.el:jakarta.el-api": {
             "locked": "3.0.3"

--- a/genie-common-internal/dependencies.lock
+++ b/genie-common-internal/dependencies.lock
@@ -106,7 +106,7 @@
             "locked": "3.17.0"
         },
         "org.apache.tika:tika-core": {
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.2.Final"
@@ -238,7 +238,7 @@
             "locked": "3.17.0"
         },
         "org.apache.tika:tika-core": {
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.2.Final"
@@ -418,7 +418,7 @@
             "locked": "1.9"
         },
         "org.apache.tika:tika-core": {
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -605,7 +605,7 @@
             "locked": "1.9"
         },
         "org.apache.tika:tika-core": {
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -738,7 +738,7 @@
             "locked": "3.17.0"
         },
         "org.apache.tika:tika-core": {
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.2.Final"
@@ -918,7 +918,7 @@
             "locked": "1.9"
         },
         "org.apache.tika:tika-core": {
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [
@@ -1082,7 +1082,7 @@
             "locked": "3.17.0"
         },
         "org.apache.tika:tika-core": {
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.2.Final"
@@ -1262,7 +1262,7 @@
             "locked": "1.9"
         },
         "org.apache.tika:tika-core": {
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.hibernate.validator:hibernate-validator": {
             "firstLevelTransitive": [

--- a/genie-swagger/dependencies.lock
+++ b/genie-swagger/dependencies.lock
@@ -268,7 +268,7 @@
                 "com.netflix.genie:genie-test-web",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -465,7 +465,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -858,7 +858,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -1053,7 +1053,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -1507,7 +1507,7 @@
                 "com.netflix.genie:genie-test-web",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -1704,7 +1704,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -2193,7 +2193,7 @@
                 "com.netflix.genie:genie-test-web",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -2390,7 +2390,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [

--- a/genie-test-web/dependencies.lock
+++ b/genie-test-web/dependencies.lock
@@ -26,7 +26,7 @@
             "project": true
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.3.2"
@@ -69,7 +69,7 @@
             "project": true
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.3.2"
@@ -113,7 +113,7 @@
             "project": true
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "jakarta.el:jakarta.el-api": {
             "locked": "3.0.3"
@@ -167,7 +167,7 @@
             "project": true
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "javax.annotation:javax.annotation-api": {
             "firstLevelTransitive": [
@@ -207,7 +207,7 @@
             "project": true
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.3.2"
@@ -251,7 +251,7 @@
             "project": true
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "jakarta.el:jakarta.el-api": {
             "locked": "3.0.3"
@@ -322,7 +322,7 @@
             "project": true
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.3.2"
@@ -366,7 +366,7 @@
             "project": true
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "jakarta.el:jakarta.el-api": {
             "locked": "3.0.3"

--- a/genie-ui/dependencies.lock
+++ b/genie-ui/dependencies.lock
@@ -399,7 +399,7 @@
             "project": true
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "io.awspring.cloud:spring-cloud-aws-autoconfigure": {
             "firstLevelTransitive": [
@@ -771,7 +771,7 @@
                 "com.netflix.genie:genie-test-web",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -968,7 +968,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -1358,7 +1358,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -1553,7 +1553,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -2254,7 +2254,7 @@
                 "com.netflix.genie:genie-test-web",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -2451,7 +2451,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [
@@ -3187,7 +3187,7 @@
                 "com.netflix.genie:genie-test-web",
                 "com.netflix.genie:genie-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "firstLevelTransitive": [
@@ -3384,7 +3384,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "firstLevelTransitive": [

--- a/genie-web/dependencies.lock
+++ b/genie-web/dependencies.lock
@@ -92,7 +92,7 @@
             "locked": "1.15"
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "locked": "1.7"
@@ -406,7 +406,7 @@
             "locked": "1.15"
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "locked": "1.7"
@@ -778,7 +778,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-test-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "locked": "1.7"
@@ -932,7 +932,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "locked": "10.1.41"
@@ -1217,7 +1217,7 @@
             "locked": "1.15"
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "locked": "1.7"
@@ -1360,7 +1360,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.aspectj:aspectjweaver": {
             "locked": "1.9.24"
@@ -1585,7 +1585,7 @@
             "locked": "1.15"
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "locked": "1.7"
@@ -1945,7 +1945,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-test-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "locked": "1.7"
@@ -2096,7 +2096,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "locked": "10.1.41"
@@ -2367,7 +2367,7 @@
             "locked": "1.15"
         },
         "commons-io:commons-io": {
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "locked": "1.7"
@@ -2727,7 +2727,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-test-web"
             ],
-            "locked": "2.11.0"
+            "locked": "2.20.0"
         },
         "commons-validator:commons-validator": {
             "locked": "1.7"
@@ -2878,7 +2878,7 @@
             "firstLevelTransitive": [
                 "com.netflix.genie:genie-common-internal"
             ],
-            "locked": "2.3.0"
+            "locked": "3.2.2"
         },
         "org.apache.tomcat:tomcat-jdbc": {
             "locked": "10.1.41"

--- a/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/apis/rest/v3/controllers/JobRestControllerIntegrationTest.java
@@ -1557,7 +1557,7 @@ class JobRestControllerIntegrationTest extends RestControllerIntegrationTestBase
             .get(JOBS_API + "/" + jobId + "/output/genie/command/" + CMD1_ID + "/config/" + GB18030_TXT)
             .then()
             .statusCode(Matchers.is(HttpStatus.OK.value()))
-            .contentType(Matchers.containsString(MediaType.TEXT_PLAIN_VALUE))
+            .contentType(Matchers.containsString(MediaType.APPLICATION_OCTET_STREAM_VALUE))
             .contentType(Matchers.containsString(utf8));
     }
 


### PR DESCRIPTION
### Summary
- Bumps `tika-core` 2.3.0 → 3.2.2 to fix CVE-2025-66516
- Bumps `commons-io` 2.11.0 → 2.20.0, a transitive requirement of tika-core 3.2.2 (without it, the pin downgrades commons-io and causes `NoSuchMethodError`)
- Updates `JobRestControllerIntegrationTest#testResponseContentType`: Tika 3.2.2 fixes a UTF-8 detection bug, so a non-UTF-8 test file is now correctly classified as `application/octet-stream` instead of `text/plain`. Only affects the `Content-Type` header for served job files; charset is still forced to UTF-8 regardless.

### Test plan
- [x] `./gradlew build` passes
- [x] `genie-netflix-smoke-tests` passes