### PR TITLE
Add opt-in per-submission-mode breakdown for user metrics

### DIFF
--- a/genie-docs/src/docs/asciidoc/_properties.adoc
+++ b/genie-docs/src/docs/asciidoc/_properties.adoc
@@ -752,6 +752,12 @@ to the number of CPU cores x 2 + 1
 |30000
 |no
 
+|genie.tasks.user-metrics.split-by-submission-mode
+|Whether to additionally publish per-user metrics broken down by submission mode (`mode=api` vs `mode=agent`)
+under separate `*.by-submission-mode.gauge` names. Leaves the existing gauges unchanged
+|false
+|no
+
 |genie.zookeeper.discovery-path
 |The namespace to use for Genie discovery service (maps agents to the node they're connected to)
 |/genie/discovery/

--- a/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsIntegrationTest.java
+++ b/genie-web/src/integTest/java/com/netflix/genie/web/data/services/impl/jpa/JpaPersistenceServiceImplJobsIntegrationTest.java
@@ -1067,15 +1067,27 @@ class JpaPersistenceServiceImplJobsIntegrationTest extends JpaPersistenceService
     @Test
     @DatabaseSetup("persistence/jobs/search.xml")
     void canGetUserResourceSummaries() {
-        final Map<String, UserResourcesSummary> summaries = this.service.getUserResourcesSummaries(
+        // API-submitted (api=true) jobs.
+        final Map<String, UserResourcesSummary> apiSummaries = this.service.getUserResourcesSummaries(
             JobStatus.getActiveStatuses(),
             true
         );
-        Assertions.assertThat(summaries.keySet()).contains("tgianos");
-        final UserResourcesSummary userResourcesSummary = summaries.get("tgianos");
-        Assertions.assertThat(userResourcesSummary.getUser()).isEqualTo("tgianos");
-        Assertions.assertThat(userResourcesSummary.getRunningJobsCount()).isEqualTo(2L);
-        Assertions.assertThat(userResourcesSummary.getUsedMemory()).isEqualTo(4096L);
+        Assertions.assertThat(apiSummaries.keySet()).contains("tgianos");
+        final UserResourcesSummary apiSummary = apiSummaries.get("tgianos");
+        Assertions.assertThat(apiSummary.getUser()).isEqualTo("tgianos");
+        Assertions.assertThat(apiSummary.getRunningJobsCount()).isEqualTo(2L);
+        Assertions.assertThat(apiSummary.getUsedMemory()).isEqualTo(4096L);
+
+        // Agent/CLI-submitted (api=false) jobs are reported separately, with memory populated.
+        final Map<String, UserResourcesSummary> agentSummaries = this.service.getUserResourcesSummaries(
+            JobStatus.getActiveStatuses(),
+            false
+        );
+        Assertions.assertThat(agentSummaries.keySet()).contains("tgianos");
+        final UserResourcesSummary agentSummary = agentSummaries.get("tgianos");
+        Assertions.assertThat(agentSummary.getUser()).isEqualTo("tgianos");
+        Assertions.assertThat(agentSummary.getRunningJobsCount()).isEqualTo(2L);
+        Assertions.assertThat(agentSummary.getUsedMemory()).isEqualTo(4096L);
     }
 
     @Test

--- a/genie-web/src/main/java/com/netflix/genie/web/properties/UserMetricsProperties.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/properties/UserMetricsProperties.java
@@ -47,4 +47,13 @@ public class UserMetricsProperties {
     private boolean enabled = true;
 
     private long refreshInterval = 30_000;
+
+    /**
+     * Whether per-user metrics are additionally published broken down by job submission mode (tagged
+     * {@code mode=api} for REST vs {@code mode=agent} for agent/CLI), under the
+     * {@code *.by-submission-mode.gauge} metric names. The existing
+     * {@code genie.user.active-jobs.gauge}/{@code genie.user.active-memory.gauge} gauges are unaffected
+     * regardless of this setting.
+     */
+    private boolean splitBySubmissionMode;
 }

--- a/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/UserMetricsTask.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/tasks/leader/UserMetricsTask.java
@@ -31,6 +31,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -46,12 +47,19 @@ public class UserMetricsTask extends LeaderTask {
     private static final String USER_ACTIVE_JOBS_METRIC_NAME = "genie.user.active-jobs.gauge";
     private static final String USER_ACTIVE_MEMORY_METRIC_NAME = "genie.user.active-memory.gauge";
     private static final String USER_ACTIVE_USERS_METRIC_NAME = "genie.user.active-users.gauge";
+    private static final String USER_ACTIVE_JOBS_BY_SUBMISSION_MODE_METRIC_NAME =
+        "genie.user.active-jobs.by-submission-mode.gauge";
+    private static final String USER_ACTIVE_MEMORY_BY_SUBMISSION_MODE_METRIC_NAME =
+        "genie.user.active-memory.by-submission-mode.gauge";
     private static final UserResourcesRecord USER_RECORD_PLACEHOLDER = new UserResourcesRecord("nobody");
     private final MeterRegistry registry;
     private final PersistenceService persistenceService;
     private final UserMetricsProperties userMetricsProperties;
 
     private final Map<String, UserResourcesRecord> userResourcesRecordMap = Maps.newHashMap();
+    // Records for the optional per-submission-mode resource breakdown: api (true/false) -> user -> record.
+    private final Map<Boolean, Map<String, UserResourcesRecord>> userResourcesBySubmissionModeRecordMap =
+        Maps.newHashMap();
     private final AtomicDouble activeUsersCount;
 
     /**
@@ -99,9 +107,7 @@ public class UserMetricsTask extends LeaderTask {
     public void run() {
         log.debug("Publishing user metrics");
 
-        // For now just report the API jobs as they're using resources on Genie web nodes
-        // Get us unblocked for now on agent migration but in future we may want to change this to further dice or
-        // combine reports by CLI vs. API
+        // An opt-in per-submission-mode breakdown (API vs. agent/CLI) is published below when enabled.
         final Map<String, UserResourcesSummary> summaries = this.persistenceService.getUserResourcesSummaries(
             JobStatus.getActiveStatuses(),
             true
@@ -131,7 +137,7 @@ public class UserMetricsTask extends LeaderTask {
             this.userResourcesRecordMap.computeIfAbsent(
                 userResourcesSummary.getUser(),
                 userName -> {
-                    // Register gauges this user user.
+                    // Register gauges for this user.
                     // Gauge creation is idempotent so it doesn't matter if the user is new or seen before.
                     // Registry holds a reference to the gauge so no need to save it.
                     Gauge.builder(
@@ -153,6 +159,13 @@ public class UserMetricsTask extends LeaderTask {
             ).update(jobs, memory);
         }
 
+        // Optionally publish a finer-grained breakdown tagged by submission mode (mode=api for REST vs
+        // mode=agent for agent/CLI). Emitted under separate metric names so the gauges above are unchanged.
+        // Disabled by default.
+        if (this.userMetricsProperties.isSplitBySubmissionMode()) {
+            this.publishResourcesBySubmissionMode(summaries);
+        }
+
         log.debug("Done publishing user metrics");
     }
 
@@ -166,6 +179,7 @@ public class UserMetricsTask extends LeaderTask {
 
         // Reset all users
         this.userResourcesRecordMap.clear();
+        this.userResourcesBySubmissionModeRecordMap.clear();
 
         // Reset active users count
         this.activeUsersCount.set(Double.NaN);
@@ -187,6 +201,70 @@ public class UserMetricsTask extends LeaderTask {
 
     private Number getUsersCount() {
         return activeUsersCount.get();
+    }
+
+    private void publishResourcesBySubmissionMode(final Map<String, UserResourcesSummary> apiSummaries) {
+        // Reuse the api=true summaries already fetched above; only the agent (api=false) slice is
+        // an additional query.
+        this.updateSubmissionModeRecords(true, apiSummaries);
+        this.updateSubmissionModeRecords(
+            false,
+            this.persistenceService.getUserResourcesSummaries(JobStatus.getActiveStatuses(), false)
+        );
+    }
+
+    private void updateSubmissionModeRecords(final boolean api, final Map<String, UserResourcesSummary> summaries) {
+        final Map<String, UserResourcesRecord> recordsForMode =
+            this.userResourcesBySubmissionModeRecordMap.computeIfAbsent(api, mode -> Maps.newHashMap());
+
+        final String modeTagValue =
+            api ? MetricsConstants.TagValues.MODE_API : MetricsConstants.TagValues.MODE_AGENT;
+
+        // Drop users no longer active in this mode so their gauges fall back to NaN.
+        recordsForMode.keySet().retainAll(summaries.keySet());
+
+        for (final UserResourcesSummary summary : summaries.values()) {
+            final String user = summary.getUser();
+            recordsForMode.computeIfAbsent(
+                user,
+                userName -> {
+                    // Gauge creation is idempotent so re-registration on reappearance is harmless.
+                    Gauge.builder(
+                            USER_ACTIVE_JOBS_BY_SUBMISSION_MODE_METRIC_NAME,
+                            () -> this.getSubmissionModeJobCount(api, userName)
+                        )
+                        .tags(
+                            MetricsConstants.TagKeys.USER, userName,
+                            MetricsConstants.TagKeys.MODE, modeTagValue
+                        )
+                        .register(this.registry);
+                    Gauge.builder(
+                            USER_ACTIVE_MEMORY_BY_SUBMISSION_MODE_METRIC_NAME,
+                            () -> this.getSubmissionModeMemoryAmount(api, userName)
+                        )
+                        .tags(
+                            MetricsConstants.TagKeys.USER, userName,
+                            MetricsConstants.TagKeys.MODE, modeTagValue
+                        )
+                        .register(this.registry);
+                    return new UserResourcesRecord(userName);
+                }
+            ).update(summary.getRunningJobsCount(), summary.getUsedMemory());
+        }
+    }
+
+    private Number getSubmissionModeJobCount(final boolean api, final String user) {
+        return this.userResourcesBySubmissionModeRecordMap
+            .getOrDefault(api, Collections.emptyMap())
+            .getOrDefault(user, USER_RECORD_PLACEHOLDER)
+            .jobCount.get();
+    }
+
+    private Number getSubmissionModeMemoryAmount(final boolean api, final String user) {
+        return this.userResourcesBySubmissionModeRecordMap
+            .getOrDefault(api, Collections.emptyMap())
+            .getOrDefault(user, USER_RECORD_PLACEHOLDER)
+            .memoryAmount.get();
     }
 
     private static class UserResourcesRecord {

--- a/genie-web/src/main/java/com/netflix/genie/web/util/MetricsConstants.java
+++ b/genie-web/src/main/java/com/netflix/genie/web/util/MetricsConstants.java
@@ -82,6 +82,12 @@ public final class MetricsConstants {
         public static final String USER = "user";
 
         /**
+         * Key to tag the job submission mode ({@code api} for REST API, {@code agent} for agent/CLI). Kept short
+         * by design: the metric name (e.g. {@code ...by-submission-mode.gauge}) already conveys the full concept.
+         */
+        public static final String MODE = "mode";
+
+        /**
          * Key to tag the user concurrent job limit.
          */
         public static final String JOBS_USER_LIMIT = "jobsUserLimit";
@@ -121,6 +127,16 @@ public final class MetricsConstants {
          * Tag value to denote failure (used with TagKeys.STATUS).
          */
         public static final String FAILURE = "failure";
+
+        /**
+         * Tag value for jobs submitted through the REST API (used with TagKeys.MODE).
+         */
+        public static final String MODE_API = "api";
+
+        /**
+         * Tag value for jobs submitted through the agent/CLI (used with TagKeys.MODE).
+         */
+        public static final String MODE_AGENT = "agent";
 
         /**
          * Utility class private constructor.

--- a/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/UserMetricsTaskSpec.groovy
+++ b/genie-web/src/test/groovy/com/netflix/genie/web/tasks/leader/UserMetricsTaskSpec.groovy
@@ -172,9 +172,77 @@ class UserMetricsTaskSpec extends Specification {
         measureMemory("boo") == Double.NaN
     }
 
+    def "Run publishes a per-submission-mode breakdown when split-by-submission-mode is enabled"() {
+        setup:
+        Map<String, UserResourcesSummary> apiSummaries = [
+            "foo": new UserResourcesSummary("foo", 10, 1024),
+            "bar": new UserResourcesSummary("bar", 20, 2048)
+        ]
+        Map<String, UserResourcesSummary> agentSummaries = [
+            "foo": new UserResourcesSummary("foo", 3, 256),
+            "baz": new UserResourcesSummary("baz", 5, 512)
+        ]
+
+        when:
+        this.task = new UserMetricsTask(this.registry, this.dataServices, this.userMetricProperties)
+
+        then:
+        1 * registry.gauge(_ as Meter.Id, _, _ as ToDoubleFunction) >> {
+            args -> return captureGauge(args[0] as Meter.Id, args[1] as Object, args[2] as ToDoubleFunction<Object>)
+        }
+
+        when:
+        this.task.run()
+
+        then:
+        _ * userMetricProperties.isSplitBySubmissionMode() >> true
+        1 * persistenceService.getUserResourcesSummaries(JobStatus.activeStatuses, true) >> apiSummaries
+        1 * persistenceService.getUserResourcesSummaries(JobStatus.activeStatuses, false) >> agentSummaries
+        _ * registry.gauge(_ as Meter.Id, _, _ as ToDoubleFunction) >> {
+            args -> return captureGauge(args[0] as Meter.Id, args[1] as Object, args[2] as ToDoubleFunction<Object>)
+        }
+
+        // The existing api=true-only gauges are still published, unchanged.
+        measureJobs("foo") == 10
+        measureMemory("bar") == 2048
+
+        // New per-submission-mode gauges: api (REST) slice.
+        measureJobsBySubmissionMode("foo", "api") == 10
+        measureJobsBySubmissionMode("bar", "api") == 20
+        measureMemoryBySubmissionMode("foo", "api") == 1024
+        measureMemoryBySubmissionMode("bar", "api") == 2048
+
+        // New per-submission-mode gauges: agent slice.
+        measureJobsBySubmissionMode("foo", "agent") == 3
+        measureJobsBySubmissionMode("baz", "agent") == 5
+        measureMemoryBySubmissionMode("foo", "agent") == 256
+        measureMemoryBySubmissionMode("baz", "agent") == 512
+
+        when: "a user drops out of a mode on the next cycle"
+        this.task.run()
+
+        then:
+        _ * userMetricProperties.isSplitBySubmissionMode() >> true
+        1 * persistenceService.getUserResourcesSummaries(JobStatus.activeStatuses, true) >> apiSummaries
+        1 * persistenceService.getUserResourcesSummaries(JobStatus.activeStatuses, false) >>
+            (["foo": new UserResourcesSummary("foo", 3, 256)] as Map<String, UserResourcesSummary>)
+        _ * registry.gauge(_ as Meter.Id, _, _ as ToDoubleFunction) >> {
+            args -> return captureGauge(args[0] as Meter.Id, args[1] as Object, args[2] as ToDoubleFunction<Object>)
+        }
+
+        // baz no longer has agent jobs, so its by-submission-mode gauges report NaN.
+        measureJobsBySubmissionMode("baz", "agent") == Double.NaN
+        measureMemoryBySubmissionMode("baz", "agent") == Double.NaN
+        measureJobsBySubmissionMode("foo", "agent") == 3
+        measureMemoryBySubmissionMode("foo", "agent") == 256
+    }
+
     Gauge captureGauge(final Meter.Id id, final Object obj, final ToDoubleFunction<Object> f) {
         String userTagValue = id.getTag(MetricsConstants.TagKeys.USER)
-        String gaugeKey = id.getName() + (userTagValue == null ? "" : ("-" + userTagValue))
+        String modeTagValue = id.getTag(MetricsConstants.TagKeys.MODE)
+        String gaugeKey = id.getName() +
+            (userTagValue == null ? "" : ("-" + userTagValue)) +
+            (modeTagValue == null ? "" : ("-" + modeTagValue))
         this.gaugesFunctions.put(gaugeKey, { -> f.applyAsDouble(obj) })
         return Mock(Gauge)
     }
@@ -190,6 +258,18 @@ class UserMetricsTaskSpec extends Specification {
 
     double measureMemory(String user) {
         String gaugeKey = UserMetricsTask.USER_ACTIVE_MEMORY_METRIC_NAME + "-" + user
+        return gaugesFunctions.get(gaugeKey).call()
+    }
+
+    double measureJobsBySubmissionMode(String user, String submissionMode) {
+        String gaugeKey =
+            UserMetricsTask.USER_ACTIVE_JOBS_BY_SUBMISSION_MODE_METRIC_NAME + "-" + user + "-" + submissionMode
+        return gaugesFunctions.get(gaugeKey).call()
+    }
+
+    double measureMemoryBySubmissionMode(String user, String submissionMode) {
+        String gaugeKey =
+            UserMetricsTask.USER_ACTIVE_MEMORY_BY_SUBMISSION_MODE_METRIC_NAME + "-" + user + "-" + submissionMode
         return gaugesFunctions.get(gaugeKey).call()
     }
 }


### PR DESCRIPTION
Introduce an opt-in `genie.tasks.user-metrics.split-by-submission-mode` flag that, when enabled, additionally publishes per-user active-jobs and active-memory gauges broken down by job submission mode (submissionMode=api for REST API vs submissionMode=agent for agent/CLI) under new `genie.user.active-jobs.by-submission-mode.gauge` / `genie.user.active-memory.by-submission-mode.gauge` metric names.

Unit and Integration Tests:
- UserMetricsTaskSpec
- JpaPersistenceServiceImplJobsIntegrationTest

**Dev Tests:**

**New metric [both api mode and agent mode included]:**

<img width="1129" height="765" alt="image" src="https://github.com/user-attachments/assets/81134904-7297-481c-a71e-3a420be6c924" />


**Legacy metric [only api mode included]:**

<img width="1122" height="691" alt="image" src="https://github.com/user-attachments/assets/0e78373f-dd8c-4085-bed9-0a984e1cb76a" />

