### PR TITLE
Enable concurrent genie push and genie snapshot workflows

### DIFF
--- a/.github/workflows/genie-publish.yml
+++ b/.github/workflows/genie-publish.yml
@@ -6,6 +6,12 @@ on:
       - v*.*.*
       - v*.*.*-rc.*
 
+# Serialize gh-pages doc pushes across this workflow and genie-snapshot.yml so
+# concurrent gitPublishPush runs don't collide with a non-fast-forward rejection.
+concurrency:
+  group: gh-pages-publish
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/genie-snapshot.yml
+++ b/.github/workflows/genie-snapshot.yml
@@ -6,6 +6,12 @@ on:
       - master
       - dev-snapshot
 
+# Serialize gh-pages doc pushes across this workflow and genie-publish.yml so
+# concurrent gitPublishPush runs don't collide with a non-fast-forward rejection.
+concurrency:
+  group: gh-pages-publish
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enable concurrent genie push and genie snapshot workflows; otherwise gh-pages doc pushes across the two workflows cause failures. 